### PR TITLE
fix(web): make meeting reconnect less disruptive

### DIFF
--- a/apps/web/src/app/components/ControlsBar.tsx
+++ b/apps/web/src/app/components/ControlsBar.tsx
@@ -116,6 +116,7 @@ function MediaClusterButton({
       badge={d.badge}
       hotkey={d.hotkey}
       disabled={disabled || d.disabled}
+      loading={d.loading}
       {...audio}
       {...video}
     />

--- a/apps/web/src/app/components/DeviceCaretMenu.tsx
+++ b/apps/web/src/app/components/DeviceCaretMenu.tsx
@@ -4,6 +4,7 @@ import {
   Check,
   ChevronUp,
   FlipHorizontal2,
+  Loader2,
   type LucideIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -136,6 +137,7 @@ export interface MediaControlClusterProps {
   badge?: number;
   hotkey?: string;
   disabled?: boolean;
+  loading?: boolean;
   selectedAudioInputDeviceId?: string;
   selectedAudioOutputDeviceId?: string;
   selectedVideoInputDeviceId?: string;
@@ -157,6 +159,7 @@ export function MediaControlCluster(props: MediaControlClusterProps) {
     badge,
     hotkey,
     disabled = false,
+    loading = false,
     selectedAudioInputDeviceId,
     selectedAudioOutputDeviceId,
     selectedVideoInputDeviceId,
@@ -218,6 +221,7 @@ export function MediaControlCluster(props: MediaControlClusterProps) {
       type="button"
       disabled={disabled}
       aria-label={label}
+      aria-busy={loading || undefined}
       onClick={onPress}
       className={
         "relative inline-flex h-12 w-full shrink-0 items-center justify-center rounded-full border " +
@@ -227,7 +231,15 @@ export function MediaControlCluster(props: MediaControlClusterProps) {
       }
       style={{ ...mainStyle, color: colors.fg }}
     >
-      <Icon size={ICON_SIZE} strokeWidth={1.75} />
+      {loading ? (
+        <Loader2
+          size={ICON_SIZE}
+          strokeWidth={1.75}
+          className="animate-spin"
+        />
+      ) : (
+        <Icon size={ICON_SIZE} strokeWidth={1.75} />
+      )}
       {typeof badge === "number" && badge > 0 ? (
         <span
           className="absolute -right-0.5 -top-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-bold text-white"

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -105,6 +105,7 @@ interface MeetsMainContentProps {
   onPrejoinMediaCommit?: (handoff: PrejoinMediaHandoff) => void;
   isCameraOff: boolean;
   isMuted: boolean;
+  isMuteTogglePending?: boolean;
   isHandRaised: boolean;
   participants: Map<string, Participant>;
   isMirrorCamera: boolean;
@@ -322,6 +323,7 @@ export default function MeetsMainContent({
   onPrejoinMediaCommit,
   isCameraOff,
   isMuted,
+  isMuteTogglePending = false,
   isHandRaised,
   participants,
   isMirrorCamera,
@@ -1348,6 +1350,7 @@ export default function MeetsMainContent({
             <ControlsBar
                 roomId={roomId}
                 isMuted={isMuted}
+                isMuteTogglePending={isMuteTogglePending}
                 isCameraOff={isCameraOff}
                 isScreenSharing={isScreenSharing}
                 activeScreenShareId={activeScreenShareId}

--- a/apps/web/src/app/components/controls-config.ts
+++ b/apps/web/src/app/components/controls-config.ts
@@ -33,6 +33,7 @@ import { HOTKEYS } from "../lib/hotkeys";
 export interface ControlsBarProps {
   roomId?: string;
   isMuted: boolean;
+  isMuteTogglePending?: boolean;
   isCameraOff: boolean;
   isScreenSharing: boolean;
   activeScreenShareId: string | null;
@@ -128,6 +129,7 @@ export interface ControlDescriptor {
   variant: ControlButtonVariant;
   badge?: number;
   disabled?: boolean;
+  loading?: boolean;
   onPress?: () => void;
 }
 
@@ -201,10 +203,19 @@ export function buildControlsConfig(p: ControlsBarProps): ControlsConfig {
     {
       id: "mic",
       icon: p.isMuted ? MicOff : Mic,
-      label: ghost ? "Ghost mode: mic locked" : p.isMuted ? "Unmute" : "Mute",
+      label: ghost
+        ? "Ghost mode: mic locked"
+        : p.isMuteTogglePending
+          ? p.isMuted
+            ? "Unmuting"
+            : "Muting"
+          : p.isMuted
+            ? "Unmute"
+            : "Mute",
       hotkey: HOTKEYS.toggleMute.keys,
       variant: ghost ? "default" : p.isMuted ? "muted" : "default",
       disabled: ghost,
+      loading: Boolean(p.isMuteTogglePending && !ghost),
       onPress: p.onToggleMute,
     },
     {

--- a/apps/web/src/app/components/mobile/MobileControlsBar.tsx
+++ b/apps/web/src/app/components/mobile/MobileControlsBar.tsx
@@ -6,6 +6,7 @@ import {
   Globe,
   Lock,
   LockOpen,
+  Loader2,
   MessageSquare,
   MessageSquareLock,
   Mic,
@@ -122,6 +123,7 @@ function MoreSectionLabel({ children }: { children: ReactNode }) {
 
 interface MobileControlsBarProps {
   isMuted: boolean;
+  isMuteTogglePending?: boolean;
   isCameraOff: boolean;
   isScreenSharing: boolean;
   activeScreenShareId: string | null;
@@ -201,6 +203,7 @@ interface MobileControlsBarProps {
 
 function MobileControlsBar({
   isMuted,
+  isMuteTogglePending = false,
   isCameraOff,
   isScreenSharing,
   activeScreenShareId,
@@ -353,6 +356,7 @@ function MobileControlsBar({
   const mutedButtonClass = `${baseButtonClass} is-muted`;
   const ghostDisabledClass = `${baseButtonClass} is-disabled`;
   const leaveButtonClass = `${baseButtonClass} is-danger`;
+  const isMicBusy = isMuteTogglePending && !isGhostMode;
 
   const handleReactionClick = useCallback(
     (reaction: ReactionOption) => {
@@ -1588,10 +1592,21 @@ function MobileControlsBar({
                     : defaultButtonClass
               }
               aria-label={
-                isGhostMode ? "Microphone locked" : isMuted ? "Unmute" : "Mute"
+                isGhostMode
+                  ? "Microphone locked"
+                  : isMicBusy
+                    ? isMuted
+                      ? "Unmuting"
+                      : "Muting"
+                    : isMuted
+                      ? "Unmute"
+                      : "Mute"
               }
+              aria-busy={isMicBusy || undefined}
             >
-              {isMuted ? (
+              {isMicBusy ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : isMuted ? (
                 <MicOff className="w-5 h-5" />
               ) : (
                 <Mic className="w-5 h-5" />

--- a/apps/web/src/app/components/mobile/MobileMeetsMainContent.tsx
+++ b/apps/web/src/app/components/mobile/MobileMeetsMainContent.tsx
@@ -89,6 +89,7 @@ interface MobileMeetsMainContentProps {
   onPrejoinMediaCommit?: (handoff: PrejoinMediaHandoff) => void;
   isCameraOff: boolean;
   isMuted: boolean;
+  isMuteTogglePending?: boolean;
   isHandRaised: boolean;
   participants: Map<string, Participant>;
   isMirrorCamera: boolean;
@@ -273,6 +274,7 @@ function MobileMeetsMainContent({
   onPrejoinMediaCommit,
   isCameraOff,
   isMuted,
+  isMuteTogglePending = false,
   isHandRaised,
   participants,
   isMirrorCamera,
@@ -1111,6 +1113,7 @@ function MobileMeetsMainContent({
       )}
       <MobileControlsBar
         isMuted={isMuted}
+        isMuteTogglePending={isMuteTogglePending}
         isCameraOff={isCameraOff}
         isScreenSharing={isScreenSharing}
         activeScreenShareId={activeScreenShareId}

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -119,6 +119,7 @@ export function useMeetMedia({
   const [cameraProducerRecoveryPulse, setCameraProducerRecoveryPulse] =
     useState(0);
   const toggleMuteInFlightRef = useRef(false);
+  const [isMuteTogglePending, setIsMuteTogglePending] = useState(false);
   const toggleCameraInFlightRef = useRef(false);
   const buildAudioConstraints = useCallback(
     (deviceId?: string): MediaTrackConstraints => ({
@@ -808,6 +809,7 @@ export function useMeetMedia({
     if (ghostEnabled || isObserverMode) return;
     if (toggleMuteInFlightRef.current) return;
     toggleMuteInFlightRef.current = true;
+    setIsMuteTogglePending(true);
     const previousMuted = isMuted;
     const nextMuted = !previousMuted;
     let producer = audioProducerRef.current;
@@ -1001,6 +1003,7 @@ export function useMeetMedia({
       setMeetError(createMeetError(err, "MEDIA_ERROR"));
     } finally {
       toggleMuteInFlightRef.current = false;
+      setIsMuteTogglePending(false);
     }
   }, [
     ghostEnabled,
@@ -1721,6 +1724,7 @@ export function useMeetMedia({
   return {
     mediaState,
     showPermissionHint,
+    isMuteTogglePending,
     requestMediaPermissions,
     handleAudioInputDeviceChange,
     handleVideoInputDeviceChange,

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -509,8 +509,9 @@ export function useMeetSocket({
   }, []);
 
   const cleanupRoomResources = useCallback(
-    (options?: { resetRoomId?: boolean }) => {
+    (options?: { resetRoomId?: boolean; preserveMeetingState?: boolean }) => {
       const resetRoomId = options?.resetRoomId !== false;
+      const preserveMeetingState = options?.preserveMeetingState === true;
       console.log("[Meets] Cleaning up room resources...");
       if (producerSyncIntervalRef.current) {
         window.clearInterval(producerSyncIntervalRef.current);
@@ -550,15 +551,17 @@ export function useMeetSocket({
         window.clearTimeout(timeoutId);
       });
       leaveTimeoutsRef.current.clear();
-      clearReactions();
-      setPendingUsers(new Map());
-      setDisplayNames(new Map());
-      setHostUserId(null);
-      setHostUserIds([]);
-      setWebinarRole(null);
-      setWebinarSpeakerUserId(null);
-      participantIdsRef.current = new Set([userId]);
-      serverRoomIdRef.current = null;
+      if (!preserveMeetingState) {
+        clearReactions();
+        setPendingUsers(new Map());
+        setDisplayNames(new Map());
+        setHostUserId(null);
+        setHostUserIds([]);
+        setWebinarRole(null);
+        setWebinarSpeakerUserId(null);
+        participantIdsRef.current = new Set([userId]);
+        serverRoomIdRef.current = null;
+      }
 
       try {
         audioProducerRef.current?.close();
@@ -592,14 +595,18 @@ export function useMeetSocket({
         consumerTransportDisconnectTimeoutRef.current = null;
       }
 
-      dispatchParticipants({ type: "CLEAR_ALL" });
+      if (!preserveMeetingState) {
+        dispatchParticipants({ type: "CLEAR_ALL" });
+      }
       setIsScreenSharing(false);
-      setActiveScreenShareId(null);
-      setIsHandRaised(false);
-      setIsTtsDisabled(false);
-      setIsDmEnabled(true);
-      setMeetingRequiresInviteCode(false);
-      setWebinarConfig(null);
+      if (!preserveMeetingState) {
+        setActiveScreenShareId(null);
+        setIsHandRaised(false);
+        setIsTtsDisabled(false);
+        setIsDmEnabled(true);
+        setMeetingRequiresInviteCode(false);
+        setWebinarConfig(null);
+      }
       if (resetRoomId) {
         currentRoomIdRef.current = null;
         runtimeStunIceServersRef.current = null;
@@ -3131,6 +3138,7 @@ export function useMeetSocket({
                 if (!isRoomEvent(eventRoomId)) return;
                 const snapshot = new Map<string, string>();
                 const nextParticipantIds = new Set<string>([userId]);
+                const previousParticipantIds = participantIdsRef.current;
                 (users || []).forEach(
                   ({ userId: snapshotUserId, displayName }) => {
                     if (displayName) {
@@ -3154,6 +3162,37 @@ export function useMeetSocket({
                     }
                   },
                 );
+                for (const previousUserId of previousParticipantIds) {
+                  if (
+                    previousUserId === userId ||
+                    nextParticipantIds.has(previousUserId)
+                  ) {
+                    continue;
+                  }
+                  const leaveTimeout = leaveTimeoutsRef.current.get(previousUserId);
+                  if (leaveTimeout) {
+                    window.clearTimeout(leaveTimeout);
+                    leaveTimeoutsRef.current.delete(previousUserId);
+                  }
+                  clearParticipantConnectionStatusTimer(previousUserId);
+                  const producersToClose = Array.from(
+                    producerMapRef.current.entries(),
+                  )
+                    .filter(([, info]) => info.userId === previousUserId)
+                    .map(([producerId]) => producerId);
+                  for (const [producerId, info] of pendingProducersRef.current) {
+                    if (info.producerUserId === previousUserId) {
+                      pendingProducersRef.current.delete(producerId);
+                    }
+                  }
+                  for (const producerId of producersToClose) {
+                    handleProducerClosed(producerId);
+                  }
+                  dispatchParticipants({
+                    type: "REMOVE_PARTICIPANT",
+                    userId: previousUserId,
+                  });
+                }
                 participantIdsRef.current = nextParticipantIds;
                 setDisplayNames(snapshot);
               },
@@ -3909,14 +3948,22 @@ export function useMeetSocket({
 
         try {
           const reconnectRoomId = currentRoomIdRef.current;
-          cleanupRoomResources({ resetRoomId: false });
-          socketRef.current?.disconnect();
-          socketRef.current = null;
-          onSocketReady?.(null);
           if (!reconnectRoomId) {
             throw new Error("Missing room ID for reconnect");
           }
-          await connectSocket(reconnectRoomId);
+          const canReuseSocket = socketRef.current?.connected === true;
+          cleanupRoomResources({
+            resetRoomId: false,
+            preserveMeetingState: true,
+          });
+          if (!canReuseSocket) {
+            socketRef.current?.disconnect();
+            socketRef.current = null;
+            onSocketReady?.(null);
+            await connectSocket(reconnectRoomId);
+          } else {
+            setMeetError(null);
+          }
           // …or while the socket was (re)connecting — bail before rejoining so
           // we don't re-enter a room we were just removed from.
           if (intentionalDisconnectRef.current) return;
@@ -3935,7 +3982,25 @@ export function useMeetSocket({
               bypassMediaPermissions ||
               joinOptions.joinMode === "webinar_attendee")
           ) {
-            await joinRoomInternal(reconnectRoomId, stream, joinOptions);
+            try {
+              await joinRoomInternal(reconnectRoomId, stream, joinOptions);
+            } catch (joinError) {
+              if (!(joinError instanceof JoinRoomRedirectError)) {
+                throw joinError;
+              }
+              cleanupRoomResources({
+                resetRoomId: false,
+                preserveMeetingState: true,
+              });
+              socketRef.current?.disconnect();
+              socketRef.current = null;
+              onSocketReady?.(null);
+              await connectSocket(reconnectRoomId, {
+                sfuUrlOverride: joinError.redirectUrl,
+              });
+              if (intentionalDisconnectRef.current) return;
+              await joinRoomInternal(reconnectRoomId, stream, joinOptions);
+            }
           } else {
             throw new Error("Missing live local media for reconnect");
           }
@@ -3983,6 +4048,7 @@ export function useMeetSocket({
     setConnectionState,
     setMeetError,
     socketRef,
+    onSocketReady,
     bypassMediaPermissions,
   ]);
 

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -841,6 +841,7 @@ export default function MeetsClient({
     handleAudioOutputDeviceChange,
     updateVideoQualityRef,
     toggleMute,
+    isMuteTogglePending,
     toggleCamera,
     toggleScreenShare,
     stopLocalTrack,
@@ -2284,6 +2285,7 @@ export default function MeetsClient({
           onPrejoinMediaCommit={handlePrejoinMediaCommit}
           isCameraOff={isCameraOff}
           isMuted={isMuted}
+          isMuteTogglePending={isMuteTogglePending}
           isHandRaised={isHandRaised}
           participants={participants}
           isMirrorCamera={isMirrorCamera}
@@ -2437,6 +2439,7 @@ export default function MeetsClient({
         onPrejoinMediaCommit={handlePrejoinMediaCommit}
         isCameraOff={isCameraOff}
         isMuted={isMuted}
+        isMuteTogglePending={isMuteTogglePending}
         isHandRaised={isHandRaised}
         participants={participants}
         isMirrorCamera={isMirrorCamera}


### PR DESCRIPTION
## Summary
- preserve meeting UI state while reconnect attempts rebuild socket/media resources
- reuse a still-connected SFU socket during transport recovery instead of forcing a hard client disconnect
- reconcile participant state from the server snapshot after reconnect and handle routed SFU redirects during reconnect

## Validation
- pnpm -C apps/web run lint
- pnpm run typecheck:web