### PR TITLE
fix(web): default SFU URL to production

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ pnpm -C apps/web run dev
 
 Notes:
 
-- Web defaults to `http://localhost:3031` SFU if `SFU_URL`/`NEXT_PUBLIC_SFU_URL` is unset.
+- Web defaults to `https://sfu.acmvit.in` if `SFU_URL`/`NEXT_PUBLIC_SFU_URL` is unset.
 - SFU has development defaults; production must set secrets and announced IPs.
 
 ---

--- a/apps/web/src/app/api/sfu/join/route.ts
+++ b/apps/web/src/app/api/sfu/join/route.ts
@@ -4,6 +4,11 @@ import { NextResponse } from "next/server";
 import { resolveHostGrant } from "@conclave/meeting-core";
 import { auth } from "@/lib/auth";
 import { lookupScheduledWebinarByRoomId } from "@/lib/sfu-user-auth";
+import {
+  normalizeRoutedSfuUrl,
+  normalizeSfuUrl,
+  resolveSfuUrl,
+} from "@/lib/sfu-url";
 
 export const runtime = "nodejs";
 
@@ -47,9 +52,6 @@ const DEFAULT_PUBLIC_STUN_URLS = [
   "stun:stun1.l.google.com:19302",
   "stun:stun2.l.google.com:19302",
 ];
-
-const resolveSfuUrl = () =>
-  process.env.SFU_URL || process.env.NEXT_PUBLIC_SFU_URL || "http://localhost:3031";
 
 type RoomRoutingResponse = {
   owner?: {
@@ -102,24 +104,6 @@ const parseEmailList = (value: string | undefined): Set<string> =>
 
 const isScheduledRoomId = (value: string): boolean =>
   /^sched-[a-f0-9]{8}$/i.test(value);
-
-const normalizeSfuUrl = (value: string): string => value.replace(/\/+$/, "");
-
-const normalizeRoutedSfuUrl = (value: unknown): string | null => {
-  if (typeof value !== "string" || !value.trim()) {
-    return null;
-  }
-
-  try {
-    const url = new URL(value.trim());
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
-      return null;
-    }
-    return normalizeSfuUrl(url.toString());
-  } catch {
-    return null;
-  }
-};
 
 let roomRoutingWarningLogged = false;
 const resolveRoutedSfuUrl = async (options: {

--- a/apps/web/src/app/api/sfu/rooms/route.ts
+++ b/apps/web/src/app/api/sfu/rooms/route.ts
@@ -1,13 +1,11 @@
 import { NextResponse } from "next/server";
+import { resolveSfuUrl } from "@/lib/sfu-url";
 
 export const runtime = "nodejs";
 
 type RoomsResponse = {
   rooms?: Array<{ id: string; clients?: number; userCount?: number }>;
 };
-
-const resolveSfuUrl = () =>
-  process.env.SFU_URL || process.env.NEXT_PUBLIC_SFU_URL || "http://localhost:3031";
 
 const resolveClientId = (request: Request) => {
   const envClientId =

--- a/apps/web/src/lib/sfu-admin-auth.ts
+++ b/apps/web/src/lib/sfu-admin-auth.ts
@@ -1,4 +1,5 @@
 import { auth } from "@/lib/auth";
+export { resolveSfuUrl } from "@/lib/sfu-url";
 
 const firstNonEmpty = (...values: Array<string | undefined>): string | undefined => {
   for (const value of values) {
@@ -108,9 +109,6 @@ const getAllowlistConfigurationError = (): string | null => {
 
   return "SFU admin access is disabled until an allowlist is configured. Set SFU_ADMIN_ALLOWLIST_* env vars.";
 };
-
-export const resolveSfuUrl = (): string =>
-  process.env.SFU_URL || process.env.NEXT_PUBLIC_SFU_URL || "http://localhost:3031";
 
 export const resolveSfuSecret = (): string =>
   process.env.SFU_SECRET || "development-secret";

--- a/apps/web/src/lib/sfu-url.ts
+++ b/apps/web/src/lib/sfu-url.ts
@@ -1,0 +1,52 @@
+const PUBLIC_SFU_URL = "https://sfu.acmvit.in";
+
+const envValue = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+};
+
+const isProductionRuntime = (): boolean =>
+  process.env.NODE_ENV === "production";
+
+const isLocalhostUrl = (value: string): boolean => {
+  try {
+    const { hostname } = new URL(value);
+    return hostname === "localhost" || hostname === "127.0.0.1";
+  } catch {
+    return false;
+  }
+};
+
+export const normalizeSfuUrl = (value: string): string =>
+  value.trim().replace(/\/+$/, "");
+
+const productionSafeSfuUrl = (value: string): string => {
+  const normalized = normalizeSfuUrl(value);
+  if (isProductionRuntime() && isLocalhostUrl(normalized)) {
+    return PUBLIC_SFU_URL;
+  }
+  return normalized;
+};
+
+export const resolveSfuUrl = (): string =>
+  productionSafeSfuUrl(
+    envValue(process.env.SFU_URL) ||
+      envValue(process.env.NEXT_PUBLIC_SFU_URL) ||
+      PUBLIC_SFU_URL,
+  );
+
+export const normalizeRoutedSfuUrl = (value: unknown): string | null => {
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return null;
+    }
+    return productionSafeSfuUrl(url.toString());
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- default web SFU resolution to https://sfu.acmvit.in instead of localhost
- centralize the SFU URL resolver for join, rooms, and admin/webinar paths
- guard production against localhost SFU env values or routed owner URLs

## Validation
- pnpm -C apps/web run lint
- pnpm run typecheck:web