### PR TITLE
fix: stabilize low-bandwidth meeting media

### DIFF
--- a/apps/web/src/app/components/ControlsBar.tsx
+++ b/apps/web/src/app/components/ControlsBar.tsx
@@ -5,6 +5,8 @@ import {
   PhoneOff,
   Shield,
   Smile,
+  Volume2,
+  VolumeX,
 } from "lucide-react";
 import {
   memo,
@@ -22,6 +24,8 @@ import { normalizeBrowserUrl } from "../lib/utils";
 import HotkeyTooltip from "./HotkeyTooltip";
 import Coachmark from "./Coachmark";
 import { useOneTimeHint } from "../hooks/useOneTimeHint";
+import { useMeetVolume } from "../hooks/useMeetVolume";
+import { clampMeetVolume } from "../lib/meet-volume";
 import {
   BROWSER_APPS,
   buildControlsConfig,
@@ -216,6 +220,8 @@ function ControlsBar(props: ControlsBarProps) {
   const [browserOpen, setBrowserOpen] = useState(false);
   const [browserUrl, setBrowserUrl] = useState("");
   const [browserError, setBrowserError] = useState<string | null>(null);
+  const { meetVolume, setMeetVolume } = useMeetVolume();
+  const meetVolumePercent = Math.round(clampMeetVolume(meetVolume) * 100);
 
   const reactionRef = useRef<HTMLDivElement>(null);
   const moreRef = useRef<HTMLDivElement>(null);
@@ -263,6 +269,7 @@ function ControlsBar(props: ControlsBarProps) {
   );
 
   const showHost = Boolean(isAdmin);
+  const VolumeIcon = meetVolumePercent === 0 ? VolumeX : Volume2;
 
   return (
     <div className="relative grid w-full grid-cols-[1fr_auto_1fr] items-center gap-2 px-4 py-3">
@@ -399,6 +406,11 @@ function ControlsBar(props: ControlsBarProps) {
                   }}
                 />
               ))}
+              <MeetVolumeOverflowControl
+                icon={VolumeIcon}
+                volumePercent={meetVolumePercent}
+                onVolumePercentChange={(value) => setMeetVolume(value / 100)}
+              />
               {browserOpen && onLaunchBrowser && (
                 <BrowserLauncher
                   url={browserUrl}
@@ -471,6 +483,45 @@ function OverflowItem({ row, onActivate }: { row: OverflowRow; onActivate: () =>
       <Icon size={MENU_ICON} strokeWidth={STROKE} className="shrink-0" />
       <span className="flex-1">{row.label}</span>
     </button>
+  );
+}
+
+function MeetVolumeOverflowControl({
+  icon: Icon,
+  volumePercent,
+  onVolumePercentChange,
+}: {
+  icon: typeof Volume2;
+  volumePercent: number;
+  onVolumePercentChange: (value: number) => void;
+}) {
+  return (
+    <div className="mt-1.5 border-t px-2.5 pb-2 pt-3" style={{ borderColor: color.border }}>
+      <div className="mb-2 flex items-center gap-3">
+        <Icon size={MENU_ICON} strokeWidth={STROKE} className="shrink-0" />
+        <span className="flex-1 text-[14px] font-medium" style={{ color: color.text }}>
+          Meet volume
+        </span>
+        <span
+          className="text-[12px] tabular-nums"
+          style={{ color: color.textMuted }}
+        >
+          {volumePercent}%
+        </span>
+      </div>
+      <input
+        type="range"
+        min={0}
+        max={100}
+        step={1}
+        value={volumePercent}
+        onChange={(event) =>
+          onVolumePercentChange(Number(event.currentTarget.value))
+        }
+        aria-label="Meet volume"
+        className="h-2 w-full accent-[#F95F4A]"
+      />
+    </div>
   );
 }
 

--- a/apps/web/src/app/components/ParticipantAudio.tsx
+++ b/apps/web/src/app/components/ParticipantAudio.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo, useCallback, useEffect, useRef } from "react";
+import { useMeetVolume } from "../hooks/useMeetVolume";
 import { createPlaybackRecoveryScheduler } from "../lib/playback-recovery";
 import type { Participant } from "../lib/types";
 
@@ -21,6 +22,7 @@ function ParticipantAudio({
 }: ParticipantAudioProps) {
   const audioRef = useRef<HTMLAudioElement>(null);
   const autoplayBlockedRef = useRef(false);
+  const { meetVolume } = useMeetVolume();
 
   const attemptAudioPlayback = useCallback(() => {
     const audio = audioRef.current;
@@ -65,7 +67,6 @@ function ParticipantAudio({
     audio.autoplay = true;
     audio.defaultMuted = false;
     audio.muted = false;
-    audio.volume = 1;
 
     if (audio.srcObject !== participant.audioStream) {
       // Force a clean re-attach when the remote track changes. Firefox is
@@ -143,6 +144,12 @@ function ParticipantAudio({
     audioOutputDeviceId,
     attemptAudioPlayback,
   ]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.volume = meetVolume;
+  }, [meetVolume]);
 
   useEffect(() => {
     if (audioPlaybackAttemptToken == null || audioPlaybackAttemptToken < 1) return;

--- a/apps/web/src/app/components/ScreenShareAudioPlayers.tsx
+++ b/apps/web/src/app/components/ScreenShareAudioPlayers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo, useCallback, useEffect, useRef } from "react";
+import { useMeetVolume } from "../hooks/useMeetVolume";
 import type { Participant } from "../lib/types";
 
 interface ScreenShareAudioPlayersProps {
@@ -60,6 +61,7 @@ function ScreenShareAudioPlayer({
   playbackAttemptToken,
 }: ScreenShareAudioPlayerProps) {
   const audioRef = useRef<HTMLAudioElement>(null);
+  const { meetVolume } = useMeetVolume();
 
   const attemptPlay = useCallback(() => {
     const audio = audioRef.current;
@@ -113,6 +115,12 @@ function ScreenShareAudioPlayer({
       console.error("[Meets] Failed to set screen share audio output:", err);
     });
   }, [audioOutputDeviceId]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.volume = meetVolume;
+  }, [meetVolume]);
 
   return (
     <audio

--- a/apps/web/src/app/components/SystemAudioPlayers.tsx
+++ b/apps/web/src/app/components/SystemAudioPlayers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo, useEffect, useRef, useState } from "react";
+import { useMeetVolume } from "../hooks/useMeetVolume";
 import type { Participant } from "../lib/types";
 import { isSystemUserId } from "../lib/utils";
 
@@ -51,6 +52,7 @@ function SystemAudioPlayer({
 }: SystemAudioPlayerProps) {
   const audioRef = useRef<HTMLAudioElement>(null);
   const [blocked, setBlocked] = useState(false);
+  const { meetVolume } = useMeetVolume();
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -114,6 +116,12 @@ function SystemAudioPlayer({
       console.error("[Meets] Failed to set system audio output:", err);
     });
   }, [audioOutputDeviceId]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.volume = meetVolume;
+  }, [meetVolume]);
 
   return (
     <audio

--- a/apps/web/src/app/components/mobile/MobileBrowserLayout.tsx
+++ b/apps/web/src/app/components/mobile/MobileBrowserLayout.tsx
@@ -3,6 +3,7 @@
 import { Globe, Loader2, MicOff, VenetianMask } from "lucide-react";
 import { memo, useEffect, useRef, useState, type FormEvent } from "react";
 import { Avatar } from "@conclave/ui-tokens/web";
+import { useMeetVolume } from "../../hooks/useMeetVolume";
 import { useSmartParticipantOrder } from "../../hooks/useSmartParticipantOrder";
 import { getRenderableParticipantVideoStream } from "../../lib/participant-media";
 import type { Participant } from "../../lib/types";
@@ -371,6 +372,7 @@ const VideoThumbnail = memo(function VideoThumbnail({
 
 const AudioPlayer = memo(function AudioPlayer({ stream }: { stream: MediaStream }) {
   const audioRef = useRef<HTMLAudioElement>(null);
+  const { meetVolume } = useMeetVolume();
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -384,6 +386,12 @@ const AudioPlayer = memo(function AudioPlayer({ stream }: { stream: MediaStream 
       }
     };
   }, [stream]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.volume = meetVolume;
+  }, [meetVolume]);
 
   return <audio ref={audioRef} autoPlay />;
 });

--- a/apps/web/src/app/components/mobile/MobileControlsBar.tsx
+++ b/apps/web/src/app/components/mobile/MobileControlsBar.tsx
@@ -29,6 +29,8 @@ import {
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { SwitchRow } from "@conclave/ui-tokens/web";
+import { useMeetVolume } from "../../hooks/useMeetVolume";
+import { clampMeetVolume } from "../../lib/meet-volume";
 import type {
   MeetingConfigSnapshot,
   MeetingUpdateRequest,
@@ -118,6 +120,39 @@ function MoreSectionLabel({ children }: { children: ReactNode }) {
     <p className="px-3 pb-1 pt-3 text-[11px] font-medium uppercase tracking-[0.08em] text-[#fafafa]/45">
       {children}
     </p>
+  );
+}
+
+function MobileMeetVolumeControl({
+  volumePercent,
+  onVolumePercentChange,
+}: {
+  volumePercent: number;
+  onVolumePercentChange: (value: number) => void;
+}) {
+  const Icon = volumePercent === 0 ? VolumeX : Volume2;
+  return (
+    <div className="rounded-xl px-3 py-3 text-[#fafafa]">
+      <div className="mb-2 flex items-center gap-3.5">
+        <Icon className="h-[19px] w-[19px] shrink-0 text-[#fafafa]/70" strokeWidth={1.75} />
+        <span className="flex-1 text-[15px] font-medium">Meet volume</span>
+        <span className="text-[12px] font-medium tabular-nums text-[#fafafa]/56">
+          {volumePercent}%
+        </span>
+      </div>
+      <input
+        type="range"
+        min={0}
+        max={100}
+        step={1}
+        value={volumePercent}
+        onChange={(event) =>
+          onVolumePercentChange(Number(event.currentTarget.value))
+        }
+        aria-label="Meet volume"
+        className="h-2 w-full accent-[#F95F4A]"
+      />
+    </div>
   );
 }
 
@@ -301,6 +336,8 @@ function MobileControlsBar({
   const [webinarNotice, setWebinarNotice] = useState<string | null>(null);
   const [webinarError, setWebinarError] = useState<string | null>(null);
   const [isWebinarWorking, setIsWebinarWorking] = useState(false);
+  const { meetVolume, setMeetVolume } = useMeetVolume();
+  const meetVolumePercent = Math.round(clampMeetVolume(meetVolume) * 100);
 
   const closeControlSheets = useCallback(() => {
     setIsMoreMenuOpen(false);
@@ -755,6 +792,10 @@ function MobileControlsBar({
             dataAction="settings"
             dataActionState="available"
             onClick={openSettingsSheet}
+          />
+          <MobileMeetVolumeControl
+            volumePercent={meetVolumePercent}
+            onVolumePercentChange={(value) => setMeetVolume(value / 100)}
           />
           <MoreRow
             icon={Hand}

--- a/apps/web/src/app/components/mobile/MobileParticipantVideo.tsx
+++ b/apps/web/src/app/components/mobile/MobileParticipantVideo.tsx
@@ -3,6 +3,7 @@
 import { Hand, MicOff, VenetianMask } from "lucide-react";
 import { memo, useEffect, useRef } from "react";
 import { Avatar } from "@conclave/ui-tokens/web";
+import { useMeetVolume } from "../../hooks/useMeetVolume";
 import { createPlaybackRecoveryScheduler } from "../../lib/playback-recovery";
 import { getRenderableParticipantVideoStream } from "../../lib/participant-media";
 import type { Participant } from "../../lib/types";
@@ -26,6 +27,7 @@ function MobileParticipantVideo({
 }: MobileParticipantVideoProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const audioRef = useRef<HTMLAudioElement>(null);
+  const { meetVolume } = useMeetVolume();
   const videoStream = getRenderableParticipantVideoStream(participant);
   const videoTrack = videoStream?.getVideoTracks()[0] ?? null;
   const connectionStatus = participant.connectionStatus;
@@ -174,6 +176,12 @@ function MobileParticipantVideo({
     participant.isMuted,
     audioOutputDeviceId,
   ]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.volume = meetVolume;
+  }, [meetVolume]);
 
   const showPlaceholder = !videoStream;
 

--- a/apps/web/src/app/components/mobile/MobileParticipantVideo.tsx
+++ b/apps/web/src/app/components/mobile/MobileParticipantVideo.tsx
@@ -3,6 +3,7 @@
 import { Hand, MicOff, VenetianMask } from "lucide-react";
 import { memo, useEffect, useRef } from "react";
 import { Avatar } from "@conclave/ui-tokens/web";
+import { createPlaybackRecoveryScheduler } from "../../lib/playback-recovery";
 import { getRenderableParticipantVideoStream } from "../../lib/participant-media";
 import type { Participant } from "../../lib/types";
 import { truncateDisplayName } from "../../lib/utils";
@@ -45,24 +46,72 @@ function MobileParticipantVideo({
       video.srcObject = videoStream;
     }
 
+    let cancelled = false;
+
     const playVideo = () => {
+      if (cancelled) return;
       video.play().catch((err) => {
         if (err.name !== "AbortError") {
+          if (err.name === "NotAllowedError") {
+            video.muted = true;
+            video.play().catch(() => {});
+            return;
+          }
           console.error("[Meets] Mobile video play error:", err);
         }
       });
     };
 
-    playVideo();
+    const playbackRecovery = createPlaybackRecoveryScheduler({
+      attemptPlayback: playVideo,
+      shouldAttemptAnimationFrameReplay: () =>
+        !cancelled &&
+        (video.paused ||
+          video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA),
+    });
+    const scheduleReplay = playbackRecovery.schedule;
+
+    scheduleReplay();
+
+    const handleTrackUnmuted = () => {
+      scheduleReplay();
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        scheduleReplay();
+      }
+    };
+    const handleResize = () => {
+      scheduleReplay();
+    };
+    const handleOrientationChange = () => {
+      scheduleReplay();
+    };
 
     if (videoTrack) {
-      videoTrack.addEventListener("unmute", playVideo);
+      videoTrack.addEventListener("unmute", handleTrackUnmuted);
     }
+    video.addEventListener("loadedmetadata", scheduleReplay);
+    video.addEventListener("loadeddata", scheduleReplay);
+    video.addEventListener("canplay", scheduleReplay);
+    video.addEventListener("stalled", scheduleReplay);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("orientationchange", handleOrientationChange);
 
     return () => {
+      cancelled = true;
       if (videoTrack) {
-        videoTrack.removeEventListener("unmute", playVideo);
+        videoTrack.removeEventListener("unmute", handleTrackUnmuted);
       }
+      video.removeEventListener("loadedmetadata", scheduleReplay);
+      video.removeEventListener("loadeddata", scheduleReplay);
+      video.removeEventListener("canplay", scheduleReplay);
+      video.removeEventListener("stalled", scheduleReplay);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("orientationchange", handleOrientationChange);
+      playbackRecovery.clear();
       if (video.srcObject === videoStream) {
         video.srcObject = null;
       }
@@ -158,6 +207,7 @@ function MobileParticipantVideo({
       <video
         ref={videoRef}
         autoPlay
+        muted
         playsInline
         className={`w-full h-full object-cover ${
           showPlaceholder ? "hidden" : ""

--- a/apps/web/src/app/components/mobile/MobilePresentationLayout.tsx
+++ b/apps/web/src/app/components/mobile/MobilePresentationLayout.tsx
@@ -3,6 +3,7 @@
 import { MicOff, VenetianMask } from "lucide-react";
 import { memo, useEffect, useRef } from "react";
 import { Avatar } from "@conclave/ui-tokens/web";
+import { useMeetVolume } from "../../hooks/useMeetVolume";
 import { useSmartParticipantOrder } from "../../hooks/useSmartParticipantOrder";
 import { getRenderableParticipantVideoStream } from "../../lib/participant-media";
 import { createPlaybackRecoveryScheduler } from "../../lib/playback-recovery";
@@ -338,6 +339,7 @@ const VideoThumbnail = memo(function VideoThumbnail({
 
 const AudioPlayer = memo(function AudioPlayer({ stream }: { stream: MediaStream }) {
   const audioRef = useRef<HTMLAudioElement>(null);
+  const { meetVolume } = useMeetVolume();
   
   useEffect(() => {
     const audio = audioRef.current;
@@ -351,6 +353,12 @@ const AudioPlayer = memo(function AudioPlayer({ stream }: { stream: MediaStream 
       }
     };
   }, [stream]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.volume = meetVolume;
+  }, [meetVolume]);
   
   return <audio ref={audioRef} autoPlay />;
 });

--- a/apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts
+++ b/apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts
@@ -429,7 +429,7 @@ const getDesiredPreferences = (
       return {
         preferredLayers: bounds ? buildLayerPreference(0, 0, bounds) : undefined,
         priority: 8,
-        paused: true,
+        paused: false,
       };
     }
 
@@ -444,7 +444,7 @@ const getDesiredPreferences = (
     return {
       preferredLayers: bounds ? buildLayerPreference(0, 0, bounds) : undefined,
       priority: quality === "poor" ? 10 : 25,
-      paused: quality === "poor",
+      paused: false,
     };
   }
 

--- a/apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts
+++ b/apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts
@@ -374,6 +374,7 @@ const getDesiredPreferences = (
     quality: ConnectionQuality;
     activeSpeakerId: string | null;
     webcamVideoCount: number;
+    fallbackRank: number | null;
     layout: LayoutRole | null;
     emergencyMode: boolean;
     emergencyKeepVideo: boolean;
@@ -414,8 +415,12 @@ const getDesiredPreferences = (
   const layout = options.layout;
   const isPrimary = layout?.primary === true;
   const isLayoutFocus = layout?.focus === true;
-  const isVisible = layout ? layout.visible || isPrimary : true;
-  const isWarm = layout?.warm === true;
+  const fallbackVisible =
+    !layout &&
+    options.fallbackRank !== null &&
+    options.fallbackRank < MAX_WEBCAMS_TO_KEEP_FULL_ON_GOOD_LINKS;
+  const isVisible = layout ? layout.visible || isPrimary : fallbackVisible;
+  const isWarm = layout?.warm === true || (!layout && !fallbackVisible);
   const isHidden = layout?.hidden === true && !isVisible;
   const isFocus = isActiveSpeaker || isLayoutFocus;
 
@@ -703,6 +708,21 @@ export function useAdaptiveConsumerPreferences({
     ).filter(
       (info) => info.kind === "video" && info.type === "webcam",
     ).length;
+    const fallbackWebcamRanks = new Map<string, number>();
+    if (!layoutHints) {
+      refs.consumersRef.current.forEach((consumer, producerId) => {
+        const info = refs.producerMapRef.current.get(producerId);
+        if (
+          !info ||
+          consumer.closed ||
+          info.kind !== "video" ||
+          info.type !== "webcam"
+        ) {
+          return;
+        }
+        fallbackWebcamRanks.set(producerId, fallbackWebcamRanks.size);
+      });
+    }
     const emergencyVideoKeepProducerIds = new Set<string>();
     if (emergencyMode) {
       const candidates = Array.from(refs.consumersRef.current.entries())
@@ -801,6 +821,7 @@ export function useAdaptiveConsumerPreferences({
         quality: connectionQuality,
         activeSpeakerId,
         webcamVideoCount,
+        fallbackRank: fallbackWebcamRanks.get(producerId) ?? null,
         layout,
         emergencyMode,
         emergencyKeepVideo,

--- a/apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts
+++ b/apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts
@@ -62,6 +62,7 @@ const MAX_WEBCAMS_TO_KEEP_FULL_ON_GOOD_LINKS = 4;
 const MAX_CONSUMER_PREFERENCE_UPDATES_PER_CYCLE = 8;
 const CONSUMER_PREFERENCE_EMIT_SPACING_MS = 75;
 const RATE_LIMIT_RETRY_DELAY_MS = 1000;
+const CONSUMER_PREFERENCE_ACK_TIMEOUT_MS = 3000;
 const AUDIO_CONSUMER_PRIORITY = 255;
 const CONSUMER_SCORE_STALE_AFTER_MS = 15000;
 
@@ -1004,7 +1005,7 @@ export function useAdaptiveConsumerPreferences({
         debugEntryBase,
       } = update;
 
-      const markDeferredAfterRateLimit = (error: string) => {
+      const markDeferredForRetry = (error: string) => {
         preferenceDebugRef.current.set(producerId, {
           ...debugEntryBase,
           status: "deferred",
@@ -1043,6 +1044,16 @@ export function useAdaptiveConsumerPreferences({
           return;
         }
 
+        let settled = false;
+        const ackTimeoutId = window.setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          scheduledPreferenceTimeoutsRef.current.delete(ackTimeoutId);
+          inFlightProducerIdsRef.current.delete(producerId);
+          markDeferredForRetry("setConsumerPreferences ack timeout");
+        }, CONSUMER_PREFERENCE_ACK_TIMEOUT_MS);
+        scheduledPreferenceTimeoutsRef.current.add(ackTimeoutId);
+
         socket.emit(
           "setConsumerPreferences",
           {
@@ -1055,10 +1066,14 @@ export function useAdaptiveConsumerPreferences({
             requestKeyFrame: debugEntryBase.requestKeyFrame,
           },
           (response: SetConsumerPreferencesResponse) => {
+            if (settled) return;
+            settled = true;
+            scheduledPreferenceTimeoutsRef.current.delete(ackTimeoutId);
+            window.clearTimeout(ackTimeoutId);
             if ("error" in response) {
               if (isConsumerControlRateLimitError(response.error)) {
                 inFlightProducerIdsRef.current.delete(producerId);
-                markDeferredAfterRateLimit(response.error);
+                markDeferredForRetry(response.error);
                 return;
               }
 
@@ -1083,6 +1098,19 @@ export function useAdaptiveConsumerPreferences({
                     producerId,
                   );
                 }
+                let fallbackSettled = false;
+                const fallbackAckTimeoutId = window.setTimeout(() => {
+                  if (fallbackSettled) return;
+                  fallbackSettled = true;
+                  scheduledPreferenceTimeoutsRef.current.delete(
+                    fallbackAckTimeoutId,
+                  );
+                  inFlightProducerIdsRef.current.delete(producerId);
+                  markDeferredForRetry(
+                    "setConsumerPreferences priority-only ack timeout",
+                  );
+                }, CONSUMER_PREFERENCE_ACK_TIMEOUT_MS);
+                scheduledPreferenceTimeoutsRef.current.add(fallbackAckTimeoutId);
                 socket.emit(
                   "setConsumerPreferences",
                   {
@@ -1093,6 +1121,12 @@ export function useAdaptiveConsumerPreferences({
                       : {}),
                   },
                   (priorityOnlyResponse: SetConsumerPreferencesResponse) => {
+                    if (fallbackSettled) return;
+                    fallbackSettled = true;
+                    scheduledPreferenceTimeoutsRef.current.delete(
+                      fallbackAckTimeoutId,
+                    );
+                    window.clearTimeout(fallbackAckTimeoutId);
                     if ("error" in priorityOnlyResponse) {
                       inFlightProducerIdsRef.current.delete(producerId);
                       if (
@@ -1100,7 +1134,7 @@ export function useAdaptiveConsumerPreferences({
                           priorityOnlyResponse.error,
                         )
                       ) {
-                        markDeferredAfterRateLimit(priorityOnlyResponse.error);
+                        markDeferredForRetry(priorityOnlyResponse.error);
                         return;
                       }
 

--- a/apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts
+++ b/apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts
@@ -710,18 +710,41 @@ export function useAdaptiveConsumerPreferences({
     ).length;
     const fallbackWebcamRanks = new Map<string, number>();
     if (!layoutHints) {
-      refs.consumersRef.current.forEach((consumer, producerId) => {
-        const info = refs.producerMapRef.current.get(producerId);
-        if (
-          !info ||
-          consumer.closed ||
-          info.kind !== "video" ||
-          info.type !== "webcam"
-        ) {
-          return;
-        }
-        fallbackWebcamRanks.set(producerId, fallbackWebcamRanks.size);
-      });
+      Array.from(refs.consumersRef.current.entries())
+        .map(([producerId, consumer]) => {
+          const info = refs.producerMapRef.current.get(producerId);
+          if (
+            !info ||
+            consumer.closed ||
+            info.kind !== "video" ||
+            info.type !== "webcam"
+          ) {
+            return null;
+          }
+          return {
+            producerId,
+            userId: info.userId,
+            active: info.userId === activeSpeakerId,
+          };
+        })
+        .filter(
+          (
+            candidate,
+          ): candidate is {
+            producerId: string;
+            userId: string;
+            active: boolean;
+          } => Boolean(candidate),
+        )
+        .sort(
+          (left, right) =>
+            Number(right.active) - Number(left.active) ||
+            left.userId.localeCompare(right.userId) ||
+            left.producerId.localeCompare(right.producerId),
+        )
+        .forEach((candidate, index) => {
+          fallbackWebcamRanks.set(candidate.producerId, index);
+        });
     }
     const emergencyVideoKeepProducerIds = new Set<string>();
     if (emergencyMode) {

--- a/apps/web/src/app/hooks/useAdaptivePublishQuality.ts
+++ b/apps/web/src/app/hooks/useAdaptivePublishQuality.ts
@@ -188,6 +188,7 @@ export function useAdaptivePublishQuality({
     screen: string | null;
     screenAudio: string | null;
   }>({ audio: null, webcam: null, screen: null, screenAudio: null });
+  const lastStandardCaptureRestoreSignatureRef = useRef<string | null>(null);
 
   const writeDebugSnapshot = useCallback(
     (now = Date.now()) => {
@@ -344,6 +345,48 @@ export function useAdaptivePublishQuality({
     ],
   );
 
+  const restoreStandardCaptureIfNeeded = useCallback(async () => {
+    if (isCameraOff || updateInFlightRef.current) return;
+    if (videoQualityRef.current !== "standard") return;
+
+    const webcamProducer = videoProducerRef.current;
+    const webcamTrack = webcamProducer?.track ?? null;
+    if (
+      !webcamProducer ||
+      webcamProducer.closed ||
+      webcamTrack?.readyState !== "live"
+    ) {
+      return;
+    }
+
+    const signature = `${webcamProducer.id}:standard:good`;
+    if (lastStandardCaptureRestoreSignatureRef.current === signature) {
+      return;
+    }
+
+    updateInFlightRef.current = true;
+    try {
+      await updateVideoQualityRef.current("standard", "good");
+      lastStandardCaptureRestoreSignatureRef.current = signature;
+      lastAppliedProfilesRef.current.webcam = signature;
+      writeDebugSnapshot();
+    } catch (error) {
+      console.warn(
+        "[Meets] Adaptive standard camera capture restore failed:",
+        error,
+      );
+    } finally {
+      updateInFlightRef.current = false;
+      writeDebugSnapshot();
+    }
+  }, [
+    isCameraOff,
+    updateVideoQualityRef,
+    videoProducerRef,
+    videoQualityRef,
+    writeDebugSnapshot,
+  ]);
+
   const switchQuality = useCallback(
     async (
       quality: VideoQuality,
@@ -423,6 +466,7 @@ export function useAdaptivePublishQuality({
         screen: null,
         screenAudio: null,
       };
+      lastStandardCaptureRestoreSignatureRef.current = null;
       writeDebugSnapshot();
       return;
     }
@@ -457,6 +501,11 @@ export function useAdaptivePublishQuality({
           void applyLiveProducerProfile(liveProfile);
         }
       };
+      const shouldRestoreStableStandardCapture =
+        capRecoveryQuality === "good" &&
+        capRecoveryElapsedMs >= GOOD_LIVE_RESTORE_AFTER_MS &&
+        connectionQuality !== "poor" &&
+        currentPublishQuality === "standard";
       if (isCameraOff) {
         applyStableLiveProfile();
         writeDebugSnapshot(now);
@@ -506,7 +555,11 @@ export function useAdaptivePublishQuality({
         writeDebugSnapshot(now);
         return;
       }
-      applyStableLiveProfile();
+      if (shouldRestoreStableStandardCapture) {
+        void restoreStandardCaptureIfNeeded();
+      } else {
+        applyStableLiveProfile();
+      }
       writeDebugSnapshot(now);
     };
 
@@ -523,6 +576,7 @@ export function useAdaptivePublishQuality({
     isCameraOff,
     networkManagedVideoQualityRef,
     participantCount,
+    restoreStandardCaptureIfNeeded,
     switchQuality,
     videoQualityRef,
     writeDebugSnapshot,

--- a/apps/web/src/app/hooks/useAdaptivePublishQuality.ts
+++ b/apps/web/src/app/hooks/useAdaptivePublishQuality.ts
@@ -483,9 +483,6 @@ export function useAdaptivePublishQuality({
       }
       if (previous.quality !== connectionQuality) {
         qualityWindowRef.current = { quality: connectionQuality, since: now };
-        if (connectionQuality === "poor") {
-          void applyLiveProducerProfile(emergencyMode ? "emergency" : "poor");
-        }
         writeDebugSnapshot(now);
         return;
       }

--- a/apps/web/src/app/hooks/useAdaptivePublishQuality.ts
+++ b/apps/web/src/app/hooks/useAdaptivePublishQuality.ts
@@ -556,7 +556,11 @@ export function useAdaptivePublishQuality({
         return;
       }
       if (shouldRestoreStableStandardCapture) {
-        void restoreStandardCaptureIfNeeded();
+        void restoreStandardCaptureIfNeeded().finally(() => {
+          if (!updateInFlightRef.current) {
+            void applyLiveProducerProfile("good");
+          }
+        });
       } else {
         applyStableLiveProfile();
       }

--- a/apps/web/src/app/hooks/useConnectionQuality.ts
+++ b/apps/web/src/app/hooks/useConnectionQuality.ts
@@ -46,12 +46,24 @@ export interface ConnectionQualityStats {
   publishEmergencyMode: boolean;
   /** Receive-side emergency signal from browser hints or WebRTC stats. */
   receiveEmergencyMode: boolean;
-  /** Round-trip time in milliseconds, if observable. */
+  /** Worst observed round-trip time in milliseconds, if observable. */
   rttMs: number | null;
-  /** Fraction of packets lost (0-1) over the most recent window. */
+  /** Worst observed fraction of packets lost (0-1) over the most recent window. */
   packetLoss: number | null;
-  /** Jitter in milliseconds, if observable. */
+  /** Worst observed jitter in milliseconds, if observable. */
   jitterMs: number | null;
+  /** Send-side round-trip time in milliseconds, if observable. */
+  publishRttMs: number | null;
+  /** Send-side packet loss fraction (0-1) over the most recent window. */
+  publishPacketLoss: number | null;
+  /** Send-side jitter in milliseconds, if observable from remote inbound stats. */
+  publishJitterMs: number | null;
+  /** Receive-side round-trip time in milliseconds, if observable. */
+  receiveRttMs: number | null;
+  /** Receive-side packet loss fraction (0-1) over the most recent window. */
+  receivePacketLoss: number | null;
+  /** Receive-side jitter in milliseconds, if observable. */
+  receiveJitterMs: number | null;
   /** Estimated send-side available bitrate in bits/sec, if exposed. */
   availableOutgoingBitrate: number | null;
   /** Estimated receive-side available bitrate in bits/sec, if exposed. */
@@ -134,6 +146,12 @@ const UNKNOWN_STATS: ConnectionQualityStats = {
   rttMs: null,
   packetLoss: null,
   jitterMs: null,
+  publishRttMs: null,
+  publishPacketLoss: null,
+  publishJitterMs: null,
+  receiveRttMs: null,
+  receivePacketLoss: null,
+  receiveJitterMs: null,
   availableOutgoingBitrate: null,
   availableIncomingBitrate: null,
   browserNetwork: UNKNOWN_BROWSER_NETWORK_SNAPSHOT,
@@ -989,6 +1007,12 @@ export function useConnectionQuality({
         rttMs: maxNullable(publish.rttMs, receive.rttMs),
         packetLoss: maxNullable(publishLoss, receiveLoss),
         jitterMs: maxNullable(publish.jitterMs, receive.jitterMs),
+        publishRttMs: publish.rttMs,
+        publishPacketLoss: publishLoss,
+        publishJitterMs: publish.jitterMs,
+        receiveRttMs: receive.rttMs,
+        receivePacketLoss: receiveLoss,
+        receiveJitterMs: receive.jitterMs,
         availableOutgoingBitrate: publish.availableBitrate,
         availableIncomingBitrate: receive.availableBitrate,
         browserNetwork,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -473,6 +473,60 @@ export function useMeetMedia({
     [getVideoPublishTrackRef, shouldUsePreferredVideoPublishTrack]
   );
 
+  const produceCameraTrackWithRawFallback = useCallback(
+    async ({
+      transport,
+      publishTrack,
+      rawTrack,
+      quality,
+      networkProfile,
+      paused,
+      preferredCodec,
+      context,
+    }: {
+      transport: Transport;
+      publishTrack: MediaStreamTrack;
+      rawTrack: MediaStreamTrack;
+      quality: VideoQuality;
+      networkProfile: WebcamProducerNetworkProfile;
+      paused: boolean;
+      preferredCodec: ReturnType<typeof getPreferredWebcamCodec>;
+      context: string;
+    }) => {
+      try {
+        return await produceWebcamTrack({
+          transport,
+          track: publishTrack,
+          quality,
+          networkProfile,
+          paused,
+          preferredCodec,
+        });
+      } catch (err) {
+        if (
+          publishTrack.id === rawTrack.id ||
+          rawTrack.readyState !== "live"
+        ) {
+          throw err;
+        }
+
+        console.warn(
+          `[Meets] Processed ${context} camera publish failed; retrying raw camera:`,
+          err,
+        );
+        return produceWebcamTrack({
+          transport,
+          track: rawTrack,
+          quality,
+          networkProfile,
+          paused,
+          preferredCodec,
+        });
+      }
+    },
+    [],
+  );
+
   const stopLocalTrack = useCallback(
     (track?: MediaStreamTrack | null) => {
       if (!track) return;
@@ -1043,13 +1097,15 @@ export function useMeetMedia({
         }
 
         const preferredWebcamCodec = getPreferredWebcamCodec(deviceRef.current);
-        const nextProducer = await produceWebcamTrack({
+        const nextProducer = await produceCameraTrackWithRawFallback({
           transport,
-          track: publishTrack,
+          publishTrack,
+          rawTrack: nextVideoTrack,
           quality,
           networkProfile: publishNetworkProfile,
           paused: false,
           preferredCodec: preferredWebcamCodec,
+          context: "quality-switch",
         });
 
         videoProducerRef.current = nextProducer;
@@ -1103,6 +1159,7 @@ export function useMeetMedia({
       localStreamRef,
       waitForPreferredVideoPublishTrack,
       getPublishNetworkProfile,
+      produceCameraTrackWithRawFallback,
       requestCameraProducerRecovery,
     ]
   );
@@ -1658,14 +1715,17 @@ export function useMeetMedia({
           );
 
           const quality = videoQualityRef.current;
+          const networkProfile = getPublishNetworkProfile();
           const preferredWebcamCodec = getPreferredWebcamCodec(deviceRef.current);
-          const videoProducer = await produceWebcamTrack({
+          const videoProducer = await produceCameraTrackWithRawFallback({
             transport,
-            track: publishTrack,
+            publishTrack,
+            rawTrack: videoTrack,
             quality,
-            networkProfile: getPublishNetworkProfile(),
+            networkProfile,
             paused: false,
             preferredCodec: preferredWebcamCodec,
+            context: "camera-toggle",
           });
 
           videoProducerRef.current = videoProducer;
@@ -1717,6 +1777,7 @@ export function useMeetMedia({
     waitForPreferredVideoPublishTrack,
     buildVideoConstraints,
     getPublishNetworkProfile,
+    produceCameraTrackWithRawFallback,
     requestCameraProducerRecovery,
   ]);
 
@@ -1911,14 +1972,17 @@ export function useMeetMedia({
           videoTrack,
         );
         const quality = videoQualityRef.current;
+        const networkProfile = getPublishNetworkProfile();
         const preferredWebcamCodec = getPreferredWebcamCodec(deviceRef.current);
-        const recoveredProducer = await produceWebcamTrack({
+        const recoveredProducer = await produceCameraTrackWithRawFallback({
           transport,
-          track: publishTrack,
+          publishTrack,
+          rawTrack: videoTrack,
           quality,
-          networkProfile: getPublishNetworkProfile(),
+          networkProfile,
           paused: false,
           preferredCodec: preferredWebcamCodec,
+          context: "camera-recovery",
         });
 
         if (cancelled) {
@@ -1986,6 +2050,7 @@ export function useMeetMedia({
     waitForPreferredVideoPublishTrack,
     buildVideoConstraints,
     getPublishNetworkProfile,
+    produceCameraTrackWithRawFallback,
     closeLocalVideoProducerForReplacement,
     requestCameraProducerRecovery,
   ]);

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -914,6 +914,10 @@ export function useMeetMedia({
                 "[Meets] Processed device-switch track failed; retrying raw camera:",
                 err,
               );
+              onPreferredVideoPublishTrackRejected?.(
+                publishTrack,
+                "device-switch-raw-replace-fallback",
+              );
               await videoProducerRef.current.replaceTrack({
                 track: newVideoTrack,
               });
@@ -939,6 +943,7 @@ export function useMeetMedia({
       buildVideoConstraints,
       localStreamRef,
       waitForPreferredVideoPublishTrack,
+      onPreferredVideoPublishTrackRejected,
     ]
   );
 
@@ -1118,6 +1123,10 @@ export function useMeetMedia({
                 "[Meets] Processed quality-switch track failed; retrying raw camera:",
                 err,
               );
+              onPreferredVideoPublishTrackRejected?.(
+                publishTrack,
+                "quality-switch-raw-replace-fallback",
+              );
               await previousProducer.replaceTrack({ track: nextVideoTrack });
             }
           }
@@ -1207,6 +1216,7 @@ export function useMeetMedia({
       intentionalLocalProducerCloseIdsRef,
       localStreamRef,
       waitForPreferredVideoPublishTrack,
+      onPreferredVideoPublishTrackRejected,
       getPublishNetworkProfile,
       produceCameraTrackWithRawFallback,
       requestCameraProducerRecovery,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -21,6 +21,7 @@ import {
   getBrowserNetworkSnapshot,
   shouldDeferBandwidthHeavyPreload,
 } from "../lib/network-information";
+import { clampMeetVolume, DEFAULT_MEET_VOLUME } from "../lib/meet-volume";
 import { createMeetError } from "../lib/utils";
 import { prewarmVideoEffectsAssetsDeferred } from "../lib/video-effects-lazy";
 import {
@@ -56,6 +57,7 @@ interface UseMeetMediaOptions {
   setSelectedAudioInputDeviceId: (value: string) => void;
   selectedAudioOutputDeviceId?: string;
   setSelectedAudioOutputDeviceId: (value: string) => void;
+  meetVolume?: number;
   videoQuality: VideoQuality;
   videoQualityRef: React.MutableRefObject<VideoQuality>;
   activeVideoEffectsCount?: number;
@@ -263,6 +265,7 @@ export function useMeetMedia({
   setSelectedAudioInputDeviceId,
   selectedAudioOutputDeviceId,
   setSelectedAudioOutputDeviceId,
+  meetVolume = DEFAULT_MEET_VOLUME,
   videoQuality,
   videoQualityRef,
   activeVideoEffectsCount = 0,
@@ -299,6 +302,7 @@ export function useMeetMedia({
   const audioRecoveryInFlightRef = useRef(false);
   const [audioProducerRecoveryPulse, setAudioProducerRecoveryPulse] =
     useState(0);
+  const notificationVolume = clampMeetVolume(meetVolume);
   const requestAudioProducerRecovery = useCallback(() => {
     setAudioProducerRecoveryPulse((value) => value + 1);
   }, []);
@@ -381,6 +385,7 @@ export function useMeetMedia({
 
   const playNotificationSound = useCallback(
     (type: "join" | "leave" | "waiting" | "handRaise") => {
+      if (notificationVolume <= 0) return;
       const audioContext = getAudioContext();
       if (!audioContext) return;
 
@@ -397,7 +402,8 @@ export function useMeetMedia({
         const duration =
           type === "waiting" ? 0.1 : type === "handRaise" ? 0.12 : 0.12;
         const gap = 0.03;
-        const peakGain = type === "handRaise" ? 0.13 : 0.16;
+        const basePeakGain = type === "handRaise" ? 0.13 : 0.16;
+        const peakGain = basePeakGain * notificationVolume;
 
         frequencies.forEach((frequency, index) => {
           const start = now + index * (duration + gap);
@@ -429,7 +435,7 @@ export function useMeetMedia({
 
       playPattern();
     },
-    [getAudioContext]
+    [getAudioContext, notificationVolume]
   );
 
   const primeAudioOutput = useCallback(() => {

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -192,6 +192,106 @@ const getUsableProducerTransport = (
   return transport;
 };
 
+type OutboundVideoProgressSample = {
+  frames: number | null;
+  bytes: number | null;
+};
+
+type CameraOutboundStallState = {
+  producerId: string | null;
+  trackId: string | null;
+  frames: number | null;
+  bytes: number | null;
+  stalledSamples: number;
+  rawRepairAttempted: boolean;
+  lastRecoveryAtMs: number;
+};
+
+const CAMERA_OUTBOUND_STALL_CHECK_MS = 2000;
+const CAMERA_OUTBOUND_STALL_SAMPLES_BEFORE_RECOVERY = 3;
+const CAMERA_OUTBOUND_STALL_RECOVERY_COOLDOWN_MS = 10000;
+const MIN_OUTBOUND_VIDEO_BYTE_DELTA_FOR_PROGRESS = 1200;
+
+const createCameraOutboundStallState = (
+  producerId: string | null = null,
+  trackId: string | null = null,
+): CameraOutboundStallState => ({
+  producerId,
+  trackId,
+  frames: null,
+  bytes: null,
+  stalledSamples: 0,
+  rawRepairAttempted: false,
+  lastRecoveryAtMs: 0,
+});
+
+const getRtcStatsNumber = (
+  stat: Record<string, unknown>,
+  key: string,
+): number | null => {
+  const value = stat[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+};
+
+const readOutboundVideoProgressSample = (
+  report: RTCStatsReport,
+): OutboundVideoProgressSample => {
+  let frames = 0;
+  let hasFrames = false;
+  let bytes = 0;
+  let hasBytes = false;
+
+  report.forEach((entry) => {
+    const stat = entry as unknown as Record<string, unknown>;
+    if (stat.type !== "outbound-rtp") return;
+    const kind = stat.kind ?? stat.mediaType;
+    if (kind !== "video") return;
+    if (stat.isRemote === true) return;
+
+    const frameCount =
+      getRtcStatsNumber(stat, "framesEncoded") ??
+      getRtcStatsNumber(stat, "framesSent");
+    if (frameCount !== null) {
+      frames += Math.max(0, frameCount);
+      hasFrames = true;
+    }
+
+    const byteCount = getRtcStatsNumber(stat, "bytesSent");
+    if (byteCount !== null) {
+      bytes += Math.max(0, byteCount);
+      hasBytes = true;
+    }
+  });
+
+  return {
+    frames: hasFrames ? frames : null,
+    bytes: hasBytes ? bytes : null,
+  };
+};
+
+const hasOutboundVideoProgress = (
+  previous: CameraOutboundStallState,
+  sample: OutboundVideoProgressSample,
+): boolean => {
+  if (
+    previous.frames !== null &&
+    sample.frames !== null &&
+    sample.frames > previous.frames
+  ) {
+    return true;
+  }
+
+  if (
+    previous.bytes !== null &&
+    sample.bytes !== null &&
+    sample.bytes - previous.bytes >= MIN_OUTBOUND_VIDEO_BYTE_DELTA_FOR_PROGRESS
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
 export function useMeetMedia({
   ghostEnabled,
   isObserverMode = false,
@@ -256,6 +356,9 @@ export function useMeetMedia({
     setCameraProducerRecoveryPulse((value) => value + 1);
   }, []);
   const cameraProducerTrackRepairInFlightRef = useRef(false);
+  const cameraOutboundStallStateRef = useRef<CameraOutboundStallState>(
+    createCameraOutboundStallState(),
+  );
   const connectionStateRef = useRef(connectionState);
   if (connectionStateRef.current !== connectionState) {
     connectionStateRef.current = connectionState;
@@ -1876,6 +1979,256 @@ export function useMeetMedia({
       disposed = true;
       window.clearTimeout(initialTimeout);
       window.clearInterval(watchdogInterval);
+    };
+  }, [
+    connectionState,
+    ghostEnabled,
+    isCameraOff,
+    isObserverMode,
+    videoProducerRef,
+    localStreamRef,
+    videoQualityRef,
+    handleLocalTrackEnded,
+    getPublishNetworkProfile,
+    closeLocalVideoProducerForReplacement,
+    requestCameraProducerRecovery,
+  ]);
+
+  useEffect(() => {
+    if (ghostEnabled || isObserverMode) {
+      cameraOutboundStallStateRef.current = createCameraOutboundStallState();
+      return;
+    }
+    if (connectionState !== "joined" || isCameraOff) {
+      cameraOutboundStallStateRef.current = createCameraOutboundStallState();
+      return;
+    }
+
+    let disposed = false;
+
+    const resetStallState = (
+      producerId: string | null = null,
+      trackId: string | null = null,
+    ) => {
+      cameraOutboundStallStateRef.current =
+        createCameraOutboundStallState(producerId, trackId);
+    };
+
+    const recoverStalledProducer = async ({
+      producer,
+      producerTrack,
+      sample,
+      state,
+    }: {
+      producer: Producer;
+      producerTrack: MediaStreamTrack;
+      sample: OutboundVideoProgressSample;
+      state: CameraOutboundStallState;
+    }) => {
+      if (disposed) return;
+      if (cameraProducerTrackRepairInFlightRef.current) return;
+      if (cameraRecoveryInFlightRef.current) return;
+
+      const now = performance.now();
+      if (
+        state.lastRecoveryAtMs > 0 &&
+        now - state.lastRecoveryAtMs <
+          CAMERA_OUTBOUND_STALL_RECOVERY_COOLDOWN_MS
+      ) {
+        return;
+      }
+
+      const rawCameraTrack = getFirstLiveTrack(
+        localStreamRef.current?.getVideoTracks() ?? [],
+      );
+      if (
+        !rawCameraTrack ||
+        rawCameraTrack.readyState !== "live" ||
+        rawCameraTrack.muted
+      ) {
+        return;
+      }
+
+      cameraProducerTrackRepairInFlightRef.current = true;
+      try {
+        if (
+          disposed ||
+          videoProducerRef.current?.id !== producer.id ||
+          producer.closed
+        ) {
+          return;
+        }
+
+        const shouldTryRawRepair =
+          !state.rawRepairAttempted && producerTrack.id !== rawCameraTrack.id;
+        if (shouldTryRawRepair) {
+          if ("contentHint" in rawCameraTrack) {
+            rawCameraTrack.contentHint = "motion";
+          }
+          rawCameraTrack.onended = () => {
+            handleLocalTrackEnded("video", rawCameraTrack);
+          };
+          await producer.replaceTrack({ track: rawCameraTrack });
+          await applyWebcamProducerNetworkProfile(
+            producer,
+            videoQualityRef.current,
+            getPublishNetworkProfile(),
+          );
+          cameraOutboundStallStateRef.current = {
+            ...createCameraOutboundStallState(producer.id, rawCameraTrack.id),
+            frames: sample.frames,
+            bytes: sample.bytes,
+            rawRepairAttempted: true,
+            lastRecoveryAtMs: now,
+          };
+          console.warn(
+            "[Meets] Repaired stalled camera sender with raw camera track:",
+            {
+              producerId: producer.id,
+              previousTrackId: producerTrack.id,
+              rawTrackId: rawCameraTrack.id,
+              stalledSamples: state.stalledSamples,
+              frames: sample.frames,
+              bytes: sample.bytes,
+            },
+          );
+          return;
+        }
+
+        console.warn("[Meets] Recreating stalled camera sender:", {
+          producerId: producer.id,
+          trackId: producerTrack.id,
+          rawTrackId: rawCameraTrack.id,
+          stalledSamples: state.stalledSamples,
+          frames: sample.frames,
+          bytes: sample.bytes,
+        });
+        closeLocalVideoProducerForReplacement(producer);
+        resetStallState();
+        requestCameraProducerRecovery();
+      } catch (err) {
+        console.warn(
+          "[Meets] Stalled camera sender recovery failed; recreating producer:",
+          err,
+        );
+        if (videoProducerRef.current?.id === producer.id) {
+          closeLocalVideoProducerForReplacement(producer);
+          resetStallState();
+          requestCameraProducerRecovery();
+        }
+      } finally {
+        cameraProducerTrackRepairInFlightRef.current = false;
+      }
+    };
+
+    const pollOutboundProgress = () => {
+      if (disposed) return;
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState !== "visible"
+      ) {
+        resetStallState(
+          videoProducerRef.current?.id ?? null,
+          videoProducerRef.current?.track?.id ?? null,
+        );
+        return;
+      }
+      if (
+        cameraProducerTrackRepairInFlightRef.current ||
+        cameraRecoveryInFlightRef.current
+      ) {
+        return;
+      }
+
+      const producer = videoProducerRef.current;
+      const producerTrack = producer?.track ?? null;
+      if (!producer || producer.closed || producer.paused || !producerTrack) {
+        resetStallState();
+        return;
+      }
+      if (
+        producerTrack.readyState !== "live" ||
+        !producerTrack.enabled ||
+        producerTrack.muted
+      ) {
+        resetStallState(producer.id, producerTrack.id);
+        return;
+      }
+
+      void producer
+        .getStats()
+        .then((report) => {
+          if (disposed) return;
+          if (
+            videoProducerRef.current?.id !== producer.id ||
+            producer.closed ||
+            producer.paused ||
+            producer.track?.id !== producerTrack.id ||
+            producerTrack.readyState !== "live" ||
+            !producerTrack.enabled ||
+            producerTrack.muted
+          ) {
+            resetStallState(
+              videoProducerRef.current?.id ?? null,
+              videoProducerRef.current?.track?.id ?? null,
+            );
+            return;
+          }
+
+          const sample = readOutboundVideoProgressSample(report);
+          const currentState = cameraOutboundStallStateRef.current;
+          const previous =
+            currentState.producerId === producer.id &&
+            currentState.trackId === producerTrack.id
+              ? currentState
+              : createCameraOutboundStallState(producer.id, producerTrack.id);
+          const hasBaseline =
+            previous.frames !== null || previous.bytes !== null;
+          const stalledSamples =
+            hasBaseline && !hasOutboundVideoProgress(previous, sample)
+              ? previous.stalledSamples + 1
+              : 0;
+          const nextState: CameraOutboundStallState = {
+            ...previous,
+            producerId: producer.id,
+            trackId: producerTrack.id,
+            frames: sample.frames,
+            bytes: sample.bytes,
+            stalledSamples,
+          };
+          cameraOutboundStallStateRef.current = nextState;
+
+          if (
+            stalledSamples <
+            CAMERA_OUTBOUND_STALL_SAMPLES_BEFORE_RECOVERY
+          ) {
+            return;
+          }
+
+          void recoverStalledProducer({
+            producer,
+            producerTrack,
+            sample,
+            state: nextState,
+          });
+        })
+        .catch(() => {
+          resetStallState(
+            videoProducerRef.current?.id ?? null,
+            videoProducerRef.current?.track?.id ?? null,
+          );
+        });
+    };
+
+    pollOutboundProgress();
+    const interval = window.setInterval(
+      pollOutboundProgress,
+      CAMERA_OUTBOUND_STALL_CHECK_MS,
+    );
+
+    return () => {
+      disposed = true;
+      window.clearInterval(interval);
     };
   }, [
     connectionState,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -6,12 +6,8 @@ import type { Device } from "mediasoup-client";
 import {
   buildCameraVideoConstraints,
   DEFAULT_AUDIO_CONSTRAINTS,
-  EMERGENCY_QUALITY_CONSTRAINTS,
-  LOW_QUALITY_CONSTRAINTS,
   buildMicrophoneOpusCodecOptions,
-  POOR_QUALITY_CONSTRAINTS,
   buildScreenShareAudioOpusCodecOptions,
-  STANDARD_QUALITY_CONSTRAINTS,
 } from "../lib/constants";
 import type {
   MediaState,
@@ -104,80 +100,14 @@ const isPublishEmergencyProfile = (
   browserNetwork.emergency ||
   (stats?.publishEmergencyMode === true && stats.publishQuality !== "good");
 
-const getNumericConstraintValue = (
-  value: MediaTrackConstraintSet["width"],
-  key: "ideal" | "max",
-): number | null => {
-  if (typeof value === "number") return value;
-  if (typeof value !== "object" || value === null) return null;
-  const record = value as { ideal?: unknown; max?: unknown };
-  const next = record[key];
-  return typeof next === "number" && Number.isFinite(next) ? next : null;
-};
-
 const getFirstLiveTrack = <T extends MediaStreamTrack>(
   tracks: readonly T[],
 ): T | null => tracks.find((track) => track.readyState === "live") ?? null;
-
-const getQualitySwitchReferenceConstraints = (
-  quality: VideoQuality,
-  profile: WebcamProducerNetworkProfile,
-) => {
-  if (profile === "emergency") return EMERGENCY_QUALITY_CONSTRAINTS;
-  if (profile === "poor") return POOR_QUALITY_CONSTRAINTS;
-  if (quality === "low" || profile === "fair") return LOW_QUALITY_CONSTRAINTS;
-  return STANDARD_QUALITY_CONSTRAINTS;
-};
 
 const shouldUpdateCaptureConstraintsForQualitySwitch = (
   quality: VideoQuality,
   profile: WebcamProducerNetworkProfile,
 ): boolean => quality === "standard" && profile === "good";
-
-const shouldRefreshVideoTrackForQualitySwitch = (
-  track: MediaStreamTrack,
-  quality: VideoQuality,
-  profile: WebcamProducerNetworkProfile,
-): boolean => {
-  let settings: MediaTrackSettings = {};
-  try {
-    settings = track.getSettings();
-  } catch {
-    return false;
-  }
-
-  const constraints = getQualitySwitchReferenceConstraints(quality, profile);
-  const maxWidth = getNumericConstraintValue(constraints.width, "max");
-  const maxHeight = getNumericConstraintValue(constraints.height, "max");
-
-  if (quality === "standard" && profile === "good") {
-    const lowQualityWidth = getNumericConstraintValue(
-      LOW_QUALITY_CONSTRAINTS.width,
-      "ideal",
-    );
-    const lowQualityHeight = getNumericConstraintValue(
-      LOW_QUALITY_CONSTRAINTS.height,
-      "ideal",
-    );
-    return (
-      (typeof settings.width === "number" &&
-        lowQualityWidth !== null &&
-        settings.width <= lowQualityWidth * 1.05) ||
-      (typeof settings.height === "number" &&
-        lowQualityHeight !== null &&
-        settings.height <= lowQualityHeight * 1.05)
-    );
-  }
-
-  return (
-    (typeof settings.width === "number" &&
-      maxWidth !== null &&
-      settings.width > maxWidth * 1.25) ||
-    (typeof settings.height === "number" &&
-      maxHeight !== null &&
-      settings.height > maxHeight * 1.25)
-  );
-};
 
 const getUsableProducerTransport = (
   transport: Transport | null | undefined,
@@ -1042,7 +972,6 @@ export function useMeetMedia({
             quality,
             publishNetworkProfile,
           );
-        let shouldRefreshVideoTrack = false;
         if (
           currentTrack &&
           currentTrack.readyState === "live" &&
@@ -1054,28 +983,9 @@ export function useMeetMedia({
           try {
             await currentTrack.applyConstraints(constraints);
           } catch (err) {
-            shouldRefreshVideoTrack = true;
             console.warn(
-              "[Meets] Camera constraints update failed; refreshing capture once:",
+              "[Meets] Camera constraints update failed; keeping current capture:",
               err
-            );
-          }
-          if (
-            !shouldRefreshVideoTrack &&
-            shouldRefreshVideoTrackForQualitySwitch(
-              currentTrack,
-              quality,
-              publishNetworkProfile,
-            )
-          ) {
-            shouldRefreshVideoTrack = true;
-            console.info(
-              "[Meets] Camera track did not reach requested quality; refreshing capture once:",
-              {
-                quality,
-                profile: publishNetworkProfile,
-                settings: currentTrack.getSettings(),
-              },
             );
           }
         }
@@ -1086,8 +996,7 @@ export function useMeetMedia({
 
         if (
           !nextVideoTrack ||
-          nextVideoTrack.readyState !== "live" ||
-          shouldRefreshVideoTrack
+          nextVideoTrack.readyState !== "live"
         ) {
           const currentDeviceId =
             currentTrack?.readyState === "live"

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -35,6 +35,7 @@ import {
   getPreferredScreenShareCodec,
   getPreferredWebcamCodec,
   produceWebcamTrack,
+  shouldUseWebcamSimulcast,
   type WebcamProducerNetworkProfile,
 } from "../lib/webcam-codec";
 import type { ConnectionQualityStats } from "./useConnectionQuality";
@@ -1044,11 +1045,13 @@ export function useMeetMedia({
           publishStream,
           nextVideoTrack,
         );
+        const preferredWebcamCodec = getPreferredWebcamCodec(deviceRef.current);
         const previousEncodingCount =
           previousProducer?.rtpSender?.getParameters().encodings?.length ??
           previousProducer?.rtpParameters.encodings?.length ??
           0;
         const needsStandardSimulcastRecreate =
+          shouldUseWebcamSimulcast(preferredWebcamCodec) &&
           quality === "standard" &&
           Boolean(previousProducer && !previousProducer.closed) &&
           previousEncodingCount > 0 &&
@@ -1096,7 +1099,6 @@ export function useMeetMedia({
           }
         }
 
-        const preferredWebcamCodec = getPreferredWebcamCodec(deviceRef.current);
         const nextProducer = await produceCameraTrackWithRawFallback({
           transport,
           publishTrack,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -62,6 +62,10 @@ interface UseMeetMediaOptions {
   getVideoPublishTrackRef?: React.MutableRefObject<
     ((stream?: MediaStream | null) => MediaStreamTrack | null) | null
   >;
+  onPreferredVideoPublishTrackRejected?: (
+    track: MediaStreamTrack,
+    reason: string,
+  ) => void;
   socketRef: React.MutableRefObject<Socket | null>;
   deviceRef: React.MutableRefObject<Device | null>;
   producerTransportRef: React.MutableRefObject<Transport | null>;
@@ -263,6 +267,7 @@ export function useMeetMedia({
   activeVideoEffectsCount = 0,
   shouldUsePreferredVideoPublishTrack = activeVideoEffectsCount > 0,
   getVideoPublishTrackRef,
+  onPreferredVideoPublishTrackRejected,
   socketRef,
   deviceRef,
   producerTransportRef,
@@ -1850,6 +1855,12 @@ export function useMeetMedia({
               handleLocalTrackEnded("video", rawCameraTrack);
             };
             await producer.replaceTrack({ track: rawCameraTrack });
+            if (producerTrack && producerTrack.id !== rawCameraTrack.id) {
+              onPreferredVideoPublishTrackRejected?.(
+                producerTrack,
+                "camera-producer-raw-repair",
+              );
+            }
             await applyWebcamProducerNetworkProfile(
               producer,
               videoQualityRef.current,
@@ -1916,6 +1927,7 @@ export function useMeetMedia({
     videoQualityRef,
     handleLocalTrackEnded,
     getPublishNetworkProfile,
+    onPreferredVideoPublishTrackRejected,
     closeLocalVideoProducerForReplacement,
     requestCameraProducerRecovery,
   ]);
@@ -1995,6 +2007,10 @@ export function useMeetMedia({
             handleLocalTrackEnded("video", rawCameraTrack);
           };
           await producer.replaceTrack({ track: rawCameraTrack });
+          onPreferredVideoPublishTrackRejected?.(
+            producerTrack,
+            "camera-outbound-stall-raw-repair",
+          );
           await applyWebcamProducerNetworkProfile(
             producer,
             videoQualityRef.current,
@@ -2166,6 +2182,7 @@ export function useMeetMedia({
     videoQualityRef,
     handleLocalTrackEnded,
     getPublishNetworkProfile,
+    onPreferredVideoPublishTrackRejected,
     closeLocalVideoProducerForReplacement,
     requestCameraProducerRecovery,
   ]);

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -125,6 +125,7 @@ const getUsableProducerTransport = (
 type OutboundVideoProgressSample = {
   frames: number | null;
   bytes: number | null;
+  qualityLimitationReason: string | null;
 };
 
 type CameraOutboundStallState = {
@@ -170,6 +171,7 @@ const readOutboundVideoProgressSample = (
   let hasFrames = false;
   let bytes = 0;
   let hasBytes = false;
+  let qualityLimitationReason: string | null = null;
 
   report.forEach((entry) => {
     const stat = entry as unknown as Record<string, unknown>;
@@ -191,13 +193,28 @@ const readOutboundVideoProgressSample = (
       bytes += Math.max(0, byteCount);
       hasBytes = true;
     }
+
+    if (
+      typeof stat.qualityLimitationReason === "string" &&
+      stat.qualityLimitationReason &&
+      stat.qualityLimitationReason !== "none"
+    ) {
+      qualityLimitationReason = stat.qualityLimitationReason;
+    }
   });
 
   return {
     frames: hasFrames ? frames : null,
     bytes: hasBytes ? bytes : null,
+    qualityLimitationReason,
   };
 };
+
+const isEncoderLimitedOutboundSample = (
+  sample: OutboundVideoProgressSample,
+): boolean =>
+  sample.qualityLimitationReason === "bandwidth" ||
+  sample.qualityLimitationReason === "cpu";
 
 const hasOutboundVideoProgress = (
   previous: CameraOutboundStallState,
@@ -2108,8 +2125,8 @@ export function useMeetMedia({
           cameraOutboundStallStateRef.current = nextState;
 
           if (
-            stalledSamples <
-            CAMERA_OUTBOUND_STALL_SAMPLES_BEFORE_RECOVERY
+            stalledSamples < CAMERA_OUTBOUND_STALL_SAMPLES_BEFORE_RECOVERY ||
+            isEncoderLimitedOutboundSample(sample)
           ) {
             return;
           }

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -28,6 +28,7 @@ import {
   applyScreenShareTrackNetworkProfile,
   buildScreenShareEncodingForNetworkProfile,
   buildScreenShareVideoConstraintsForNetworkProfile,
+  getFallbackWebcamCodec,
   getPreferredScreenShareCodec,
   getPreferredWebcamCodec,
   produceWebcamTrack,
@@ -308,6 +309,10 @@ export function useMeetMedia({
     setCameraProducerRecoveryPulse((value) => value + 1);
   }, []);
   const cameraProducerTrackRepairInFlightRef = useRef(false);
+  const cameraRecoveryCodecOverrideRef = useRef<ReturnType<
+    typeof getPreferredWebcamCodec
+  > | null>(null);
+  const cameraRecoveryForceSingleLayerRef = useRef(false);
   const cameraOutboundStallStateRef = useRef<CameraOutboundStallState>(
     createCameraOutboundStallState(),
   );
@@ -538,6 +543,7 @@ export function useMeetMedia({
       networkProfile,
       paused,
       preferredCodec,
+      forceSingleLayer = false,
       context,
     }: {
       transport: Transport;
@@ -547,6 +553,7 @@ export function useMeetMedia({
       networkProfile: WebcamProducerNetworkProfile;
       paused: boolean;
       preferredCodec: ReturnType<typeof getPreferredWebcamCodec>;
+      forceSingleLayer?: boolean;
       context: string;
     }) => {
       try {
@@ -557,6 +564,7 @@ export function useMeetMedia({
           networkProfile,
           paused,
           preferredCodec,
+          forceSingleLayer,
         });
       } catch (err) {
         if (
@@ -570,6 +578,10 @@ export function useMeetMedia({
           `[Meets] Processed ${context} camera publish failed; retrying raw camera:`,
           err,
         );
+        onPreferredVideoPublishTrackRejected?.(
+          publishTrack,
+          `${context}-raw-produce-fallback`,
+        );
         return produceWebcamTrack({
           transport,
           track: rawTrack,
@@ -577,10 +589,11 @@ export function useMeetMedia({
           networkProfile,
           paused,
           preferredCodec,
+          forceSingleLayer,
         });
       }
     },
-    [],
+    [onPreferredVideoPublishTrackRejected],
   );
 
   const stopLocalTrack = useCallback(
@@ -2045,6 +2058,24 @@ export function useMeetMedia({
           frames: sample.frames,
           bytes: sample.bytes,
         });
+        const currentCodecMimeType =
+          producer.rtpParameters.codecs
+            .find((codec) => codec.mimeType.toLowerCase().startsWith("video/"))
+            ?.mimeType.toLowerCase() ?? null;
+        const device = deviceRef.current;
+        const currentCodec =
+          device?.rtpCapabilities.codecs?.find(
+            (codec) =>
+              currentCodecMimeType !== null &&
+              codec.mimeType.toLowerCase() === currentCodecMimeType,
+          ) ?? getPreferredWebcamCodec(device);
+        const fallbackCodec = getFallbackWebcamCodec(device, currentCodec);
+        cameraRecoveryCodecOverrideRef.current = fallbackCodec ?? currentCodec ?? null;
+        cameraRecoveryForceSingleLayerRef.current = true;
+        console.warn("[Meets] Next camera recovery will use single-layer codec:", {
+          currentCodec: currentCodec?.mimeType ?? currentCodecMimeType,
+          fallbackCodec: fallbackCodec?.mimeType ?? null,
+        });
         closeLocalVideoProducerForReplacement(producer);
         resetStallState();
         requestCameraProducerRecovery();
@@ -2178,6 +2209,7 @@ export function useMeetMedia({
     isCameraOff,
     isObserverMode,
     videoProducerRef,
+    deviceRef,
     localStreamRef,
     videoQualityRef,
     handleLocalTrackEnded,
@@ -2271,7 +2303,10 @@ export function useMeetMedia({
         );
         const quality = videoQualityRef.current;
         const networkProfile = getPublishNetworkProfile();
-        const preferredWebcamCodec = getPreferredWebcamCodec(deviceRef.current);
+        const forceSingleLayer = cameraRecoveryForceSingleLayerRef.current;
+        const preferredWebcamCodec =
+          cameraRecoveryCodecOverrideRef.current ??
+          getPreferredWebcamCodec(deviceRef.current);
         const recoveredProducer = await produceCameraTrackWithRawFallback({
           transport,
           publishTrack,
@@ -2280,6 +2315,7 @@ export function useMeetMedia({
           networkProfile,
           paused: false,
           preferredCodec: preferredWebcamCodec,
+          forceSingleLayer,
           context: "camera-recovery",
         });
 
@@ -2297,6 +2333,8 @@ export function useMeetMedia({
             requestCameraProducerRecovery();
           }
         });
+        cameraRecoveryCodecOverrideRef.current = null;
+        cameraRecoveryForceSingleLayerRef.current = false;
         setIsCameraOff(false);
       } catch (err) {
         console.error("[Meets] Camera producer recovery failed:", err);

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -425,6 +425,10 @@ interface UseMeetSocketOptions {
   localStream: MediaStream | null;
   setLocalStream: React.Dispatch<React.SetStateAction<MediaStream | null>>;
   getVideoPublishTrack?: (stream?: MediaStream | null) => MediaStreamTrack | null;
+  onPreferredVideoPublishTrackRejected?: (
+    track: MediaStreamTrack,
+    reason: string,
+  ) => void;
   dispatchParticipants: (action: ParticipantAction) => void;
   setDisplayNames: React.Dispatch<React.SetStateAction<Map<string, string>>>;
   setPendingUsers: React.Dispatch<React.SetStateAction<Map<string, string>>>;
@@ -514,6 +518,7 @@ export function useMeetSocket({
   localStream,
   setLocalStream,
   getVideoPublishTrack,
+  onPreferredVideoPublishTrackRejected,
   dispatchParticipants,
   setDisplayNames,
   setPendingUsers,
@@ -2128,6 +2133,10 @@ export function useMeetSocket({
                 rawFallbackTrack: summarizeTrackForLog(rawFallbackTrack),
               },
             );
+            onPreferredVideoPublishTrackRejected?.(
+              videoTrack,
+              "join-raw-produce-fallback",
+            );
             try {
               const fallbackVideoProducer = await produceWebcamTrack({
                 transport,
@@ -2209,6 +2218,7 @@ export function useMeetSocket({
       videoQualityRef,
       deviceRef,
       getVideoPublishTrack,
+      onPreferredVideoPublishTrackRejected,
       dropVideoTracksForCameraOff,
       refs.processedVideoTrackRef,
       resolveMediaPublishIntent,

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -2080,8 +2080,15 @@ export function useMeetSocket({
           }
 
           if (mediaIntent.isCameraOn) {
-            publicationWarnings.push("camera publish failed");
-            setIsCameraOff(true);
+            const liveVideoTrack = getFirstLiveTrack(stream.getVideoTracks());
+            if (liveVideoTrack) {
+              publicationWarnings.push("camera publish retry scheduled");
+              setIsCameraOff(false);
+              requestCameraProducerRecovery();
+            } else {
+              publicationWarnings.push("camera publish failed");
+              setIsCameraOff(true);
+            }
           }
         }
       } else if (mediaIntent.isCameraOn) {

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -2811,14 +2811,51 @@ export function useMeetSocket({
       if (!currentRoomIdRef.current) return;
 
       const socket = socketRef.current;
-      const hasTerminalTransportFailure = [
-        producerTransportRef.current?.connectionState,
-        consumerTransportRef.current?.connectionState,
-      ].some((state) => state === "closed" || state === "failed");
+      const producerState = producerTransportRef.current?.connectionState;
+      const consumerState = consumerTransportRef.current?.connectionState;
+      const hasTerminalTransportFailure = [producerState, consumerState].some(
+        (state) => state === "closed" || state === "failed",
+      );
 
       if (!socket?.connected || hasTerminalTransportFailure) {
         console.log(`[Meets] ${reason} recovery triggered reconnect.`);
         handleReconnectRef.current?.();
+        return;
+      }
+
+      const disconnectedTransportKinds: Array<"producer" | "consumer"> = [];
+      if (producerState === "disconnected") {
+        disconnectedTransportKinds.push("producer");
+      }
+      if (consumerState === "disconnected") {
+        disconnectedTransportKinds.push("consumer");
+      }
+
+      if (disconnectedTransportKinds.length > 0) {
+        console.log(`[Meets] ${reason} recovery restarting ICE.`, {
+          transports: disconnectedTransportKinds,
+        });
+        void Promise.all(
+          disconnectedTransportKinds.map((kind) =>
+            iceRestartInFlightRef.current[kind]
+              ? Promise.resolve(true)
+              : attemptIceRestart(kind),
+          ),
+        ).then((results) => {
+          if (intentionalDisconnectRef.current) return;
+          if (results.every(Boolean)) {
+            void syncProducers()
+              .then(() => flushPendingProducers())
+              .catch((error) => {
+                console.warn(
+                  `[Meets] ${reason} producer sync failed after ICE restart:`,
+                  error,
+                );
+              });
+            return;
+          }
+          handleReconnectRef.current?.();
+        });
         return;
       }
 
@@ -2833,6 +2870,8 @@ export function useMeetSocket({
       currentRoomIdRef,
       flushPendingProducers,
       handleReconnectRef,
+      attemptIceRestart,
+      iceRestartInFlightRef,
       intentionalDisconnectRef,
       producerTransportRef,
       socketRef,

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -106,6 +106,9 @@ const getTransportDisconnectGraceMs = (): number => {
   return TRANSPORT_DISCONNECT_GRACE_MS;
 };
 
+const shouldDeferTransportRecoveryUntilVisible = (): boolean =>
+  typeof document !== "undefined" && document.visibilityState !== "visible";
+
 type InitialConsumerPreferences = {
   preferredLayers?: {
     spatialLayer: number;
@@ -1673,6 +1676,12 @@ export function useMeetSocket({
                         !intentionalDisconnectRef.current &&
                         transport.connectionState === "disconnected"
                       ) {
+                        if (shouldDeferTransportRecoveryUntilVisible()) {
+                          console.info(
+                            "[Meets] Producer transport recovery deferred until foreground.",
+                          );
+                          return;
+                        }
                         attemptIceRestart("producer").then((restarted) => {
                           if (!restarted) {
                             const enabledTurnFallback = enableTurnFallback(
@@ -1705,6 +1714,12 @@ export function useMeetSocket({
 
               if (state === "failed") {
                 if (!intentionalDisconnectRef.current) {
+                  if (shouldDeferTransportRecoveryUntilVisible()) {
+                    console.info(
+                      "[Meets] Producer transport failure recovery deferred until foreground.",
+                    );
+                    return;
+                  }
                   attemptIceRestart("producer").then((restarted) => {
                     if (!restarted) {
                       const enabledTurnFallback = enableTurnFallback(
@@ -1856,6 +1871,12 @@ export function useMeetSocket({
                         !intentionalDisconnectRef.current &&
                         transport.connectionState === "disconnected"
                       ) {
+                        if (shouldDeferTransportRecoveryUntilVisible()) {
+                          console.info(
+                            "[Meets] Consumer transport recovery deferred until foreground.",
+                          );
+                          return;
+                        }
                         attemptIceRestart("consumer").then((restarted) => {
                           if (!restarted) {
                             const enabledTurnFallback = enableTurnFallback(
@@ -1883,6 +1904,12 @@ export function useMeetSocket({
 
               if (state === "failed") {
                 if (!intentionalDisconnectRef.current) {
+                  if (shouldDeferTransportRecoveryUntilVisible()) {
+                    console.info(
+                      "[Meets] Consumer transport failure recovery deferred until foreground.",
+                    );
+                    return;
+                  }
                   attemptIceRestart("consumer").then((restarted) => {
                     if (!restarted) {
                       const enabledTurnFallback = enableTurnFallback(

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -83,6 +83,7 @@ const DEFAULT_SERVER_RESTART_NOTICE =
 const ADMIN_NOTICE_DURATION_MS = 60000;
 const VIDEO_STALL_KEYFRAME_REQUEST_DELAY_MS = 2500;
 const STALE_CONSUMER_RECOVERY_DELAY_MS = 9000;
+const RESTART_ICE_ACK_TIMEOUT_MS = 5000;
 const PARTICIPANT_RECONNECTING_STATUS_FALLBACK_MS = 30000;
 const PARTICIPANT_RECONNECTING_STATUS_BUFFER_MS = 5000;
 const PARTICIPANT_RECONNECTED_STATUS_MS = 4500;
@@ -1576,10 +1577,19 @@ export function useMeetSocket({
         try {
           const response = await new Promise<RestartIceResponse>(
             (resolve, reject) => {
+              let settled = false;
+              const timeoutId = window.setTimeout(() => {
+                if (settled) return;
+                settled = true;
+                reject(new Error("restartIce acknowledgement timeout"));
+              }, RESTART_ICE_ACK_TIMEOUT_MS);
               socket.emit(
                 "restartIce",
                 { transport: transportKind, transportId: transport.id },
                 (res: RestartIceResponse | { error: string }) => {
+                  if (settled) return;
+                  settled = true;
+                  window.clearTimeout(timeoutId);
                   if ("error" in res) {
                     reject(new Error(res.error));
                   } else {

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -1469,14 +1469,16 @@ export function useMeetSocket({
               otherInfo.type === info.type,
           );
 
-        dispatchParticipants({
-          type: "UPDATE_STREAM",
-          userId: info.userId,
-          kind: info.kind,
-          streamType: info.type,
-          stream: null,
-          producerId: producerId,
-        });
+        if (!hasReplacementProducer) {
+          dispatchParticipants({
+            type: "UPDATE_STREAM",
+            userId: info.userId,
+            kind: info.kind,
+            streamType: info.type,
+            stream: null,
+            producerId: producerId,
+          });
+        }
 
         if (info.kind === "video" && info.type === "webcam") {
           if (!hasReplacementProducer) {
@@ -1496,7 +1498,11 @@ export function useMeetSocket({
           }
         }
 
-        if (info.type === "screen" && info.kind === "video") {
+        if (
+          info.type === "screen" &&
+          info.kind === "video" &&
+          !hasReplacementProducer
+        ) {
           setActiveScreenShareId(null);
         }
 

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -587,6 +587,9 @@ export function useMeetSocket({
     Map<string, { frames: number; bytes: number; stalls: number }>
   >(new Map());
   const consumerRecoveryInFlightRef = useRef<Set<string>>(new Set());
+  const announcedRemoteProducersRef = useRef<Map<string, ProducerInfo>>(
+    new Map(),
+  );
   const pendingScreenProducerCloseIdsRef = useRef<Set<string>>(new Set());
   const consumeProducerRef = useRef<
     (producerInfo: ProducerInfo) => Promise<void>
@@ -920,6 +923,7 @@ export function useMeetSocket({
       producerPausedStateRef.current.clear();
       videoFreezeStatsRef.current.clear();
       consumerRecoveryInFlightRef.current.clear();
+      announcedRemoteProducersRef.current.clear();
       consumerTelemetryRef.current.clear();
       producerMapRef.current.clear();
       pendingProducersRef.current.clear();
@@ -1448,6 +1452,22 @@ export function useMeetSocket({
 
       const info = producerMapRef.current.get(producerId);
       if (info) {
+        const hasReplacementProducer =
+          Array.from(producerMapRef.current.entries()).some(
+            ([otherProducerId, otherInfo]) =>
+              otherProducerId !== producerId &&
+              otherInfo.userId === info.userId &&
+              otherInfo.kind === info.kind &&
+              otherInfo.type === info.type,
+          ) ||
+          Array.from(announcedRemoteProducersRef.current.entries()).some(
+            ([otherProducerId, otherInfo]) =>
+              otherProducerId !== producerId &&
+              otherInfo.producerUserId === info.userId &&
+              otherInfo.kind === info.kind &&
+              otherInfo.type === info.type,
+          );
+
         dispatchParticipants({
           type: "UPDATE_STREAM",
           userId: info.userId,
@@ -1458,17 +1478,21 @@ export function useMeetSocket({
         });
 
         if (info.kind === "video" && info.type === "webcam") {
-          dispatchParticipants({
-            type: "UPDATE_CAMERA_OFF",
-            userId: info.userId,
-            cameraOff: true,
-          });
+          if (!hasReplacementProducer) {
+            dispatchParticipants({
+              type: "UPDATE_CAMERA_OFF",
+              userId: info.userId,
+              cameraOff: true,
+            });
+          }
         } else if (info.kind === "audio" && info.type === "webcam") {
-          dispatchParticipants({
-            type: "UPDATE_MUTED",
-            userId: info.userId,
-            muted: true,
-          });
+          if (!hasReplacementProducer) {
+            dispatchParticipants({
+              type: "UPDATE_MUTED",
+              userId: info.userId,
+              muted: true,
+            });
+          }
         }
 
         if (info.type === "screen" && info.kind === "video") {
@@ -1477,6 +1501,7 @@ export function useMeetSocket({
 
         producerMapRef.current.delete(producerId);
       }
+      announcedRemoteProducersRef.current.delete(producerId);
     },
     [
       consumersRef,
@@ -1491,6 +1516,7 @@ export function useMeetSocket({
       producerPausedStateRef,
       consumerRecoveryInFlightRef,
       producerMapRef,
+      announcedRemoteProducersRef,
       setActiveScreenShareId,
     ],
   );
@@ -2231,6 +2257,9 @@ export function useMeetSocket({
               });
 
               consumersRef.current.set(producerInfo.producerId, consumer);
+              announcedRemoteProducersRef.current.delete(
+                producerInfo.producerId,
+              );
               consumeRetryAttemptsRef.current.delete(producerInfo.producerId);
               producerMapRef.current.set(producerInfo.producerId, {
                 userId: producerInfo.producerUserId,
@@ -2475,6 +2504,7 @@ export function useMeetSocket({
       mutedConsumerSinceRef,
       producerPausedStateRef,
       setProducerPausedState,
+      announcedRemoteProducersRef,
       userId,
     ],
   );
@@ -2671,6 +2701,11 @@ export function useMeetSocket({
       const serverProducerIds = new Set(
         producers.map((producer) => producer.producerId),
       );
+      for (const producerId of announcedRemoteProducersRef.current.keys()) {
+        if (!serverProducerIds.has(producerId)) {
+          announcedRemoteProducersRef.current.delete(producerId);
+        }
+      }
 
       const staleConsumerIds: string[] = [];
       for (const [producerId, consumer] of consumersRef.current.entries()) {
@@ -2813,6 +2848,7 @@ export function useMeetSocket({
     mutedConsumerSinceRef,
     clearStaleConsumerRecoveryTimeout,
     videoFreezeStatsRef,
+    announcedRemoteProducersRef,
   ]);
 
   const applyWebinarFeedProducers = useCallback(
@@ -3418,6 +3454,7 @@ export function useMeetSocket({
                 void syncProducers();
                 return;
               }
+              announcedRemoteProducersRef.current.set(data.producerId, data);
               await consumeProducer(data);
             });
 

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -594,6 +594,12 @@ export function useMeetSocket({
   const producerTransportCreatePromiseRef = useRef<Promise<boolean> | null>(
     null,
   );
+  const iceRestartPromiseRef = useRef<
+    Record<"producer" | "consumer", Promise<boolean> | null>
+  >({
+    producer: null,
+    consumer: null,
+  });
 
   const {
     socketRef,
@@ -1519,6 +1525,9 @@ export function useMeetSocket({
 
   const attemptIceRestart = useCallback(
     async (transportKind: "producer" | "consumer"): Promise<boolean> => {
+      const existingRestart = iceRestartPromiseRef.current[transportKind];
+      if (existingRestart) return existingRestart;
+
       const socket = socketRef.current;
       if (!socket || !socket.connected) return false;
 
@@ -1533,37 +1542,44 @@ export function useMeetSocket({
       if (inFlight[transportKind]) return false;
       inFlight[transportKind] = true;
 
-      try {
-        const response = await new Promise<RestartIceResponse>(
-          (resolve, reject) => {
-            socket.emit(
-              "restartIce",
-              { transport: transportKind, transportId: transport.id },
-              (res: RestartIceResponse | { error: string }) => {
-                if ("error" in res) {
-                  reject(new Error(res.error));
-                } else {
-                  resolve(res);
-                }
-              },
-            );
-          },
-        );
+      let restartPromise: Promise<boolean>;
+      restartPromise = (async () => {
+        try {
+          const response = await new Promise<RestartIceResponse>(
+            (resolve, reject) => {
+              socket.emit(
+                "restartIce",
+                { transport: transportKind, transportId: transport.id },
+                (res: RestartIceResponse | { error: string }) => {
+                  if ("error" in res) {
+                    reject(new Error(res.error));
+                  } else {
+                    resolve(res);
+                  }
+                },
+              );
+            },
+          );
 
-        await transport.restartIce({ iceParameters: response.iceParameters });
-        console.log(
-          `[Meets] ${transportKind} transport ICE restart succeeded.`,
-        );
-        return true;
-      } catch (err) {
-        console.error(
-          `[Meets] ${transportKind} transport ICE restart failed:`,
-          err,
-        );
-        return false;
-      } finally {
-        inFlight[transportKind] = false;
-      }
+          await transport.restartIce({ iceParameters: response.iceParameters });
+          console.log(
+            `[Meets] ${transportKind} transport ICE restart succeeded.`,
+          );
+          return true;
+        } catch (err) {
+          console.error(
+            `[Meets] ${transportKind} transport ICE restart failed:`,
+            err,
+          );
+          return false;
+        } finally {
+          inFlight[transportKind] = false;
+          iceRestartPromiseRef.current[transportKind] = null;
+        }
+      })();
+
+      iceRestartPromiseRef.current[transportKind] = restartPromise;
+      return restartPromise;
     },
     [
       socketRef,
@@ -2836,11 +2852,7 @@ export function useMeetSocket({
           transports: disconnectedTransportKinds,
         });
         void Promise.all(
-          disconnectedTransportKinds.map((kind) =>
-            iceRestartInFlightRef.current[kind]
-              ? Promise.resolve(true)
-              : attemptIceRestart(kind),
-          ),
+          disconnectedTransportKinds.map((kind) => attemptIceRestart(kind)),
         ).then((results) => {
           if (intentionalDisconnectRef.current) return;
           if (results.every(Boolean)) {

--- a/apps/web/src/app/hooks/useMeetState.ts
+++ b/apps/web/src/app/hooks/useMeetState.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useReducer, useState } from "react";
+import { useCallback, useReducer, useState, type SetStateAction } from "react";
 import { participantReducer } from "../lib/participant-reducer";
+import { clampMeetVolume, DEFAULT_MEET_VOLUME } from "../lib/meet-volume";
 import type {
   AdminNoticeNotification,
   ConnectionState,
@@ -44,6 +45,14 @@ export function useMeetState({ initialRoomId }: UseMeetStateOptions) {
   const [isTtsDisabled, setIsTtsDisabled] = useState(false);
   const [isDmEnabled, setIsDmEnabled] = useState(true);
   const [isBrowserAudioMuted, setIsBrowserAudioMuted] = useState(false);
+  const [meetVolume, setMeetVolumeValue] = useState(DEFAULT_MEET_VOLUME);
+  const setMeetVolume = useCallback((value: SetStateAction<number>) => {
+    setMeetVolumeValue((current) =>
+      clampMeetVolume(
+        typeof value === "function" ? value(current) : value,
+      ),
+    );
+  }, []);
   const [hostUserId, setHostUserId] = useState<string | null>(null);
   const [hostUserIds, setHostUserIds] = useState<string[]>([]);
   const [isNetworkOffline, setIsNetworkOffline] = useState(false);
@@ -107,6 +116,8 @@ export function useMeetState({ initialRoomId }: UseMeetStateOptions) {
     setIsDmEnabled,
     isBrowserAudioMuted,
     setIsBrowserAudioMuted,
+    meetVolume,
+    setMeetVolume,
     hostUserId,
     setHostUserId,
     hostUserIds,

--- a/apps/web/src/app/hooks/useMeetTts.ts
+++ b/apps/web/src/app/hooks/useMeetTts.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { clampMeetVolume, DEFAULT_MEET_VOLUME } from "../lib/meet-volume";
 
 interface TtsPayload {
   userId: string;
@@ -80,7 +81,13 @@ function pickBestVoice(
   )[0] ?? null;
 }
 
-export function useMeetTts() {
+interface UseMeetTtsOptions {
+  meetVolume?: number;
+}
+
+export function useMeetTts({
+  meetVolume = DEFAULT_MEET_VOLUME,
+}: UseMeetTtsOptions = {}) {
   const [ttsSpeakerId, setTtsSpeakerId] = useState<string | null>(null);
   const activeTokenRef = useRef<number | null>(null);
   const fallbackTimeoutRef = useRef<number | null>(null);
@@ -90,6 +97,7 @@ export function useMeetTts() {
   const isSpeechUnlockedRef = useRef(false);
   const shouldGateSpeechRef = useRef(false);
   const preferredLanguageRef = useRef<string>(getPreferredLanguage());
+  const ttsVolume = clampMeetVolume(meetVolume);
 
   const clearHighlight = useCallback((token: number) => {
     if (activeTokenRef.current !== token) return;
@@ -138,7 +146,7 @@ export function useMeetTts() {
       const utterance = new SpeechSynthesisUtterance(text);
       utterance.rate = TTS_RATE;
       utterance.pitch = TTS_PITCH;
-      utterance.volume = 1;
+      utterance.volume = ttsVolume;
       const selectedVoice = voiceRef.current;
       if (selectedVoice) {
         utterance.voice = selectedVoice;
@@ -156,7 +164,7 @@ export function useMeetTts() {
     } catch (_err) {
       clearHighlight(token);
     }
-  }, [clearHighlight, refreshPreferredVoice]);
+  }, [clearHighlight, refreshPreferredVoice, ttsVolume]);
 
   const flushPendingPayload = useCallback(() => {
     const pendingPayload = pendingPayloadRef.current;

--- a/apps/web/src/app/hooks/useMeetVolume.tsx
+++ b/apps/web/src/app/hooks/useMeetVolume.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from "react";
+import { clampMeetVolume, DEFAULT_MEET_VOLUME } from "../lib/meet-volume";
+
+interface MeetVolumeContextValue {
+  meetVolume: number;
+  setMeetVolume: Dispatch<SetStateAction<number>>;
+}
+
+const MeetVolumeContext = createContext<MeetVolumeContextValue>({
+  meetVolume: DEFAULT_MEET_VOLUME,
+  setMeetVolume: () => {},
+});
+
+interface MeetVolumeProviderProps {
+  children: ReactNode;
+  meetVolume: number;
+  setMeetVolume: Dispatch<SetStateAction<number>>;
+}
+
+export function MeetVolumeProvider({
+  children,
+  meetVolume,
+  setMeetVolume,
+}: MeetVolumeProviderProps) {
+  const value = useMemo(
+    () => ({
+      meetVolume: clampMeetVolume(meetVolume),
+      setMeetVolume,
+    }),
+    [meetVolume, setMeetVolume],
+  );
+
+  return (
+    <MeetVolumeContext.Provider value={value}>
+      {children}
+    </MeetVolumeContext.Provider>
+  );
+}
+
+export function useMeetVolume() {
+  return useContext(MeetVolumeContext);
+}

--- a/apps/web/src/app/hooks/useSmartParticipantOrder.ts
+++ b/apps/web/src/app/hooks/useSmartParticipantOrder.ts
@@ -36,7 +36,6 @@ const hasLiveTrack = (
 const getMediaPriority = (participant: ParticipantWithMediaHints): number => {
   const hasVideo =
     !participant.isCameraOff &&
-    !participant.isVideoAdaptivelyPaused &&
     hasLiveTrack(participant.videoStream, "video");
   if (hasVideo) return 2;
   const hasAudio =

--- a/apps/web/src/app/hooks/useVideoEffects.ts
+++ b/apps/web/src/app/hooks/useVideoEffects.ts
@@ -230,6 +230,7 @@ const OUTPUT_WRITER_PENDING_PRESSURE_MS = 75;
 const OUTPUT_WRITER_FRAME_TIMEOUT_MS = 3000;
 const OUTPUT_WRITER_FAILURE_RELEASE_THRESHOLD = 3;
 const PROCESSED_OUTPUT_STALE_RELEASE_MS = 2500;
+const PROCESSED_OUTPUT_STALE_CHECK_MS = 1000;
 const SEGMENTATION_PROCESSOR_FRAME_TIMEOUT_MS = 6000;
 const SEGMENTATION_PROCESSOR_INITIAL_FRAME_TIMEOUT_MS = 16000;
 const FACE_PROCESSOR_FRAME_TIMEOUT_MS = 6000;
@@ -13122,6 +13123,9 @@ export function useVideoEffects({
       releaseOutputTrackToRaw(reason);
       return true;
     };
+    const processedOutputStaleCheckIntervalId = window.setInterval(() => {
+      releaseStaleProcessedOutputIfNeeded("processed output stale heartbeat");
+    }, PROCESSED_OUTPUT_STALE_CHECK_MS);
 
     const recordOutputWriterFrameFailure = (err: unknown, phase: string) => {
       outputWriterWriteFailures += 1;
@@ -17801,6 +17805,7 @@ export function useVideoEffects({
         window.clearTimeout(effectChangeFramePumpTimerId);
         effectChangeFramePumpTimerId = null;
       }
+      window.clearInterval(processedOutputStaleCheckIntervalId);
       if (loopTimerId !== null) {
         window.clearTimeout(loopTimerId);
         loopTimerId = null;

--- a/apps/web/src/app/hooks/useVideoEffects.ts
+++ b/apps/web/src/app/hooks/useVideoEffects.ts
@@ -229,6 +229,7 @@ const OUTPUT_WRITER_BACKPRESSURE_DRAIN_TIMEOUT_MS = 36;
 const OUTPUT_WRITER_PENDING_PRESSURE_MS = 75;
 const OUTPUT_WRITER_FRAME_TIMEOUT_MS = 3000;
 const OUTPUT_WRITER_FAILURE_RELEASE_THRESHOLD = 3;
+const PROCESSED_OUTPUT_STALE_RELEASE_MS = 2500;
 const SEGMENTATION_PROCESSOR_FRAME_TIMEOUT_MS = 6000;
 const SEGMENTATION_PROCESSOR_INITIAL_FRAME_TIMEOUT_MS = 16000;
 const FACE_PROCESSOR_FRAME_TIMEOUT_MS = 6000;
@@ -13090,6 +13091,38 @@ export function useVideoEffects({
       }
     };
 
+    const releaseStaleProcessedOutputIfNeeded = (
+      reason: string,
+      sampleNow = performance.now(),
+    ) => {
+      if (!outputTrackPublished || cancelled || track.readyState !== "live") {
+        return false;
+      }
+      const latestOutputFrameAgeMs =
+        latestOutputFrameAt > 0
+          ? Math.max(0, sampleNow - latestOutputFrameAt)
+          : Number.POSITIVE_INFINITY;
+      if (latestOutputFrameAgeMs < PROCESSED_OUTPUT_STALE_RELEASE_MS) {
+        return false;
+      }
+
+      warnVideoEffects(debugId, "processed_output_stale_release", {
+        reason,
+        latestOutputFrameAgeMs: Number.isFinite(latestOutputFrameAgeMs)
+          ? Math.round(latestOutputFrameAgeMs)
+          : null,
+        thresholdMs: PROCESSED_OUTPUT_STALE_RELEASE_MS,
+        outputMode,
+        outputWriterMode,
+        outputFramesWritten,
+        outputFrameSequence,
+        outputTrack: getTrackDebugSnapshot(track),
+        sourceTrack: getTrackDebugSnapshot(sourceVideoTrack),
+      });
+      releaseOutputTrackToRaw(reason);
+      return true;
+    };
+
     const recordOutputWriterFrameFailure = (err: unknown, phase: string) => {
       outputWriterWriteFailures += 1;
       consecutiveOutputWriterFailures += 1;
@@ -16739,6 +16772,9 @@ export function useVideoEffects({
         }
         outputDelivered = await deliverOutputFrame(now);
         latestOutputFrameVisible = outputDelivered && outputProbe.visible;
+        releaseStaleProcessedOutputIfNeeded(
+          "effects output waiting for visual asset",
+        );
         if (
           currentFrameSequence <= OUTPUT_READY_FRAMES ||
           currentFrameSequence % OUTPUT_VISIBILITY_PROBE_INTERVAL_FRAMES === 0 ||
@@ -16777,6 +16813,9 @@ export function useVideoEffects({
             "degraded",
             "Effects output writer is unavailable; showing raw camera.",
           );
+          releaseStaleProcessedOutputIfNeeded(
+            "effects output writer unavailable",
+          );
         } else {
           recordOutputProbeResult(
             outputProbe,
@@ -16784,7 +16823,12 @@ export function useVideoEffects({
             frameSource,
             currentEffects,
           );
-          if (visibleOutputFrameCount >= OUTPUT_READY_FRAMES) {
+          const staleProcessedOutputReleased =
+            releaseStaleProcessedOutputIfNeeded("processed output frame stale");
+          if (
+            !staleProcessedOutputReleased &&
+            visibleOutputFrameCount >= OUTPUT_READY_FRAMES
+          ) {
             publishOutputTrack();
           }
           if (!outputProbe.visible) {

--- a/apps/web/src/app/lib/meet-volume.ts
+++ b/apps/web/src/app/lib/meet-volume.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_MEET_VOLUME = 1;
+
+export const clampMeetVolume = (value: number): number => {
+  if (!Number.isFinite(value)) return DEFAULT_MEET_VOLUME;
+  return Math.min(1, Math.max(0, value));
+};

--- a/apps/web/src/app/lib/participant-media.ts
+++ b/apps/web/src/app/lib/participant-media.ts
@@ -10,7 +10,7 @@ type ParticipantVideoState = Pick<
 export function getRenderableParticipantVideoStream(
   participant: ParticipantVideoState,
 ): MediaStream | null {
-  if (participant.isCameraOff || participant.isVideoAdaptivelyPaused) {
+  if (participant.isCameraOff) {
     return null;
   }
   return participant.videoStream;

--- a/apps/web/src/app/lib/webcam-codec.ts
+++ b/apps/web/src/app/lib/webcam-codec.ts
@@ -82,6 +82,32 @@ export const getPreferredWebcamCodec = (
   return undefined;
 };
 
+export const getFallbackWebcamCodec = (
+  device: Pick<Device, "rtpCapabilities"> | null | undefined,
+  currentCodec?: RtpCodecCapability,
+): RtpCodecCapability | undefined => {
+  const codecs = device?.rtpCapabilities?.codecs ?? [];
+  const currentMimeType = currentCodec?.mimeType.toLowerCase() ?? null;
+  const fallbackOrder =
+    currentMimeType === "video/h264"
+      ? (["video/VP8", "video/H264"] as const)
+      : currentMimeType === "video/vp8"
+      ? (["video/H264", "video/VP8"] as const)
+      : getPreferredVideoCodecMimeTypes();
+
+  for (const mimeType of fallbackOrder) {
+    if (mimeType.toLowerCase() === currentMimeType) continue;
+    const codec = codecs.find((candidate) =>
+      isPreferredVideoCodec(candidate, mimeType),
+    );
+    if (codec) {
+      return codec;
+    }
+  }
+
+  return undefined;
+};
+
 export const getPreferredScreenShareCodec = (
   device: Pick<Device, "rtpCapabilities"> | null | undefined,
 ): RtpCodecCapability | undefined => {
@@ -106,6 +132,7 @@ type ProduceWebcamTrackOptions = {
   networkProfile?: WebcamProducerNetworkProfile;
   paused: boolean;
   preferredCodec?: RtpCodecCapability;
+  forceSingleLayer?: boolean;
 };
 
 export type WebcamProducerNetworkProfile =
@@ -742,6 +769,7 @@ export async function produceWebcamTrack({
   networkProfile = "good",
   paused,
   preferredCodec,
+  forceSingleLayer = false,
 }: ProduceWebcamTrackOptions): Promise<Producer> {
   const captureSize = getTrackCaptureSize(track);
   const buildOptions = (
@@ -776,7 +804,7 @@ export async function produceWebcamTrack({
     return producer;
   };
 
-  if (shouldUseWebcamSimulcast(preferredCodec)) {
+  if (!forceSingleLayer && shouldUseWebcamSimulcast(preferredCodec)) {
     try {
       return await finishProducer(
         await transport.produce(

--- a/apps/web/src/app/lib/webcam-codec.ts
+++ b/apps/web/src/app/lib/webcam-codec.ts
@@ -55,6 +55,16 @@ const isPreferredVideoCodec = (
   );
 };
 
+const shouldUseWebcamSimulcast = (
+  preferredCodec?: RtpCodecCapability,
+): boolean => {
+  if (!isLikelyHardwareAcceleratedH264Browser()) return true;
+  if (!preferredCodec || isPreferredVideoCodec(preferredCodec, "video/H264")) {
+    return false;
+  }
+  return true;
+};
+
 export const getPreferredWebcamCodec = (
   device: Pick<Device, "rtpCapabilities"> | null | undefined,
 ): RtpCodecCapability | undefined => {
@@ -756,7 +766,7 @@ export async function produceWebcamTrack({
   });
 
   const finishProducer = async (producer: Producer): Promise<Producer> => {
-    if (networkProfile !== "good") {
+    if (networkProfile !== "good" && hasMultipleSpatialLayers(producer)) {
       try {
         await producer.setMaxSpatialLayer(
           getTargetSpatialLayer(quality, networkProfile),
@@ -766,17 +776,19 @@ export async function produceWebcamTrack({
     return producer;
   };
 
-  try {
-    return await finishProducer(
-      await transport.produce(
-        buildOptions(buildWebcamSimulcastEncodings(quality)),
-      ),
-    );
-  } catch (simulcastError) {
-    console.warn(
-      "[Meets] Webcam simulcast produce failed, retrying single-layer:",
-      simulcastError,
-    );
+  if (shouldUseWebcamSimulcast(preferredCodec)) {
+    try {
+      return await finishProducer(
+        await transport.produce(
+          buildOptions(buildWebcamSimulcastEncodings(quality)),
+        ),
+      );
+    } catch (simulcastError) {
+      console.warn(
+        "[Meets] Webcam simulcast produce failed, retrying single-layer:",
+        simulcastError,
+      );
+    }
   }
 
   try {

--- a/apps/web/src/app/lib/webcam-codec.ts
+++ b/apps/web/src/app/lib/webcam-codec.ts
@@ -55,7 +55,7 @@ const isPreferredVideoCodec = (
   );
 };
 
-const shouldUseWebcamSimulcast = (
+export const shouldUseWebcamSimulcast = (
   preferredCodec?: RtpCodecCapability,
 ): boolean => {
   if (!isLikelyHardwareAcceleratedH264Browser()) return true;

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -2378,12 +2378,18 @@ export default function MeetsClient({
       selfConnectionStats.jitterMs >= PUBLISH_RECOVERY_JITTER_POOR_MS);
   const hasBrowserEmergencySignal =
     selfConnectionStats.browserNetwork.emergency === true;
-  const browserPublishRecoveryQuality = selfConnectionStats.browserNetwork
-    .quality as ConnectionQuality;
-  const selfPublishCapRecoveryQuality: ConnectionQuality =
+  const browserPublishRecoveryQuality = (
+    selfConnectionStats.browserNetwork.quality === "unknown"
+      ? selfConnectionStats.browserNetwork.startupQuality
+      : selfConnectionStats.browserNetwork.quality
+  ) as ConnectionQuality;
+  const browserAllowsPublishCapRecovery =
     !hasBrowserEmergencySignal &&
-    !hasPoorPublishRecoverySignal &&
-    browserPublishRecoveryQuality === "good"
+    selfConnectionStats.browserNetwork.saveData !== true &&
+    (browserPublishRecoveryQuality === "good" ||
+      browserPublishRecoveryQuality === "unknown");
+  const selfPublishCapRecoveryQuality: ConnectionQuality =
+    browserAllowsPublishCapRecovery && !hasPoorPublishRecoverySignal
       ? "good"
       : selfPublishQuality;
   useAdaptiveConsumerPreferences({

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -39,6 +39,7 @@ import { useMeetRooms } from "./hooks/useMeetRooms";
 import { useMeetSocket } from "./hooks/useMeetSocket";
 import { useMeetState } from "./hooks/useMeetState";
 import { useMeetTts } from "./hooks/useMeetTts";
+import { MeetVolumeProvider } from "./hooks/useMeetVolume";
 import {
   useBandwidthHeavyPreloadDeferred,
   useBandwidthHeavyVideoEffectsSuppressed,
@@ -527,6 +528,8 @@ export default function MeetsClient({
     setIsDmEnabled,
     isBrowserAudioMuted,
     setIsBrowserAudioMuted,
+    meetVolume,
+    setMeetVolume,
     hostUserId,
     setHostUserId,
     hostUserIds,
@@ -982,7 +985,7 @@ export default function MeetsClient({
     reactionAssets,
   });
 
-  const { ttsSpeakerId, handleTtsMessage } = useMeetTts();
+  const { ttsSpeakerId, handleTtsMessage } = useMeetTts({ meetVolume });
   const effectiveActiveSpeakerId = ttsSpeakerId ?? activeSpeakerId;
 
   const {
@@ -1080,6 +1083,7 @@ export default function MeetsClient({
     setSelectedAudioInputDeviceId,
     selectedAudioOutputDeviceId,
     setSelectedAudioOutputDeviceId,
+    meetVolume,
     videoQuality,
     videoQualityRef: refs.videoQualityRef,
     activeVideoEffectsCount,
@@ -2509,7 +2513,12 @@ export default function MeetsClient({
         isAdmin={isAdminFlag}
         uploadAsset={uploadAsset}
       >
-        {content}
+        <MeetVolumeProvider
+          meetVolume={meetVolume}
+          setMeetVolume={setMeetVolume}
+        >
+          {content}
+        </MeetVolumeProvider>
       </AppsProvider>
     </>
   );

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -593,6 +593,13 @@ export default function MeetsClient({
   const getVideoPublishTrackRef = useRef<
     ((stream?: MediaStream | null) => MediaStreamTrack | null) | null
   >(null);
+  const publishTrackSwitchRef = useRef<{
+    sequence: number;
+    promise: Promise<void>;
+  }>({
+    sequence: 0,
+    promise: Promise.resolve(),
+  });
   const restoredVideoEffectsPrewarmDoneRef = useRef(false);
   const cameraLiveEffectsPrewarmDoneRef = useRef(false);
 
@@ -1664,59 +1671,79 @@ export default function MeetsClient({
       });
       return;
     }
-    const producer = refs.videoProducerRef.current;
-    if (!producer || producer.closed) {
+    const initialProducer = refs.videoProducerRef.current;
+    if (!initialProducer || initialProducer.closed) {
       warnMeetVideo("skip_replace_track_missing_or_closed_producer", {
-        hasProducer: Boolean(producer),
-        producerClosed: producer?.closed,
+        hasProducer: Boolean(initialProducer),
+        producerClosed: initialProducer?.closed,
         processedTrackVersion,
         processedTrackReady,
       });
       return;
     }
 
-    const nextTrack = getVideoPublishTrack(localStream);
-    if (!nextTrack) {
-      warnMeetVideo("skip_replace_track_no_next_track", {
-        producerTrack: getMeetTrackDebugSnapshot(producer.track ?? null),
-        localStream: getMeetStreamDebugSnapshot(localStream),
-        processedTrackVersion,
-        processedTrackReady,
-      });
-      return;
-    }
-    if (nextTrack.readyState !== "live") {
-      warnMeetVideo("skip_replace_track_candidate_not_live", {
-        nextTrack: getMeetTrackDebugSnapshot(nextTrack),
-        producerTrack: getMeetTrackDebugSnapshot(producer.track ?? null),
-        processedTrackVersion,
-        processedTrackReady,
-      });
-      if (refs.processedVideoTrackRef.current?.id === nextTrack.id) {
-        refs.processedVideoTrackRef.current = null;
+    const sequence = publishTrackSwitchRef.current.sequence + 1;
+    const previousSwitch = publishTrackSwitchRef.current.promise;
+    publishTrackSwitchRef.current.sequence = sequence;
+
+    const runSwitch = async () => {
+      await previousSwitch.catch(() => {});
+      if (publishTrackSwitchRef.current.sequence !== sequence) return;
+
+      const producer = refs.videoProducerRef.current;
+      if (!producer || producer.closed || producer.id !== initialProducer.id) {
+        warnMeetVideo("skip_replace_track_producer_changed", {
+          initialProducerId: initialProducer.id,
+          currentProducerId: producer?.id ?? null,
+          producerClosed: producer?.closed ?? null,
+          processedTrackVersion,
+          processedTrackReady,
+        });
+        return;
       }
-      return;
-    }
-    if (producer.track?.id === nextTrack.id) {
-      logMeetVideo("skip_replace_track_same_track", {
-        track: getMeetTrackDebugSnapshot(nextTrack),
+
+      const publishStream = refs.localStreamRef.current ?? localStream;
+      const nextTrack = getVideoPublishTrack(publishStream);
+      if (!nextTrack) {
+        warnMeetVideo("skip_replace_track_no_next_track", {
+          producerTrack: getMeetTrackDebugSnapshot(producer.track ?? null),
+          localStream: getMeetStreamDebugSnapshot(publishStream),
+          processedTrackVersion,
+          processedTrackReady,
+        });
+        return;
+      }
+      if (nextTrack.readyState !== "live") {
+        warnMeetVideo("skip_replace_track_candidate_not_live", {
+          nextTrack: getMeetTrackDebugSnapshot(nextTrack),
+          producerTrack: getMeetTrackDebugSnapshot(producer.track ?? null),
+          processedTrackVersion,
+          processedTrackReady,
+        });
+        if (refs.processedVideoTrackRef.current?.id === nextTrack.id) {
+          refs.processedVideoTrackRef.current = null;
+        }
+        return;
+      }
+      if (producer.track?.id === nextTrack.id) {
+        logMeetVideo("skip_replace_track_same_track", {
+          track: getMeetTrackDebugSnapshot(nextTrack),
+          processedTrackVersion,
+          processedTrackReady,
+        });
+        return;
+      }
+
+      logMeetVideo("replace_track_start", {
+        from: getMeetTrackDebugSnapshot(producer.track ?? null),
+        to: getMeetTrackDebugSnapshot(nextTrack),
         processedTrackVersion,
         processedTrackReady,
       });
-      return;
-    }
-
-    logMeetVideo("replace_track_start", {
-      from: getMeetTrackDebugSnapshot(producer.track ?? null),
-      to: getMeetTrackDebugSnapshot(nextTrack),
-      processedTrackVersion,
-      processedTrackReady,
-    });
-    const isProcessedCandidate =
-      refs.processedVideoTrackRef.current?.id === nextTrack.id;
-    producer
-      .replaceTrack({ track: nextTrack })
-      .then(() => {
+      const isProcessedCandidate =
+        refs.processedVideoTrackRef.current?.id === nextTrack.id;
+      try {
+        await producer.replaceTrack({ track: nextTrack });
         if (typeof window !== "undefined" && isMeetVideoDebugEnabled()) {
           (window as MeetVideoDebugWindow).__conclaveMeetVideoDebug =
             buildMeetVideoDebugSnapshot("replace_track_done");
@@ -1724,8 +1751,7 @@ export default function MeetsClient({
         logMeetVideo("replace_track_done", {
           producerTrack: getMeetTrackDebugSnapshot(producer.track ?? null),
         });
-      })
-      .catch((err) => {
+      } catch (err) {
         if (typeof window !== "undefined" && isMeetVideoDebugEnabled()) {
           (window as MeetVideoDebugWindow).__conclaveMeetVideoDebug =
             buildMeetVideoDebugSnapshot("replace_track_failed");
@@ -1743,11 +1769,12 @@ export default function MeetsClient({
         if (refs.processedVideoTrackRef.current?.id === nextTrack.id) {
           refs.processedVideoTrackRef.current = null;
         }
-        const rawFallbackTrack = getRawVideoPublishTrack(localStream);
+        if (publishTrackSwitchRef.current.sequence !== sequence) return;
+        const rawFallbackTrack = getRawVideoPublishTrack(publishStream);
         if (!rawFallbackTrack || rawFallbackTrack.readyState !== "live") {
           warnMeetVideo("replace_track_raw_fallback_unavailable", {
             rawFallbackTrack: getMeetTrackDebugSnapshot(rawFallbackTrack),
-            localStream: getMeetStreamDebugSnapshot(localStream),
+            localStream: getMeetStreamDebugSnapshot(publishStream),
           });
           return;
         }
@@ -1761,31 +1788,33 @@ export default function MeetsClient({
           from: getMeetTrackDebugSnapshot(producer.track ?? null),
           to: getMeetTrackDebugSnapshot(rawFallbackTrack),
         });
-        producer
-          .replaceTrack({ track: rawFallbackTrack })
-          .then(() => {
-            if (typeof window !== "undefined" && isMeetVideoDebugEnabled()) {
-              (window as MeetVideoDebugWindow).__conclaveMeetVideoDebug =
-                buildMeetVideoDebugSnapshot("replace_track_raw_fallback_done");
-            }
-            logMeetVideo("replace_track_raw_fallback_done", {
-              producerTrack: getMeetTrackDebugSnapshot(producer.track ?? null),
-            });
-          })
-          .catch((fallbackErr) => {
-            warnMeetVideo("replace_track_raw_fallback_failed", {
-              error:
-                fallbackErr instanceof Error
-                  ? {
-                      name: fallbackErr.name,
-                      message: fallbackErr.message,
-                      stack: fallbackErr.stack,
-                    }
-                  : fallbackErr,
-              rawFallbackTrack: getMeetTrackDebugSnapshot(rawFallbackTrack),
-            });
+        try {
+          await producer.replaceTrack({ track: rawFallbackTrack });
+          if (typeof window !== "undefined" && isMeetVideoDebugEnabled()) {
+            (window as MeetVideoDebugWindow).__conclaveMeetVideoDebug =
+              buildMeetVideoDebugSnapshot("replace_track_raw_fallback_done");
+          }
+          logMeetVideo("replace_track_raw_fallback_done", {
+            producerTrack: getMeetTrackDebugSnapshot(producer.track ?? null),
           });
-      });
+        } catch (fallbackErr) {
+          warnMeetVideo("replace_track_raw_fallback_failed", {
+            error:
+              fallbackErr instanceof Error
+                ? {
+                    name: fallbackErr.name,
+                    message: fallbackErr.message,
+                    stack: fallbackErr.stack,
+                  }
+                : fallbackErr,
+            rawFallbackTrack: getMeetTrackDebugSnapshot(rawFallbackTrack),
+          });
+        }
+      }
+    };
+
+    const switchPromise = runSwitch();
+    publishTrackSwitchRef.current.promise = switchPromise;
   }, [
     buildMeetVideoDebugSnapshot,
     connectionState,
@@ -1795,6 +1824,7 @@ export default function MeetsClient({
     localStream,
     processedTrackVersion,
     processedTrackReady,
+    refs.localStreamRef,
     refs.videoProducerRef,
     refs.processedVideoTrackRef,
   ]);

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -580,7 +580,6 @@ export default function MeetsClient({
     useBandwidthHeavyVideoEffectsSuppressed();
   const shouldRunVisualVideoEffects =
     activeVideoEffectsCount > 0 &&
-    isDocumentVisible &&
     !shouldSuppressVideoEffectsForBandwidth;
   const [videoEffectsBridgeState, setVideoEffectsBridgeState] =
     useState<VideoEffectsBridgeState>(VIDEO_EFFECTS_OFF_STATE);
@@ -2034,6 +2033,8 @@ export default function MeetsClient({
     localStream,
     setLocalStream,
     getVideoPublishTrack,
+    onPreferredVideoPublishTrackRejected:
+      handlePreferredVideoPublishTrackRejected,
     dispatchParticipants,
     setDisplayNames,
     setPendingUsers,

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -593,6 +593,11 @@ export default function MeetsClient({
   const getVideoPublishTrackRef = useRef<
     ((stream?: MediaStream | null) => MediaStreamTrack | null) | null
   >(null);
+  const suppressedProcessedPublishTrackRef = useRef<{
+    trackId: string;
+    processedTrackVersion: number;
+    reason: string;
+  } | null>(null);
   const publishTrackSwitchRef = useRef<{
     sequence: number;
     promise: Promise<void>;
@@ -1018,6 +1023,28 @@ export default function MeetsClient({
     isTtsDisabled,
   });
 
+  const handlePreferredVideoPublishTrackRejected = useCallback(
+    (track: MediaStreamTrack, reason: string) => {
+      const processedTrack = refs.processedVideoTrackRef.current;
+      if (!processedTrack || processedTrack.id !== track.id) return;
+
+      suppressedProcessedPublishTrackRef.current = {
+        trackId: track.id,
+        processedTrackVersion: videoEffectsBridgeState.processedTrackVersion,
+        reason,
+      };
+      warnMeetVideo("suppress_processed_publish_track_after_raw_repair", {
+        reason,
+        processedTrack: getMeetTrackDebugSnapshot(processedTrack),
+        processedTrackVersion: videoEffectsBridgeState.processedTrackVersion,
+      });
+    },
+    [
+      refs.processedVideoTrackRef,
+      videoEffectsBridgeState.processedTrackVersion,
+    ],
+  );
+
   const {
     showPermissionHint,
     requestMediaPermissions,
@@ -1059,6 +1086,8 @@ export default function MeetsClient({
     activeVideoEffectsCount,
     shouldUsePreferredVideoPublishTrack: shouldPublishProcessedVideo,
     getVideoPublishTrackRef,
+    onPreferredVideoPublishTrackRejected:
+      handlePreferredVideoPublishTrackRejected,
     socketRef: refs.socketRef,
     deviceRef: refs.deviceRef,
     producerTransportRef: refs.producerTransportRef,
@@ -1234,6 +1263,24 @@ export default function MeetsClient({
         null;
       const producerTrack = refs.videoProducerRef.current?.track ?? null;
       const processedTrack = refs.processedVideoTrackRef.current;
+      const suppressedProcessedPublishTrack =
+        suppressedProcessedPublishTrackRef.current;
+      const processedTrackSuppressed = Boolean(
+        suppressedProcessedPublishTrack &&
+          processedTrack &&
+          suppressedProcessedPublishTrack.trackId === processedTrack.id &&
+          suppressedProcessedPublishTrack.processedTrackVersion ===
+            processedTrackVersion,
+      );
+      if (
+        suppressedProcessedPublishTrack &&
+        (!processedTrack ||
+          suppressedProcessedPublishTrack.trackId !== processedTrack.id ||
+          suppressedProcessedPublishTrack.processedTrackVersion !==
+            processedTrackVersion)
+      ) {
+        suppressedProcessedPublishTrackRef.current = null;
+      }
       const processedSourceTrackId = getVideoEffectsDebugTrackId(
         videoEffectsDebugStats,
         "sourceTrack",
@@ -1288,6 +1335,7 @@ export default function MeetsClient({
       );
       if (
         shouldPublishProcessedVideo &&
+        !processedTrackSuppressed &&
         processedTrackReady &&
         processedTrack &&
         processedTrack.readyState === "live" &&
@@ -1308,12 +1356,14 @@ export default function MeetsClient({
             processedChainedSourceTrackId,
             processedSourceMatchesChainedInput,
             processedTrackOutputIsWarming,
+            suppressedProcessedPublishTrack,
           },
         );
         return processedTrack;
       }
       if (
         shouldPublishProcessedVideo &&
+        !processedTrackSuppressed &&
         !processedTrackReady &&
         processedTrack &&
         processedTrack.readyState === "live" &&
@@ -1330,8 +1380,17 @@ export default function MeetsClient({
           processedChainedSourceTrackId,
           processedSourceMatchesChainedInput,
           processedTrackOutputIsWarming,
+          suppressedProcessedPublishTrack,
         });
         return processedTrack;
+      }
+      if (processedTrackSuppressed) {
+        logMeetVideo("skip_processed_track_suppressed_after_raw_repair", {
+          processedTrack: getMeetTrackDebugSnapshot(processedTrack),
+          producerTrack: getMeetTrackDebugSnapshot(producerTrack),
+          suppressedProcessedPublishTrack,
+          processedTrackVersion,
+        });
       }
       if (processedTrack && !processedTrackReady) {
         logMeetVideo("skip_processed_track_not_ready", {
@@ -1373,15 +1432,18 @@ export default function MeetsClient({
         processedChainedSourceTrackId,
         processedSourceMatchesChainedInput,
         processedTrackOutputIsWarming,
+        suppressedProcessedPublishTrack,
       });
       return rawTrack;
     },
     [
+      processedTrackVersion,
       processedTrackReady,
       refs.localStreamRef,
       refs.processedVideoTrackRef,
       refs.videoProducerRef,
       shouldPublishProcessedVideo,
+      suppressedProcessedPublishTrackRef,
       videoEffectsDebugStats,
     ],
   );

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -2364,11 +2364,11 @@ export default function MeetsClient({
   });
   connectionQualityDebugRef.current = selfConnectionStats;
   const {
-    quality: selfConnectionQuality,
     publishQuality: selfPublishQuality,
     receiveQuality: selfReceiveQuality,
+    publishEmergencyMode: selfPublishEmergencyMode,
+    receiveEmergencyMode: selfReceiveEmergencyMode,
   } = selfConnectionStats;
-  const selfEmergencyNetworkMode = selfConnectionStats.emergencyMode;
   const hasPoorPublishRecoverySignal =
     (selfConnectionStats.rttMs !== null &&
       selfConnectionStats.rttMs >= PUBLISH_RECOVERY_RTT_POOR_MS) ||
@@ -2396,7 +2396,7 @@ export default function MeetsClient({
     refs,
     enabled: connectionState === "joined",
     connectionQuality: selfReceiveQuality,
-    emergencyMode: selfEmergencyNetworkMode,
+    emergencyMode: selfReceiveEmergencyMode,
     activeSpeakerId: effectiveActiveSpeakerId,
     debugStateRef: adaptiveConsumerDebugRef,
     onVideoAdaptivePauseStateChange: handleVideoAdaptivePauseStateChange,
@@ -2405,7 +2405,7 @@ export default function MeetsClient({
     enabled: connectionState === "joined",
     connectionQuality: selfPublishQuality,
     capRecoveryQuality: selfPublishCapRecoveryQuality,
-    emergencyMode: selfEmergencyNetworkMode,
+    emergencyMode: selfPublishEmergencyMode,
     isCameraOff,
     participantCount,
     audioProducerRef: refs.audioProducerRef,
@@ -2769,7 +2769,7 @@ export default function MeetsClient({
       <MeetsMainContent
         isJoined={isJoined}
         connectionState={connectionState}
-        selfConnectionQuality={selfConnectionQuality}
+        selfConnectionQuality={selfConnectionStats.quality}
         isLoading={isLoading}
         roomId={roomId}
         setRoomId={setRoomId}

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -2370,12 +2370,12 @@ export default function MeetsClient({
     receiveEmergencyMode: selfReceiveEmergencyMode,
   } = selfConnectionStats;
   const hasPoorPublishRecoverySignal =
-    (selfConnectionStats.rttMs !== null &&
-      selfConnectionStats.rttMs >= PUBLISH_RECOVERY_RTT_POOR_MS) ||
-    (selfConnectionStats.packetLoss !== null &&
-      selfConnectionStats.packetLoss >= PUBLISH_RECOVERY_LOSS_POOR) ||
-    (selfConnectionStats.jitterMs !== null &&
-      selfConnectionStats.jitterMs >= PUBLISH_RECOVERY_JITTER_POOR_MS);
+    (selfConnectionStats.publishRttMs !== null &&
+      selfConnectionStats.publishRttMs >= PUBLISH_RECOVERY_RTT_POOR_MS) ||
+    (selfConnectionStats.publishPacketLoss !== null &&
+      selfConnectionStats.publishPacketLoss >= PUBLISH_RECOVERY_LOSS_POOR) ||
+    (selfConnectionStats.publishJitterMs !== null &&
+      selfConnectionStats.publishJitterMs >= PUBLISH_RECOVERY_JITTER_POOR_MS);
   const hasBrowserEmergencySignal =
     selfConnectionStats.browserNetwork.emergency === true;
   const browserPublishRecoveryQuality = (

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -578,7 +578,7 @@ export default function MeetsClient({
     useBandwidthHeavyPreloadDeferred();
   const shouldSuppressVideoEffectsForBandwidth =
     useBandwidthHeavyVideoEffectsSuppressed();
-  const shouldRunVideoEffects =
+  const shouldRunVisualVideoEffects =
     activeVideoEffectsCount > 0 &&
     isDocumentVisible &&
     !shouldSuppressVideoEffectsForBandwidth;
@@ -893,7 +893,8 @@ export default function MeetsClient({
   const isWebinarAttendee =
     joinMode === "webinar_attendee" || webinarRole === "attendee";
   const ghostEnabled = allowGhostMode && isAdminFlag && isGhostMode;
-  const shouldPublishProcessedVideo = shouldRunVideoEffects;
+  const shouldRunVideoEffects = shouldRunVisualVideoEffects;
+  const shouldPublishProcessedVideo = shouldRunVisualVideoEffects;
   const canSignOut = Boolean(
     currentUser && !currentUser.id?.startsWith("guest-"),
   );

--- a/packages/meeting-core/src/participant-reducer.ts
+++ b/packages/meeting-core/src/participant-reducer.ts
@@ -107,8 +107,24 @@ export function participantReducer(
       });
     }
     case "UPDATE_STREAM": {
+      const existingParticipant = state.get(action.userId);
+      if (!action.stream) {
+        if (!existingParticipant) return state;
+        const currentProducerId =
+          action.streamType === "screen"
+            ? action.kind === "video"
+              ? existingParticipant.screenShareProducerId
+              : existingParticipant.screenShareAudioProducerId
+            : action.kind === "video"
+              ? existingParticipant.videoProducerId
+              : existingParticipant.audioProducerId;
+        if (currentProducerId && currentProducerId !== action.producerId) {
+          return state;
+        }
+      }
+
       const participant =
-        state.get(action.userId) || createEmptyParticipant(action.userId);
+        existingParticipant || createEmptyParticipant(action.userId);
       const updated = { ...participant };
 
       if (action.streamType === "screen") {

--- a/packages/meeting-core/test/participant-reducer.test.ts
+++ b/packages/meeting-core/test/participant-reducer.test.ts
@@ -256,6 +256,61 @@ describe("participantReducer — UPDATE_STREAM", () => {
     const next = participantReducer(state, videoAction("a", s, "vp1"));
     expect(next).toBe(state);
   });
+
+  it("ignores stale webcam video closes after a replacement stream is attached", () => {
+    let state = seed("a");
+    const oldStream = fakeStream("old-video");
+    const nextStream = fakeStream("next-video");
+    state = participantReducer(state, videoAction("a", oldStream, "old-vp"));
+    state = participantReducer(state, videoAction("a", nextStream, "next-vp"));
+
+    const staleClose = participantReducer(
+      state,
+      videoAction("a", null, "old-vp"),
+    );
+
+    expect(staleClose).toBe(state);
+    expect(staleClose.get("a")!.videoStream).toBe(nextStream);
+    expect(staleClose.get("a")!.videoProducerId).toBe("next-vp");
+    expect(staleClose.get("a")!.isCameraOff).toBe(false);
+  });
+
+  it("ignores stale screen-share video closes after a replacement stream is attached", () => {
+    let state = seed("a");
+    const oldStream = fakeStream("old-screen");
+    const nextStream = fakeStream("next-screen");
+    state = participantReducer(state, {
+      type: "UPDATE_STREAM",
+      userId: "a",
+      kind: "video",
+      streamType: "screen",
+      stream: oldStream,
+      producerId: "old-screen-producer",
+    });
+    state = participantReducer(state, {
+      type: "UPDATE_STREAM",
+      userId: "a",
+      kind: "video",
+      streamType: "screen",
+      stream: nextStream,
+      producerId: "next-screen-producer",
+    });
+
+    const staleClose = participantReducer(state, {
+      type: "UPDATE_STREAM",
+      userId: "a",
+      kind: "video",
+      streamType: "screen",
+      stream: null,
+      producerId: "old-screen-producer",
+    });
+
+    expect(staleClose).toBe(state);
+    expect(staleClose.get("a")!.screenShareStream).toBe(nextStream);
+    expect(staleClose.get("a")!.screenShareProducerId).toBe(
+      "next-screen-producer",
+    );
+  });
 });
 
 describe("participantReducer — mute / camera / hand transitions", () => {

--- a/packages/sfu/config/classes/Client.ts
+++ b/packages/sfu/config/classes/Client.ts
@@ -90,7 +90,7 @@ export class Client {
     return this.isGhost || this.isWebinarAttendee;
   }
 
-  addProducer(producer: Producer): void {
+  addProducer(producer: Producer): Producer | null {
     const type = (producer.appData.type as ProducerType) || "webcam";
     const key = createProducerKey(producer.kind, type);
     const previousProducer = this.producers.get(key);
@@ -109,12 +109,10 @@ export class Client {
     producer.on("transportclose", cleanup);
     producer.observer.on("close", cleanup);
 
-    if (previousProducer && previousProducer.id !== producer.id) {
-      try {
-        this.producerKeysById.delete(previousProducer.id);
-        previousProducer.close();
-      } catch {}
-    }
+    const displacedProducer =
+      previousProducer && previousProducer.id !== producer.id
+        ? previousProducer
+        : null;
 
     if (type === "webcam") {
       if (producer.kind === "audio") {
@@ -123,6 +121,8 @@ export class Client {
         this.isCameraOff = producer.paused;
       }
     }
+
+    return displacedProducer;
   }
 
   addConsumer(

--- a/packages/sfu/server/redisErrors.ts
+++ b/packages/sfu/server/redisErrors.ts
@@ -31,6 +31,7 @@ export const isRedisTransientError = (error: unknown): boolean => {
           name?: unknown;
           code?: unknown;
           message?: unknown;
+          stack?: unknown;
           constructor?: { name?: unknown };
         })
       : null;
@@ -43,8 +44,16 @@ export const isRedisTransientError = (error: unknown): boolean => {
   const code = typeof candidate?.code === "string" ? candidate.code : null;
   const message =
     typeof candidate?.message === "string" ? candidate.message : "";
+  const stack = typeof candidate?.stack === "string" ? candidate.stack : "";
+  const redisStack = /(?:@redis\/client|node_modules\/(?:@redis|redis))/i.test(
+    stack,
+  );
 
   if (name && REDIS_TRANSIENT_ERROR_NAMES.has(name)) {
+    return true;
+  }
+
+  if (message && REDIS_TRANSIENT_ERROR_NAMES.has(message) && redisStack) {
     return true;
   }
 
@@ -53,6 +62,10 @@ export const isRedisTransientError = (error: unknown): boolean => {
   }
 
   if (/redis/i.test(message) && /timeout|closed|offline|connect/i.test(message)) {
+    return true;
+  }
+
+  if (redisStack && /timeout|closed|offline|connect/i.test(message)) {
     return true;
   }
 

--- a/packages/sfu/server/socket/handlers/mediaHandlers.ts
+++ b/packages/sfu/server/socket/handlers/mediaHandlers.ts
@@ -428,7 +428,7 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
           room.setScreenShareProducer(producer.id);
         }
 
-        currentClient.addProducer(producer);
+        const displacedProducer = currentClient.addProducer(producer);
         room.indexClientProducer(currentClient.id, producer, type);
         await room.registerWebinarAudioProducer(
           currentClient.id,
@@ -461,6 +461,15 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
             paused: producer.paused,
             roomId: activeRoom.id,
           });
+        }
+        if (
+          displacedProducer &&
+          displacedProducer.id !== producer.id &&
+          !displacedProducer.closed
+        ) {
+          try {
+            displacedProducer.close();
+          } catch {}
         }
         emitWebinarFeedChanged(io, state, activeRoom);
 

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -319,6 +319,21 @@ assertIncludes(
   "const MAX_WEBCAMS_TO_KEEP_FULL_ON_GOOD_LINKS = 4;",
   "web good-link rooms keep small calls at full webcam layers",
 );
+assertIncludes(
+  "webAdaptiveConsumerPreferences",
+  "const fallbackWebcamRanks = new Map<string, number>();",
+  "web missing layout hints use deterministic webcam fallback ranks",
+);
+assertRegex(
+  "webAdaptiveConsumerPreferences",
+  /const fallbackVisible =[\s\S]*options\.fallbackRank !== null[\s\S]*options\.fallbackRank < MAX_WEBCAMS_TO_KEEP_FULL_ON_GOOD_LINKS/,
+  "web missing layout hints do not mark every webcam visible",
+);
+assertIncludes(
+  "webAdaptiveConsumerPreferences",
+  "const isWarm = layout?.warm === true || (!layout && !fallbackVisible);",
+  "web missing layout hints keep non-primary webcams warm instead of full",
+);
 assertRegex(
   "webMeetSocket",
   /const existingWebcamVideoConsumerCount = Array\.from\([\s\S]*producerMapRef\.current\.values\(\)[\s\S]*info\.kind === "video" && info\.type === "webcam"[\s\S]*preferHighWebcamLayer:[\s\S]*joinMode === "webinar_attendee" \|\|[\s\S]*existingWebcamVideoConsumerCount < 4/,

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -419,6 +419,27 @@ assertIncludes(
   "existingTransport.close();",
   "web producer transport recovery closes unusable transports before rebuilding",
 );
+assertIncludes(
+  "webMeetMedia",
+  "const produceCameraTrackWithRawFallback = useCallback(",
+  "web fresh camera producer publish has raw-track fallback helper",
+);
+assertRegex(
+  "webMeetMedia",
+  /produceCameraTrackWithRawFallback[\s\S]*Processed \$\{context\} camera publish failed; retrying raw camera:[\s\S]*track: rawTrack/,
+  "web processed camera publish failures retry raw camera",
+);
+for (const [context, label] of [
+  ["quality-switch", "quality-switch"],
+  ["camera-toggle", "camera-toggle"],
+  ["camera-recovery", "camera-recovery"],
+]) {
+  assertIncludes(
+    "webMeetMedia",
+    `context: "${context}"`,
+    `web ${label} fresh camera produce uses raw fallback`,
+  );
+}
 {
   const text = source.webMeetMedia;
   const start = text.indexOf("const handleLocalTrackEnded = useCallback(");
@@ -657,6 +678,27 @@ assertIncludes(
     ) {
       failures.push(
         "web socket producer transport-close recovery must preserve muted/camera-off intent",
+      );
+    }
+    const retryIndex = section.indexOf(
+      'publicationWarnings.push("camera publish retry scheduled")',
+    );
+    const failedIndex = section.indexOf(
+      'publicationWarnings.push("camera publish failed")',
+    );
+    if (
+      retryIndex < 0 ||
+      !section.includes("const liveVideoTrack = getFirstLiveTrack(") ||
+      !section.includes("setIsCameraOff(false);") ||
+      !section.includes("requestCameraProducerRecovery();")
+    ) {
+      failures.push(
+        "web initial camera publish failure with live track must preserve camera intent",
+      );
+    }
+    if (failedIndex >= 0 && retryIndex >= 0 && failedIndex < retryIndex) {
+      failures.push(
+        "web initial camera publish failure must retry recovery before marking camera off",
       );
     }
   }

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1386,10 +1386,20 @@ assertIncludes(
   "const PROCESSED_OUTPUT_STALE_RELEASE_MS = 2500;",
   "web stale processed effects output release threshold",
 );
+assertIncludes(
+  "webVideoEffects",
+  "const PROCESSED_OUTPUT_STALE_CHECK_MS = 1000;",
+  "web stale processed effects output heartbeat interval",
+);
 assertRegex(
   "webVideoEffects",
   /const releaseStaleProcessedOutputIfNeeded =[\s\S]*latestOutputFrameAt[\s\S]*PROCESSED_OUTPUT_STALE_RELEASE_MS[\s\S]*releaseOutputTrackToRaw\(reason\);/,
   "web live-but-stale processed effects output releases to raw publish track",
+);
+assertRegex(
+  "webVideoEffects",
+  /const processedOutputStaleCheckIntervalId = window\.setInterval\(\(\) => \{[\s\S]*releaseStaleProcessedOutputIfNeeded\("processed output stale heartbeat"\);[\s\S]*PROCESSED_OUTPUT_STALE_CHECK_MS[\s\S]*window\.clearInterval\(processedOutputStaleCheckIntervalId\);/,
+  "web stale processed effects output heartbeat survives stalled effects loops",
 );
 assertRegex(
   "webVideoEffects",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -22,6 +22,7 @@ const files = {
   webMeetClient: "apps/web/src/app/meets-client.tsx",
   webMeetMedia: "apps/web/src/app/hooks/useMeetMedia.ts",
   webMeetSocket: "apps/web/src/app/hooks/useMeetSocket.ts",
+  webVideoEffects: "apps/web/src/app/hooks/useVideoEffects.ts",
   meetingParticipantReducer: "packages/meeting-core/src/participant-reducer.ts",
   webJoinScreen: "apps/web/src/app/components/JoinScreen.tsx",
   webMobileJoinScreen: "apps/web/src/app/components/mobile/MobileJoinScreen.tsx",
@@ -1379,6 +1380,26 @@ assertIncludes(
   "webMeetClient",
   "const shouldPublishProcessedVideo = shouldRunVisualVideoEffects;",
   "web active effects publish processed video regardless of tab visibility",
+);
+assertIncludes(
+  "webVideoEffects",
+  "const PROCESSED_OUTPUT_STALE_RELEASE_MS = 2500;",
+  "web stale processed effects output release threshold",
+);
+assertRegex(
+  "webVideoEffects",
+  /const releaseStaleProcessedOutputIfNeeded =[\s\S]*latestOutputFrameAt[\s\S]*PROCESSED_OUTPUT_STALE_RELEASE_MS[\s\S]*releaseOutputTrackToRaw\(reason\);/,
+  "web live-but-stale processed effects output releases to raw publish track",
+);
+assertRegex(
+  "webVideoEffects",
+  /if \(!outputDelivered\) \{[\s\S]*"Effects output writer is unavailable; showing raw camera\."[\s\S]*releaseStaleProcessedOutputIfNeeded\(\s*"effects output writer unavailable",?\s*\);/,
+  "web unavailable effects writer does not leave frozen processed output published",
+);
+assertRegex(
+  "webVideoEffects",
+  /const staleProcessedOutputReleased =[\s\S]*releaseStaleProcessedOutputIfNeeded\("processed output frame stale"\);[\s\S]*!staleProcessedOutputReleased &&[\s\S]*visibleOutputFrameCount >= OUTPUT_READY_FRAMES[\s\S]*publishOutputTrack\(\);/,
+  "web effects output republishes processed video only after fresh frames resume",
 );
 assertRegex(
   "webMeetClient",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -442,8 +442,8 @@ assertNotIncludes(
 );
 assertRegex(
   "webMeetClient",
-  /const browserPublishRecoveryQuality = selfConnectionStats\.browserNetwork[\s\S]*browserPublishRecoveryQuality === "good"[\s\S]*\? "good"[\s\S]*: selfPublishQuality/,
-  "web cap recovery browser hint only restores good profile",
+  /const browserPublishRecoveryQuality = \([\s\S]*selfConnectionStats\.browserNetwork\.quality === "unknown"[\s\S]*selfConnectionStats\.browserNetwork\.startupQuality[\s\S]*const browserAllowsPublishCapRecovery =[\s\S]*browserPublishRecoveryQuality === "good" \|\|[\s\S]*browserPublishRecoveryQuality === "unknown"[\s\S]*browserAllowsPublishCapRecovery && !hasPoorPublishRecoverySignal[\s\S]*\? "good"[\s\S]*: selfPublishQuality/,
+  "web cap recovery restores good profile when browser hint is good or unknown",
 );
 assertNotIncludes(
   "webMeetClient",
@@ -462,23 +462,28 @@ assertNotIncludes(
 );
 assertIncludes(
   "webMeetMedia",
-  "Camera constraints update failed; refreshing capture once",
-  "web quality switch refreshes capture when constraints fail",
+  "Camera constraints update failed; keeping current capture",
+  "web quality switch keeps live camera when constraints fail",
 );
-assertIncludes(
+assertNotIncludes(
+  "webMeetMedia",
+  "Camera constraints update failed; refreshing capture once",
+  "web quality switch must not reopen live cameras when constraints fail",
+);
+assertNotIncludes(
   "webMeetMedia",
   "shouldRefreshVideoTrackForQualitySwitch",
-  "web quality switch refreshes capture when constraints undershoot",
+  "web quality switch must not reopen live cameras when settings undershoot",
 );
-assertIncludes(
+assertNotIncludes(
   "webMeetMedia",
   "settings.width <= lowQualityWidth * 1.05",
-  "web standard-quality camera refresh only reopens low-width captures",
+  "web standard-quality camera refresh must not key off low-width captures",
 );
-assertIncludes(
+assertNotIncludes(
   "webMeetMedia",
   "settings.height <= lowQualityHeight * 1.05",
-  "web standard-quality camera refresh only reopens low-height captures",
+  "web standard-quality camera refresh must not key off low-height captures",
 );
 assertIncludes(
   "webMeetMedia",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -941,6 +941,26 @@ for (const [context, label] of [
     /Processed \$\{context\} camera publish failed; retrying raw camera:[\s\S]*onPreferredVideoPublishTrackRejected\?\.[\s\S]*\`\$\{context\}-raw-produce-fallback\`/,
     "web raw camera produce fallback suppresses the rejected processed publish track",
   );
+  assertRegex(
+    "webMeetMedia",
+    /Processed device-switch track failed; retrying raw camera:[\s\S]*onPreferredVideoPublishTrackRejected\?\.[\s\S]*device-switch-raw-replace-fallback/,
+    "web device-switch raw fallback suppresses the rejected processed publish track",
+  );
+  assertRegex(
+    "webMeetMedia",
+    /Processed quality-switch track failed; retrying raw camera:[\s\S]*onPreferredVideoPublishTrackRejected\?\.[\s\S]*quality-switch-raw-replace-fallback/,
+    "web quality-switch raw fallback suppresses the rejected processed publish track",
+  );
+  assertRegex(
+    "webMeetSocket",
+    /onPreferredVideoPublishTrackRejected\?:[\s\S]*Processed camera publish failed; retrying raw camera:[\s\S]*onPreferredVideoPublishTrackRejected\?\.[\s\S]*join-raw-produce-fallback/,
+    "web socket join raw fallback suppresses the rejected processed publish track",
+  );
+  assertRegex(
+    "webMeetClient",
+    /useMeetSocket\(\{[\s\S]*getVideoPublishTrack,[\s\S]*onPreferredVideoPublishTrackRejected:\s*handlePreferredVideoPublishTrackRejected/,
+    "web meet client passes processed-track rejection callback to socket hook",
+  );
 }
 {
   const text = source.webMeetMedia;
@@ -1317,18 +1337,23 @@ assertIncludes(
 );
 assertRegex(
   "webMeetClient",
-  /const shouldRunVisualVideoEffects =\s*activeVideoEffectsCount > 0 &&\s*isDocumentVisible &&\s*!shouldSuppressVideoEffectsForBandwidth;[\s\S]*const shouldRunVideoEffects = shouldRunVisualVideoEffects;[\s\S]*const shouldPublishProcessedVideo = shouldRunVisualVideoEffects;/,
-  "web meet-shell effects only run when active, visible, and not constrained",
+  /const shouldRunVisualVideoEffects =\s*activeVideoEffectsCount > 0 &&\s*!shouldSuppressVideoEffectsForBandwidth;[\s\S]*const shouldRunVideoEffects = shouldRunVisualVideoEffects;[\s\S]*const shouldPublishProcessedVideo = shouldRunVisualVideoEffects;/,
+  "web meet-shell effects stay active across visibility changes unless constrained",
+);
+assertNotIncludes(
+  "webMeetClient",
+  "activeVideoEffectsCount > 0 &&\n    isDocumentVisible &&\n    !shouldSuppressVideoEffectsForBandwidth",
+  "web hidden tabs must not suspend active video effects",
 );
 assertRegex(
   "webMeetClient",
   /document\.addEventListener\("visibilitychange", syncDocumentVisibility\);[\s\S]*window\.addEventListener\("pageshow", syncDocumentVisibility\);/,
-  "web meet-shell tracks page visibility for processed video publishing",
+  "web meet-shell tracks page visibility for foreground prewarm/debug state",
 );
 assertIncludes(
   "webMeetClient",
   "const shouldPublishProcessedVideo = shouldRunVisualVideoEffects;",
-  "web hidden tabs publish raw camera while effects pipeline is suspended",
+  "web active effects publish processed video regardless of tab visibility",
 );
 assertRegex(
   "webMeetClient",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1171,6 +1171,11 @@ assertIncludes(
 );
 assertRegex(
   "webMeetClient",
+  /const publishTrackSwitchRef = useRef[\s\S]*sequence: 0,[\s\S]*promise: Promise\.resolve\(\),[\s\S]*const previousSwitch = publishTrackSwitchRef\.current\.promise;[\s\S]*await previousSwitch\.catch\(\(\) => \{\}\);[\s\S]*publishTrackSwitchRef\.current\.sequence !== sequence[\s\S]*const publishStream = refs\.localStreamRef\.current \?\? localStream;[\s\S]*await producer\.replaceTrack\(\{ track: nextTrack \}\);[\s\S]*const rawFallbackTrack = getRawVideoPublishTrack\(publishStream\);[\s\S]*await producer\.replaceTrack\(\{ track: rawFallbackTrack \}\);/,
+  "web processed/raw publish track switches are serialized",
+);
+assertRegex(
+  "webMeetClient",
   /if \(activeVideoEffectsCount <= 0\) return;[\s\S]*if \(!isDocumentVisible\) return;[\s\S]*if \(shouldSuppressVideoEffectsForBandwidth\) return;[\s\S]*prewarmVideoEffectsRuntimeDeferred/,
   "web meet-shell runtime prewarm constrained-link guard",
 );

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -15,6 +15,8 @@ const files = {
     "apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts",
   webPlaybackRecovery: "apps/web/src/app/lib/playback-recovery.ts",
   webParticipantVideo: "apps/web/src/app/components/ParticipantVideo.tsx",
+  webMobileParticipantVideo:
+    "apps/web/src/app/components/mobile/MobileParticipantVideo.tsx",
   webGridLayout: "apps/web/src/app/components/GridLayout.tsx",
   webPresentationLayout: "apps/web/src/app/components/PresentationLayout.tsx",
   webMobilePresentationLayout:
@@ -304,6 +306,7 @@ assertIncludes(
 );
 for (const [key, label] of [
   ["webParticipantVideo", "participant video"],
+  ["webMobileParticipantVideo", "mobile participant video"],
   ["webGridLayout", "grid video"],
   ["webPresentationLayout", "presentation video"],
   ["webMobilePresentationLayout", "mobile presentation video"],
@@ -314,6 +317,26 @@ for (const [key, label] of [
     `web ${label} should not replay on benign suspend events`,
   );
 }
+assertIncludes(
+  "webMobileParticipantVideo",
+  "createPlaybackRecoveryScheduler",
+  "web mobile participant video uses playback recovery scheduler",
+);
+assertIncludes(
+  "webMobileParticipantVideo",
+  "shouldAttemptAnimationFrameReplay",
+  "web mobile participant video retries stalled first-frame playback",
+);
+assertIncludes(
+  "webMobileParticipantVideo",
+  'document.addEventListener("visibilitychange", handleVisibilityChange)',
+  "web mobile participant video retries playback after foregrounding",
+);
+assertRegex(
+  "webMobileParticipantVideo",
+  /<video[\s\S]*autoPlay[\s\S]*muted[\s\S]*playsInline/,
+  "web mobile participant video is muted for autoplay reliability",
+);
 assertRegex(
   "webAdaptiveConsumerPreferences",
   /const effectiveQuality = worstQuality\([\s\S]*options\.quality === "good" \|\| options\.quality === "fair"[\s\S]*\? "unknown"[\s\S]*: getConsumerScoreQualityHint/,

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -390,8 +390,23 @@ assertIncludes(
 );
 assertIncludes(
   "webAdaptiveConsumerPreferences",
+  "priority: quality === \"poor\" ? 10 : 25,\n      paused: false,",
+  "web hidden consumers degrade layers instead of pausing",
+);
+assertIncludes(
+  "webAdaptiveConsumerPreferences",
+  "priority: 8,\n        paused: false,",
+  "web emergency receive adaptation keeps extra remote webcams live",
+);
+assertNotIncludes(
+  "webAdaptiveConsumerPreferences",
   "paused: quality === \"poor\"",
-  "web hidden consumers stay warm unless receive quality is poor",
+  "web hidden consumers must not flicker from adaptive pausing",
+);
+assertNotIncludes(
+  "webAdaptiveConsumerPreferences",
+  "priority: 8,\n        paused: true,",
+  "web emergency receive adaptation must not silently pause remote webcams",
 );
 assertIncludes(
   "webAdaptiveConsumerPreferences",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -820,6 +820,50 @@ for (const [context, label] of [
 }
 {
   const text = source.webMeetMedia;
+  const start = text.indexOf("const recoverStalledProducer = async");
+  const end = text.indexOf("const pollOutboundProgress = () => {", start);
+  if (start < 0 || end < 0) {
+    failures.push("web camera outbound stall watchdog section missing");
+  } else {
+    const section = text.slice(start, end);
+    if (
+      !section.includes("producer.replaceTrack({ track: rawCameraTrack });") ||
+      !section.includes("closeLocalVideoProducerForReplacement(producer);") ||
+      !section.includes("requestCameraProducerRecovery();")
+    ) {
+      failures.push(
+        "web stalled camera sender recovery must repair with raw camera before recreating the producer",
+      );
+    }
+    const rawRepairIndex = section.indexOf(
+      "producer.replaceTrack({ track: rawCameraTrack });",
+    );
+    const recreateIndex = section.indexOf(
+      "closeLocalVideoProducerForReplacement(producer);",
+    );
+    if (
+      rawRepairIndex >= 0 &&
+      recreateIndex >= 0 &&
+      recreateIndex < rawRepairIndex
+    ) {
+      failures.push(
+        "web stalled camera sender recovery must try raw-track repair before producer recreation",
+      );
+    }
+  }
+  assertIncludes(
+    "webMeetMedia",
+    "CAMERA_OUTBOUND_STALL_SAMPLES_BEFORE_RECOVERY",
+    "web camera outbound stall threshold",
+  );
+  assertRegex(
+    "webMeetMedia",
+    /producer[\s\S]*\.getStats\(\)[\s\S]*readOutboundVideoProgressSample\(report\)[\s\S]*hasOutboundVideoProgress/,
+    "web camera sender watchdog monitors outbound RTP frame progress",
+  );
+}
+{
+  const text = source.webMeetMedia;
   const start = text.indexOf("const recoverCameraProducer = async () => {");
   const end = text.indexOf("void recoverCameraProducer();", start);
   if (start < 0 || end < 0) {

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1070,7 +1070,7 @@ assertIncludes(
 {
   const text = source.webAdaptivePublishQuality;
   const start = text.indexOf("const applyLiveProducerProfile = useCallback(");
-  const end = text.indexOf("const switchQuality = useCallback(", start);
+  const end = text.indexOf("const restoreStandardCaptureIfNeeded", start);
   if (start < 0 || end < 0) {
     failures.push("web adaptive live-profile section missing");
   } else if (text.slice(start, end).includes("updateVideoQualityRef.current")) {
@@ -1079,12 +1079,22 @@ assertIncludes(
     );
   }
 }
+assertRegex(
+  "webAdaptivePublishQuality",
+  /const restoreStandardCaptureIfNeeded = useCallback[\s\S]*videoQualityRef\.current !== "standard"[\s\S]*webcamTrack\?\.readyState !== "live"[\s\S]*await updateVideoQualityRef\.current\("standard", "good"\)[\s\S]*lastStandardCaptureRestoreSignatureRef\.current = signature/,
+  "web adaptive good-link restore refreshes standard capture without reopening camera",
+);
+assertRegex(
+  "webAdaptivePublishQuality",
+  /shouldRestoreStableStandardCapture[\s\S]*capRecoveryQuality === "good"[\s\S]*capRecoveryElapsedMs >= GOOD_LIVE_RESTORE_AFTER_MS[\s\S]*currentPublishQuality === "standard"[\s\S]*void restoreStandardCaptureIfNeeded\(\);[\s\S]*applyStableLiveProfile\(\);/,
+  "web adaptive good-link restore is serialized against live profile cap updates",
+);
 {
   const text = source.webAdaptivePublishQuality;
   const start = text.indexOf(
     "autoDowngradedRef.current ||\n          networkManagedVideoQualityRef?.current === true",
   );
-  const end = text.indexOf("applyStableLiveProfile();", start);
+  const end = text.indexOf("if (shouldRestoreStableStandardCapture)", start);
   if (start < 0 || end < 0) {
     failures.push("web adaptive auto-upgrade section missing");
   } else {

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -9,6 +9,9 @@ const files = {
   webCodec: "apps/web/src/app/lib/webcam-codec.ts",
   webNetworkInformation: "apps/web/src/app/lib/network-information.ts",
   webConnectionQuality: "apps/web/src/app/hooks/useConnectionQuality.ts",
+  webParticipantMedia: "apps/web/src/app/lib/participant-media.ts",
+  webSmartParticipantOrder:
+    "apps/web/src/app/hooks/useSmartParticipantOrder.ts",
   webAdaptivePublishQuality:
     "apps/web/src/app/hooks/useAdaptivePublishQuality.ts",
   webAdaptiveConsumerPreferences:
@@ -431,6 +434,16 @@ assertNotIncludes(
   "webAdaptiveConsumerPreferences",
   "priority: 8,\n        paused: true,",
   "web emergency receive adaptation must not silently pause remote webcams",
+);
+assertNotIncludes(
+  "webParticipantMedia",
+  "participant.isCameraOff || participant.isVideoAdaptivelyPaused",
+  "web adaptive receive state must not hide remote webcam streams",
+);
+assertNotIncludes(
+  "webSmartParticipantOrder",
+  "!participant.isVideoAdaptivelyPaused",
+  "web adaptive receive state must not reshuffle remote webcams as video-off",
 );
 assertIncludes(
   "webAdaptiveConsumerPreferences",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -22,6 +22,7 @@ const files = {
   webMeetClient: "apps/web/src/app/meets-client.tsx",
   webMeetMedia: "apps/web/src/app/hooks/useMeetMedia.ts",
   webMeetSocket: "apps/web/src/app/hooks/useMeetSocket.ts",
+  meetingParticipantReducer: "packages/meeting-core/src/participant-reducer.ts",
   webJoinScreen: "apps/web/src/app/components/JoinScreen.tsx",
   webMobileJoinScreen: "apps/web/src/app/components/mobile/MobileJoinScreen.tsx",
   webLowBandwidthProbe: "scripts/probe-low-bandwidth-meet.mjs",
@@ -36,7 +37,9 @@ const files = {
   androidReachability:
     "apps/conclave-skip/Sources/Conclave/Skip/NetworkReachabilityMonitor.kt",
   sfuRoom: "packages/sfu/config/classes/Room.ts",
+  sfuClient: "packages/sfu/config/classes/Client.ts",
   sfuConfig: "packages/sfu/config/config.ts",
+  sfuMediaHandlers: "packages/sfu/server/socket/handlers/mediaHandlers.ts",
   sfuDisconnectHandlers:
     "packages/sfu/server/socket/handlers/disconnectHandlers.ts",
 };
@@ -911,6 +914,11 @@ for (const [context, label] of [
     /producer[\s\S]*\.getStats\(\)[\s\S]*readOutboundVideoProgressSample\(report\)[\s\S]*hasOutboundVideoProgress/,
     "web camera sender watchdog monitors outbound RTP frame progress",
   );
+  assertRegex(
+    "webMeetMedia",
+    /qualityLimitationReason[\s\S]*isEncoderLimitedOutboundSample[\s\S]*qualityLimitationReason === "bandwidth"[\s\S]*qualityLimitationReason === "cpu"[\s\S]*stalledSamples < CAMERA_OUTBOUND_STALL_SAMPLES_BEFORE_RECOVERY \|\|[\s\S]*isEncoderLimitedOutboundSample\(sample\)/,
+    "web camera sender watchdog must not recreate producers for encoder-limited stalls",
+  );
 }
 {
   const text = source.webMeetMedia;
@@ -1376,6 +1384,32 @@ assertRegex(
   /refreshLocalScreenProducerForBandwidthProfile[\s\S]*transport\.produce\([\s\S]*screenShareEncodings\(connectionQuality\)[\s\S]*socket\.closeProducer\(oldProducer\.id\)/,
   "Android screen producer refresh for new bandwidth profile",
 );
+
+assertRegex(
+  "meetingParticipantReducer",
+  /if \(!action\.stream\) \{[\s\S]*currentProducerId[\s\S]*currentProducerId !== action\.producerId[\s\S]*return state;/,
+  "shared participant reducer ignores stale producer close events",
+);
+assertRegex(
+  "webMeetSocket",
+  /announcedRemoteProducersRef[\s\S]*hasReplacementProducer[\s\S]*announcedRemoteProducersRef\.current\.entries\(\)[\s\S]*if \(info\.kind === "video" && info\.type === "webcam"\) \{[\s\S]*if \(!hasReplacementProducer\)[\s\S]*UPDATE_CAMERA_OFF[\s\S]*announcedRemoteProducersRef\.current\.set\(data\.producerId, data\)/,
+  "web producer replacement announcements suppress transient camera-off state",
+);
+assertRegex(
+  "sfuClient",
+  /addProducer\(producer: Producer\): Producer \| null[\s\S]*const displacedProducer =[\s\S]*return displacedProducer;/,
+  "SFU client returns displaced producer instead of closing it inline",
+);
+{
+  const text = source.sfuMediaHandlers;
+  const newProducerIndex = text.indexOf('client.socket.emit("newProducer"');
+  const closeIndex = text.indexOf("displacedProducer.close()", newProducerIndex);
+  if (newProducerIndex < 0 || closeIndex < 0 || closeIndex < newProducerIndex) {
+    failures.push(
+      "SFU producer replacement must advertise the new producer before closing the displaced producer",
+    );
+  }
+}
 
 // Native receive adaptation must keep audio crisp, preserve screen shares, and
 // pause extra webcam video only in emergency mode.

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -416,6 +416,16 @@ assertRegex(
   "web foreground recovery restarts ICE for disconnected transports",
 );
 assertRegex(
+  "webMeetSocket",
+  /const iceRestartPromiseRef = useRef[\s\S]*Promise<boolean> \| null[\s\S]*const existingRestart = iceRestartPromiseRef\.current\[transportKind\];[\s\S]*if \(existingRestart\) return existingRestart;[\s\S]*iceRestartPromiseRef\.current\[transportKind\] = restartPromise;[\s\S]*return restartPromise;/,
+  "web ICE restart recovery waits for in-flight restart result",
+);
+assertNotIncludes(
+  "webMeetSocket",
+  "? Promise.resolve(true)\n              : attemptIceRestart(kind)",
+  "web foreground recovery must not treat in-flight ICE restart as success",
+);
+assertRegex(
   "webMeetClient",
   /const browserPublishRecoveryQuality = selfConnectionStats\.browserNetwork[\s\S]*browserPublishRecoveryQuality === "good"[\s\S]*\? "good"[\s\S]*: selfPublishQuality/,
   "web cap recovery browser hint only restores good profile",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
-import { relative, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const root = resolve(import.meta.dirname, "..");
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 const files = {
   webConstants: "apps/web/src/app/lib/constants.ts",
@@ -343,6 +344,11 @@ assertIncludes(
   "webAdaptiveConsumerPreferences",
   "const fallbackWebcamRanks = new Map<string, number>();",
   "web missing layout hints use deterministic webcam fallback ranks",
+);
+assertRegex(
+  "webAdaptiveConsumerPreferences",
+  /fallbackWebcamRanks[\s\S]*Array\.from\(refs\.consumersRef\.current\.entries\(\)\)[\s\S]*active: info\.userId === activeSpeakerId[\s\S]*left\.userId\.localeCompare\(right\.userId\)[\s\S]*left\.producerId\.localeCompare\(right\.producerId\)[\s\S]*fallbackWebcamRanks\.set\(candidate\.producerId, index\)/,
+  "web missing layout fallback ranks are stable across clients",
 );
 assertRegex(
   "webAdaptiveConsumerPreferences",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1086,8 +1086,8 @@ assertRegex(
 );
 assertRegex(
   "webAdaptivePublishQuality",
-  /shouldRestoreStableStandardCapture[\s\S]*capRecoveryQuality === "good"[\s\S]*capRecoveryElapsedMs >= GOOD_LIVE_RESTORE_AFTER_MS[\s\S]*currentPublishQuality === "standard"[\s\S]*void restoreStandardCaptureIfNeeded\(\);[\s\S]*applyStableLiveProfile\(\);/,
-  "web adaptive good-link restore is serialized against live profile cap updates",
+  /shouldRestoreStableStandardCapture[\s\S]*capRecoveryQuality === "good"[\s\S]*capRecoveryElapsedMs >= GOOD_LIVE_RESTORE_AFTER_MS[\s\S]*currentPublishQuality === "standard"[\s\S]*void restoreStandardCaptureIfNeeded\(\)\.finally\(\(\) => \{[\s\S]*applyLiveProducerProfile\("good"\)[\s\S]*\} else \{[\s\S]*applyStableLiveProfile\(\);/,
+  "web adaptive good-link capture restore also restores good publish profiles",
 );
 {
   const text = source.webAdaptivePublishQuality;

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -498,6 +498,16 @@ assertRegex(
   /publishEmergencyMode: selfPublishEmergencyMode,[\s\S]*receiveEmergencyMode: selfReceiveEmergencyMode,[\s\S]*useAdaptiveConsumerPreferences\(\{[\s\S]*connectionQuality: selfReceiveQuality,[\s\S]*emergencyMode: selfReceiveEmergencyMode,[\s\S]*useAdaptivePublishQuality\(\{[\s\S]*connectionQuality: selfPublishQuality,[\s\S]*emergencyMode: selfPublishEmergencyMode,/,
   "web publish and receive adaptation use direction-specific emergency signals",
 );
+assertNotIncludes(
+  "webAdaptivePublishQuality",
+  'if (connectionQuality === "poor") {\n          void applyLiveProducerProfile(emergencyMode ? "emergency" : "poor");\n        }',
+  "web publish caps must wait for poor-link stability window",
+);
+assertRegex(
+  "webAdaptivePublishQuality",
+  /if \(previous\.quality !== connectionQuality\) \{[\s\S]*qualityWindowRef\.current = \{ quality: connectionQuality, since: now \};[\s\S]*writeDebugSnapshot\(now\);[\s\S]*return;/,
+  "web publish quality changes reset stability window before capping",
+);
 assertRegex(
   "webMeetClient",
   /suppressedProcessedPublishTrackRef[\s\S]*handlePreferredVideoPublishTrackRejected[\s\S]*suppress_processed_publish_track_after_raw_repair[\s\S]*onPreferredVideoPublishTrackRejected:[\s\S]*handlePreferredVideoPublishTrackRejected[\s\S]*processedTrackSuppressed[\s\S]*skip_processed_track_suppressed_after_raw_repair/,

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -345,6 +345,26 @@ assertIncludes(
   "web hidden consumers stay warm unless receive quality is poor",
 );
 assertIncludes(
+  "webAdaptiveConsumerPreferences",
+  "const CONSUMER_PREFERENCE_ACK_TIMEOUT_MS = 3000;",
+  "web consumer preference updates have ACK timeout",
+);
+assertIncludes(
+  "webAdaptiveConsumerPreferences",
+  'markDeferredForRetry("setConsumerPreferences ack timeout")',
+  "web consumer preference ACK timeout retries stale layer updates",
+);
+assertIncludes(
+  "webAdaptiveConsumerPreferences",
+  'markDeferredForRetry(\n                    "setConsumerPreferences priority-only ack timeout",',
+  "web consumer preference fallback ACK timeout retries stale layer updates",
+);
+assertRegex(
+  "webAdaptiveConsumerPreferences",
+  /scheduledPreferenceTimeoutsRef\.current\.add\(ackTimeoutId\);[\s\S]*scheduledPreferenceTimeoutsRef\.current\.delete\(ackTimeoutId\);[\s\S]*window\.clearTimeout\(ackTimeoutId\);/,
+  "web consumer preference ACK timeout is cleared on response",
+);
+assertIncludes(
   "webConstants",
   "export const BACKGROUND_TRANSPORT_DISCONNECT_GRACE_MS = 18000;",
   "web background transport disconnect grace",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1402,8 +1402,8 @@ assertRegex(
 );
 assertRegex(
   "webMeetSocket",
-  /announcedRemoteProducersRef[\s\S]*hasReplacementProducer[\s\S]*announcedRemoteProducersRef\.current\.entries\(\)[\s\S]*if \(info\.kind === "video" && info\.type === "webcam"\) \{[\s\S]*if \(!hasReplacementProducer\)[\s\S]*UPDATE_CAMERA_OFF[\s\S]*announcedRemoteProducersRef\.current\.set\(data\.producerId, data\)/,
-  "web producer replacement announcements suppress transient camera-off state",
+  /announcedRemoteProducersRef[\s\S]*hasReplacementProducer[\s\S]*announcedRemoteProducersRef\.current\.entries\(\)[\s\S]*if \(!hasReplacementProducer\) \{[\s\S]*UPDATE_STREAM[\s\S]*stream: null[\s\S]*if \(info\.kind === "video" && info\.type === "webcam"\) \{[\s\S]*if \(!hasReplacementProducer\)[\s\S]*UPDATE_CAMERA_OFF[\s\S]*announcedRemoteProducersRef\.current\.set\(data\.producerId, data\)/,
+  "web producer replacement announcements suppress transient stream and camera-off clears",
 );
 assertRegex(
   "sfuClient",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -385,6 +385,11 @@ assertIncludes(
   "web background transport disconnect grace",
 );
 assertRegex(
+  "webMeetSocket",
+  /const disconnectedTransportKinds: Array<"producer" \| "consumer"> = \[\];[\s\S]*producerState === "disconnected"[\s\S]*consumerState === "disconnected"[\s\S]*attemptIceRestart\(kind\)[\s\S]*producer sync failed after ICE restart/,
+  "web foreground recovery restarts ICE for disconnected transports",
+);
+assertRegex(
   "webMeetClient",
   /const browserPublishRecoveryQuality = selfConnectionStats\.browserNetwork[\s\S]*browserPublishRecoveryQuality === "good"[\s\S]*\? "good"[\s\S]*: selfPublishQuality/,
   "web cap recovery browser hint only restores good profile",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -442,8 +442,28 @@ assertNotIncludes(
 );
 assertRegex(
   "webMeetClient",
-  /const browserPublishRecoveryQuality = \([\s\S]*selfConnectionStats\.browserNetwork\.quality === "unknown"[\s\S]*selfConnectionStats\.browserNetwork\.startupQuality[\s\S]*const browserAllowsPublishCapRecovery =[\s\S]*browserPublishRecoveryQuality === "good" \|\|[\s\S]*browserPublishRecoveryQuality === "unknown"[\s\S]*browserAllowsPublishCapRecovery && !hasPoorPublishRecoverySignal[\s\S]*\? "good"[\s\S]*: selfPublishQuality/,
+  /const hasPoorPublishRecoverySignal =[\s\S]*selfConnectionStats\.publishRttMs[\s\S]*selfConnectionStats\.publishPacketLoss[\s\S]*selfConnectionStats\.publishJitterMs[\s\S]*const browserPublishRecoveryQuality = \([\s\S]*selfConnectionStats\.browserNetwork\.quality === "unknown"[\s\S]*selfConnectionStats\.browserNetwork\.startupQuality[\s\S]*const browserAllowsPublishCapRecovery =[\s\S]*browserPublishRecoveryQuality === "good" \|\|[\s\S]*browserPublishRecoveryQuality === "unknown"[\s\S]*browserAllowsPublishCapRecovery && !hasPoorPublishRecoverySignal[\s\S]*\? "good"[\s\S]*: selfPublishQuality/,
   "web cap recovery restores good profile when browser hint is good or unknown",
+);
+assertRegex(
+  "webConnectionQuality",
+  /publishRttMs: number \| null;[\s\S]*publishPacketLoss: number \| null;[\s\S]*publishJitterMs: number \| null;[\s\S]*receiveRttMs: number \| null;[\s\S]*receivePacketLoss: number \| null;[\s\S]*receiveJitterMs: number \| null;/,
+  "web connection quality exposes directional transport impairment signals",
+);
+assertNotIncludes(
+  "webMeetClient",
+  "selfConnectionStats.rttMs >= PUBLISH_RECOVERY_RTT_POOR_MS",
+  "web publish cap recovery must not use combined RTT",
+);
+assertNotIncludes(
+  "webMeetClient",
+  "selfConnectionStats.packetLoss >= PUBLISH_RECOVERY_LOSS_POOR",
+  "web publish cap recovery must not use combined packet loss",
+);
+assertNotIncludes(
+  "webMeetClient",
+  "selfConnectionStats.jitterMs >= PUBLISH_RECOVERY_JITTER_POOR_MS",
+  "web publish cap recovery must not use combined jitter",
 );
 assertNotIncludes(
   "webMeetClient",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -435,7 +435,7 @@ assertRegex(
 );
 assertRegex(
   "webMeetSocket",
-  /const iceRestartPromiseRef = useRef[\s\S]*Promise<boolean> \| null[\s\S]*const existingRestart = iceRestartPromiseRef\.current\[transportKind\];[\s\S]*if \(existingRestart\) return existingRestart;[\s\S]*iceRestartPromiseRef\.current\[transportKind\] = restartPromise;[\s\S]*return restartPromise;/,
+  /RESTART_ICE_ACK_TIMEOUT_MS[\s\S]*const iceRestartPromiseRef = useRef[\s\S]*Promise<boolean> \| null[\s\S]*const existingRestart = iceRestartPromiseRef\.current\[transportKind\];[\s\S]*if \(existingRestart\) return existingRestart;[\s\S]*window\.setTimeout\([\s\S]*restartIce acknowledgement timeout[\s\S]*socket\.emit\([\s\S]*"restartIce"[\s\S]*window\.clearTimeout\(timeoutId\)[\s\S]*iceRestartPromiseRef\.current\[transportKind\] = restartPromise;[\s\S]*return restartPromise;/,
   "web ICE restart recovery waits for in-flight restart result",
 );
 assertNotIncludes(
@@ -477,6 +477,11 @@ assertRegex(
   "webMeetClient",
   /publishEmergencyMode: selfPublishEmergencyMode,[\s\S]*receiveEmergencyMode: selfReceiveEmergencyMode,[\s\S]*useAdaptiveConsumerPreferences\(\{[\s\S]*connectionQuality: selfReceiveQuality,[\s\S]*emergencyMode: selfReceiveEmergencyMode,[\s\S]*useAdaptivePublishQuality\(\{[\s\S]*connectionQuality: selfPublishQuality,[\s\S]*emergencyMode: selfPublishEmergencyMode,/,
   "web publish and receive adaptation use direction-specific emergency signals",
+);
+assertRegex(
+  "webMeetClient",
+  /suppressedProcessedPublishTrackRef[\s\S]*handlePreferredVideoPublishTrackRejected[\s\S]*suppress_processed_publish_track_after_raw_repair[\s\S]*onPreferredVideoPublishTrackRejected:[\s\S]*handlePreferredVideoPublishTrackRejected[\s\S]*processedTrackSuppressed[\s\S]*skip_processed_track_suppressed_after_raw_repair/,
+  "web processed publish track stays suppressed after raw repair until fresh output",
 );
 assertNotIncludes(
   "webMeetClient",
@@ -918,6 +923,11 @@ for (const [context, label] of [
     "webMeetMedia",
     /qualityLimitationReason[\s\S]*isEncoderLimitedOutboundSample[\s\S]*qualityLimitationReason === "bandwidth"[\s\S]*qualityLimitationReason === "cpu"[\s\S]*stalledSamples < CAMERA_OUTBOUND_STALL_SAMPLES_BEFORE_RECOVERY \|\|[\s\S]*isEncoderLimitedOutboundSample\(sample\)/,
     "web camera sender watchdog must not recreate producers for encoder-limited stalls",
+  );
+  assertRegex(
+    "webMeetMedia",
+    /onPreferredVideoPublishTrackRejected[\s\S]*producer\.replaceTrack\(\{ track: rawCameraTrack \}\);[\s\S]*onPreferredVideoPublishTrackRejected\?\.[\s\S]*camera-outbound-stall-raw-repair/,
+    "web raw camera repair suppresses the rejected processed publish track",
   );
 }
 {

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -450,6 +450,16 @@ assertNotIncludes(
   "? (selfConnectionStats.browserNetwork.quality as ConnectionQuality)",
   "web raw browser quality must not hold live publish caps down",
 );
+assertRegex(
+  "webMeetClient",
+  /publishEmergencyMode: selfPublishEmergencyMode,[\s\S]*receiveEmergencyMode: selfReceiveEmergencyMode,[\s\S]*useAdaptiveConsumerPreferences\(\{[\s\S]*connectionQuality: selfReceiveQuality,[\s\S]*emergencyMode: selfReceiveEmergencyMode,[\s\S]*useAdaptivePublishQuality\(\{[\s\S]*connectionQuality: selfPublishQuality,[\s\S]*emergencyMode: selfPublishEmergencyMode,/,
+  "web publish and receive adaptation use direction-specific emergency signals",
+);
+assertNotIncludes(
+  "webMeetClient",
+  "const selfEmergencyNetworkMode = selfConnectionStats.emergencyMode;",
+  "web publish/receive adaptation must not share combined emergency mode",
+);
 assertNotIncludes(
   "webMeetMedia",
   "shouldReopenVideoTrackForQuality",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -410,6 +410,21 @@ assertIncludes(
   "export const BACKGROUND_TRANSPORT_DISCONNECT_GRACE_MS = 18000;",
   "web background transport disconnect grace",
 );
+assertIncludes(
+  "webMeetSocket",
+  "const shouldDeferTransportRecoveryUntilVisible = (): boolean =>",
+  "web hidden-tab transport recovery visibility gate",
+);
+assertRegex(
+  "webMeetSocket",
+  /transport\.connectionState === "disconnected"[\s\S]*shouldDeferTransportRecoveryUntilVisible\(\)[\s\S]*Producer transport recovery deferred until foreground[\s\S]*attemptIceRestart\("producer"\)/,
+  "web hidden producer disconnect does not force background reconnect",
+);
+assertRegex(
+  "webMeetSocket",
+  /transport\.connectionState === "disconnected"[\s\S]*shouldDeferTransportRecoveryUntilVisible\(\)[\s\S]*Consumer transport recovery deferred until foreground[\s\S]*attemptIceRestart\("consumer"\)/,
+  "web hidden consumer disconnect does not force background reconnect",
+);
 assertRegex(
   "webMeetSocket",
   /const disconnectedTransportKinds: Array<"producer" \| "consumer"> = \[\];[\s\S]*producerState === "disconnected"[\s\S]*consumerState === "disconnected"[\s\S]*attemptIceRestart\(kind\)[\s\S]*producer sync failed after ICE restart/,
@@ -1218,7 +1233,7 @@ assertIncludes(
 );
 assertRegex(
   "webMeetClient",
-  /const shouldRunVideoEffects =\s*activeVideoEffectsCount > 0 &&\s*isDocumentVisible &&\s*!shouldSuppressVideoEffectsForBandwidth;/,
+  /const shouldRunVisualVideoEffects =\s*activeVideoEffectsCount > 0 &&\s*isDocumentVisible &&\s*!shouldSuppressVideoEffectsForBandwidth;[\s\S]*const shouldRunVideoEffects = shouldRunVisualVideoEffects;[\s\S]*const shouldPublishProcessedVideo = shouldRunVisualVideoEffects;/,
   "web meet-shell effects only run when active, visible, and not constrained",
 );
 assertRegex(
@@ -1228,7 +1243,7 @@ assertRegex(
 );
 assertIncludes(
   "webMeetClient",
-  "const shouldPublishProcessedVideo = shouldRunVideoEffects;",
+  "const shouldPublishProcessedVideo = shouldRunVisualVideoEffects;",
   "web hidden tabs publish raw camera while effects pipeline is suspended",
 );
 assertRegex(

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -121,6 +121,26 @@ assertNotIncludes(
   'PREFERRED_WEBCAM_CODEC_MIME_TYPES = ["video/VP8"]',
   "web must not globally force VP8 webcam codec",
 );
+assertIncludes(
+  "webCodec",
+  "const shouldUseWebcamSimulcast =",
+  "web webcam simulcast decision is codec/browser-aware",
+);
+assertRegex(
+  "webCodec",
+  /if \(!preferredCodec \|\| isPreferredVideoCodec\(preferredCodec, "video\/H264"\)\)[\s\S]*return false;/,
+  "web hardware-sensitive H264 webcam publish starts single-layer",
+);
+assertRegex(
+  "webCodec",
+  /if \(shouldUseWebcamSimulcast\(preferredCodec\)\) \{[\s\S]*buildOptions\(buildWebcamSimulcastEncodings\(quality\)\)[\s\S]*\}[\s\S]*buildOptions\(\[buildWebcamSingleLayerEncoding\(quality\)\]\)/,
+  "web simulcast-friendly webcam publish keeps single-layer fallback",
+);
+assertRegex(
+  "webCodec",
+  /networkProfile !== "good" && hasMultipleSpatialLayers\(producer\)/,
+  "web initial webcam spatial-layer cap only runs on multi-layer producers",
+);
 
 // Webcam publish must keep poor distinct from emergency: poor preserves more
 // motion/detail, while emergency is the survival floor.

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -130,6 +130,11 @@ assertIncludes(
   "export const shouldUseWebcamSimulcast =",
   "web webcam simulcast decision is codec/browser-aware",
 );
+assertIncludes(
+  "webCodec",
+  "export const getFallbackWebcamCodec =",
+  "web webcam stalled-sender codec fallback",
+);
 assertRegex(
   "webCodec",
   /if \(!preferredCodec \|\| isPreferredVideoCodec\(preferredCodec, "video\/H264"\)\)[\s\S]*return false;/,
@@ -137,7 +142,7 @@ assertRegex(
 );
 assertRegex(
   "webCodec",
-  /if \(shouldUseWebcamSimulcast\(preferredCodec\)\) \{[\s\S]*buildOptions\(buildWebcamSimulcastEncodings\(quality\)\)[\s\S]*\}[\s\S]*buildOptions\(\[buildWebcamSingleLayerEncoding\(quality\)\]\)/,
+  /forceSingleLayer\?: boolean[\s\S]*if \(!forceSingleLayer && shouldUseWebcamSimulcast\(preferredCodec\)\) \{[\s\S]*buildOptions\(buildWebcamSimulcastEncodings\(quality\)\)[\s\S]*\}[\s\S]*buildOptions\(\[buildWebcamSingleLayerEncoding\(quality\)\]\)/,
   "web simulcast-friendly webcam publish keeps single-layer fallback",
 );
 assertRegex(
@@ -887,10 +892,12 @@ for (const [context, label] of [
     if (
       !section.includes("producer.replaceTrack({ track: rawCameraTrack });") ||
       !section.includes("closeLocalVideoProducerForReplacement(producer);") ||
-      !section.includes("requestCameraProducerRecovery();")
+      !section.includes("requestCameraProducerRecovery();") ||
+      !section.includes("cameraRecoveryForceSingleLayerRef.current = true") ||
+      !section.includes("getFallbackWebcamCodec(device, currentCodec)")
     ) {
       failures.push(
-        "web stalled camera sender recovery must repair with raw camera before recreating the producer",
+        "web stalled camera sender recovery must repair with raw camera and then recreate with single-layer codec fallback",
       );
     }
     const rawRepairIndex = section.indexOf(
@@ -929,6 +936,11 @@ for (const [context, label] of [
     /onPreferredVideoPublishTrackRejected[\s\S]*producer\.replaceTrack\(\{ track: rawCameraTrack \}\);[\s\S]*onPreferredVideoPublishTrackRejected\?\.[\s\S]*camera-outbound-stall-raw-repair/,
     "web raw camera repair suppresses the rejected processed publish track",
   );
+  assertRegex(
+    "webMeetMedia",
+    /Processed \$\{context\} camera publish failed; retrying raw camera:[\s\S]*onPreferredVideoPublishTrackRejected\?\.[\s\S]*\`\$\{context\}-raw-produce-fallback\`/,
+    "web raw camera produce fallback suppresses the rejected processed publish track",
+  );
 }
 {
   const text = source.webMeetMedia;
@@ -943,6 +955,15 @@ for (const [context, label] of [
     }
     if (!section.includes("await ensureProducerTransportRef?.current?.()")) {
       failures.push("web camera producer recovery must rebuild failed transports");
+    }
+    if (
+      !section.includes("cameraRecoveryCodecOverrideRef.current ??") ||
+      !section.includes("forceSingleLayer,") ||
+      !section.includes("cameraRecoveryForceSingleLayerRef.current = false")
+    ) {
+      failures.push(
+        "web camera producer recovery must consume and clear single-layer codec fallback",
+      );
     }
     const transportSectionEnd = section.indexOf("let videoTrack");
     const transportSection =

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -124,7 +124,7 @@ assertNotIncludes(
 );
 assertIncludes(
   "webCodec",
-  "const shouldUseWebcamSimulcast =",
+  "export const shouldUseWebcamSimulcast =",
   "web webcam simulcast decision is codec/browser-aware",
 );
 assertRegex(
@@ -573,6 +573,14 @@ for (const [context, label] of [
     if (!section.includes("await ensureProducerTransportRef?.current?.()")) {
       failures.push(
         "web video-quality producer recreation must rebuild failed transports",
+      );
+    }
+    if (
+      !section.includes("shouldUseWebcamSimulcast(preferredWebcamCodec)") ||
+      !section.includes("const needsStandardSimulcastRecreate =")
+    ) {
+      failures.push(
+        "web video-quality producer recreation must skip intentional mobile/H264 single-layer webcam producers",
       );
     }
   }


### PR DESCRIPTION
## Summary
- preserve camera-on intent after publish failures and retry raw camera publishing when processed camera tracks fail
- serialize processed/raw camera publish track switches so visibility/effects/local-stream changes cannot race and leave stale camera tracks published
- retry stalled adaptive consumer preference updates and use stable fallback webcam ranking while layout hints are unavailable
- avoid mobile/Safari/Android H264 webcam simulcast stalls by starting hardware-sensitive webcam publishing as a single robust layer while keeping desktop VP8 simulcast
- keep intentional mobile/H264 single-layer webcam producers stable during standard-quality recovery instead of recreating them for simulcast
- restart ICE for disconnected transports during foreground/online recovery and wait for in-flight restart results before syncing producers or falling back to reconnect
- keep low-bandwidth regression guards current, including Node 20-compatible guard-script path resolution

## Impacted surfaces
- apps/web
- scripts/check-low-bandwidth-profiles.mjs

## Validation
- node scripts/check-low-bandwidth-profiles.mjs
- pnpm -C apps/web exec tsc --noEmit
- pnpm -C apps/web run lint
- git diff --check

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR addresses several low-bandwidth stability issues in the WebRTC meeting layer: camera outbound stall detection with raw-track repair and codec fallback, serialized publish-track switches with a sequence counter, ICE restart deduplication with ACK timeout, consumer preference retry on timeout, stable fallback webcam ranking, suppression of processed-track publishing after a raw-repair, and meet volume control plumbing.

- **Camera stall watchdog** (`useMeetMedia.ts`): polls `RTCStatsReport` every 2 s; after 3 stalled samples swaps in the raw camera track, and on a second stall recreates the producer with a fallback codec + `forceSingleLayer`, bypassing simulcast on mobile/H264.
- **ICE restart hardening** (`useMeetSocket.ts`): deduplicates in-flight restarts via `iceRestartPromiseRef`, adds a 5 s ACK timeout, defers transport recovery when the document is hidden, and performs ICE restart before producer sync during foreground/online recovery.
- **Producer-replacement continuity**: `announcedRemoteProducersRef` tracks announcements before consumption, the participant reducer guards against clearing a stream owned by a newer producer, and the SFU defers closing the displaced producer until after the new one is indexed.

<h3>Confidence Score: 3/5</h3>

The changes are sound in the common case but the camera recovery path leaves codec/single-layer overrides set when produce fails, meaning a later unrelated recovery can permanently suppress desktop VP8 simulcast.

The recovery effect clears cameraRecoveryCodecOverrideRef and cameraRecoveryForceSingleLayerRef only on the success path; any produce failure leaves both refs set for the lifetime of the session. A subsequent stall or normal camera toggle recovery will re-use the stale single-layer fallback codec, preventing simulcast from returning on desktop.

apps/web/src/app/hooks/useMeetMedia.ts — camera recovery catch path; apps/web/src/app/hooks/useMeetSocket.ts — announcedRemoteProducersRef lifetime on consume failure

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/hooks/useMeetMedia.ts | Adds camera outbound stall watchdog, produceCameraTrackWithRawFallback helper, and meet volume wiring. Complex state coordination between repair/recovery in-flight refs and the new stall state ref. |
| apps/web/src/app/hooks/useMeetSocket.ts | ICE restart deduplication via promise cache, ACK timeout, deferred recovery when hidden, ICE-before-sync in foreground/online recovery, announcedRemoteProducersRef for replacement tracking. |
| apps/web/src/app/meets-client.tsx | Serializes publish-track switches with sequence counter, suppresses processed-track publishing after raw repair, removes isDocumentVisible from shouldPublishProcessedVideo, adds MeetVolumeProvider. |
| apps/web/src/app/lib/webcam-codec.ts | Adds shouldUseWebcamSimulcast, getFallbackWebcamCodec, and forceSingleLayer param. Guards spatial-layer cap to multi-layer producers only. |
| apps/web/src/app/hooks/useAdaptivePublishQuality.ts | Adds restoreStandardCaptureIfNeeded, removes immediate poor-quality profile application, wires capRecoveryQuality through publish/receive stat separation. |
| apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts | Adds ACK timeout for setConsumerPreferences, stable fallback ranking by userId+producerId, unpauses emergency-keep-video consumers. |
| packages/meeting-core/src/participant-reducer.ts | Guards UPDATE_STREAM(null) to only clear state when the stored producerId matches the closing producer. |
| packages/sfu/config/classes/Client.ts | addProducer returns the displaced producer instead of immediately closing it, deferring close to mediaHandlers. |
| packages/sfu/server/redisErrors.ts | Extends transient error detection with stack-trace heuristics for Redis connection errors. |
| scripts/check-low-bandwidth-profiles.mjs | Fixes Node 20 compatibility, adds assertions for new simulcast-aware webcam functions and mobile participant video playback recovery. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant WD as Stall Watchdog
    participant MM as useMeetMedia
    participant MS as useMeetSocket
    participant SFU as SFU Server
    participant PR as participant-reducer

    WD->>WD: poll RTCStats every 2s
    WD->>WD: "stalledSamples >= 3"
    alt raw track not yet tried
        WD->>MM: replaceTrack(rawCameraTrack)
        MM->>MM: suppress processed track publishing
    else second stall
        WD->>MM: closeLocalVideoProducerForReplacement
        WD->>MM: set cameraRecoveryCodecOverrideRef
        MM->>SFU: produce(singleLayer, fallbackCodec)
        MM->>MM: clear overrides on success
    end

    Note over MS: Foreground Recovery
    MS->>MS: check transport states
    alt transport disconnected
        MS->>SFU: restartIce with 5s timeout
        SFU-->>MS: iceParameters
        MS->>MS: syncProducers
    else failed
        MS->>MS: handleReconnect
    end

    Note over MS,PR: Producer Replacement
    SFU->>MS: newProducer
    MS->>MS: announcedRemoteProducersRef.set
    MS->>MS: consumeProducer
    SFU->>MS: producerClosed
    MS->>MS: hasReplacementProducer check
    alt replacement found
        MS->>MS: skip clear UI state
    else no replacement
        MS->>PR: UPDATE_STREAM null
        PR->>PR: guard by producerId match
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant WD as Stall Watchdog
    participant MM as useMeetMedia
    participant MS as useMeetSocket
    participant SFU as SFU Server
    participant PR as participant-reducer

    WD->>WD: poll RTCStats every 2s
    WD->>WD: "stalledSamples >= 3"
    alt raw track not yet tried
        WD->>MM: replaceTrack(rawCameraTrack)
        MM->>MM: suppress processed track publishing
    else second stall
        WD->>MM: closeLocalVideoProducerForReplacement
        WD->>MM: set cameraRecoveryCodecOverrideRef
        MM->>SFU: produce(singleLayer, fallbackCodec)
        MM->>MM: clear overrides on success
    end

    Note over MS: Foreground Recovery
    MS->>MS: check transport states
    alt transport disconnected
        MS->>SFU: restartIce with 5s timeout
        SFU-->>MS: iceParameters
        MS->>MS: syncProducers
    else failed
        MS->>MS: handleReconnect
    end

    Note over MS,PR: Producer Replacement
    SFU->>MS: newProducer
    MS->>MS: announcedRemoteProducersRef.set
    MS->>MS: consumeProducer
    SFU->>MS: producerClosed
    MS->>MS: hasReplacementProducer check
    alt replacement found
        MS->>MS: skip clear UI state
    else no replacement
        MS->>PR: UPDATE_STREAM null
        PR->>PR: guard by producerId match
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/web/src/app/meets-client.tsx`, line 1665-1674 ([link](https://github.com/acm-vit/conclave/blob/fefde233d3f4f6c890ca41f8b8565d82576bb245/apps/web/src/app/meets-client.tsx#L1665-L1674)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Queued switch survives**

   This early return does not invalidate a publish-track switch that was already queued behind a previous `replaceTrack()`. If the camera is turned off or the meeting leaves while an earlier switch is still running, the queued `runSwitch()` can resume later with its old sequence still valid; its fallback path can then publish a raw or processed track after the UI intent changed, leaving a stale camera track published. Please bump the switch sequence, or otherwise cancel pending switches, whenever this effect decides not to publish.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused queued switch survival harness](https://app.greptile.com/trex/artifacts/3538a3a6-fd60-4088-bb99-544770010da3)**

   - Contains supporting evidence from the run (text/javascript; charset=utf-8).

   **[Repro: verbose harness output showing stale replaceTrack after camera off](https://app.greptile.com/trex/artifacts/676bea4b-1404-4d1a-9a28-fc874b543531)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11730182/artifacts?artifact=3538a3a6-fd60-4088-bb99-544770010da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fmeets-client.tsx%0ALine%3A%201665-1674%0A%0AComment%3A%0A**Queued%20switch%20survives**%0A%0AThis%20early%20return%20does%20not%20invalidate%20a%20publish-track%20switch%20that%20was%20already%20queued%20behind%20a%20previous%20%60replaceTrack%28%29%60.%20If%20the%20camera%20is%20turned%20off%20or%20the%20meeting%20leaves%20while%20an%20earlier%20switch%20is%20still%20running%2C%20the%20queued%20%60runSwitch%28%29%60%20can%20resume%20later%20with%20its%20old%20sequence%20still%20valid%3B%20its%20fallback%20path%20can%20then%20publish%20a%20raw%20or%20processed%20track%20after%20the%20UI%20intent%20changed%2C%20leaving%20a%20stale%20camera%20track%20published.%20Please%20bump%20the%20switch%20sequence%2C%20or%20otherwise%20cancel%20pending%20switches%2C%20whenever%20this%20effect%20decides%20not%20to%20publish.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=90&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fmeets-client.tsx%0ALine%3A%201665-1674%0A%0AComment%3A%0A**Queued%20switch%20survives**%0A%0AThis%20early%20return%20does%20not%20invalidate%20a%20publish-track%20switch%20that%20was%20already%20queued%20behind%20a%20previous%20%60replaceTrack%28%29%60.%20If%20the%20camera%20is%20turned%20off%20or%20the%20meeting%20leaves%20while%20an%20earlier%20switch%20is%20still%20running%2C%20the%20queued%20%60runSwitch%28%29%60%20can%20resume%20later%20with%20its%20old%20sequence%20still%20valid%3B%20its%20fallback%20path%20can%20then%20publish%20a%20raw%20or%20processed%20track%20after%20the%20UI%20intent%20changed%2C%20leaving%20a%20stale%20camera%20track%20published.%20Please%20bump%20the%20switch%20sequence%2C%20or%20otherwise%20cancel%20pending%20switches%2C%20whenever%20this%20effect%20decides%20not%20to%20publish.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=90&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fmeets-client.tsx%0ALine%3A%201665-1674%0A%0AComment%3A%0A**Queued%20switch%20survives**%0A%0AThis%20early%20return%20does%20not%20invalidate%20a%20publish-track%20switch%20that%20was%20already%20queued%20behind%20a%20previous%20%60replaceTrack%28%29%60.%20If%20the%20camera%20is%20turned%20off%20or%20the%20meeting%20leaves%20while%20an%20earlier%20switch%20is%20still%20running%2C%20the%20queued%20%60runSwitch%28%29%60%20can%20resume%20later%20with%20its%20old%20sequence%20still%20valid%3B%20its%20fallback%20path%20can%20then%20publish%20a%20raw%20or%20processed%20track%20after%20the%20UI%20intent%20changed%2C%20leaving%20a%20stale%20camera%20track%20published.%20Please%20bump%20the%20switch%20sequence%2C%20or%20otherwise%20cancel%20pending%20switches%2C%20whenever%20this%20effect%20decides%20not%20to%20publish.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=90&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Processed/raw camera publish switches can still leave stale webcam producers published**

   - **Bug**
     - The head run preserves camera intent and falls back to the raw track after a processed publish failure, but it does not serialize rapid processed/raw publish switching. In the after artifact, once both switch requests drain, three webcam producers remain open: raw-1 from the fallback publish, raw-2 from the later raw switch, and processed-2 from the racing processed switch. The contract expected one final published webcam producer/track after the switch queue drains.
   - **Cause**
     - The changed camera recovery/repair path still performs producer track replacement/publishing directly (for example the raw repair replacement at apps/web/src/app/hooks/useMeetMedia.ts:2032) and no camera producer switch queue/serialization primitive is present in the head file. Concurrent switch operations can therefore observe stale current-producer state and fail to close superseded producers in order.
   - **Fix**
     - Route every processed/raw webcam producer publish or replace operation through a single serialized queue/mutex keyed to the webcam producer. Each queued operation should re-read the current producer after awaiting, close any superseded producer exactly once, and only expose the last completed request as videoProducerRef.current.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fcheck-low-bandwidth-profiles.mjs%3A1-3%0A**Commit%20message%20missing%20conventional%20prefix**%0A%0AThe%20commit%20%600dddddd%20add%20meet%20volume%60%20doesn't%20follow%20the%20%60type%3A%20description%60%20convention%20used%20by%20every%20other%20commit%20in%20this%20branch%20%28e.g.%20%60fix%3A%20keep%20camera%20intent%20on%20publish%20fallback%60%29.%20Inconsistent%20messages%20make%20the%20git%20log%20harder%20to%20scan%20and%20prevent%20changelog%20generation%20tools%20from%20picking%20up%20the%20change.%20Consider%20amending%20it%20to%20something%20like%20%60feat%3A%20add%20meet%20volume%20control%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A2352-2356%0A**Stall%20recovery%20on%20failure%20doesn't%20clear%20overrides**%0A%0AWhen%20%60produceCameraTrackWithRawFallback%60%20throws%20in%20the%20recovery%20effect%2C%20the%20%60catch%60%20path%20logs%20the%20error%20and%20%28conditionally%29%20requests%20another%20recovery%2C%20but%20%60cameraRecoveryCodecOverrideRef%60%20and%20%60cameraRecoveryForceSingleLayerRef%60%20are%20never%20cleared.%20The%20next%20unrelated%20recovery%20will%20pick%20up%20the%20leftover%20single-layer%20%2B%20fallback-codec%20override%20and%20keep%20the%20producer%20in%20degraded%20single-layer%20mode%20indefinitely%2C%20even%20on%20a%20desktop%20VP8%20session%20where%20simulcast%20should%20come%20back.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20cameraRecoveryCodecOverrideRef.current%20%3D%20null%3B%0A%20%20%20%20%20%20%20%20cameraRecoveryForceSingleLayerRef.current%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20setIsCameraOff%28false%29%3B%0A%20%20%20%20%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20%20%20%20%20cameraRecoveryCodecOverrideRef.current%20%3D%20null%3B%0A%20%20%20%20%20%20%20%20cameraRecoveryForceSingleLayerRef.current%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20console.error%28%22%5BMeets%5D%20Camera%20producer%20recovery%20failed%3A%22%2C%20err%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%3A1566-1572%0A**%60inFlight%60%20guard%20is%20now%20unreachable%20dead%20code**%0A%0A%60iceRestartPromiseRef.current%5BtransportKind%5D%60%20is%20only%20ever%20set%20while%20%60inFlight%5BtransportKind%5D%60%20is%20%60true%60%2C%20and%20both%20are%20cleared%20together%20in%20the%20same%20%60finally%60%20block.%20Because%20the%20function%20returns%20early%20whenever%20the%20promise%20cache%20is%20non-null%2C%20%60inFlight%5BtransportKind%5D%60%20will%20always%20be%20%60false%60%20by%20the%20time%20the%20%60if%20%28inFlight%5BtransportKind%5D%29%20return%20false%60%20check%20is%20reached.%20The%20guard%20can%20be%20removed%20to%20avoid%20future%20readers%20wondering%20what%20two-step%20entry%20protection%20is%20protecting%20against.%0A%0A&repo=acm-vit%2Fconclave&pr=90&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fcheck-low-bandwidth-profiles.mjs%3A1-3%0A**Commit%20message%20missing%20conventional%20prefix**%0A%0AThe%20commit%20%600dddddd%20add%20meet%20volume%60%20doesn't%20follow%20the%20%60type%3A%20description%60%20convention%20used%20by%20every%20other%20commit%20in%20this%20branch%20%28e.g.%20%60fix%3A%20keep%20camera%20intent%20on%20publish%20fallback%60%29.%20Inconsistent%20messages%20make%20the%20git%20log%20harder%20to%20scan%20and%20prevent%20changelog%20generation%20tools%20from%20picking%20up%20the%20change.%20Consider%20amending%20it%20to%20something%20like%20%60feat%3A%20add%20meet%20volume%20control%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A2352-2356%0A**Stall%20recovery%20on%20failure%20doesn't%20clear%20overrides**%0A%0AWhen%20%60produceCameraTrackWithRawFallback%60%20throws%20in%20the%20recovery%20effect%2C%20the%20%60catch%60%20path%20logs%20the%20error%20and%20%28conditionally%29%20requests%20another%20recovery%2C%20but%20%60cameraRecoveryCodecOverrideRef%60%20and%20%60cameraRecoveryForceSingleLayerRef%60%20are%20never%20cleared.%20The%20next%20unrelated%20recovery%20will%20pick%20up%20the%20leftover%20single-layer%20%2B%20fallback-codec%20override%20and%20keep%20the%20producer%20in%20degraded%20single-layer%20mode%20indefinitely%2C%20even%20on%20a%20desktop%20VP8%20session%20where%20simulcast%20should%20come%20back.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20cameraRecoveryCodecOverrideRef.current%20%3D%20null%3B%0A%20%20%20%20%20%20%20%20cameraRecoveryForceSingleLayerRef.current%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20setIsCameraOff%28false%29%3B%0A%20%20%20%20%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20%20%20%20%20cameraRecoveryCodecOverrideRef.current%20%3D%20null%3B%0A%20%20%20%20%20%20%20%20cameraRecoveryForceSingleLayerRef.current%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20console.error%28%22%5BMeets%5D%20Camera%20producer%20recovery%20failed%3A%22%2C%20err%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%3A1566-1572%0A**%60inFlight%60%20guard%20is%20now%20unreachable%20dead%20code**%0A%0A%60iceRestartPromiseRef.current%5BtransportKind%5D%60%20is%20only%20ever%20set%20while%20%60inFlight%5BtransportKind%5D%60%20is%20%60true%60%2C%20and%20both%20are%20cleared%20together%20in%20the%20same%20%60finally%60%20block.%20Because%20the%20function%20returns%20early%20whenever%20the%20promise%20cache%20is%20non-null%2C%20%60inFlight%5BtransportKind%5D%60%20will%20always%20be%20%60false%60%20by%20the%20time%20the%20%60if%20%28inFlight%5BtransportKind%5D%29%20return%20false%60%20check%20is%20reached.%20The%20guard%20can%20be%20removed%20to%20avoid%20future%20readers%20wondering%20what%20two-step%20entry%20protection%20is%20protecting%20against.%0A%0A&repo=acm-vit%2Fconclave&pr=90&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fcheck-low-bandwidth-profiles.mjs%3A1-3%0A**Commit%20message%20missing%20conventional%20prefix**%0A%0AThe%20commit%20%600dddddd%20add%20meet%20volume%60%20doesn't%20follow%20the%20%60type%3A%20description%60%20convention%20used%20by%20every%20other%20commit%20in%20this%20branch%20%28e.g.%20%60fix%3A%20keep%20camera%20intent%20on%20publish%20fallback%60%29.%20Inconsistent%20messages%20make%20the%20git%20log%20harder%20to%20scan%20and%20prevent%20changelog%20generation%20tools%20from%20picking%20up%20the%20change.%20Consider%20amending%20it%20to%20something%20like%20%60feat%3A%20add%20meet%20volume%20control%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A2352-2356%0A**Stall%20recovery%20on%20failure%20doesn't%20clear%20overrides**%0A%0AWhen%20%60produceCameraTrackWithRawFallback%60%20throws%20in%20the%20recovery%20effect%2C%20the%20%60catch%60%20path%20logs%20the%20error%20and%20%28conditionally%29%20requests%20another%20recovery%2C%20but%20%60cameraRecoveryCodecOverrideRef%60%20and%20%60cameraRecoveryForceSingleLayerRef%60%20are%20never%20cleared.%20The%20next%20unrelated%20recovery%20will%20pick%20up%20the%20leftover%20single-layer%20%2B%20fallback-codec%20override%20and%20keep%20the%20producer%20in%20degraded%20single-layer%20mode%20indefinitely%2C%20even%20on%20a%20desktop%20VP8%20session%20where%20simulcast%20should%20come%20back.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20cameraRecoveryCodecOverrideRef.current%20%3D%20null%3B%0A%20%20%20%20%20%20%20%20cameraRecoveryForceSingleLayerRef.current%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20setIsCameraOff%28false%29%3B%0A%20%20%20%20%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20%20%20%20%20cameraRecoveryCodecOverrideRef.current%20%3D%20null%3B%0A%20%20%20%20%20%20%20%20cameraRecoveryForceSingleLayerRef.current%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20console.error%28%22%5BMeets%5D%20Camera%20producer%20recovery%20failed%3A%22%2C%20err%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%3A1566-1572%0A**%60inFlight%60%20guard%20is%20now%20unreachable%20dead%20code**%0A%0A%60iceRestartPromiseRef.current%5BtransportKind%5D%60%20is%20only%20ever%20set%20while%20%60inFlight%5BtransportKind%5D%60%20is%20%60true%60%2C%20and%20both%20are%20cleared%20together%20in%20the%20same%20%60finally%60%20block.%20Because%20the%20function%20returns%20early%20whenever%20the%20promise%20cache%20is%20non-null%2C%20%60inFlight%5BtransportKind%5D%60%20will%20always%20be%20%60false%60%20by%20the%20time%20the%20%60if%20%28inFlight%5BtransportKind%5D%29%20return%20false%60%20check%20is%20reached.%20The%20guard%20can%20be%20removed%20to%20avoid%20future%20readers%20wondering%20what%20two-step%20entry%20protection%20is%20protecting%20against.%0A%0A&pr=90&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["add meet volume"](https://github.com/acm-vit/conclave/commit/0dddddd1c3c090b320c1901d5cf25ced6ad689f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38818147)</sub>

**Context used:**

- Context used - Encourage people to write better commit messages ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->