### PR TITLE
fix(web): allow routed public rooms to be created

### DIFF
--- a/apps/web/src/app/api/sfu/join/route.ts
+++ b/apps/web/src/app/api/sfu/join/route.ts
@@ -316,16 +316,16 @@ export async function POST(request: Request) {
   // security invariant + regression tests) lives in resolveHostGrant: a host
   // *intent* only grants room-creation, so the creator becomes host via the
   // SFU's server-authoritative createdRoom path — never seizing an existing room.
-  const canHonorBodyRoomCreation =
-    Boolean(sessionUser?.id) || clientId !== "public" || requestedHost;
   const { isHost, allowRoomCreation } = resolveHostGrant({
     isWebinarAttendeeJoin,
     isForcedHost,
     scheduledRoomHostMatch,
     isScheduledHostRoom,
     requestedHost,
-    bodyAllowRoomCreation:
-      canHonorBodyRoomCreation && Boolean(body?.allowRoomCreation),
+    // `/abc123` public room links intentionally create the room on first join.
+    // This still does not mint host/admin for an existing room; the SFU only
+    // promotes the requester through its server-authoritative createdRoom path.
+    bodyAllowRoomCreation: Boolean(body?.allowRoomCreation),
   });
 
   const secret = process.env.SFU_SECRET || "development-secret";


### PR DESCRIPTION
## Summary
- honor explicit room-creation intent from routed public room URLs like /abc123
- keep host/admin privilege protection unchanged: this does not mint host for an existing room; SFU only promotes the creator on createdRoom

## Validation
- pnpm -C packages/meeting-core test
- pnpm -C apps/web run lint
- pnpm run typecheck:web