### PR TITLE
fix: preserve media during background reconnects

### DIFF
--- a/apps/web/src/app/api/klipy/gifs/route.ts
+++ b/apps/web/src/app/api/klipy/gifs/route.ts
@@ -1,0 +1,190 @@
+import { NextResponse } from "next/server";
+import type {
+  KlipyGifResult,
+  KlipyGifSearchResponse,
+} from "../../../lib/klipy-gifs";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const KLIPY_API_BASE_URL = "https://api.klipy.com/api/v1";
+const KLIPY_MEDIA_HOST = "static.klipy.com";
+const DEFAULT_PER_PAGE = 16;
+const MAX_PER_PAGE = 32;
+const MAX_QUERY_LENGTH = 80;
+const RATING = "pg";
+const GIF_SIZE_PREFERENCE = ["md", "sm", "hd", "xs"] as const;
+const PREVIEW_SIZE_PREFERENCE = ["sm", "xs", "md", "hd"] as const;
+const GIF_FORMAT_PREFERENCE = ["gif"] as const;
+const PREVIEW_FORMAT_PREFERENCE = ["webp", "gif", "jpg"] as const;
+
+interface KlipyRendition {
+  url: string;
+  width?: number;
+  height?: number;
+}
+
+const clampInteger = (
+  value: string | null,
+  fallback: number,
+  min: number,
+  max: number,
+): number => {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+
+const asString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim() ? value.trim() : null;
+
+const asDimension = (value: unknown): number | undefined => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const rounded = Math.round(value);
+  return rounded > 0 && rounded <= 4096 ? rounded : undefined;
+};
+
+const normalizeKlipyMediaUrl = (value: unknown): string | null => {
+  const raw = asString(value);
+  if (!raw) return null;
+
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:" || url.hostname !== KLIPY_MEDIA_HOST) {
+      return null;
+    }
+    return url.href;
+  } catch {
+    return null;
+  }
+};
+
+const findRendition = (
+  file: unknown,
+  sizes: readonly string[],
+  formats: readonly string[],
+): KlipyRendition | null => {
+  const fileRecord = asRecord(file);
+  if (!fileRecord) return null;
+
+  for (const size of sizes) {
+    const sizeRecord = asRecord(fileRecord[size]);
+    if (!sizeRecord) continue;
+
+    for (const format of formats) {
+      const renditionRecord = asRecord(sizeRecord[format]);
+      if (!renditionRecord) continue;
+
+      const url = normalizeKlipyMediaUrl(renditionRecord.url);
+      if (!url) continue;
+
+      return {
+        url,
+        width: asDimension(renditionRecord.width),
+        height: asDimension(renditionRecord.height),
+      };
+    }
+  }
+
+  return null;
+};
+
+const normalizeKlipyGif = (value: unknown): KlipyGifResult | null => {
+  const item = asRecord(value);
+  if (!item) return null;
+
+  const gif = findRendition(
+    item.file,
+    GIF_SIZE_PREFERENCE,
+    GIF_FORMAT_PREFERENCE,
+  );
+  const preview = findRendition(
+    item.file,
+    PREVIEW_SIZE_PREFERENCE,
+    PREVIEW_FORMAT_PREFERENCE,
+  );
+  if (!gif) return null;
+
+  const rawId = asString(item.slug) ?? asString(item.id) ?? gif.url;
+  const title = (asString(item.title) ?? "GIF").slice(0, 140);
+  const slug = asString(item.slug);
+
+  return {
+    id: rawId.slice(0, 120),
+    title,
+    url: gif.url,
+    previewUrl: preview?.url ?? gif.url,
+    ...(slug ? { pageUrl: `https://klipy.com/gifs/${encodeURIComponent(slug)}` } : {}),
+    ...(gif.width ?? preview?.width ? { width: gif.width ?? preview?.width } : {}),
+    ...(gif.height ?? preview?.height
+      ? { height: gif.height ?? preview?.height }
+      : {}),
+    source: "klipy",
+  };
+};
+
+export async function GET(request: Request) {
+  const apiKey = process.env.KLIPY_API_KEY?.trim();
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "Klipy API key is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const query = (searchParams.get("q") ?? searchParams.get("query") ?? "")
+    .trim()
+    .slice(0, MAX_QUERY_LENGTH);
+  const page = clampInteger(searchParams.get("page"), 1, 1, 50);
+  const perPage = clampInteger(
+    searchParams.get("per_page") ?? searchParams.get("limit"),
+    DEFAULT_PER_PAGE,
+    8,
+    MAX_PER_PAGE,
+  );
+
+  const endpoint = query ? "search" : "trending";
+  const url = new URL(
+    `${KLIPY_API_BASE_URL}/${encodeURIComponent(apiKey)}/gifs/${endpoint}`,
+  );
+  url.searchParams.set("page", String(page));
+  url.searchParams.set("per_page", String(perPage));
+  url.searchParams.set("rating", RATING);
+  if (query) {
+    url.searchParams.set("q", query);
+  }
+
+  const response = await fetch(url, {
+    headers: { accept: "application/json" },
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    return NextResponse.json(
+      { error: "Klipy request failed" },
+      { status: 502 },
+    );
+  }
+
+  const body = await response.json();
+  const data = asRecord(asRecord(body)?.data);
+  const rawItems = Array.isArray(data?.data) ? data.data : [];
+  const gifs = rawItems
+    .map((item) => normalizeKlipyGif(item))
+    .filter((item): item is KlipyGifResult => Boolean(item));
+
+  const payload: KlipyGifSearchResponse = {
+    gifs,
+    page: typeof data?.current_page === "number" ? data.current_page : page,
+    hasNext: data?.has_next === true,
+  };
+
+  return NextResponse.json(payload, {
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/apps/web/src/app/components/ChatGifAttachmentView.tsx
+++ b/apps/web/src/app/components/ChatGifAttachmentView.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import type { ChatGifAttachment } from "../lib/types";
+
+interface ChatGifAttachmentViewProps {
+  gif: ChatGifAttachment;
+  className?: string;
+  imageClassName?: string;
+  widthClassName?: string;
+}
+
+function getGifStyle(gif: ChatGifAttachment): CSSProperties | undefined {
+  if (!gif.width || !gif.height) return undefined;
+  return {
+    aspectRatio: `${gif.width} / ${gif.height}`,
+  };
+}
+
+export default function ChatGifAttachmentView({
+  gif,
+  className = "",
+  imageClassName = "",
+  widthClassName = "w-[240px]",
+}: ChatGifAttachmentViewProps) {
+  const hasRatio = Boolean(gif.width && gif.height);
+  const content = (
+    <img
+      src={gif.url}
+      alt={gif.title || "GIF"}
+      loading="lazy"
+      className={`${hasRatio ? "h-full" : "h-auto"} w-full object-contain ${imageClassName}`}
+    />
+  );
+
+  const baseClassName = `block ${widthClassName} max-w-full overflow-hidden rounded-[16px] bg-black/25 ${className}`;
+
+  if (gif.pageUrl) {
+    return (
+      <a
+        href={gif.pageUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={baseClassName}
+        style={getGifStyle(gif)}
+        title={gif.title}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <div className={baseClassName} style={getGifStyle(gif)} title={gif.title}>
+      {content}
+    </div>
+  );
+}

--- a/apps/web/src/app/components/ChatOverlay.tsx
+++ b/apps/web/src/app/components/ChatOverlay.tsx
@@ -7,6 +7,7 @@ import { color } from "@conclave/ui-tokens";
 import type { ChatMessage } from "../lib/types";
 import { getActionText } from "../lib/chat-commands";
 import { formatDisplayName } from "../lib/utils";
+import ChatGifAttachmentView from "./ChatGifAttachmentView";
 
 interface ChatOverlayProps {
   messages: ChatMessage[];
@@ -54,6 +55,12 @@ function ChatOverlay({ messages, onDismiss }: ChatOverlayProps) {
                 >
                   {actionText}
                 </p>
+              ) : message.gif ? (
+                <ChatGifAttachmentView
+                  gif={message.gif}
+                  className="mt-2 rounded-xl"
+                  widthClassName="w-[150px]"
+                />
               ) : (
                 <p
                   className="mt-0.5 break-words text-[13.5px] leading-snug"

--- a/apps/web/src/app/components/ChatPanel.tsx
+++ b/apps/web/src/app/components/ChatPanel.tsx
@@ -3,9 +3,11 @@
 import { ArrowDown, MessageSquare, Send, X } from "lucide-react";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Avatar } from "@conclave/ui-tokens/web";
-import type { ChatMessage } from "../lib/types";
+import type { ChatGifAttachment, ChatMessage } from "../lib/types";
 import { getActionText, getCommandSuggestions } from "../lib/chat-commands";
 import { formatDisplayName, getChatMessageSegments } from "../lib/utils";
+import ChatGifAttachmentView from "./ChatGifAttachmentView";
+import GifPicker from "./GifPicker";
 
 interface MentionableParticipant {
   userId: string;
@@ -20,6 +22,7 @@ interface ChatPanelProps {
   chatInput: string;
   onInputChange: (value: string) => void;
   onSend: (content: string) => void;
+  onSendGif: (gif: ChatGifAttachment) => void;
   onClose: () => void;
   currentUserId: string;
   isGhostMode?: boolean;
@@ -28,6 +31,24 @@ interface ChatPanelProps {
   isAdmin?: boolean;
   mentionableParticipants?: MentionableParticipant[];
 }
+
+const areGifsEqual = (
+  previousGif?: ChatGifAttachment,
+  nextGif?: ChatGifAttachment,
+): boolean => {
+  if (previousGif === nextGif) return true;
+  if (!previousGif || !nextGif) return false;
+  return (
+    previousGif.id === nextGif.id &&
+    previousGif.title === nextGif.title &&
+    previousGif.url === nextGif.url &&
+    (previousGif.previewUrl ?? "") === (nextGif.previewUrl ?? "") &&
+    (previousGif.pageUrl ?? "") === (nextGif.pageUrl ?? "") &&
+    (previousGif.width ?? 0) === (nextGif.width ?? 0) &&
+    (previousGif.height ?? 0) === (nextGif.height ?? 0) &&
+    previousGif.source === nextGif.source
+  );
+};
 
 const areMessagesEqual = (
   previousMessages: ChatMessage[],
@@ -47,6 +68,7 @@ const areMessagesEqual = (
       previousMessage.displayName !== nextMessage.displayName ||
       previousMessage.content !== nextMessage.content ||
       previousMessage.timestamp !== nextMessage.timestamp ||
+      !areGifsEqual(previousMessage.gif, nextMessage.gif) ||
       (previousMessage.isDirect ?? false) !== (nextMessage.isDirect ?? false) ||
       (previousMessage.dmTargetUserId ?? "") !==
         (nextMessage.dmTargetUserId ?? "") ||
@@ -106,6 +128,7 @@ const areChatPanelPropsEqual = (
     previousIsAdmin !== nextIsAdmin ||
     previousProps.onInputChange !== nextProps.onInputChange ||
     previousProps.onSend !== nextProps.onSend ||
+    previousProps.onSendGif !== nextProps.onSendGif ||
     previousProps.onClose !== nextProps.onClose
   ) {
     return false;
@@ -126,6 +149,7 @@ function ChatPanel({
   chatInput,
   onInputChange,
   onSend,
+  onSendGif,
   onClose,
   currentUserId,
   isGhostMode = false,
@@ -293,6 +317,12 @@ function ChatPanel({
       onSend(chatInput);
       onInputChange("");
     }
+  };
+
+  const handleSendGif = (gif: ChatGifAttachment) => {
+    if (isChatDisabled) return;
+    onSendGif(gif);
+    onInputChange("");
   };
 
   const applyMentionSuggestion = (index: number) => {
@@ -543,23 +573,33 @@ function ChatPanel({
                         {directMessageLabel}
                       </p>
                     ) : null}
-                    <div
-                      className={`inline-block max-w-full px-3.5 py-2 text-[13.5px] leading-relaxed break-words whitespace-pre-wrap ${
-                        isOwn
-                          ? "rounded-[18px] bg-[#F95F4A] text-white shadow-sm shadow-black/10 selection:bg-white/25 selection:text-white"
-                          : "bg-white/[0.05] text-[#fafafa] selection:bg-[#F95F4A]/40 selection:text-white"
-                      } ${
-                        isOwn
-                          ? groupedWithPrevious
-                            ? "rounded-tr-md"
-                            : ""
-                          : "rounded-[18px]"
-                      } ${
-                        !isOwn && groupedWithPrevious ? "rounded-tl-md" : ""
-                      } ${msg.isDirect ? "ring-1 ring-amber-300/30" : ""}`}
-                    >
-                      {renderMessageContent(msg.content)}
-                    </div>
+                    {msg.gif ? (
+                      <div
+                        className={`inline-block max-w-full overflow-hidden rounded-[18px] ring-1 ${
+                          isOwn ? "ring-[#F95F4A]/55" : "ring-white/10"
+                        } ${msg.isDirect ? "ring-amber-300/30" : ""}`}
+                      >
+                        <ChatGifAttachmentView gif={msg.gif} />
+                      </div>
+                    ) : (
+                      <div
+                        className={`inline-block max-w-full px-3.5 py-2 text-[13.5px] leading-relaxed break-words whitespace-pre-wrap ${
+                          isOwn
+                            ? "rounded-[18px] bg-[#F95F4A] text-white shadow-sm shadow-black/10 selection:bg-white/25 selection:text-white"
+                            : "bg-white/[0.05] text-[#fafafa] selection:bg-[#F95F4A]/40 selection:text-white"
+                        } ${
+                          isOwn
+                            ? groupedWithPrevious
+                              ? "rounded-tr-md"
+                              : ""
+                            : "rounded-[18px]"
+                        } ${
+                          !isOwn && groupedWithPrevious ? "rounded-tl-md" : ""
+                        } ${msg.isDirect ? "ring-1 ring-amber-300/30" : ""}`}
+                      >
+                        {renderMessageContent(msg.content)}
+                      </div>
+                    )}
                   </div>
                 </div>
               );
@@ -641,6 +681,7 @@ function ChatPanel({
             </div>
           )}
           <div className="flex items-end gap-2 rounded-2xl border border-white/10 bg-white/[0.04] py-2 pl-3 pr-2 transition-colors focus-within:border-white/20 focus-within:bg-white/[0.055]">
+            <GifPicker disabled={isChatDisabled} onSelect={handleSendGif} />
             <textarea
               ref={textareaRef}
               value={chatInput}

--- a/apps/web/src/app/components/GifPicker.tsx
+++ b/apps/web/src/app/components/GifPicker.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { Images, Loader2, Search, X } from "lucide-react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ChatGifAttachment } from "../lib/types";
+import {
+  klipyGifResultToAttachment,
+  type KlipyGifResult,
+  type KlipyGifSearchResponse,
+} from "../lib/klipy-gifs";
+
+interface GifPickerProps {
+  disabled?: boolean;
+  onSelect: (gif: ChatGifAttachment) => void;
+  variant?: "desktop" | "mobile";
+}
+
+const SEARCH_DEBOUNCE_MS = 250;
+const GIFS_PER_PAGE = 16;
+
+function GifPicker({
+  disabled = false,
+  onSelect,
+  variant = "desktop",
+}: GifPickerProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [gifs, setGifs] = useState<KlipyGifResult[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasNext, setHasNext] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!disabled) return;
+    setIsOpen(false);
+  }, [disabled]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedQuery(query.trim());
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [query]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const frameId = window.requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(frameId);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const controller = new AbortController();
+    const loadGifs = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams({
+          page: "1",
+          limit: String(GIFS_PER_PAGE),
+        });
+        if (debouncedQuery) {
+          params.set("q", debouncedQuery);
+        }
+
+        const response = await fetch(`/api/klipy/gifs?${params.toString()}`, {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error("GIF search failed.");
+        }
+        const body = (await response.json()) as KlipyGifSearchResponse;
+        setGifs(body.gifs);
+        setPage(body.page);
+        setHasNext(body.hasNext);
+      } catch (loadError) {
+        if (controller.signal.aborted) return;
+        setGifs([]);
+        setHasNext(false);
+        setError(
+          loadError instanceof Error ? loadError.message : "GIF search failed.",
+        );
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadGifs();
+    return () => controller.abort();
+  }, [debouncedQuery, isOpen]);
+
+  const loadMore = useCallback(async () => {
+    if (isLoading || isLoadingMore || !hasNext) return;
+
+    setIsLoadingMore(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({
+        page: String(page + 1),
+        limit: String(GIFS_PER_PAGE),
+      });
+      if (debouncedQuery) {
+        params.set("q", debouncedQuery);
+      }
+
+      const response = await fetch(`/api/klipy/gifs?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error("More GIFs failed to load.");
+      }
+      const body = (await response.json()) as KlipyGifSearchResponse;
+      setGifs((prev) => [...prev, ...body.gifs]);
+      setPage(body.page);
+      setHasNext(body.hasNext);
+    } catch (loadError) {
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "More GIFs failed to load.",
+      );
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [debouncedQuery, hasNext, isLoading, isLoadingMore, page]);
+
+  const panelClassName = useMemo(
+    () =>
+      variant === "mobile"
+        ? "absolute bottom-full left-0 z-20 mb-2 w-[min(22rem,calc(100vw-2rem))]"
+        : "absolute bottom-full left-0 z-20 mb-2 w-[20rem]",
+    [variant],
+  );
+
+  const handleSelect = (gif: KlipyGifResult) => {
+    onSelect(klipyGifResultToAttachment(gif));
+    setIsOpen(false);
+    setQuery("");
+  };
+
+  return (
+    <div ref={rootRef} className="relative shrink-0">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-label="Search GIFs"
+        aria-expanded={isOpen}
+        title="Search GIFs"
+        className={`inline-flex h-8 w-8 items-center justify-center rounded-lg transition-[background-color,color,opacity] ${
+          isOpen
+            ? "bg-white/[0.12] text-[#fafafa]"
+            : "text-[#a1a1aa] hover:bg-white/[0.07] hover:text-[#fafafa]"
+        } disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent`}
+      >
+        <Images size={18} strokeWidth={1.75} />
+      </button>
+
+      {isOpen ? (
+        <div
+          className={`${panelClassName} overflow-hidden rounded-xl border border-white/10 bg-[#232327] shadow-2xl shadow-black/40`}
+        >
+          <div className="flex items-center gap-2 border-b border-white/10 px-2.5 py-2">
+            <Search size={15} strokeWidth={1.75} className="text-[#a1a1aa]" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search GIFs"
+              className="min-w-0 flex-1 bg-transparent text-[13px] text-[#fafafa] placeholder:text-[#a1a1aa] focus:outline-none"
+            />
+            {query ? (
+              <button
+                type="button"
+                onClick={() => setQuery("")}
+                aria-label="Clear GIF search"
+                className="inline-flex h-6 w-6 items-center justify-center rounded-md text-[#a1a1aa] transition-colors hover:bg-white/[0.08] hover:text-[#fafafa]"
+              >
+                <X size={14} strokeWidth={1.75} />
+              </button>
+            ) : null}
+          </div>
+
+          <div className="max-h-[18rem] overflow-y-auto p-2">
+            {isLoading ? (
+              <div className="flex h-32 items-center justify-center text-[#a1a1aa]">
+                <Loader2 size={20} strokeWidth={1.75} className="animate-spin" />
+              </div>
+            ) : error ? (
+              <div className="flex h-32 items-center justify-center px-4 text-center text-[13px] text-[#a1a1aa]">
+                {error}
+              </div>
+            ) : gifs.length === 0 ? (
+              <div className="flex h-32 items-center justify-center px-4 text-center text-[13px] text-[#a1a1aa]">
+                No GIFs found
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-1.5">
+                {gifs.map((gif) => (
+                  <button
+                    key={`${gif.id}-${gif.url}`}
+                    type="button"
+                    onClick={() => handleSelect(gif)}
+                    className="group relative aspect-[4/3] overflow-hidden rounded-lg bg-black/30 outline-none ring-1 ring-white/[0.06] transition-[filter,ring-color] hover:brightness-110 hover:ring-white/20 focus-visible:ring-2 focus-visible:ring-[#F95F4A]"
+                    title={gif.title}
+                  >
+                    <img
+                      src={gif.previewUrl}
+                      alt={gif.title}
+                      loading="lazy"
+                      className="h-full w-full object-cover"
+                    />
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between gap-2 border-t border-white/10 px-2.5 py-2">
+            <a
+              href="https://klipy.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[11px] font-medium text-[#a1a1aa] transition-colors hover:text-[#fafafa]"
+            >
+              Powered by Klipy
+            </a>
+            {hasNext && !isLoading ? (
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={isLoadingMore}
+                className="inline-flex h-7 items-center justify-center rounded-md bg-white/[0.07] px-2.5 text-[12px] font-medium text-[#fafafa] transition-colors hover:bg-white/[0.12] disabled:opacity-50"
+              >
+                {isLoadingMore ? (
+                  <Loader2
+                    size={14}
+                    strokeWidth={1.75}
+                    className="animate-spin"
+                  />
+                ) : (
+                  "More"
+                )}
+              </button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default memo(GifPicker);

--- a/apps/web/src/app/components/GridLayout.tsx
+++ b/apps/web/src/app/components/GridLayout.tsx
@@ -3542,20 +3542,56 @@ const OverflowGalleryTile = memo(function OverflowGalleryTile({
       video.srcObject = videoStream;
     }
 
+    let cancelled = false;
+
     const playVideo = () => {
+      if (cancelled) return;
       video.play().catch(() => {});
     };
 
-    playVideo();
+    const playbackRecovery = createPlaybackRecoveryScheduler({
+      attemptPlayback: playVideo,
+      shouldAttemptAnimationFrameReplay: () =>
+        !cancelled &&
+        (video.paused ||
+          video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA),
+    });
+    const scheduleReplay = playbackRecovery.schedule;
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        scheduleReplay();
+      }
+    };
+    const handleWindowChange = () => {
+      scheduleReplay();
+    };
+
+    scheduleReplay();
 
     if (videoTrack) {
-      videoTrack.addEventListener("unmute", playVideo);
+      videoTrack.addEventListener("unmute", scheduleReplay);
     }
+    video.addEventListener("loadedmetadata", scheduleReplay);
+    video.addEventListener("loadeddata", scheduleReplay);
+    video.addEventListener("canplay", scheduleReplay);
+    video.addEventListener("stalled", scheduleReplay);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("resize", handleWindowChange);
+    window.addEventListener("orientationchange", handleWindowChange);
 
     return () => {
+      cancelled = true;
       if (videoTrack) {
-        videoTrack.removeEventListener("unmute", playVideo);
+        videoTrack.removeEventListener("unmute", scheduleReplay);
       }
+      video.removeEventListener("loadedmetadata", scheduleReplay);
+      video.removeEventListener("loadeddata", scheduleReplay);
+      video.removeEventListener("canplay", scheduleReplay);
+      video.removeEventListener("stalled", scheduleReplay);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("resize", handleWindowChange);
+      window.removeEventListener("orientationchange", handleWindowChange);
+      playbackRecovery.clear();
       if (video.srcObject === videoStream) {
         video.srcObject = null;
       }

--- a/apps/web/src/app/components/JoinScreen.tsx
+++ b/apps/web/src/app/components/JoinScreen.tsx
@@ -42,7 +42,6 @@ import MeetsErrorBanner from "./MeetsErrorBanner";
 import { useCameraPermissionState } from "../hooks/useCameraPermissionState";
 import {
   useBandwidthHeavyPreloadDeferred,
-  useBandwidthHeavyVideoEffectsSuppressed,
 } from "../hooks/useBandwidthHeavyPreloadDeferred";
 import {
   countActiveVideoEffects,
@@ -286,11 +285,7 @@ function JoinScreen({
   const activeVideoEffectsCount = countActiveVideoEffects(videoEffects);
   const shouldDeferPreviewVideoEffectsPreload =
     useBandwidthHeavyPreloadDeferred();
-  const shouldSuppressPreviewVideoEffectsForBandwidth =
-    useBandwidthHeavyVideoEffectsSuppressed();
-  const shouldRunPreviewVideoEffects =
-    activeVideoEffectsCount > 0 &&
-    !shouldSuppressPreviewVideoEffectsForBandwidth;
+  const shouldRunPreviewVideoEffects = activeVideoEffectsCount > 0;
   const [videoEffectsBridgeState, setVideoEffectsBridgeState] =
     useState<VideoEffectsBridgeState>(VIDEO_EFFECTS_OFF_STATE);
   const processedPreviewStream = shouldRunPreviewVideoEffects

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -31,6 +31,7 @@ import type {
 } from "../hooks/useVideoEffects";
 import type {
   AdminNoticeNotification,
+  ChatGifAttachment,
   ChatMessage,
   ConnectionState,
   MeetError,
@@ -149,6 +150,7 @@ interface MeetsMainContentProps {
   chatInput: string;
   setChatInput: Dispatch<SetStateAction<string>>;
   sendChat: (content: string) => void;
+  sendChatGif: (gif: ChatGifAttachment) => void;
   chatOverlayMessages: ChatMessage[];
   setChatOverlayMessages: Dispatch<SetStateAction<ChatMessage[]>>;
   socket: Socket | null;
@@ -369,6 +371,7 @@ export default function MeetsMainContent({
   chatInput,
   setChatInput,
   sendChat,
+  sendChatGif,
   chatOverlayMessages,
   setChatOverlayMessages,
   socket,
@@ -948,6 +951,13 @@ export default function MeetsMainContent({
   const handleSendChat = useCallback((content: string) => {
     sendChatRef.current(content);
   }, []);
+  const sendChatGifRef = useRef(sendChatGif);
+  useEffect(() => {
+    sendChatGifRef.current = sendChatGif;
+  }, [sendChatGif]);
+  const handleSendChatGif = useCallback((gif: ChatGifAttachment) => {
+    sendChatGifRef.current(gif);
+  }, []);
 
   const handleToggleTtsDisabled = useCallback(() => {
     if (!socket) return;
@@ -1473,6 +1483,7 @@ export default function MeetsMainContent({
           chatInput={chatInput}
           onInputChange={setChatInput}
           onSend={handleSendChat}
+          onSendGif={handleSendChatGif}
           onClose={handleToggleChat}
           currentUserId={currentUserId}
           isGhostMode={ghostEnabled}

--- a/apps/web/src/app/components/mobile/MobileBrowserLayout.tsx
+++ b/apps/web/src/app/components/mobile/MobileBrowserLayout.tsx
@@ -6,6 +6,7 @@ import { Avatar } from "@conclave/ui-tokens/web";
 import { useMeetVolume } from "../../hooks/useMeetVolume";
 import { useSmartParticipantOrder } from "../../hooks/useSmartParticipantOrder";
 import { getRenderableParticipantVideoStream } from "../../lib/participant-media";
+import { createPlaybackRecoveryScheduler } from "../../lib/playback-recovery";
 import type { Participant } from "../../lib/types";
 import {
   isSystemUserId,
@@ -339,20 +340,56 @@ const VideoThumbnail = memo(function VideoThumbnail({
       video.srcObject = videoStream;
     }
 
+    let cancelled = false;
+
     const playVideo = () => {
+      if (cancelled) return;
       video.play().catch(() => {});
     };
 
-    playVideo();
+    const playbackRecovery = createPlaybackRecoveryScheduler({
+      attemptPlayback: playVideo,
+      shouldAttemptAnimationFrameReplay: () =>
+        !cancelled &&
+        (video.paused ||
+          video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA),
+    });
+    const scheduleReplay = playbackRecovery.schedule;
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        scheduleReplay();
+      }
+    };
+    const handleWindowChange = () => {
+      scheduleReplay();
+    };
+
+    scheduleReplay();
 
     if (videoTrack) {
-      videoTrack.addEventListener("unmute", playVideo);
+      videoTrack.addEventListener("unmute", scheduleReplay);
     }
+    video.addEventListener("loadedmetadata", scheduleReplay);
+    video.addEventListener("loadeddata", scheduleReplay);
+    video.addEventListener("canplay", scheduleReplay);
+    video.addEventListener("stalled", scheduleReplay);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("resize", handleWindowChange);
+    window.addEventListener("orientationchange", handleWindowChange);
 
     return () => {
+      cancelled = true;
       if (videoTrack) {
-        videoTrack.removeEventListener("unmute", playVideo);
+        videoTrack.removeEventListener("unmute", scheduleReplay);
       }
+      video.removeEventListener("loadedmetadata", scheduleReplay);
+      video.removeEventListener("loadeddata", scheduleReplay);
+      video.removeEventListener("canplay", scheduleReplay);
+      video.removeEventListener("stalled", scheduleReplay);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("resize", handleWindowChange);
+      window.removeEventListener("orientationchange", handleWindowChange);
+      playbackRecovery.clear();
       if (video.srcObject === videoStream) {
         video.srcObject = null;
       }

--- a/apps/web/src/app/components/mobile/MobileChatPanel.tsx
+++ b/apps/web/src/app/components/mobile/MobileChatPanel.tsx
@@ -2,9 +2,11 @@
 
 import { Send } from "lucide-react";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
-import type { ChatMessage } from "../../lib/types";
+import type { ChatGifAttachment, ChatMessage } from "../../lib/types";
 import { getActionText, getCommandSuggestions } from "../../lib/chat-commands";
 import { formatDisplayName, getChatMessageSegments } from "../../lib/utils";
+import ChatGifAttachmentView from "../ChatGifAttachmentView";
+import GifPicker from "../GifPicker";
 
 interface MentionableParticipant {
   userId: string;
@@ -19,6 +21,7 @@ interface MobileChatPanelProps {
   chatInput: string;
   onInputChange: (value: string) => void;
   onSend: (content: string) => void;
+  onSendGif: (gif: ChatGifAttachment) => void;
   onClose: () => void;
   isOpen: boolean;
   currentUserId: string;
@@ -35,6 +38,7 @@ function MobileChatPanel({
   chatInput,
   onInputChange,
   onSend,
+  onSendGif,
   onClose,
   isOpen,
   currentUserId,
@@ -144,6 +148,13 @@ function MobileChatPanel({
       setLocalValue("");
       onInputChange("");
     }
+  };
+
+  const handleSendGif = (gif: ChatGifAttachment) => {
+    if (isChatDisabled) return;
+    onSendGif(gif);
+    setLocalValue("");
+    onInputChange("");
   };
 
   const applyMentionSuggestion = (index: number) => {
@@ -340,22 +351,41 @@ function MobileChatPanel({
                         {resolveDisplayName(message.userId)}
                       </span>
                     )}
-                    <div
-                      className={`max-w-[80%] rounded-[18px] px-3 py-2 ${
-                        isOwn
-                          ? "bg-[#F95F4A] text-white rounded-br-md selection:bg-white/90 selection:text-[#131316]"
-                          : "bg-[#2e2e33]/90 text-[#fafafa] rounded-bl-md selection:bg-[#F95F4A]/40 selection:text-white"
-                      } ${message.isDirect ? "ring-1 ring-amber-300/30" : ""}`}
-                    >
-                      <p className="text-sm break-words">
-                        {directMessageLabel ? (
-                          <span className="mb-1 block text-[11px] font-medium text-amber-300/80">
-                            {directMessageLabel}
-                          </span>
-                        ) : null}
-                        {renderMessageContent(message.content)}
-                      </p>
-                    </div>
+                    {directMessageLabel && message.gif ? (
+                      <span className="mb-1 px-1 text-[11px] font-medium text-amber-300/80">
+                        {directMessageLabel}
+                      </span>
+                    ) : null}
+                    {message.gif ? (
+                      <div
+                        className={`max-w-[80%] overflow-hidden rounded-[18px] ring-1 ${
+                          isOwn ? "ring-[#F95F4A]/55" : "ring-white/10"
+                        } ${message.isDirect ? "ring-amber-300/30" : ""}`}
+                      >
+                        <ChatGifAttachmentView
+                          gif={message.gif}
+                          className="rounded-[18px]"
+                          widthClassName="w-[220px]"
+                        />
+                      </div>
+                    ) : (
+                      <div
+                        className={`max-w-[80%] rounded-[18px] px-3 py-2 ${
+                          isOwn
+                            ? "bg-[#F95F4A] text-white rounded-br-md selection:bg-white/90 selection:text-[#131316]"
+                            : "bg-[#2e2e33]/90 text-[#fafafa] rounded-bl-md selection:bg-[#F95F4A]/40 selection:text-white"
+                        } ${message.isDirect ? "ring-1 ring-amber-300/30" : ""}`}
+                      >
+                        <p className="text-sm break-words">
+                          {directMessageLabel ? (
+                            <span className="mb-1 block text-[11px] font-medium text-amber-300/80">
+                              {directMessageLabel}
+                            </span>
+                          ) : null}
+                          {renderMessageContent(message.content)}
+                        </p>
+                      </div>
+                    )}
                     <span className="text-[9px] text-[#fafafa]/35 mt-0.5 px-1">
                       {formatTime(message.timestamp)}
                     </span>
@@ -425,6 +455,11 @@ function MobileChatPanel({
                 })}
               </div>
             )}
+            <GifPicker
+              disabled={isChatDisabled}
+              onSelect={handleSendGif}
+              variant="mobile"
+            />
             <input
               ref={inputRef}
               type="text"

--- a/apps/web/src/app/components/mobile/MobileGridLayout.tsx
+++ b/apps/web/src/app/components/mobile/MobileGridLayout.tsx
@@ -18,6 +18,7 @@ import {
 } from "@conclave/meeting-core";
 import { Avatar } from "@conclave/ui-tokens/web";
 import { useSmartParticipantOrderWithMetadata } from "../../hooks/useSmartParticipantOrder";
+import { createPlaybackRecoveryScheduler } from "../../lib/playback-recovery";
 import { getRenderableParticipantVideoStream } from "../../lib/participant-media";
 import type { Participant } from "../../lib/types";
 import { isSystemUserId, truncateDisplayName } from "../../lib/utils";
@@ -1177,28 +1178,67 @@ const ParticipantTile = memo(function ParticipantTile({
       video.srcObject = videoStream;
     }
 
+    let cancelled = false;
     const playVideo = () => {
-      video.play().catch(() => {});
+      if (cancelled) return;
+      video.play().catch((err) => {
+        if (err.name === "NotAllowedError") {
+          video.muted = true;
+          video.play().catch(() => {});
+          return;
+        }
+        if (err.name !== "AbortError") {
+          console.error("[Meets] Mobile grid video play error:", err);
+        }
+      });
     };
 
-    playVideo();
+    const playbackRecovery = createPlaybackRecoveryScheduler({
+      attemptPlayback: playVideo,
+      shouldAttemptAnimationFrameReplay: () =>
+        !cancelled &&
+        (video.paused ||
+          video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA),
+    });
+    const scheduleReplay = playbackRecovery.schedule;
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        scheduleReplay();
+      }
+    };
+    const handleResize = () => {
+      scheduleReplay();
+    };
+    const handleOrientationChange = () => {
+      scheduleReplay();
+    };
 
-    if (videoTrack) {
-      videoTrack.addEventListener("unmute", playVideo);
-    }
+    scheduleReplay();
+    videoTrack?.addEventListener("unmute", scheduleReplay);
+    video.addEventListener("loadedmetadata", scheduleReplay);
+    video.addEventListener("loadeddata", scheduleReplay);
+    video.addEventListener("canplay", scheduleReplay);
+    video.addEventListener("stalled", scheduleReplay);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("orientationchange", handleOrientationChange);
 
     return () => {
-      if (videoTrack) {
-        videoTrack.removeEventListener("unmute", playVideo);
-      }
+      cancelled = true;
+      videoTrack?.removeEventListener("unmute", scheduleReplay);
+      video.removeEventListener("loadedmetadata", scheduleReplay);
+      video.removeEventListener("loadeddata", scheduleReplay);
+      video.removeEventListener("canplay", scheduleReplay);
+      video.removeEventListener("stalled", scheduleReplay);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("orientationchange", handleOrientationChange);
+      playbackRecovery.clear();
       if (video.srcObject === videoStream) {
         video.srcObject = null;
       }
     };
-  }, [
-    videoStream,
-    videoTrack,
-  ]);
+  }, [videoStream, videoTrack]);
 
   const showPlaceholder = !videoStream;
   const label = truncateDisplayName(displayName, variant === "rail" ? 14 : 20);
@@ -1270,28 +1310,58 @@ function WarmRemoteVideo({ participant }: { participant: Participant }) {
       video.srcObject = videoStream;
     }
 
+    let cancelled = false;
     const playVideo = () => {
+      if (cancelled) return;
       video.play().catch(() => {});
     };
 
-    playVideo();
+    const playbackRecovery = createPlaybackRecoveryScheduler({
+      attemptPlayback: playVideo,
+      shouldAttemptAnimationFrameReplay: () =>
+        !cancelled &&
+        (video.paused ||
+          video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA),
+    });
+    const scheduleReplay = playbackRecovery.schedule;
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        scheduleReplay();
+      }
+    };
+    const handleResize = () => {
+      scheduleReplay();
+    };
+    const handleOrientationChange = () => {
+      scheduleReplay();
+    };
 
-    if (videoTrack) {
-      videoTrack.addEventListener("unmute", playVideo);
-    }
+    scheduleReplay();
+    videoTrack?.addEventListener("unmute", scheduleReplay);
+    video.addEventListener("loadedmetadata", scheduleReplay);
+    video.addEventListener("loadeddata", scheduleReplay);
+    video.addEventListener("canplay", scheduleReplay);
+    video.addEventListener("stalled", scheduleReplay);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("orientationchange", handleOrientationChange);
 
     return () => {
-      if (videoTrack) {
-        videoTrack.removeEventListener("unmute", playVideo);
-      }
+      cancelled = true;
+      videoTrack?.removeEventListener("unmute", scheduleReplay);
+      video.removeEventListener("loadedmetadata", scheduleReplay);
+      video.removeEventListener("loadeddata", scheduleReplay);
+      video.removeEventListener("canplay", scheduleReplay);
+      video.removeEventListener("stalled", scheduleReplay);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("orientationchange", handleOrientationChange);
+      playbackRecovery.clear();
       if (video.srcObject === videoStream) {
         video.srcObject = null;
       }
     };
-  }, [
-    videoStream,
-    videoTrack,
-  ]);
+  }, [videoStream, videoTrack]);
 
   if (!videoStream) {
     return null;

--- a/apps/web/src/app/components/mobile/MobileJoinScreen.tsx
+++ b/apps/web/src/app/components/mobile/MobileJoinScreen.tsx
@@ -41,7 +41,6 @@ import AndroidUpsellSheet from "./AndroidUpsellSheet";
 import { useCameraPermissionState } from "../../hooks/useCameraPermissionState";
 import {
   useBandwidthHeavyPreloadDeferred,
-  useBandwidthHeavyVideoEffectsSuppressed,
 } from "../../hooks/useBandwidthHeavyPreloadDeferred";
 import {
   countActiveVideoEffects,
@@ -230,11 +229,7 @@ function MobileJoinScreen({
   const activeVideoEffectsCount = countActiveVideoEffects(videoEffects);
   const shouldDeferPreviewVideoEffectsPreload =
     useBandwidthHeavyPreloadDeferred();
-  const shouldSuppressPreviewVideoEffectsForBandwidth =
-    useBandwidthHeavyVideoEffectsSuppressed();
-  const shouldRunPreviewVideoEffects =
-    activeVideoEffectsCount > 0 &&
-    !shouldSuppressPreviewVideoEffectsForBandwidth;
+  const shouldRunPreviewVideoEffects = activeVideoEffectsCount > 0;
   const [videoEffectsBridgeState, setVideoEffectsBridgeState] =
     useState<VideoEffectsBridgeState>(VIDEO_EFFECTS_OFF_STATE);
   const processedPreviewStream = shouldRunPreviewVideoEffects

--- a/apps/web/src/app/components/mobile/MobileMeetsMainContent.tsx
+++ b/apps/web/src/app/components/mobile/MobileMeetsMainContent.tsx
@@ -7,6 +7,7 @@ import type { Dispatch, PointerEvent, SetStateAction } from "react";
 import type { Socket } from "socket.io-client";
 import type {
   AdminNoticeNotification,
+  ChatGifAttachment,
   ChatMessage,
   ConnectionState,
   MeetError,
@@ -128,6 +129,7 @@ interface MobileMeetsMainContentProps {
   chatInput: string;
   setChatInput: Dispatch<SetStateAction<string>>;
   sendChat: (content: string) => void;
+  sendChatGif: (gif: ChatGifAttachment) => void;
   chatOverlayMessages: ChatMessage[];
   setChatOverlayMessages: Dispatch<SetStateAction<ChatMessage[]>>;
   socket: Socket | null;
@@ -314,6 +316,7 @@ function MobileMeetsMainContent({
   chatInput,
   setChatInput,
   sendChat,
+  sendChatGif,
   chatOverlayMessages,
   setChatOverlayMessages,
   socket,
@@ -1229,6 +1232,7 @@ function MobileMeetsMainContent({
           chatInput={chatInput}
           onInputChange={setChatInput}
           onSend={sendChat}
+          onSendGif={sendChatGif}
           onClose={handleToggleChat}
           isOpen={isChatOpen}
           currentUserId={currentUserId}

--- a/apps/web/src/app/components/mobile/MobilePresentationLayout.tsx
+++ b/apps/web/src/app/components/mobile/MobilePresentationLayout.tsx
@@ -306,20 +306,56 @@ const VideoThumbnail = memo(function VideoThumbnail({
       video.srcObject = videoStream;
     }
 
+    let cancelled = false;
+
     const playVideo = () => {
+      if (cancelled) return;
       video.play().catch(() => {});
     };
 
-    playVideo();
+    const playbackRecovery = createPlaybackRecoveryScheduler({
+      attemptPlayback: playVideo,
+      shouldAttemptAnimationFrameReplay: () =>
+        !cancelled &&
+        (video.paused ||
+          video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA),
+    });
+    const scheduleReplay = playbackRecovery.schedule;
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        scheduleReplay();
+      }
+    };
+    const handleWindowChange = () => {
+      scheduleReplay();
+    };
+
+    scheduleReplay();
 
     if (videoTrack) {
-      videoTrack.addEventListener("unmute", playVideo);
+      videoTrack.addEventListener("unmute", scheduleReplay);
     }
+    video.addEventListener("loadedmetadata", scheduleReplay);
+    video.addEventListener("loadeddata", scheduleReplay);
+    video.addEventListener("canplay", scheduleReplay);
+    video.addEventListener("stalled", scheduleReplay);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("resize", handleWindowChange);
+    window.addEventListener("orientationchange", handleWindowChange);
 
     return () => {
+      cancelled = true;
       if (videoTrack) {
-        videoTrack.removeEventListener("unmute", playVideo);
+        videoTrack.removeEventListener("unmute", scheduleReplay);
       }
+      video.removeEventListener("loadedmetadata", scheduleReplay);
+      video.removeEventListener("loadeddata", scheduleReplay);
+      video.removeEventListener("canplay", scheduleReplay);
+      video.removeEventListener("stalled", scheduleReplay);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("resize", handleWindowChange);
+      window.removeEventListener("orientationchange", handleWindowChange);
+      playbackRecovery.clear();
       if (video.srcObject === videoStream) {
         video.srcObject = null;
       }

--- a/apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts
+++ b/apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts
@@ -287,6 +287,18 @@ const sameConsumerLayers = (
   );
 };
 
+const isConsumerLayerUpgrade = (
+  previous: ConsumerLayerPreference | undefined,
+  next: ConsumerLayerPreference,
+): boolean => {
+  if (!previous) return true;
+  if (next.spatialLayer > previous.spatialLayer) return true;
+  return (
+    next.spatialLayer === previous.spatialLayer &&
+    (next.temporalLayer ?? -1) > (previous.temporalLayer ?? -1)
+  );
+};
+
 const telemetryConfirmsPreferences = (
   telemetry:
     | {
@@ -867,8 +879,7 @@ export function useAdaptiveConsumerPreferences({
         preferences.paused === false &&
         Boolean(preferredLayers) &&
         (wasPaused ||
-          !previousLayers ||
-          preferredLayers!.spatialLayer > previousLayers.spatialLayer);
+          isConsumerLayerUpgrade(previousLayers, preferredLayers!));
       const debugEntryBase = {
         producerId,
         consumerId: consumer.id,

--- a/apps/web/src/app/hooks/useAdaptivePublishQuality.ts
+++ b/apps/web/src/app/hooks/useAdaptivePublishQuality.ts
@@ -43,6 +43,7 @@ const FAIR_LIVE_CAP_AFTER_MS = 5000;
 const POOR_LIVE_CAP_AFTER_MS = 2500;
 const GOOD_LIVE_RESTORE_AFTER_MS = 15000;
 const MAX_AUTO_UPGRADE_PARTICIPANTS = 4;
+const STANDARD_CAPTURE_RESTORE_RETRY_MS = 1000;
 
 type QualityWindow = {
   quality: ConnectionQuality;
@@ -189,6 +190,7 @@ export function useAdaptivePublishQuality({
     screenAudio: string | null;
   }>({ audio: null, webcam: null, screen: null, screenAudio: null });
   const lastStandardCaptureRestoreSignatureRef = useRef<string | null>(null);
+  const standardCaptureRestoreRetryTimeoutRef = useRef<number | null>(null);
 
   const writeDebugSnapshot = useCallback(
     (now = Date.now()) => {
@@ -346,7 +348,24 @@ export function useAdaptivePublishQuality({
   );
 
   const restoreStandardCaptureIfNeeded = useCallback(async () => {
-    if (isCameraOff || updateInFlightRef.current) return;
+    const scheduleRestoreRetry = () => {
+      if (
+        typeof window === "undefined" ||
+        standardCaptureRestoreRetryTimeoutRef.current !== null
+      ) {
+        return;
+      }
+      standardCaptureRestoreRetryTimeoutRef.current = window.setTimeout(() => {
+        standardCaptureRestoreRetryTimeoutRef.current = null;
+        void restoreStandardCaptureIfNeeded();
+      }, STANDARD_CAPTURE_RESTORE_RETRY_MS);
+    };
+
+    if (isCameraOff) return;
+    if (updateInFlightRef.current) {
+      scheduleRestoreRetry();
+      return;
+    }
     if (videoQualityRef.current !== "standard") return;
 
     const webcamProducer = videoProducerRef.current;
@@ -375,6 +394,7 @@ export function useAdaptivePublishQuality({
         "[Meets] Adaptive standard camera capture restore failed:",
         error,
       );
+      scheduleRestoreRetry();
     } finally {
       updateInFlightRef.current = false;
       writeDebugSnapshot();
@@ -467,6 +487,10 @@ export function useAdaptivePublishQuality({
         screenAudio: null,
       };
       lastStandardCaptureRestoreSignatureRef.current = null;
+      if (standardCaptureRestoreRetryTimeoutRef.current !== null) {
+        window.clearTimeout(standardCaptureRestoreRetryTimeoutRef.current);
+        standardCaptureRestoreRetryTimeoutRef.current = null;
+      }
       writeDebugSnapshot();
       return;
     }
@@ -566,7 +590,13 @@ export function useAdaptivePublishQuality({
 
     evaluate();
     const interval = window.setInterval(evaluate, CHECK_INTERVAL_MS);
-    return () => window.clearInterval(interval);
+    return () => {
+      window.clearInterval(interval);
+      if (standardCaptureRestoreRetryTimeoutRef.current !== null) {
+        window.clearTimeout(standardCaptureRestoreRetryTimeoutRef.current);
+        standardCaptureRestoreRetryTimeoutRef.current = null;
+      }
+    };
   }, [
     applyLiveProducerProfile,
     capRecoveryQuality,

--- a/apps/web/src/app/hooks/useAdaptivePublishQuality.ts
+++ b/apps/web/src/app/hooks/useAdaptivePublishQuality.ts
@@ -94,6 +94,21 @@ const needsStandardCaptureRestore = (track: MediaStreamTrack): boolean => {
   );
 };
 
+const getStandardCaptureRestoreSignature = (
+  producerId: string,
+  track: MediaStreamTrack,
+): string => {
+  const settings = track.getSettings();
+  return [
+    producerId,
+    "standard",
+    "good",
+    settings.width ?? "unknown-width",
+    settings.height ?? "unknown-height",
+    settings.frameRate ?? "unknown-fps",
+  ].join(":");
+};
+
 export type AdaptivePublishQualityDebugSnapshot = {
   enabled: boolean;
   timestamp: number;
@@ -393,7 +408,10 @@ export function useAdaptivePublishQuality({
       return;
     }
 
-    const signature = `${webcamProducer.id}:standard:good`;
+    const signature = getStandardCaptureRestoreSignature(
+      webcamProducer.id,
+      webcamTrack,
+    );
     if (lastStandardCaptureRestoreSignatureRef.current === signature) {
       return;
     }

--- a/apps/web/src/app/hooks/useAdaptivePublishQuality.ts
+++ b/apps/web/src/app/hooks/useAdaptivePublishQuality.ts
@@ -44,6 +44,9 @@ const POOR_LIVE_CAP_AFTER_MS = 2500;
 const GOOD_LIVE_RESTORE_AFTER_MS = 15000;
 const MAX_AUTO_UPGRADE_PARTICIPANTS = 4;
 const STANDARD_CAPTURE_RESTORE_RETRY_MS = 1000;
+const STANDARD_CAPTURE_MIN_WIDTH = 960;
+const STANDARD_CAPTURE_MIN_HEIGHT = 540;
+const STANDARD_CAPTURE_MIN_FRAMERATE = 24;
 
 type QualityWindow = {
   quality: ConnectionQuality;
@@ -77,6 +80,18 @@ type PublishProducerEncodingDebugSnapshot = {
   scaleResolutionDownBy: number | null;
   priority: RTCPriorityType | null;
   networkPriority: RTCPriorityType | null;
+};
+
+const needsStandardCaptureRestore = (track: MediaStreamTrack): boolean => {
+  const settings = track.getSettings();
+  return (
+    (typeof settings.width === "number" &&
+      settings.width < STANDARD_CAPTURE_MIN_WIDTH) ||
+    (typeof settings.height === "number" &&
+      settings.height < STANDARD_CAPTURE_MIN_HEIGHT) ||
+    (typeof settings.frameRate === "number" &&
+      settings.frameRate < STANDARD_CAPTURE_MIN_FRAMERATE)
+  );
 };
 
 export type AdaptivePublishQualityDebugSnapshot = {
@@ -385,7 +400,15 @@ export function useAdaptivePublishQuality({
 
     updateInFlightRef.current = true;
     try {
-      await updateVideoQualityRef.current("standard", "good");
+      if (needsStandardCaptureRestore(webcamTrack)) {
+        await updateVideoQualityRef.current("standard", "good");
+      } else {
+        await applyWebcamProducerNetworkProfile(
+          webcamProducer,
+          "standard",
+          "good",
+        );
+      }
       lastStandardCaptureRestoreSignatureRef.current = signature;
       lastAppliedProfilesRef.current.webcam = signature;
       writeDebugSnapshot();

--- a/apps/web/src/app/hooks/useBandwidthHeavyPreloadDeferred.ts
+++ b/apps/web/src/app/hooks/useBandwidthHeavyPreloadDeferred.ts
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import {
   getBrowserNetworkInformation,
   shouldDeferBandwidthHeavyPreload,
-  shouldSuppressBandwidthHeavyVideoEffects,
 } from "../lib/network-information";
 
 const useNetworkBoolean = (readValue: () => boolean): boolean => {
@@ -31,8 +30,4 @@ const useNetworkBoolean = (readValue: () => boolean): boolean => {
 
 export function useBandwidthHeavyPreloadDeferred(): boolean {
   return useNetworkBoolean(shouldDeferBandwidthHeavyPreload);
-}
-
-export function useBandwidthHeavyVideoEffectsSuppressed(): boolean {
-  return useNetworkBoolean(shouldSuppressBandwidthHeavyVideoEffects);
 }

--- a/apps/web/src/app/hooks/useMeetChat.ts
+++ b/apps/web/src/app/hooks/useMeetChat.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useRef, useState } from "react";
 import type { Socket } from "socket.io-client";
-import type { ChatMessage } from "../lib/types";
+import type { ChatGifAttachment, ChatMessage } from "../lib/types";
 import {
   createLocalChatMessage,
   formatActionContent,
@@ -72,13 +72,14 @@ export function useMeetChat({
   );
 
   const buildOptimisticMessage = useCallback(
-    (content: string): ChatMessage =>
+    (content: string, gif?: ChatGifAttachment): ChatMessage =>
       normalizeChatMessage({
         id: `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         userId: currentUserId,
         displayName: currentUserDisplayName,
         content,
         timestamp: Date.now(),
+        ...(gif ? { gif } : {}),
       }).message,
     [currentUserDisplayName, currentUserId],
   );
@@ -90,17 +91,18 @@ export function useMeetChat({
   }, [setChatMessages, setChatOverlayMessages, setUnreadCount]);
 
   const sendChatInternal = useCallback(
-    (content: string) => {
+    (content: string, gif?: ChatGifAttachment) => {
       const socket = socketRef.current;
       const trimmedContent = content.trim();
-      if (!socket || !trimmedContent) return;
+      if (!socket || (!trimmedContent && !gif)) return;
 
-      const optimisticMessage = buildOptimisticMessage(trimmedContent);
+      const messageContent = trimmedContent || gif?.title || "GIF";
+      const optimisticMessage = buildOptimisticMessage(messageContent, gif);
       setChatMessages((prev) => [...prev, optimisticMessage]);
 
       socket.emit(
         "sendChat",
-        { content: trimmedContent },
+        { content: messageContent, ...(gif ? { gif } : {}) },
         (
           response:
             | { success: boolean; message?: ChatMessage }
@@ -283,6 +285,25 @@ export function useMeetChat({
     ],
   );
 
+  const sendChatGif = useCallback(
+    (gif: ChatGifAttachment) => {
+      if (ghostEnabled || isObserverMode) return;
+      if (isChatLocked && !isAdmin) {
+        appendLocalMessage("Chat is locked by the host.");
+        return;
+      }
+      sendChatInternal(gif.title || "GIF", gif);
+    },
+    [
+      ghostEnabled,
+      isObserverMode,
+      isChatLocked,
+      isAdmin,
+      appendLocalMessage,
+      sendChatInternal,
+    ],
+  );
+
   return {
     chatMessages,
     setChatMessages,
@@ -295,6 +316,7 @@ export function useMeetChat({
     setChatInput,
     toggleChat,
     sendChat,
+    sendChatGif,
     isChatOpenRef,
   };
 }

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -1532,6 +1532,10 @@ export function useMeetMedia({
 
     const recoverAudioProducer = async () => {
       let createdTrack: MediaStreamTrack | null = null;
+      const hadLiveAudioTrackBeforeRecovery =
+        localStreamRef.current
+          ?.getAudioTracks()
+          .some((track) => track.readyState === "live") === true;
       try {
         let transport = getUsableProducerTransport(
           producerTransportRef.current,
@@ -1607,18 +1611,21 @@ export function useMeetMedia({
       } catch (err) {
         console.error("[Meets] Audio producer recovery failed:", err);
         if (!cancelled) {
-          const existingAudioTracks = localStreamRef.current?.getAudioTracks() ?? [];
-          existingAudioTracks.forEach((track) => {
-            stopLocalTrack(track);
-          });
-          setLocalStream((prev) => {
-            if (!prev) return prev;
-            const remaining = prev
-              .getTracks()
-              .filter((track) => track.kind !== "audio");
-            return new MediaStream(remaining);
-          });
-          setIsMuted(true);
+          if (createdTrack) {
+            stopLocalTrack(createdTrack);
+            const currentStream = localStreamRef.current;
+            if (currentStream?.getTracks().includes(createdTrack)) {
+              const remaining = currentStream
+                .getTracks()
+                .filter((track) => track !== createdTrack);
+              const nextStream = new MediaStream(remaining);
+              localStreamRef.current = nextStream;
+              setLocalStream(nextStream);
+            }
+          }
+          if (!hadLiveAudioTrackBeforeRecovery) {
+            setIsMuted(true);
+          }
           setMeetError(createMeetError(err, "MEDIA_ERROR"));
         }
       } finally {

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -88,6 +88,7 @@ interface UseMeetMediaOptions {
   >;
   permissionHintTimeoutRef: React.MutableRefObject<number | null>;
   audioContextRef: React.MutableRefObject<AudioContext | null>;
+  mediaRecoveryBlockedRef?: React.MutableRefObject<boolean>;
 }
 
 const getStartupAwarePublishQuality = (
@@ -319,6 +320,7 @@ export function useMeetMedia({
   intentionalTrackStopsRef,
   permissionHintTimeoutRef,
   audioContextRef,
+  mediaRecoveryBlockedRef,
 }: UseMeetMediaOptions) {
   const [mediaState, setMediaState] = useState<MediaState>({
     hasAudioPermission: false,
@@ -332,18 +334,24 @@ export function useMeetMedia({
     ) => Promise<void>
   >(async () => {});
   const audioRecoveryInFlightRef = useRef(false);
+  const isMediaRecoveryBlocked = useCallback(
+    () => mediaRecoveryBlockedRef?.current === true,
+    [mediaRecoveryBlockedRef],
+  );
   const [audioProducerRecoveryPulse, setAudioProducerRecoveryPulse] =
     useState(0);
   const notificationVolume = clampMeetVolume(meetVolume);
   const requestAudioProducerRecovery = useCallback(() => {
+    if (isMediaRecoveryBlocked()) return;
     setAudioProducerRecoveryPulse((value) => value + 1);
-  }, []);
+  }, [isMediaRecoveryBlocked]);
   const cameraRecoveryInFlightRef = useRef(false);
   const [cameraProducerRecoveryPulse, setCameraProducerRecoveryPulse] =
     useState(0);
   const requestCameraProducerRecovery = useCallback(() => {
+    if (isMediaRecoveryBlocked()) return;
     setCameraProducerRecoveryPulse((value) => value + 1);
-  }, []);
+  }, [isMediaRecoveryBlocked]);
   const cameraProducerTrackRepairInFlightRef = useRef(false);
   const cameraRecoveryCodecOverrideRef = useRef<ReturnType<
     typeof getPreferredWebcamCodec
@@ -1530,10 +1538,12 @@ export function useMeetMedia({
     if (ghostEnabled || isObserverMode) return;
     if (connectionState !== "joined") return;
     if (isMuted) return;
+    if (isMediaRecoveryBlocked()) return;
 
     let disposed = false;
     const requestRecovery = (reason: "initial" | "watchdog") => {
       if (disposed || audioRecoveryInFlightRef.current) return;
+      if (isMediaRecoveryBlocked()) return;
 
       const producer = audioProducerRef.current;
       const producerTrack = producer?.track ?? null;
@@ -1575,6 +1585,7 @@ export function useMeetMedia({
     ghostEnabled,
     isMuted,
     isObserverMode,
+    isMediaRecoveryBlocked,
     audioProducerRef,
     resetAudioProducer,
     requestAudioProducerRecovery,
@@ -1584,6 +1595,7 @@ export function useMeetMedia({
     if (ghostEnabled || isObserverMode) return;
     if (connectionState !== "joined") return;
     if (isMuted) return;
+    if (isMediaRecoveryBlocked()) return;
     if (audioProducerRef.current) {
       const existingProducer = audioProducerRef.current;
       if (
@@ -1606,7 +1618,23 @@ export function useMeetMedia({
         localStreamRef.current
           ?.getAudioTracks()
           .some((track) => track.readyState === "live") === true;
+      const removeCreatedTrackFromLocalStream = () => {
+        if (!createdTrack) return;
+        stopLocalTrack(createdTrack);
+        const currentStream = localStreamRef.current;
+        if (currentStream?.getTracks().includes(createdTrack)) {
+          const remaining = currentStream
+            .getTracks()
+            .filter((track) => track !== createdTrack);
+          const nextStream = new MediaStream(remaining);
+          localStreamRef.current = nextStream;
+          setLocalStream(nextStream);
+        }
+        createdTrack = null;
+      };
+
       try {
+        if (isMediaRecoveryBlocked()) return;
         let transport = getUsableProducerTransport(
           producerTransportRef.current,
         );
@@ -1635,6 +1663,10 @@ export function useMeetMedia({
         if (!audioTrack) {
           throw new Error("No audio track available for recovery");
         }
+        if (isMediaRecoveryBlocked()) {
+          removeCreatedTrackFromLocalStream();
+          return;
+        }
 
         markAudioTrackForSpeech(audioTrack);
         audioTrack.onended = () => {
@@ -1654,6 +1686,10 @@ export function useMeetMedia({
           localStreamRef.current = nextStream;
           setLocalStream(nextStream);
         }
+        if (isMediaRecoveryBlocked()) {
+          removeCreatedTrackFromLocalStream();
+          return;
+        }
 
         const audioProducer = await transport.produce({
           track: audioTrack,
@@ -1668,6 +1704,7 @@ export function useMeetMedia({
           try {
             audioProducer.close();
           } catch {}
+          removeCreatedTrackFromLocalStream();
           return;
         }
 
@@ -1675,24 +1712,13 @@ export function useMeetMedia({
         audioProducer.on("transportclose", () => {
           if (audioProducerRef.current?.id === audioProducer.id) {
             audioProducerRef.current = null;
-            setAudioProducerRecoveryPulse((value) => value + 1);
+            requestAudioProducerRecovery();
           }
         });
       } catch (err) {
         console.error("[Meets] Audio producer recovery failed:", err);
+        removeCreatedTrackFromLocalStream();
         if (!cancelled) {
-          if (createdTrack) {
-            stopLocalTrack(createdTrack);
-            const currentStream = localStreamRef.current;
-            if (currentStream?.getTracks().includes(createdTrack)) {
-              const remaining = currentStream
-                .getTracks()
-                .filter((track) => track !== createdTrack);
-              const nextStream = new MediaStream(remaining);
-              localStreamRef.current = nextStream;
-              setLocalStream(nextStream);
-            }
-          }
           if (!hadLiveAudioTrackBeforeRecovery) {
             setIsMuted(true);
           }
@@ -1714,6 +1740,7 @@ export function useMeetMedia({
     connectionState,
     audioProducerRecoveryPulse,
     isMuted,
+    isMediaRecoveryBlocked,
     selectedAudioInputDeviceId,
     handleLocalTrackEnded,
     stopLocalTrack,
@@ -1728,6 +1755,7 @@ export function useMeetMedia({
     resetAudioProducer,
     getPublishNetworkProfile,
     markAudioTrackForSpeech,
+    requestAudioProducerRecovery,
   ]);
 
   const toggleCamera = useCallback(async () => {
@@ -1929,10 +1957,17 @@ export function useMeetMedia({
     if (ghostEnabled || isObserverMode) return;
     if (connectionState !== "joined") return;
     if (isCameraOff) return;
+    if (isMediaRecoveryBlocked()) return;
 
     let disposed = false;
     const requestRecovery = (reason: "initial" | "watchdog") => {
-      if (disposed || cameraRecoveryInFlightRef.current) return;
+      if (
+        disposed ||
+        cameraRecoveryInFlightRef.current ||
+        isMediaRecoveryBlocked()
+      ) {
+        return;
+      }
 
       const producer = videoProducerRef.current;
       const producerTrack = producer?.track ?? null;
@@ -1953,7 +1988,11 @@ export function useMeetMedia({
         cameraProducerTrackRepairInFlightRef.current = true;
         void (async () => {
           try {
-            if (videoProducerRef.current?.id !== producer.id || producer.closed) {
+            if (
+              videoProducerRef.current?.id !== producer.id ||
+              producer.closed ||
+              isMediaRecoveryBlocked()
+            ) {
               return;
             }
             if ("contentHint" in rawCameraTrack) {
@@ -1985,7 +2024,10 @@ export function useMeetMedia({
               "[Meets] Camera producer raw-track repair failed; recreating producer:",
               err,
             );
-            if (videoProducerRef.current?.id === producer.id) {
+            if (
+              !isMediaRecoveryBlocked() &&
+              videoProducerRef.current?.id === producer.id
+            ) {
               closeLocalVideoProducerForReplacement(producer);
               requestCameraProducerRecovery();
             }
@@ -2029,6 +2071,7 @@ export function useMeetMedia({
     connectionState,
     ghostEnabled,
     isCameraOff,
+    isMediaRecoveryBlocked,
     isObserverMode,
     videoProducerRef,
     localStreamRef,
@@ -2045,7 +2088,11 @@ export function useMeetMedia({
       cameraOutboundStallStateRef.current = createCameraOutboundStallState();
       return;
     }
-    if (connectionState !== "joined" || isCameraOff) {
+    if (
+      connectionState !== "joined" ||
+      isCameraOff ||
+      isMediaRecoveryBlocked()
+    ) {
       cameraOutboundStallStateRef.current = createCameraOutboundStallState();
       return;
     }
@@ -2076,6 +2123,13 @@ export function useMeetMedia({
       if (disposed) return;
       if (cameraProducerTrackRepairInFlightRef.current) return;
       if (cameraRecoveryInFlightRef.current) return;
+      if (isMediaRecoveryBlocked()) {
+        cameraOutboundStallStateRef.current = {
+          ...state,
+          lastRecoveryAtMs: performance.now(),
+        };
+        return;
+      }
 
       const now = performance.now();
       if (
@@ -2102,8 +2156,28 @@ export function useMeetMedia({
         if (
           disposed ||
           videoProducerRef.current?.id !== producer.id ||
-          producer.closed
+          producer.closed ||
+          isMediaRecoveryBlocked()
         ) {
+          return;
+        }
+
+        if (!allowProducerRecreate) {
+          cameraOutboundStallStateRef.current = {
+            ...state,
+            lastRecoveryAtMs: now,
+          };
+          console.warn(
+            "[Meets] Camera sender stalled in background; keeping producer open.",
+            {
+              producerId: producer.id,
+              trackId: producerTrack.id,
+              rawTrackId: rawCameraTrack.id,
+              stalledSamples: state.stalledSamples,
+              frames: sample.frames,
+              bytes: sample.bytes,
+            },
+          );
           return;
         }
 
@@ -2147,25 +2221,6 @@ export function useMeetMedia({
           return;
         }
 
-        if (!allowProducerRecreate) {
-          cameraOutboundStallStateRef.current = {
-            ...state,
-            lastRecoveryAtMs: now,
-          };
-          console.warn(
-            "[Meets] Camera sender stalled in background; keeping producer open.",
-            {
-              producerId: producer.id,
-              trackId: producerTrack.id,
-              rawTrackId: rawCameraTrack.id,
-              stalledSamples: state.stalledSamples,
-              frames: sample.frames,
-              bytes: sample.bytes,
-            },
-          );
-          return;
-        }
-
         console.warn("[Meets] Recreating stalled camera sender:", {
           producerId: producer.id,
           trackId: producerTrack.id,
@@ -2186,7 +2241,8 @@ export function useMeetMedia({
               codec.mimeType.toLowerCase() === currentCodecMimeType,
           ) ?? getPreferredWebcamCodec(device);
         const fallbackCodec = getFallbackWebcamCodec(device, currentCodec);
-        cameraRecoveryCodecOverrideRef.current = fallbackCodec ?? currentCodec ?? null;
+        cameraRecoveryCodecOverrideRef.current =
+          fallbackCodec ?? currentCodec ?? null;
         cameraRecoveryForceSingleLayerRef.current = true;
         console.warn("[Meets] Next camera recovery will use single-layer codec:", {
           currentCodec: currentCodec?.mimeType ?? currentCodecMimeType,
@@ -2200,7 +2256,10 @@ export function useMeetMedia({
           "[Meets] Stalled camera sender recovery failed; recreating producer:",
           err,
         );
-        if (videoProducerRef.current?.id === producer.id) {
+        if (
+          !isMediaRecoveryBlocked() &&
+          videoProducerRef.current?.id === producer.id
+        ) {
           closeLocalVideoProducerForReplacement(producer);
           resetStallState();
           requestCameraProducerRecovery();
@@ -2212,6 +2271,10 @@ export function useMeetMedia({
 
     const pollOutboundProgress = () => {
       if (disposed) return;
+      if (isMediaRecoveryBlocked()) {
+        resetStallState();
+        return;
+      }
       if (
         cameraProducerTrackRepairInFlightRef.current ||
         cameraRecoveryInFlightRef.current
@@ -2237,7 +2300,7 @@ export function useMeetMedia({
       void producer
         .getStats()
         .then((report) => {
-          if (disposed) return;
+          if (disposed || isMediaRecoveryBlocked()) return;
           if (
             videoProducerRef.current?.id !== producer.id ||
             producer.closed ||
@@ -2318,6 +2381,7 @@ export function useMeetMedia({
     ghostEnabled,
     isCameraOff,
     isObserverMode,
+    isMediaRecoveryBlocked,
     videoProducerRef,
     deviceRef,
     localStreamRef,
@@ -2333,6 +2397,7 @@ export function useMeetMedia({
     if (ghostEnabled || isObserverMode) return;
     if (connectionState !== "joined") return;
     if (isCameraOff) return;
+    if (isMediaRecoveryBlocked()) return;
     const existingProducer = videoProducerRef.current;
     const existingTrack = existingProducer?.track ?? null;
     if (
@@ -2357,7 +2422,23 @@ export function useMeetMedia({
         localStreamRef.current
           ?.getVideoTracks()
           .some((track) => track.readyState === "live") === true;
+      const removeCreatedTrackFromLocalStream = () => {
+        if (!createdTrack) return;
+        stopLocalTrack(createdTrack);
+        const currentStream = localStreamRef.current;
+        if (currentStream?.getTracks().includes(createdTrack)) {
+          const remaining = currentStream
+            .getTracks()
+            .filter((track) => track !== createdTrack);
+          const nextStream = new MediaStream(remaining);
+          localStreamRef.current = nextStream;
+          setLocalStream(nextStream);
+        }
+        createdTrack = null;
+      };
+
       try {
+        if (isMediaRecoveryBlocked()) return;
         let transport = getUsableProducerTransport(producerTransportRef.current);
         if (!transport) {
           const transportReady =
@@ -2384,6 +2465,10 @@ export function useMeetMedia({
         if (!videoTrack) {
           throw new Error("No video track available for recovery");
         }
+        if (isMediaRecoveryBlocked()) {
+          removeCreatedTrackFromLocalStream();
+          return;
+        }
 
         if ("contentHint" in videoTrack) {
           videoTrack.contentHint = "motion";
@@ -2404,6 +2489,10 @@ export function useMeetMedia({
           const nextStream = new MediaStream([...remainingTracks, videoTrack]);
           localStreamRef.current = nextStream;
           setLocalStream(nextStream);
+        }
+        if (isMediaRecoveryBlocked()) {
+          removeCreatedTrackFromLocalStream();
+          return;
         }
 
         const publishStream =
@@ -2436,6 +2525,7 @@ export function useMeetMedia({
           try {
             recoveredProducer.close();
           } catch {}
+          removeCreatedTrackFromLocalStream();
           return;
         }
 
@@ -2449,19 +2539,8 @@ export function useMeetMedia({
         setIsCameraOff(false);
       } catch (err) {
         console.error("[Meets] Camera producer recovery failed:", err);
+        removeCreatedTrackFromLocalStream();
         if (!cancelled) {
-          if (createdTrack) {
-            stopLocalTrack(createdTrack);
-            const currentStream = localStreamRef.current;
-            if (currentStream?.getTracks().includes(createdTrack)) {
-              const remaining = currentStream
-                .getTracks()
-                .filter((track) => track !== createdTrack);
-              const nextStream = new MediaStream(remaining);
-              localStreamRef.current = nextStream;
-              setLocalStream(nextStream);
-            }
-          }
           if (!hadLiveCameraTrackBeforeRecovery) {
             setIsCameraOff(true);
           }
@@ -2487,6 +2566,7 @@ export function useMeetMedia({
     connectionState,
     cameraProducerRecoveryPulse,
     isCameraOff,
+    isMediaRecoveryBlocked,
     handleLocalTrackEnded,
     stopLocalTrack,
     setLocalStream,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -132,6 +132,7 @@ const getUsableProducerTransport = (
 type OutboundVideoProgressSample = {
   frames: number | null;
   bytes: number | null;
+  framesPerSecond: number | null;
   qualityLimitationReason: string | null;
 };
 
@@ -178,6 +179,7 @@ const readOutboundVideoProgressSample = (
   let hasFrames = false;
   let bytes = 0;
   let hasBytes = false;
+  let framesPerSecond: number | null = null;
   let qualityLimitationReason: string | null = null;
 
   report.forEach((entry) => {
@@ -201,6 +203,11 @@ const readOutboundVideoProgressSample = (
       hasBytes = true;
     }
 
+    const currentFramesPerSecond = getRtcStatsNumber(stat, "framesPerSecond");
+    if (currentFramesPerSecond !== null) {
+      framesPerSecond = Math.max(framesPerSecond ?? 0, currentFramesPerSecond);
+    }
+
     if (
       typeof stat.qualityLimitationReason === "string" &&
       stat.qualityLimitationReason &&
@@ -213,6 +220,7 @@ const readOutboundVideoProgressSample = (
   return {
     frames: hasFrames ? frames : null,
     bytes: hasBytes ? bytes : null,
+    framesPerSecond,
     qualityLimitationReason,
   };
 };
@@ -227,13 +235,36 @@ const hasOutboundVideoProgress = (
   previous: CameraOutboundStallState,
   sample: OutboundVideoProgressSample,
 ): boolean => {
-  // When frame counters exist, byte trickle alone is not video progress: RTP
-  // padding/RTX can advance bytes while the camera frame stream is frozen.
+  // When frame counters exist, flat frames alone are not enough to prove a
+  // sender stall: static/low-motion cameras can legitimately stay quiet. Only
+  // count it as stalled when RTP bytes keep moving, which means the sender path
+  // is alive but no new camera frames are being encoded.
   if (
     previous.frames !== null &&
     sample.frames !== null
   ) {
-    return sample.frames > previous.frames;
+    if (sample.frames > previous.frames) return true;
+    if (
+      sample.framesPerSecond !== null &&
+      sample.framesPerSecond > 0
+    ) {
+      return true;
+    }
+    if (
+      previous.bytes !== null &&
+      sample.bytes !== null &&
+      sample.bytes - previous.bytes >= MIN_OUTBOUND_VIDEO_BYTE_DELTA_FOR_PROGRESS
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  if (
+    sample.framesPerSecond !== null &&
+    sample.framesPerSecond > 0
+  ) {
+    return true;
   }
 
   if (

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -995,6 +995,8 @@ export function useMeetMedia({
               await audioProducerRef.current.replaceTrack({
                 track: newAudioTrack,
               });
+            } else if (!isMuted) {
+              requestAudioProducerRecovery();
             }
 
             const remainingTracks =
@@ -1026,6 +1028,7 @@ export function useMeetMedia({
       buildAudioConstraints,
       markAudioTrackForSpeech,
       stopTracksExcept,
+      requestAudioProducerRecovery,
     ]
   );
 

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -614,6 +614,14 @@ export function useMeetMedia({
     [intentionalTrackStopsRef]
   );
 
+  const commitLocalStream = useCallback(
+    (nextStream: MediaStream | null) => {
+      localStreamRef.current = nextStream;
+      setLocalStream(nextStream);
+    },
+    [localStreamRef, setLocalStream],
+  );
+
   const closeLocalVideoProducerForReplacement = useCallback(
     (producer: Producer) => {
       intentionalLocalProducerCloseIdsRef.current.add(producer.id);
@@ -647,6 +655,30 @@ export function useMeetMedia({
   const handleLocalTrackEnded = useCallback(
     (kind: "audio" | "video", track: MediaStreamTrack) => {
       if (consumeIntentionalStop(track)) return;
+
+      const currentStream = localStreamRef.current;
+      const hasCurrentLocalTrack =
+        currentStream
+          ?.getTracks()
+          .some(
+            (currentTrack) =>
+              currentTrack === track || currentTrack.id === track.id,
+          ) === true;
+      const activeProducer =
+        kind === "audio" ? audioProducerRef.current : videoProducerRef.current;
+      const producerTrack = activeProducer?.track ?? null;
+      const hasCurrentProducerTrack =
+        producerTrack === track || producerTrack?.id === track.id;
+
+      if (!hasCurrentLocalTrack && !hasCurrentProducerTrack) {
+        console.info("[Meets] Ignoring ended stale local track:", {
+          kind,
+          trackId: track.id,
+          activeProducerId: activeProducer?.id ?? null,
+          activeProducerTrackId: producerTrack?.id ?? null,
+        });
+        return;
+      }
 
       if (kind === "audio") {
         const producer = audioProducerRef.current;
@@ -684,18 +716,23 @@ export function useMeetMedia({
         }
       }
 
-      setLocalStream((prev) => {
-        if (!prev) return prev;
-        const remaining = prev.getTracks().filter((t) => t.kind !== kind);
-        return new MediaStream(remaining);
-      });
+      if (hasCurrentLocalTrack && currentStream) {
+        const remaining = currentStream
+          .getTracks()
+          .filter(
+            (currentTrack) =>
+              currentTrack !== track && currentTrack.id !== track.id,
+          );
+        commitLocalStream(new MediaStream(remaining));
+      }
     },
     [
       consumeIntentionalStop,
       closeLocalVideoProducerForReplacement,
+      commitLocalStream,
       setIsMuted,
       setIsCameraOff,
-      setLocalStream,
+      localStreamRef,
       audioProducerRef,
       videoProducerRef,
       socketRef,
@@ -837,7 +874,8 @@ export function useMeetMedia({
               handleLocalTrackEnded("audio", newAudioTrack);
             };
             newAudioTrack.enabled = !isMuted;
-            const oldAudioTrack = localStream?.getAudioTracks()[0];
+            const previousStream = localStreamRef.current;
+            const oldAudioTrack = previousStream?.getAudioTracks()[0] ?? null;
 
             if (audioProducerRef.current) {
               await audioProducerRef.current.replaceTrack({
@@ -845,19 +883,18 @@ export function useMeetMedia({
               });
             }
 
-            setLocalStream((prev) => {
-              if (prev) {
-                if (oldAudioTrack) {
-                  prev.removeTrack(oldAudioTrack);
-                }
-                prev.addTrack(newAudioTrack);
-                if (oldAudioTrack) {
-                  stopLocalTrack(oldAudioTrack);
-                }
-                return new MediaStream(prev.getTracks());
-              }
-              return newStream;
-            });
+            const remainingTracks =
+              previousStream
+                ?.getTracks()
+                .filter((track) => track.kind !== "audio") ?? [];
+            const nextStream = new MediaStream([
+              ...remainingTracks,
+              newAudioTrack,
+            ]);
+            commitLocalStream(nextStream);
+            if (oldAudioTrack && oldAudioTrack.id !== newAudioTrack.id) {
+              stopLocalTrack(oldAudioTrack);
+            }
           }
         } catch (err) {
           console.error("[Meets] Failed to switch audio input device:", err);
@@ -867,12 +904,12 @@ export function useMeetMedia({
     [
       connectionState,
       isMuted,
-      localStream,
       handleLocalTrackEnded,
       stopLocalTrack,
       setSelectedAudioInputDeviceId,
       audioProducerRef,
-      setLocalStream,
+      localStreamRef,
+      commitLocalStream,
       buildAudioConstraints,
       markAudioTrackForSpeech,
     ]
@@ -1420,13 +1457,13 @@ export function useMeetMedia({
       console.error("[Meets] Failed to restart audio:", err);
       if (createdTrack) {
         stopLocalTrack(createdTrack);
-        setLocalStream((prev) => {
-          if (!prev) return prev;
-          const remaining = prev
+        const currentStream = localStreamRef.current;
+        if (currentStream?.getTracks().includes(createdTrack)) {
+          const remaining = currentStream
             .getTracks()
             .filter((track) => track !== createdTrack && track.kind !== "audio");
-          return new MediaStream(remaining);
-        });
+          commitLocalStream(new MediaStream(remaining));
+        }
       }
       setIsMuted(previousMuted);
       setMeetError(createMeetError(err, "MEDIA_ERROR"));
@@ -1446,7 +1483,7 @@ export function useMeetMedia({
     emitToggleMute,
     audioProducerRef,
     localStreamRef,
-    setLocalStream,
+    commitLocalStream,
     producerTransportRef,
     ensureProducerTransportRef,
     setIsMuted,
@@ -1686,16 +1723,16 @@ export function useMeetMedia({
           } catch {}
           videoProducerRef.current = null;
 
-          setLocalStream((prev) => {
-            if (!prev) return prev;
-            prev.getVideoTracks().forEach((track) => {
+          const previousStream = localStreamRef.current;
+          if (previousStream) {
+            previousStream.getVideoTracks().forEach((track) => {
               stopLocalTrack(track);
             });
-            const remainingTracks = prev
+            const remainingTracks = previousStream
               .getTracks()
               .filter((track) => track.kind !== "video");
-            return new MediaStream(remainingTracks);
-          });
+            commitLocalStream(new MediaStream(remainingTracks));
+          }
           return;
         }
 
@@ -1814,15 +1851,15 @@ export function useMeetMedia({
           console.error("[Meets] Failed to restart video:", err);
           if (createdTrack) {
             stopLocalTrack(createdTrack);
-            setLocalStream((prev) => {
-              if (!prev) return prev;
-              const remaining = prev
+            const currentStream = localStreamRef.current;
+            if (currentStream?.getTracks().includes(createdTrack)) {
+              const remaining = currentStream
                 .getTracks()
                 .filter(
                   (track) => track !== createdTrack && track.kind !== "video",
                 );
-              return new MediaStream(remaining);
-            });
+              commitLocalStream(new MediaStream(remaining));
+            }
           }
           setIsCameraOff(true);
           setMeetError(createMeetError(err, "MEDIA_ERROR"));
@@ -1843,6 +1880,7 @@ export function useMeetMedia({
     producerTransportRef,
     ensureProducerTransportRef,
     setLocalStream,
+    commitLocalStream,
     localStreamRef,
     videoQualityRef,
     setIsCameraOff,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -1440,6 +1440,7 @@ export function useMeetMedia({
           codecOptions: buildMicrophoneOpusCodecOptions(
             getPublishNetworkProfile(),
           ),
+          stopTracks: false,
           appData: { type: "webcam" as ProducerType, paused: false },
         });
 
@@ -1628,6 +1629,7 @@ export function useMeetMedia({
           codecOptions: buildMicrophoneOpusCodecOptions(
             getPublishNetworkProfile(),
           ),
+          stopTracks: false,
           appData: { type: "webcam" as ProducerType, paused: false },
         });
 

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -2249,6 +2249,7 @@ export function useMeetMedia({
     localStreamRef,
     videoQualityRef,
     handleLocalTrackEnded,
+    waitForPreferredVideoPublishTrack,
     getPublishNetworkProfile,
     onPreferredVideoPublishTrackRejected,
     closeLocalVideoProducerForReplacement,
@@ -2334,35 +2335,28 @@ export function useMeetMedia({
           return;
         }
 
-        if (!allowProducerRecreate) {
-          cameraOutboundStallStateRef.current = {
-            ...state,
-            lastRecoveryAtMs: now,
-          };
-          console.warn(
-            "[Meets] Camera sender stalled in background; keeping producer open.",
-            {
-              producerId: producer.id,
-              trackId: producerTrack.id,
-              rawTrackId: rawCameraTrack.id,
-              stalledSamples: state.stalledSamples,
-              frames: sample.frames,
-              bytes: sample.bytes,
-            },
+        const shouldTryPreferredRepair = !state.rawRepairAttempted;
+        if (shouldTryPreferredRepair) {
+          const publishStream =
+            localStreamRef.current ?? new MediaStream([rawCameraTrack]);
+          const publishTrack = await waitForPreferredVideoPublishTrack(
+            publishStream,
+            rawCameraTrack,
           );
-          return;
-        }
-
-        const shouldTryRawRepair = !state.rawRepairAttempted;
-        if (shouldTryRawRepair) {
+          if (!publishTrack || publishTrack.readyState !== "live") {
+            return;
+          }
           if ("contentHint" in rawCameraTrack) {
             rawCameraTrack.contentHint = "motion";
           }
           rawCameraTrack.onended = () => {
             handleLocalTrackEnded("video", rawCameraTrack);
           };
-          await producer.replaceTrack({ track: rawCameraTrack });
-          if (producerTrack.id !== rawCameraTrack.id) {
+          await producer.replaceTrack({ track: publishTrack });
+          if (
+            publishTrack.id === rawCameraTrack.id &&
+            producerTrack.id !== rawCameraTrack.id
+          ) {
             onPreferredVideoPublishTrackRejected?.(
               producerTrack,
               "camera-outbound-stall-raw-repair",
@@ -2374,17 +2368,38 @@ export function useMeetMedia({
             getPublishNetworkProfile(),
           );
           cameraOutboundStallStateRef.current = {
-            ...createCameraOutboundStallState(producer.id, rawCameraTrack.id),
+            ...createCameraOutboundStallState(producer.id, publishTrack.id),
             frames: sample.frames,
             bytes: sample.bytes,
             rawRepairAttempted: true,
             lastRecoveryAtMs: now,
           };
           console.warn(
-            "[Meets] Refreshed stalled camera sender with raw camera track:",
+            "[Meets] Refreshed stalled camera sender with preferred camera track:",
             {
               producerId: producer.id,
               previousTrackId: producerTrack.id,
+              publishTrackId: publishTrack.id,
+              rawTrackId: rawCameraTrack.id,
+              usedRawFallback: publishTrack.id === rawCameraTrack.id,
+              stalledSamples: state.stalledSamples,
+              frames: sample.frames,
+              bytes: sample.bytes,
+            },
+          );
+          return;
+        }
+
+        if (!allowProducerRecreate) {
+          cameraOutboundStallStateRef.current = {
+            ...state,
+            lastRecoveryAtMs: now,
+          };
+          console.warn(
+            "[Meets] Camera sender stalled in background; keeping producer open.",
+            {
+              producerId: producer.id,
+              trackId: producerTrack.id,
               rawTrackId: rawCameraTrack.id,
               stalledSamples: state.stalledSamples,
               frames: sample.frames,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -580,9 +580,15 @@ export function useMeetMedia({
     [socketRef]
   );
 
-  const resetAudioProducer = useCallback(
+  const closeLocalAudioProducerForReplacement = useCallback(
     (producer: Producer | null) => {
       if (!producer) return;
+      intentionalLocalProducerCloseIdsRef.current.add(producer.id);
+      socketRef.current?.emit(
+        "closeProducer",
+        { producerId: producer.id },
+        () => {},
+      );
       try {
         producer.close();
       } catch {}
@@ -590,7 +596,7 @@ export function useMeetMedia({
         audioProducerRef.current = null;
       }
     },
-    [audioProducerRef]
+    [audioProducerRef, intentionalLocalProducerCloseIdsRef, socketRef],
   );
 
   const getPublishNetworkProfile =
@@ -794,15 +800,7 @@ export function useMeetMedia({
       if (kind === "audio") {
         const producer = audioProducerRef.current;
         if (producer) {
-          socketRef.current?.emit(
-            "closeProducer",
-            { producerId: producer.id },
-            () => {}
-          );
-          try {
-            producer.close();
-          } catch {}
-          audioProducerRef.current = null;
+          closeLocalAudioProducerForReplacement(producer);
         }
         if (connectionStateRef.current === "joined") {
           console.warn(
@@ -839,6 +837,7 @@ export function useMeetMedia({
     },
     [
       consumeIntentionalStop,
+      closeLocalAudioProducerForReplacement,
       closeLocalVideoProducerForReplacement,
       commitLocalStream,
       setIsMuted,
@@ -846,7 +845,6 @@ export function useMeetMedia({
       localStreamRef,
       audioProducerRef,
       videoProducerRef,
-      socketRef,
       requestAudioProducerRecovery,
       requestCameraProducerRecovery,
     ]
@@ -993,7 +991,7 @@ export function useMeetMedia({
 
             const currentAudioProducer = audioProducerRef.current;
             if (currentAudioProducer?.closed) {
-              resetAudioProducer(currentAudioProducer);
+              closeLocalAudioProducerForReplacement(currentAudioProducer);
             }
             const audioProducer = audioProducerRef.current;
             if (audioProducer) {
@@ -1032,7 +1030,7 @@ export function useMeetMedia({
       commitLocalStream,
       buildAudioConstraints,
       markAudioTrackForSpeech,
-      resetAudioProducer,
+      closeLocalAudioProducerForReplacement,
       stopTracksExcept,
       requestAudioProducerRecovery,
     ]
@@ -1423,12 +1421,7 @@ export function useMeetMedia({
         producer &&
         (producer.closed || producer.track?.readyState !== "live")
       ) {
-        socketRef.current?.emit(
-          "closeProducer",
-          { producerId: producer.id },
-          () => {}
-        );
-        resetAudioProducer(producer);
+        closeLocalAudioProducerForReplacement(producer);
         producer = null;
       }
 
@@ -1562,7 +1555,7 @@ export function useMeetMedia({
                 "[Meets] unmute retry also failed — recreating to be safe:",
                 retry.error
               );
-              resetAudioProducer(producer);
+              closeLocalAudioProducerForReplacement(producer);
               producer = null;
             }
           } else {
@@ -1574,7 +1567,7 @@ export function useMeetMedia({
               "[Meets] unmute failed (server error / dead producer) — recreating:",
               toggleResult.error
             );
-            resetAudioProducer(producer);
+            closeLocalAudioProducerForReplacement(producer);
             producer = null;
           }
         }
@@ -1635,7 +1628,7 @@ export function useMeetMedia({
     ensureProducerTransportRef,
     setIsMuted,
     setMeetError,
-    resetAudioProducer,
+    closeLocalAudioProducerForReplacement,
     getPublishNetworkProfile,
     markAudioTrackForSpeech,
     toggleMuteInFlightRef,
@@ -1659,7 +1652,7 @@ export function useMeetMedia({
       if (!needsRecovery) return;
 
       if (producer && audioProducerRef.current?.id === producer.id) {
-        resetAudioProducer(producer);
+        closeLocalAudioProducerForReplacement(producer);
       }
 
       console.warn("[Meets] Audio producer recovery triggered:", {
@@ -1694,7 +1687,7 @@ export function useMeetMedia({
     isObserverMode,
     isMediaRecoveryBlocked,
     audioProducerRef,
-    resetAudioProducer,
+    closeLocalAudioProducerForReplacement,
     requestAudioProducerRecovery,
   ]);
 
@@ -1709,7 +1702,7 @@ export function useMeetMedia({
         existingProducer.closed ||
         existingProducer.track?.readyState !== "live"
       ) {
-        resetAudioProducer(existingProducer);
+        closeLocalAudioProducerForReplacement(existingProducer);
       } else {
         return;
       }
@@ -1861,7 +1854,7 @@ export function useMeetMedia({
     setLocalStream,
     setIsMuted,
     setMeetError,
-    resetAudioProducer,
+    closeLocalAudioProducerForReplacement,
     getPublishNetworkProfile,
     markAudioTrackForSpeech,
     requestAudioProducerRecovery,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -714,6 +714,25 @@ export function useMeetMedia({
     [localStreamRef, setLocalStream],
   );
 
+  const stopTracksExcept = useCallback(
+    (
+      tracks: readonly MediaStreamTrack[],
+      keepTracks: readonly (MediaStreamTrack | null | undefined)[],
+    ) => {
+      const keepTrackIds = new Set(
+        keepTracks
+          .filter((track): track is MediaStreamTrack => Boolean(track))
+          .map((track) => track.id),
+      );
+      for (const track of tracks) {
+        if (!keepTrackIds.has(track.id)) {
+          stopLocalTrack(track);
+        }
+      }
+    },
+    [stopLocalTrack],
+  );
+
   const closeLocalVideoProducerForReplacement = useCallback(
     (producer: Producer) => {
       intentionalLocalProducerCloseIdsRef.current.add(producer.id);
@@ -967,7 +986,7 @@ export function useMeetMedia({
             };
             newAudioTrack.enabled = !isMuted;
             const previousStream = localStreamRef.current;
-            const oldAudioTrack = previousStream?.getAudioTracks()[0] ?? null;
+            const previousAudioTracks = previousStream?.getAudioTracks() ?? [];
 
             if (audioProducerRef.current) {
               await audioProducerRef.current.replaceTrack({
@@ -984,9 +1003,7 @@ export function useMeetMedia({
               newAudioTrack,
             ]);
             commitLocalStream(nextStream);
-            if (oldAudioTrack && oldAudioTrack.id !== newAudioTrack.id) {
-              stopLocalTrack(oldAudioTrack);
-            }
+            stopTracksExcept(previousAudioTracks, [newAudioTrack]);
           }
         } catch (err) {
           console.error("[Meets] Failed to switch audio input device:", err);
@@ -997,13 +1014,13 @@ export function useMeetMedia({
       connectionState,
       isMuted,
       handleLocalTrackEnded,
-      stopLocalTrack,
       setSelectedAudioInputDeviceId,
       audioProducerRef,
       localStreamRef,
       commitLocalStream,
       buildAudioConstraints,
       markAudioTrackForSpeech,
+      stopTracksExcept,
     ]
   );
 
@@ -1026,7 +1043,7 @@ export function useMeetMedia({
             handleLocalTrackEnded("video", newVideoTrack);
           };
           const previousStream = localStreamRef.current ?? localStream;
-          const oldVideoTrack = previousStream?.getVideoTracks()[0] ?? null;
+          const previousVideoTracks = previousStream?.getVideoTracks() ?? [];
           const remainingTracks =
             previousStream
               ?.getTracks()
@@ -1060,9 +1077,10 @@ export function useMeetMedia({
             }
           }
 
-          if (oldVideoTrack && oldVideoTrack !== newVideoTrack) {
-            stopLocalTrack(oldVideoTrack);
-          }
+          stopTracksExcept(previousVideoTracks, [
+            newVideoTrack,
+            videoProducerRef.current?.track ?? null,
+          ]);
         }
       } catch (err) {
         console.error("[Meets] Failed to switch video input device:", err);
@@ -1073,13 +1091,13 @@ export function useMeetMedia({
       isCameraOff,
       localStream,
       handleLocalTrackEnded,
-      stopLocalTrack,
       videoProducerRef,
       setLocalStream,
       buildVideoConstraints,
       localStreamRef,
       waitForPreferredVideoPublishTrack,
       onPreferredVideoPublishTrackRejected,
+      stopTracksExcept,
     ]
   );
 
@@ -1142,7 +1160,7 @@ export function useMeetMedia({
           JSON.stringify(constraints)
         );
 
-        const currentTrack = localStream.getVideoTracks()[0];
+        const currentTrack = getFirstLiveTrack(localStream.getVideoTracks());
         const shouldUpdateCaptureConstraints =
           shouldUpdateCaptureConstraintsForQualitySwitch(
             quality,
@@ -1166,9 +1184,9 @@ export function useMeetMedia({
           }
         }
 
-        let nextVideoTrack = localStream.getVideoTracks()[0];
+        let nextVideoTrack = getFirstLiveTrack(localStream.getVideoTracks());
         let publishStream = localStreamRef.current ?? localStream;
-        let oldVideoTrackToStop: MediaStreamTrack | null = null;
+        let oldVideoTracksToStop: MediaStreamTrack[] = [];
 
         if (
           !nextVideoTrack ||
@@ -1212,7 +1230,7 @@ export function useMeetMedia({
 
           const previousStream = localStreamRef.current ?? localStream;
           rollbackStream = previousStream;
-          oldVideoTrackToStop = previousStream?.getVideoTracks()[0] ?? null;
+          oldVideoTracksToStop = previousStream?.getVideoTracks() ?? [];
           const remainingTracks = previousStream
             .getTracks()
             .filter((track) => track.kind !== "video");
@@ -1271,13 +1289,10 @@ export function useMeetMedia({
             quality,
             publishNetworkProfile,
           );
-          if (
-            oldVideoTrackToStop &&
-            oldVideoTrackToStop !== nextVideoTrack &&
-            oldVideoTrackToStop !== previousProducer.track
-          ) {
-            stopLocalTrack(oldVideoTrackToStop);
-          }
+          stopTracksExcept(oldVideoTracksToStop, [
+            nextVideoTrack,
+            previousProducer.track,
+          ]);
           return;
         }
 
@@ -1325,9 +1340,10 @@ export function useMeetMedia({
             previousProducer.close();
           } catch {}
         }
-        if (oldVideoTrackToStop && oldVideoTrackToStop !== nextVideoTrack) {
-          stopLocalTrack(oldVideoTrackToStop);
-        }
+        stopTracksExcept(oldVideoTracksToStop, [
+          nextVideoTrack,
+          nextProducer.track,
+        ]);
       } catch (err) {
         console.error("[Meets] Failed to update video quality:", err);
         if (rollbackStream && replacementTrack) {
@@ -1343,6 +1359,7 @@ export function useMeetMedia({
       localStream,
       handleLocalTrackEnded,
       stopLocalTrack,
+      stopTracksExcept,
       setLocalStream,
       socketRef,
       deviceRef,
@@ -1387,10 +1404,14 @@ export function useMeetMedia({
       }
 
       if (nextMuted) {
-        const currentTrack = localStreamRef.current?.getAudioTracks()[0];
-        if (currentTrack && currentTrack.readyState === "live") {
-          currentTrack.enabled = false;
-        }
+        const currentAudioTracks =
+          localStreamRef.current?.getAudioTracks() ?? [];
+        const liveAudioTracks = currentAudioTracks.filter(
+          (track) => track.readyState === "live",
+        );
+        liveAudioTracks.forEach((track) => {
+          track.enabled = false;
+        });
 
         if (producer) {
           try {
@@ -1402,9 +1423,11 @@ export function useMeetMedia({
               "[Meets] toggleMute failed, rolling back mute:",
               toggleResult.error
             );
-            if (currentTrack && currentTrack.readyState === "live") {
-              currentTrack.enabled = true;
-            }
+            liveAudioTracks.forEach((track) => {
+              if (track.readyState === "live") {
+                track.enabled = true;
+              }
+            });
             try {
               producer.resume();
             } catch {}
@@ -1431,7 +1454,9 @@ export function useMeetMedia({
         }
       }
 
-      let audioTrack = localStreamRef.current?.getAudioTracks()[0] ?? null;
+      let audioTrack = getFirstLiveTrack(
+        localStreamRef.current?.getAudioTracks() ?? [],
+      );
 
       if (audioTrack && audioTrack.readyState !== "live") {
         stopLocalTrack(audioTrack);
@@ -1703,7 +1728,9 @@ export function useMeetMedia({
           }
         }
 
-        let audioTrack = localStreamRef.current?.getAudioTracks()[0] ?? null;
+        let audioTrack = getFirstLiveTrack(
+          localStreamRef.current?.getAudioTracks() ?? [],
+        );
 
         if (!audioTrack || audioTrack.readyState !== "live") {
           const stream = await navigator.mediaDevices.getUserMedia({
@@ -2516,7 +2543,9 @@ export function useMeetMedia({
           }
         }
 
-        let videoTrack = localStreamRef.current?.getVideoTracks()[0] ?? null;
+        let videoTrack = getFirstLiveTrack(
+          localStreamRef.current?.getVideoTracks() ?? [],
+        );
 
         if (!videoTrack || videoTrack.readyState !== "live") {
           const stream = await navigator.mediaDevices.getUserMedia({

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -1322,21 +1322,22 @@ export function useMeetMedia({
           handleLocalTrackEnded("audio", nextAudioTrack);
         };
 
-        setLocalStream((prev) => {
-          if (prev) {
-            const newStream = new MediaStream(prev.getTracks());
-            newStream.getAudioTracks().forEach((t) => {
-              if (t.id === nextAudioTrack.id) return;
-              stopLocalTrack(t);
-              newStream.removeTrack(t);
-            });
-            if (!newStream.getAudioTracks().some((t) => t.id === nextAudioTrack.id)) {
-              newStream.addTrack(nextAudioTrack);
-            }
-            return newStream;
+        const previousStream = localStreamRef.current;
+        previousStream?.getAudioTracks().forEach((track) => {
+          if (track.id !== nextAudioTrack.id) {
+            stopLocalTrack(track);
           }
-          return new MediaStream([nextAudioTrack]);
         });
+        const remainingTracks =
+          previousStream
+            ?.getTracks()
+            .filter((track) => track.kind !== "audio") ?? [];
+        const nextStream = new MediaStream([
+          ...remainingTracks,
+          nextAudioTrack,
+        ]);
+        localStreamRef.current = nextStream;
+        setLocalStream(nextStream);
 
         audioTrack = nextAudioTrack;
       }
@@ -1572,18 +1573,17 @@ export function useMeetMedia({
         };
 
         if (createdTrack) {
-          setLocalStream((prev) => {
-            if (prev) {
-              const next = new MediaStream(prev.getTracks());
-              next.getAudioTracks().forEach((track) => {
-                stopLocalTrack(track);
-                next.removeTrack(track);
-              });
-              next.addTrack(audioTrack);
-              return next;
-            }
-            return new MediaStream([audioTrack]);
+          const previousStream = localStreamRef.current;
+          previousStream?.getAudioTracks().forEach((track) => {
+            stopLocalTrack(track);
           });
+          const remainingTracks =
+            previousStream
+              ?.getTracks()
+              .filter((track) => track.kind !== "audio") ?? [];
+          const nextStream = new MediaStream([...remainingTracks, audioTrack]);
+          localStreamRef.current = nextStream;
+          setLocalStream(nextStream);
         }
 
         const audioProducer = await transport.produce({

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -2258,6 +2258,7 @@ export function useMeetMedia({
 
     const recoverCameraProducer = async () => {
       let createdTrack: MediaStreamTrack | null = null;
+      let consumedRecoveryPublishOverride = false;
       const hadLiveCameraTrackBeforeRecovery =
         localStreamRef.current
           ?.getVideoTracks()
@@ -2320,9 +2321,11 @@ export function useMeetMedia({
         const quality = videoQualityRef.current;
         const networkProfile = getPublishNetworkProfile();
         const forceSingleLayer = cameraRecoveryForceSingleLayerRef.current;
+        const recoveryCodecOverride = cameraRecoveryCodecOverrideRef.current;
+        consumedRecoveryPublishOverride =
+          forceSingleLayer || recoveryCodecOverride !== null;
         const preferredWebcamCodec =
-          cameraRecoveryCodecOverrideRef.current ??
-          getPreferredWebcamCodec(deviceRef.current);
+          recoveryCodecOverride ?? getPreferredWebcamCodec(deviceRef.current);
         const recoveredProducer = await produceCameraTrackWithRawFallback({
           transport,
           publishTrack,
@@ -2349,8 +2352,6 @@ export function useMeetMedia({
             requestCameraProducerRecovery();
           }
         });
-        cameraRecoveryCodecOverrideRef.current = null;
-        cameraRecoveryForceSingleLayerRef.current = false;
         setIsCameraOff(false);
       } catch (err) {
         console.error("[Meets] Camera producer recovery failed:", err);
@@ -2373,6 +2374,10 @@ export function useMeetMedia({
           setMeetError(createMeetError(err, "MEDIA_ERROR"));
         }
       } finally {
+        if (consumedRecoveryPublishOverride) {
+          cameraRecoveryCodecOverrideRef.current = null;
+          cameraRecoveryForceSingleLayerRef.current = false;
+        }
         cameraRecoveryInFlightRef.current = false;
       }
     };

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -991,8 +991,13 @@ export function useMeetMedia({
             const previousStream = localStreamRef.current;
             const previousAudioTracks = previousStream?.getAudioTracks() ?? [];
 
-            if (audioProducerRef.current) {
-              await audioProducerRef.current.replaceTrack({
+            const currentAudioProducer = audioProducerRef.current;
+            if (currentAudioProducer?.closed) {
+              resetAudioProducer(currentAudioProducer);
+            }
+            const audioProducer = audioProducerRef.current;
+            if (audioProducer) {
+              await audioProducer.replaceTrack({
                 track: newAudioTrack,
               });
             } else if (!isMuted) {
@@ -1027,6 +1032,7 @@ export function useMeetMedia({
       commitLocalStream,
       buildAudioConstraints,
       markAudioTrackForSpeech,
+      resetAudioProducer,
       stopTracksExcept,
       requestAudioProducerRecovery,
     ]
@@ -1061,13 +1067,18 @@ export function useMeetMedia({
               .filter((track) => track.kind !== "video") ?? [];
           const nextStream = new MediaStream([...remainingTracks, newVideoTrack]);
 
-          if (videoProducerRef.current) {
+          const currentVideoProducer = videoProducerRef.current;
+          if (currentVideoProducer?.closed) {
+            closeLocalVideoProducerForReplacement(currentVideoProducer);
+          }
+          const videoProducer = videoProducerRef.current;
+          if (videoProducer) {
             const publishTrack = await waitForPreferredVideoPublishTrack(
               nextStream,
               newVideoTrack,
             );
             try {
-              await videoProducerRef.current.replaceTrack({
+              await videoProducer.replaceTrack({
                 track: publishTrack,
               });
             } catch (err) {
@@ -1080,7 +1091,7 @@ export function useMeetMedia({
                 publishTrack,
                 "device-switch-raw-replace-fallback",
               );
-              await videoProducerRef.current.replaceTrack({
+              await videoProducer.replaceTrack({
                 track: newVideoTrack,
               });
             }
@@ -1113,6 +1124,7 @@ export function useMeetMedia({
       waitForPreferredVideoPublishTrack,
       onPreferredVideoPublishTrackRejected,
       stopTracksExcept,
+      closeLocalVideoProducerForReplacement,
       requestCameraProducerRecovery,
     ]
   );

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -227,12 +227,13 @@ const hasOutboundVideoProgress = (
   previous: CameraOutboundStallState,
   sample: OutboundVideoProgressSample,
 ): boolean => {
+  // When frame counters exist, byte trickle alone is not video progress: RTP
+  // padding/RTX can advance bytes while the camera frame stream is frozen.
   if (
     previous.frames !== null &&
-    sample.frames !== null &&
-    sample.frames > previous.frames
+    sample.frames !== null
   ) {
-    return true;
+    return sample.frames > previous.frames;
   }
 
   if (
@@ -1986,11 +1987,13 @@ export function useMeetMedia({
       producerTrack,
       sample,
       state,
+      allowProducerRecreate,
     }: {
       producer: Producer;
       producerTrack: MediaStreamTrack;
       sample: OutboundVideoProgressSample;
       state: CameraOutboundStallState;
+      allowProducerRecreate: boolean;
     }) => {
       if (disposed) return;
       if (cameraProducerTrackRepairInFlightRef.current) return;
@@ -2066,6 +2069,25 @@ export function useMeetMedia({
           return;
         }
 
+        if (!allowProducerRecreate) {
+          cameraOutboundStallStateRef.current = {
+            ...state,
+            lastRecoveryAtMs: now,
+          };
+          console.warn(
+            "[Meets] Camera sender stalled in background; keeping producer open.",
+            {
+              producerId: producer.id,
+              trackId: producerTrack.id,
+              rawTrackId: rawCameraTrack.id,
+              stalledSamples: state.stalledSamples,
+              frames: sample.frames,
+              bytes: sample.bytes,
+            },
+          );
+          return;
+        }
+
         console.warn("[Meets] Recreating stalled camera sender:", {
           producerId: producer.id,
           trackId: producerTrack.id,
@@ -2113,16 +2135,6 @@ export function useMeetMedia({
     const pollOutboundProgress = () => {
       if (disposed) return;
       if (
-        typeof document !== "undefined" &&
-        document.visibilityState !== "visible"
-      ) {
-        resetStallState(
-          videoProducerRef.current?.id ?? null,
-          videoProducerRef.current?.track?.id ?? null,
-        );
-        return;
-      }
-      if (
         cameraProducerTrackRepairInFlightRef.current ||
         cameraRecoveryInFlightRef.current
       ) {
@@ -2165,6 +2177,9 @@ export function useMeetMedia({
           }
 
           const sample = readOutboundVideoProgressSample(report);
+          const allowProducerRecreate =
+            typeof document === "undefined" ||
+            document.visibilityState === "visible";
           const currentState = cameraOutboundStallStateRef.current;
           const previous =
             currentState.producerId === producer.id &&
@@ -2199,6 +2214,7 @@ export function useMeetMedia({
             producerTrack,
             sample,
             state: nextState,
+            allowProducerRecreate,
           });
         })
         .catch(() => {

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -1142,7 +1142,8 @@ export function useMeetMedia({
       networkProfileOverride?: WebcamProducerNetworkProfile,
     ) => {
       if (isCameraOff) return;
-      if (!localStream) return;
+      const currentStream = localStreamRef.current ?? localStream;
+      if (!currentStream) return;
 
       let rollbackStream: MediaStream | null = null;
       let replacementTrack: MediaStreamTrack | null = null;
@@ -1160,7 +1161,7 @@ export function useMeetMedia({
           JSON.stringify(constraints)
         );
 
-        const currentTrack = getFirstLiveTrack(localStream.getVideoTracks());
+        const currentTrack = getFirstLiveTrack(currentStream.getVideoTracks());
         const shouldUpdateCaptureConstraints =
           shouldUpdateCaptureConstraintsForQualitySwitch(
             quality,
@@ -1184,8 +1185,8 @@ export function useMeetMedia({
           }
         }
 
-        let nextVideoTrack = getFirstLiveTrack(localStream.getVideoTracks());
-        let publishStream = localStreamRef.current ?? localStream;
+        let nextVideoTrack = getFirstLiveTrack(currentStream.getVideoTracks());
+        let publishStream = currentStream;
         let oldVideoTracksToStop: MediaStreamTrack[] = [];
 
         if (
@@ -1228,7 +1229,7 @@ export function useMeetMedia({
             handleLocalTrackEnded("video", newVideoTrack);
           };
 
-          const previousStream = localStreamRef.current ?? localStream;
+          const previousStream = localStreamRef.current ?? currentStream;
           rollbackStream = previousStream;
           oldVideoTracksToStop = previousStream?.getVideoTracks() ?? [];
           const remainingTracks = previousStream

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -112,6 +112,10 @@ const getFirstLiveTrack = <T extends MediaStreamTrack>(
   tracks: readonly T[],
 ): T | null => tracks.find((track) => track.readyState === "live") ?? null;
 
+const TOGGLE_MUTE_STRICT_ACK_TIMEOUT_MS = 5000;
+const TOGGLE_MUTE_FAST_ACK_TIMEOUT_MS = 1500;
+const TOGGLE_MUTE_BACKGROUND_ACK_TIMEOUT_MS = 3000;
+
 const shouldUpdateCaptureConstraintsForQualitySwitch = (
   quality: VideoQuality,
   profile: WebcamProducerNetworkProfile,
@@ -416,6 +420,17 @@ export function useMeetMedia({
   if (connectionStateRef.current !== connectionState) {
     connectionStateRef.current = connectionState;
   }
+  const isMutedRef = useRef(isMuted);
+  useEffect(() => {
+    isMutedRef.current = isMuted;
+  }, [isMuted]);
+  const setMutedIntent = useCallback(
+    (value: boolean) => {
+      isMutedRef.current = value;
+      setIsMuted(value);
+    },
+    [setIsMuted],
+  );
   const toggleMuteInFlightRef = useRef(false);
   const [isMuteTogglePending, setIsMuteTogglePending] = useState(false);
   const toggleCameraInFlightRef = useRef(false);
@@ -539,7 +554,11 @@ export function useMeetMedia({
   }, [getAudioContext]);
 
   const emitToggleMute = useCallback(
-    (producerId: string, paused: boolean) => {
+    (
+      producerId: string,
+      paused: boolean,
+      options?: { timeoutMs?: number },
+    ) => {
       const socket = socketRef.current;
       if (!socket || !socket.connected) {
         return Promise.resolve({
@@ -550,15 +569,13 @@ export function useMeetMedia({
 
       return new Promise<{ ok: boolean; error?: string }>((resolve) => {
         let settled = false;
-        // 1500ms was too tight: a slow-but-healthy ack would time out and (on
-        // unmute) trigger a destructive producer-recreate. The toggle itself is
-        // delivered reliably (TCP) and the SFU acts on the event, not the ack —
-        // so we can afford to wait for the ack rather than assume failure.
+        const timeoutMs =
+          options?.timeoutMs ?? TOGGLE_MUTE_STRICT_ACK_TIMEOUT_MS;
         const timeout = window.setTimeout(() => {
           if (settled) return;
           settled = true;
           resolve({ ok: false, error: "toggleMute timeout" });
-        }, 5000);
+        }, timeoutMs);
 
         socket.emit(
           "toggleMute",
@@ -596,6 +613,63 @@ export function useMeetMedia({
       }
     },
     [audioProducerRef, intentionalLocalProducerCloseIdsRef, socketRef],
+  );
+
+  const confirmAudioProducerUnmuted = useCallback(
+    (producerId: string) => {
+      void (async () => {
+        const firstResult = await emitToggleMute(producerId, false, {
+          timeoutMs: TOGGLE_MUTE_FAST_ACK_TIMEOUT_MS,
+        });
+        if (firstResult.ok) return;
+
+        let currentProducer = audioProducerRef.current;
+        if (
+          isMutedRef.current ||
+          !currentProducer ||
+          currentProducer.id !== producerId ||
+          currentProducer.closed
+        ) {
+          return;
+        }
+
+        let confirmationError = firstResult.error;
+        if (firstResult.error === "toggleMute timeout") {
+          console.warn(
+            "[Meets] unmute ack timed out; confirming microphone state in background:",
+            firstResult.error,
+          );
+          const retryResult = await emitToggleMute(producerId, false, {
+            timeoutMs: TOGGLE_MUTE_BACKGROUND_ACK_TIMEOUT_MS,
+          });
+          if (retryResult.ok) return;
+          confirmationError = retryResult.error;
+        }
+
+        currentProducer = audioProducerRef.current;
+        if (
+          isMutedRef.current ||
+          !currentProducer ||
+          currentProducer.id !== producerId ||
+          currentProducer.closed
+        ) {
+          return;
+        }
+
+        console.warn(
+          "[Meets] unmute confirmation failed; refreshing microphone producer:",
+          confirmationError,
+        );
+        closeLocalAudioProducerForReplacement(currentProducer);
+        requestAudioProducerRecovery();
+      })();
+    },
+    [
+      audioProducerRef,
+      closeLocalAudioProducerForReplacement,
+      emitToggleMute,
+      requestAudioProducerRecovery,
+    ],
   );
 
   const getPublishNetworkProfile =
@@ -1438,7 +1512,9 @@ export function useMeetMedia({
           try {
             producer.pause();
           } catch {}
-          const toggleResult = await emitToggleMute(producer.id, true);
+          const toggleResult = await emitToggleMute(producer.id, true, {
+            timeoutMs: TOGGLE_MUTE_STRICT_ACK_TIMEOUT_MS,
+          });
           if (!toggleResult.ok) {
             console.warn(
               "[Meets] toggleMute failed, rolling back mute:",
@@ -1452,7 +1528,7 @@ export function useMeetMedia({
             try {
               producer.resume();
             } catch {}
-            setIsMuted(false);
+            setMutedIntent(false);
             setMeetError({
               code: "TRANSPORT_ERROR",
               message: toggleResult.error || "Failed to mute microphone",
@@ -1461,7 +1537,7 @@ export function useMeetMedia({
             return;
           }
         }
-        setIsMuted(true);
+        setMutedIntent(true);
         return;
       }
 
@@ -1526,50 +1602,10 @@ export function useMeetMedia({
         try {
           producer.resume();
         } catch {}
-        const toggleResult = await emitToggleMute(producer.id, false);
-        if (!toggleResult.ok) {
-          const isTimeout = toggleResult.error === "toggleMute timeout";
-          const producerDead =
-            producer.closed || producer.track?.readyState !== "live";
-          if (isTimeout && !producerDead) {
-            // A slow/lost ACK on a healthy producer does NOT mean the producer
-            // is broken: the SFU resumes its producer from the toggleMute event
-            // itself (reliably delivered), not the ack. Keep the producer and
-            // retry the toggle idempotently rather than recreating it — a
-            // recreate fires producerClosed+newProducer and forces every
-            // listener to re-consume (a multi-RTT audio gap, and a prime cause
-            // of "I unmuted but nobody can hear me").
-            console.warn(
-              "[Meets] unmute ack timed out but producer is healthy — retrying toggle:",
-              toggleResult.error
-            );
-            const retry = await emitToggleMute(producer.id, false);
-            if (!retry.ok) {
-              // The retry ALSO failed (likely a real disconnect/non-delivery,
-              // not just a slow ack). Don't claim "unmuted" over a producer that
-              // may still be paused server-side — recreate so a fresh, resumed
-              // producer is published (or transport.produce() throws and we roll
-              // back to muted below).
-              console.warn(
-                "[Meets] unmute retry also failed — recreating to be safe:",
-                retry.error
-              );
-              closeLocalAudioProducerForReplacement(producer);
-              producer = null;
-            }
-          } else {
-            // An EXPLICIT server error (e.g. "Microphone producer not found")
-            // or a dead local producer means the SFU has no live producer for
-            // us — keeping it would leave us silently muted server-side. Tear
-            // down + recreate so a fresh producer is published.
-            console.warn(
-              "[Meets] unmute failed (server error / dead producer) — recreating:",
-              toggleResult.error
-            );
-            closeLocalAudioProducerForReplacement(producer);
-            producer = null;
-          }
-        }
+        setMutedIntent(false);
+        setMeetError(null);
+        confirmAudioProducerUnmuted(producer.id);
+        return;
       }
 
       if (!producer) {
@@ -1591,7 +1627,8 @@ export function useMeetMedia({
           }
         });
       }
-      setIsMuted(false);
+      setMutedIntent(false);
+      setMeetError(null);
     } catch (err) {
       console.error("[Meets] Failed to restart audio:", err);
       if (createdTrack) {
@@ -1604,7 +1641,7 @@ export function useMeetMedia({
           commitLocalStream(new MediaStream(remaining));
         }
       }
-      setIsMuted(previousMuted);
+      setMutedIntent(previousMuted);
       setMeetError(createMeetError(err, "MEDIA_ERROR"));
     } finally {
       toggleMuteInFlightRef.current = false;
@@ -1625,11 +1662,12 @@ export function useMeetMedia({
     commitLocalStream,
     producerTransportRef,
     ensureProducerTransportRef,
-    setIsMuted,
     setMeetError,
     closeLocalAudioProducerForReplacement,
+    confirmAudioProducerUnmuted,
     getPublishNetworkProfile,
     markAudioTrackForSpeech,
+    setMutedIntent,
     toggleMuteInFlightRef,
   ]);
 

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -2353,8 +2353,7 @@ export function useMeetMedia({
           return;
         }
 
-        const shouldTryRawRepair =
-          !state.rawRepairAttempted && producerTrack.id !== rawCameraTrack.id;
+        const shouldTryRawRepair = !state.rawRepairAttempted;
         if (shouldTryRawRepair) {
           if ("contentHint" in rawCameraTrack) {
             rawCameraTrack.contentHint = "motion";
@@ -2363,10 +2362,12 @@ export function useMeetMedia({
             handleLocalTrackEnded("video", rawCameraTrack);
           };
           await producer.replaceTrack({ track: rawCameraTrack });
-          onPreferredVideoPublishTrackRejected?.(
-            producerTrack,
-            "camera-outbound-stall-raw-repair",
-          );
+          if (producerTrack.id !== rawCameraTrack.id) {
+            onPreferredVideoPublishTrackRejected?.(
+              producerTrack,
+              "camera-outbound-stall-raw-repair",
+            );
+          }
           await applyWebcamProducerNetworkProfile(
             producer,
             videoQualityRef.current,
@@ -2380,7 +2381,7 @@ export function useMeetMedia({
             lastRecoveryAtMs: now,
           };
           console.warn(
-            "[Meets] Repaired stalled camera sender with raw camera track:",
+            "[Meets] Refreshed stalled camera sender with raw camera track:",
             {
               producerId: producer.id,
               previousTrackId: producerTrack.id,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -236,29 +236,16 @@ const hasOutboundVideoProgress = (
   previous: CameraOutboundStallState,
   sample: OutboundVideoProgressSample,
 ): boolean => {
-  // When frame counters exist, flat frames alone are not enough to prove a
-  // sender stall: static/low-motion cameras can legitimately stay quiet. Only
-  // count it as stalled when RTP bytes keep moving, which means the sender path
-  // is alive but no new camera frames are being encoded.
-  if (
-    previous.frames !== null &&
-    sample.frames !== null
-  ) {
+  // When frame counters exist, they are the strongest signal. A healthy camera
+  // sender should either advance frames or report a positive FPS; flat frames
+  // with flat bytes is a dead sender, and flat frames with only bytes moving is
+  // usually padding/retransmission without usable video.
+  if (previous.frames !== null && sample.frames !== null) {
     if (sample.frames > previous.frames) return true;
-    if (
-      sample.framesPerSecond !== null &&
-      sample.framesPerSecond > 0
-    ) {
+    if (sample.framesPerSecond !== null && sample.framesPerSecond > 0) {
       return true;
     }
-    if (
-      previous.bytes !== null &&
-      sample.bytes !== null &&
-      sample.bytes - previous.bytes >= MIN_OUTBOUND_VIDEO_BYTE_DELTA_FOR_PROGRESS
-    ) {
-      return false;
-    }
-    return true;
+    return false;
   }
 
   if (
@@ -277,6 +264,18 @@ const hasOutboundVideoProgress = (
   }
 
   return false;
+};
+
+const shouldDisableMediaIntentAfterRecoveryFailure = (
+  error: unknown,
+  meetError: MeetError,
+): boolean => {
+  if (meetError.code === "PERMISSION_DENIED") return true;
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("NotFoundError") ||
+    message.includes("DevicesNotFoundError")
+  );
 };
 
 export function useMeetMedia({
@@ -1710,28 +1709,28 @@ export function useMeetMedia({
     if (audioRecoveryInFlightRef.current) return;
 
     let cancelled = false;
+    let createdTrack: MediaStreamTrack | null = null;
+    const removeCreatedTrackFromLocalStream = () => {
+      if (!createdTrack) return;
+      stopLocalTrack(createdTrack);
+      const currentStream = localStreamRef.current;
+      if (currentStream?.getTracks().includes(createdTrack)) {
+        const remaining = currentStream
+          .getTracks()
+          .filter((track) => track !== createdTrack);
+        const nextStream = new MediaStream(remaining);
+        localStreamRef.current = nextStream;
+        setLocalStream(nextStream);
+      }
+      createdTrack = null;
+    };
     audioRecoveryInFlightRef.current = true;
 
     const recoverAudioProducer = async () => {
-      let createdTrack: MediaStreamTrack | null = null;
       const hadLiveAudioTrackBeforeRecovery =
         localStreamRef.current
           ?.getAudioTracks()
           .some((track) => track.readyState === "live") === true;
-      const removeCreatedTrackFromLocalStream = () => {
-        if (!createdTrack) return;
-        stopLocalTrack(createdTrack);
-        const currentStream = localStreamRef.current;
-        if (currentStream?.getTracks().includes(createdTrack)) {
-          const remaining = currentStream
-            .getTracks()
-            .filter((track) => track !== createdTrack);
-          const nextStream = new MediaStream(remaining);
-          localStreamRef.current = nextStream;
-          setLocalStream(nextStream);
-        }
-        createdTrack = null;
-      };
 
       try {
         if (isMediaRecoveryBlocked()) return;
@@ -1811,6 +1810,7 @@ export function useMeetMedia({
         }
 
         audioProducerRef.current = audioProducer;
+        createdTrack = null;
         audioProducer.on("transportclose", () => {
           if (audioProducerRef.current?.id === audioProducer.id) {
             audioProducerRef.current = null;
@@ -1821,10 +1821,14 @@ export function useMeetMedia({
         console.error("[Meets] Audio producer recovery failed:", err);
         removeCreatedTrackFromLocalStream();
         if (!cancelled) {
-          if (!hadLiveAudioTrackBeforeRecovery) {
+          const meetErr = createMeetError(err, "MEDIA_ERROR");
+          if (
+            !hadLiveAudioTrackBeforeRecovery &&
+            shouldDisableMediaIntentAfterRecoveryFailure(err, meetErr)
+          ) {
             setIsMuted(true);
           }
-          setMeetError(createMeetError(err, "MEDIA_ERROR"));
+          setMeetError(meetErr);
         }
       } finally {
         audioRecoveryInFlightRef.current = false;
@@ -1835,6 +1839,7 @@ export function useMeetMedia({
 
     return () => {
       cancelled = true;
+      removeCreatedTrackFromLocalStream();
     };
   }, [
     ghostEnabled,
@@ -2526,29 +2531,29 @@ export function useMeetMedia({
     if (cameraRecoveryInFlightRef.current) return;
 
     let cancelled = false;
+    let createdTrack: MediaStreamTrack | null = null;
+    const removeCreatedTrackFromLocalStream = () => {
+      if (!createdTrack) return;
+      stopLocalTrack(createdTrack);
+      const currentStream = localStreamRef.current;
+      if (currentStream?.getTracks().includes(createdTrack)) {
+        const remaining = currentStream
+          .getTracks()
+          .filter((track) => track !== createdTrack);
+        const nextStream = new MediaStream(remaining);
+        localStreamRef.current = nextStream;
+        setLocalStream(nextStream);
+      }
+      createdTrack = null;
+    };
     cameraRecoveryInFlightRef.current = true;
 
     const recoverCameraProducer = async () => {
-      let createdTrack: MediaStreamTrack | null = null;
       let consumedRecoveryPublishOverride = false;
       const hadLiveCameraTrackBeforeRecovery =
         localStreamRef.current
           ?.getVideoTracks()
           .some((track) => track.readyState === "live") === true;
-      const removeCreatedTrackFromLocalStream = () => {
-        if (!createdTrack) return;
-        stopLocalTrack(createdTrack);
-        const currentStream = localStreamRef.current;
-        if (currentStream?.getTracks().includes(createdTrack)) {
-          const remaining = currentStream
-            .getTracks()
-            .filter((track) => track !== createdTrack);
-          const nextStream = new MediaStream(remaining);
-          localStreamRef.current = nextStream;
-          setLocalStream(nextStream);
-        }
-        createdTrack = null;
-      };
 
       try {
         if (isMediaRecoveryBlocked()) return;
@@ -2645,6 +2650,7 @@ export function useMeetMedia({
         }
 
         videoProducerRef.current = recoveredProducer;
+        createdTrack = null;
         recoveredProducer.on("transportclose", () => {
           if (videoProducerRef.current?.id === recoveredProducer.id) {
             videoProducerRef.current = null;
@@ -2656,10 +2662,14 @@ export function useMeetMedia({
         console.error("[Meets] Camera producer recovery failed:", err);
         removeCreatedTrackFromLocalStream();
         if (!cancelled) {
-          if (!hadLiveCameraTrackBeforeRecovery) {
+          const meetErr = createMeetError(err, "MEDIA_ERROR");
+          if (
+            !hadLiveCameraTrackBeforeRecovery &&
+            shouldDisableMediaIntentAfterRecoveryFailure(err, meetErr)
+          ) {
             setIsCameraOff(true);
           }
-          setMeetError(createMeetError(err, "MEDIA_ERROR"));
+          setMeetError(meetErr);
         }
       } finally {
         if (consumedRecoveryPublishOverride) {
@@ -2674,6 +2684,7 @@ export function useMeetMedia({
 
     return () => {
       cancelled = true;
+      removeCreatedTrackFromLocalStream();
     };
   }, [
     ghostEnabled,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -340,18 +340,71 @@ export function useMeetMedia({
   );
   const [audioProducerRecoveryPulse, setAudioProducerRecoveryPulse] =
     useState(0);
-  const notificationVolume = clampMeetVolume(meetVolume);
-  const requestAudioProducerRecovery = useCallback(() => {
-    if (isMediaRecoveryBlocked()) return;
-    setAudioProducerRecoveryPulse((value) => value + 1);
-  }, [isMediaRecoveryBlocked]);
   const cameraRecoveryInFlightRef = useRef(false);
   const [cameraProducerRecoveryPulse, setCameraProducerRecoveryPulse] =
     useState(0);
+  const pendingAudioProducerRecoveryRef = useRef(false);
+  const pendingCameraProducerRecoveryRef = useRef(false);
+  const [blockedProducerRecoveryFlushPulse, setBlockedProducerRecoveryFlushPulse] =
+    useState(0);
+  const flushQueuedProducerRecoveries = useCallback(() => {
+    if (pendingAudioProducerRecoveryRef.current) {
+      pendingAudioProducerRecoveryRef.current = false;
+      setAudioProducerRecoveryPulse((value) => value + 1);
+    }
+    if (pendingCameraProducerRecoveryRef.current) {
+      pendingCameraProducerRecoveryRef.current = false;
+      setCameraProducerRecoveryPulse((value) => value + 1);
+    }
+  }, []);
+  const queueBlockedProducerRecovery = useCallback(
+    (kind: "audio" | "camera") => {
+      if (kind === "audio") {
+        pendingAudioProducerRecoveryRef.current = true;
+      } else {
+        pendingCameraProducerRecoveryRef.current = true;
+      }
+      setBlockedProducerRecoveryFlushPulse((value) => value + 1);
+    },
+    [],
+  );
+  const notificationVolume = clampMeetVolume(meetVolume);
+  const requestAudioProducerRecovery = useCallback(() => {
+    if (isMediaRecoveryBlocked()) {
+      queueBlockedProducerRecovery("audio");
+      return;
+    }
+    setAudioProducerRecoveryPulse((value) => value + 1);
+  }, [isMediaRecoveryBlocked, queueBlockedProducerRecovery]);
   const requestCameraProducerRecovery = useCallback(() => {
-    if (isMediaRecoveryBlocked()) return;
+    if (isMediaRecoveryBlocked()) {
+      queueBlockedProducerRecovery("camera");
+      return;
+    }
     setCameraProducerRecoveryPulse((value) => value + 1);
-  }, [isMediaRecoveryBlocked]);
+  }, [isMediaRecoveryBlocked, queueBlockedProducerRecovery]);
+  useEffect(() => {
+    if (
+      !pendingAudioProducerRecoveryRef.current &&
+      !pendingCameraProducerRecoveryRef.current
+    ) {
+      return;
+    }
+    if (!isMediaRecoveryBlocked()) {
+      flushQueuedProducerRecoveries();
+      return;
+    }
+    const intervalId = window.setInterval(() => {
+      if (isMediaRecoveryBlocked()) return;
+      window.clearInterval(intervalId);
+      flushQueuedProducerRecoveries();
+    }, 250);
+    return () => window.clearInterval(intervalId);
+  }, [
+    blockedProducerRecoveryFlushPulse,
+    flushQueuedProducerRecoveries,
+    isMediaRecoveryBlocked,
+  ]);
   const cameraProducerTrackRepairInFlightRef = useRef(false);
   const cameraRecoveryCodecOverrideRef = useRef<ReturnType<
     typeof getPreferredWebcamCodec
@@ -736,7 +789,7 @@ export function useMeetMedia({
           console.warn(
             "[Meets] Local audio track ended unexpectedly; recovering audio producer.",
           );
-          setAudioProducerRecoveryPulse((value) => value + 1);
+          requestAudioProducerRecovery();
         } else {
           setIsMuted(true);
         }
@@ -749,7 +802,7 @@ export function useMeetMedia({
           console.warn(
             "[Meets] Local video track ended unexpectedly; recovering camera producer.",
           );
-          setCameraProducerRecoveryPulse((value) => value + 1);
+          requestCameraProducerRecovery();
         } else {
           setIsCameraOff(true);
         }
@@ -775,8 +828,8 @@ export function useMeetMedia({
       audioProducerRef,
       videoProducerRef,
       socketRef,
-      setAudioProducerRecoveryPulse,
-      setCameraProducerRecoveryPulse,
+      requestAudioProducerRecovery,
+      requestCameraProducerRecovery,
     ]
   );
 
@@ -1488,7 +1541,7 @@ export function useMeetMedia({
         audioProducer.on("transportclose", () => {
           if (audioProducerRef.current?.id === audioProducerId) {
             audioProducerRef.current = null;
-            setAudioProducerRecoveryPulse((value) => value + 1);
+            requestAudioProducerRecovery();
           }
         });
       }
@@ -2252,18 +2305,29 @@ export function useMeetMedia({
         resetStallState();
         requestCameraProducerRecovery();
       } catch (err) {
+        if (
+          !allowProducerRecreate ||
+          isMediaRecoveryBlocked() ||
+          videoProducerRef.current?.id !== producer.id
+        ) {
+          cameraOutboundStallStateRef.current = {
+            ...state,
+            lastRecoveryAtMs: performance.now(),
+          };
+          console.warn(
+            "[Meets] Stalled camera sender recovery failed; keeping producer open:",
+            err,
+          );
+          return;
+        }
+
         console.warn(
           "[Meets] Stalled camera sender recovery failed; recreating producer:",
           err,
         );
-        if (
-          !isMediaRecoveryBlocked() &&
-          videoProducerRef.current?.id === producer.id
-        ) {
-          closeLocalVideoProducerForReplacement(producer);
-          resetStallState();
-          requestCameraProducerRecovery();
-        }
+        closeLocalVideoProducerForReplacement(producer);
+        resetStallState();
+        requestCameraProducerRecovery();
       } finally {
         cameraProducerTrackRepairInFlightRef.current = false;
       }

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -1071,7 +1071,7 @@ export function useMeetMedia({
               await audioProducer.replaceTrack({
                 track: newAudioTrack,
               });
-            } else if (!isMuted) {
+            } else {
               requestAudioProducerRecovery();
             }
 
@@ -1541,16 +1541,6 @@ export function useMeetMedia({
         return;
       }
 
-      let transport = getUsableProducerTransport(producerTransportRef.current);
-      if (!transport) {
-        const transportReady =
-          (await ensureProducerTransportRef?.current?.()) ?? false;
-        transport = getUsableProducerTransport(producerTransportRef.current);
-        if (!transportReady || !transport) {
-          throw new Error("Audio transport unavailable");
-        }
-      }
-
       let audioTrack = getFirstLiveTrack(
         localStreamRef.current?.getAudioTracks() ?? [],
       );
@@ -1608,29 +1598,36 @@ export function useMeetMedia({
         return;
       }
 
-      if (!producer) {
-        const audioProducer = await transport.produce({
-          track: audioTrack,
-          codecOptions: buildMicrophoneOpusCodecOptions(
-            getPublishNetworkProfile(),
-          ),
-          stopTracks: false,
-          appData: { type: "webcam" as ProducerType, paused: false },
-        });
-
-        audioProducerRef.current = audioProducer;
-        const audioProducerId = audioProducer.id;
-        audioProducer.on("transportclose", () => {
-          if (audioProducerRef.current?.id === audioProducerId) {
-            audioProducerRef.current = null;
-            requestAudioProducerRecovery();
-          }
-        });
-      }
       setMutedIntent(false);
       setMeetError(null);
+      requestAudioProducerRecovery();
+      return;
     } catch (err) {
       console.error("[Meets] Failed to restart audio:", err);
+      const meetErr = createMeetError(err, "MEDIA_ERROR");
+      const liveAudioTrackAfterFailure = getFirstLiveTrack(
+        localStreamRef.current?.getAudioTracks() ?? [],
+      );
+      const shouldRetryAudioUnmute =
+        !nextMuted &&
+        liveAudioTrackAfterFailure !== null &&
+        !shouldDisableMediaIntentAfterRecoveryFailure(err, meetErr);
+
+      if (shouldRetryAudioUnmute) {
+        liveAudioTrackAfterFailure.enabled = true;
+        if (
+          producer &&
+          !producer.closed &&
+          audioProducerRef.current?.id === producer.id
+        ) {
+          closeLocalAudioProducerForReplacement(producer);
+        }
+        setMutedIntent(false);
+        setMeetError(null);
+        requestAudioProducerRecovery();
+        return;
+      }
+
       if (createdTrack) {
         stopLocalTrack(createdTrack);
         const currentStream = localStreamRef.current;
@@ -1642,7 +1639,7 @@ export function useMeetMedia({
         }
       }
       setMutedIntent(previousMuted);
-      setMeetError(createMeetError(err, "MEDIA_ERROR"));
+      setMeetError(meetErr);
     } finally {
       toggleMuteInFlightRef.current = false;
       setIsMuteTogglePending(false);
@@ -1660,27 +1657,31 @@ export function useMeetMedia({
     audioProducerRef,
     localStreamRef,
     commitLocalStream,
-    producerTransportRef,
-    ensureProducerTransportRef,
     setMeetError,
     closeLocalAudioProducerForReplacement,
     confirmAudioProducerUnmuted,
-    getPublishNetworkProfile,
     markAudioTrackForSpeech,
     setMutedIntent,
+    requestAudioProducerRecovery,
     toggleMuteInFlightRef,
   ]);
 
   useEffect(() => {
     if (ghostEnabled || isObserverMode) return;
     if (connectionState !== "joined") return;
-    if (isMuted) return;
+    const getReusableAudioTrack = () =>
+      getFirstLiveTrack(
+        (localStreamRef.current ?? localStream)?.getAudioTracks() ?? [],
+      );
+    if (isMuted && !getReusableAudioTrack()) return;
     if (isMediaRecoveryBlocked()) return;
 
     let disposed = false;
     const requestRecovery = (reason: "initial" | "watchdog") => {
       if (disposed || audioRecoveryInFlightRef.current) return;
       if (isMediaRecoveryBlocked()) return;
+      const liveAudioTrack = getReusableAudioTrack();
+      if (isMutedRef.current && !liveAudioTrack) return;
 
       const producer = audioProducerRef.current;
       const producerTrack = producer?.track ?? null;
@@ -1724,6 +1725,8 @@ export function useMeetMedia({
     isObserverMode,
     isMediaRecoveryBlocked,
     audioProducerRef,
+    localStream,
+    localStreamRef,
     closeLocalAudioProducerForReplacement,
     requestAudioProducerRecovery,
   ]);
@@ -1731,7 +1734,10 @@ export function useMeetMedia({
   useEffect(() => {
     if (ghostEnabled || isObserverMode) return;
     if (connectionState !== "joined") return;
-    if (isMuted) return;
+    const reusableAudioTrack = getFirstLiveTrack(
+      (localStreamRef.current ?? localStream)?.getAudioTracks() ?? [],
+    );
+    if (isMuted && !reusableAudioTrack) return;
     if (isMediaRecoveryBlocked()) return;
     if (audioProducerRef.current) {
       const existingProducer = audioProducerRef.current;
@@ -1787,11 +1793,18 @@ export function useMeetMedia({
           }
         }
 
+        const shouldStartPaused = isMutedRef.current;
         let audioTrack = getFirstLiveTrack(
-          localStreamRef.current?.getAudioTracks() ?? [],
+          (localStreamRef.current ?? localStream)?.getAudioTracks() ?? [],
         );
 
         if (!audioTrack || audioTrack.readyState !== "live") {
+          if (shouldStartPaused) {
+            console.info(
+              "[Meets] Skipping muted microphone producer warmup without a reusable audio track.",
+            );
+            return;
+          }
           const stream = await navigator.mediaDevices.getUserMedia({
             audio: buildAudioConstraints(selectedAudioInputDeviceId),
           });
@@ -1808,6 +1821,7 @@ export function useMeetMedia({
         }
 
         markAudioTrackForSpeech(audioTrack);
+        audioTrack.enabled = !shouldStartPaused;
         audioTrack.onended = () => {
           handleLocalTrackEnded("audio", audioTrack);
         };
@@ -1836,8 +1850,14 @@ export function useMeetMedia({
             getPublishNetworkProfile(),
           ),
           stopTracks: false,
-          appData: { type: "webcam" as ProducerType, paused: false },
+          appData: { type: "webcam" as ProducerType, paused: shouldStartPaused },
         });
+
+        if (shouldStartPaused) {
+          try {
+            audioProducer.pause();
+          } catch {}
+        }
 
         if (cancelled) {
           try {
@@ -1860,13 +1880,19 @@ export function useMeetMedia({
         removeCreatedTrackFromLocalStream();
         if (!cancelled) {
           const meetErr = createMeetError(err, "MEDIA_ERROR");
+          const failedMutedWarmup =
+            isMutedRef.current &&
+            hadLiveAudioTrackBeforeRecovery &&
+            !shouldDisableMediaIntentAfterRecoveryFailure(err, meetErr);
           if (
             !hadLiveAudioTrackBeforeRecovery &&
             shouldDisableMediaIntentAfterRecoveryFailure(err, meetErr)
           ) {
             setIsMuted(true);
           }
-          setMeetError(meetErr);
+          if (!failedMutedWarmup) {
+            setMeetError(meetErr);
+          }
         }
       } finally {
         audioRecoveryInFlightRef.current = false;
@@ -1885,6 +1911,7 @@ export function useMeetMedia({
     connectionState,
     audioProducerRecoveryPulse,
     isMuted,
+    localStream,
     isMediaRecoveryBlocked,
     selectedAudioInputDeviceId,
     handleLocalTrackEnded,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -973,11 +973,14 @@ export function useMeetMedia({
       setSelectedAudioInputDeviceId(deviceId);
 
       if (connectionState === "joined") {
+        let acquiredAudioTracks: MediaStreamTrack[] = [];
+        let committedNewAudioTrack: MediaStreamTrack | null = null;
         try {
           const newStream = await navigator.mediaDevices.getUserMedia({
             audio: buildAudioConstraints(deviceId),
           });
 
+          acquiredAudioTracks = newStream.getAudioTracks();
           const newAudioTrack = newStream.getAudioTracks()[0];
           if (newAudioTrack) {
             markAudioTrackForSpeech(newAudioTrack);
@@ -1003,9 +1006,11 @@ export function useMeetMedia({
               newAudioTrack,
             ]);
             commitLocalStream(nextStream);
+            committedNewAudioTrack = newAudioTrack;
             stopTracksExcept(previousAudioTracks, [newAudioTrack]);
           }
         } catch (err) {
+          stopTracksExcept(acquiredAudioTracks, [committedNewAudioTrack]);
           console.error("[Meets] Failed to switch audio input device:", err);
         }
       }
@@ -1029,11 +1034,14 @@ export function useMeetMedia({
       if (connectionState !== "joined") return;
       if (isCameraOff) return;
 
+      let acquiredVideoTracks: MediaStreamTrack[] = [];
+      let committedNewVideoTrack: MediaStreamTrack | null = null;
       try {
         const newStream = await navigator.mediaDevices.getUserMedia({
           video: buildVideoConstraints(deviceId),
         });
 
+        acquiredVideoTracks = newStream.getVideoTracks();
         const newVideoTrack = newStream.getVideoTracks()[0];
         if (newVideoTrack) {
           if ("contentHint" in newVideoTrack) {
@@ -1049,8 +1057,6 @@ export function useMeetMedia({
               ?.getTracks()
               .filter((track) => track.kind !== "video") ?? [];
           const nextStream = new MediaStream([...remainingTracks, newVideoTrack]);
-          localStreamRef.current = nextStream;
-          setLocalStream(nextStream);
 
           if (videoProducerRef.current) {
             const publishTrack = await waitForPreferredVideoPublishTrack(
@@ -1075,14 +1081,20 @@ export function useMeetMedia({
                 track: newVideoTrack,
               });
             }
+          } else {
+            requestCameraProducerRecovery();
           }
 
+          localStreamRef.current = nextStream;
+          setLocalStream(nextStream);
+          committedNewVideoTrack = newVideoTrack;
           stopTracksExcept(previousVideoTracks, [
             newVideoTrack,
             videoProducerRef.current?.track ?? null,
           ]);
         }
       } catch (err) {
+        stopTracksExcept(acquiredVideoTracks, [committedNewVideoTrack]);
         console.error("[Meets] Failed to switch video input device:", err);
       }
     },
@@ -1098,6 +1110,7 @@ export function useMeetMedia({
       waitForPreferredVideoPublishTrack,
       onPreferredVideoPublishTrackRejected,
       stopTracksExcept,
+      requestCameraProducerRecovery,
     ]
   );
 

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -65,6 +65,10 @@ import type {
   ConsumerTelemetrySnapshot,
   MeetRefs,
 } from "./useMeetRefs";
+import type {
+  ConnectionQuality,
+  ConnectionQualityStats,
+} from "./useConnectionQuality";
 
 type ConsumerTelemetryPayload = Omit<
   ConsumerTelemetrySnapshot,
@@ -92,11 +96,27 @@ const STALE_REPLACEMENT_CLEANUP_DELAY_MS = 5000;
 const TURN_URL_PATTERN = /^turns?:/i;
 const TRANSPORT_CC_FEEDBACK_TYPE = "transport-cc";
 
-const getBrowserPublishNetworkProfile = (): WebcamProducerNetworkProfile => {
-  const snapshot = getBrowserNetworkSnapshot();
-  const quality =
-    snapshot.quality === "unknown" ? snapshot.startupQuality : snapshot.quality;
-  if (snapshot.emergency) return "emergency";
+const getConnectionStatsNetworkProfile = (
+  stats: ConnectionQualityStats | null | undefined,
+  direction: "publish" | "receive",
+): WebcamProducerNetworkProfile => {
+  const snapshot = stats?.browserNetwork ?? getBrowserNetworkSnapshot();
+  const statsQuality =
+    direction === "publish" ? stats?.publishQuality : stats?.receiveQuality;
+  const statsEmergency =
+    direction === "publish"
+      ? stats?.publishEmergencyMode
+      : stats?.receiveEmergencyMode;
+  const quality: ConnectionQuality =
+    statsQuality && statsQuality !== "unknown"
+      ? statsQuality
+      : ((snapshot.quality === "unknown"
+          ? snapshot.startupQuality
+          : snapshot.quality) as ConnectionQuality);
+
+  if (snapshot.emergency || (statsEmergency === true && quality !== "good")) {
+    return "emergency";
+  }
   if (quality === "poor") return "poor";
   if (quality === "fair") return "fair";
   return "good";
@@ -122,7 +142,10 @@ type InitialConsumerPreferences = {
 
 const getInitialConsumerPreferences = (
   producerInfo: ProducerInfo,
-  options: { preferHighWebcamLayer?: boolean } = {},
+  options: {
+    preferHighWebcamLayer?: boolean;
+    networkProfile?: WebcamProducerNetworkProfile;
+  } = {},
 ): InitialConsumerPreferences => {
   if (producerInfo.kind === "audio") {
     return { priority: 255 };
@@ -132,7 +155,7 @@ const getInitialConsumerPreferences = (
     return {};
   }
 
-  const networkProfile = getBrowserPublishNetworkProfile();
+  const networkProfile = options.networkProfile ?? "good";
 
   if (producerInfo.type === "screen") {
     return {
@@ -462,6 +485,7 @@ interface UseMeetSocketOptions {
   setActiveScreenShareId: (value: string | null) => void;
   setNetworkManagedVideoQuality: (value: VideoQuality) => void;
   videoQualityRef: React.MutableRefObject<VideoQuality>;
+  connectionQualityRef?: React.MutableRefObject<ConnectionQualityStats | null>;
   updateVideoQualityRef: React.MutableRefObject<
     (
       quality: VideoQuality,
@@ -550,6 +574,7 @@ export function useMeetSocket({
   setActiveScreenShareId,
   setNetworkManagedVideoQuality,
   videoQualityRef,
+  connectionQualityRef,
   updateVideoQualityRef,
   requestMediaPermissions,
   requestAudioProducerRecovery,
@@ -653,6 +678,18 @@ export function useMeetSocket({
     iceRestartInFlightRef,
     producerSyncIntervalRef,
   } = refs;
+
+  const getPublishNetworkProfile = useCallback(
+    () =>
+      getConnectionStatsNetworkProfile(connectionQualityRef?.current, "publish"),
+    [connectionQualityRef],
+  );
+
+  const getReceiveNetworkProfile = useCallback(
+    () =>
+      getConnectionStatsNetworkProfile(connectionQualityRef?.current, "receive"),
+    [connectionQualityRef],
+  );
 
   useEffect(() => {
     participantIdsRef.current = new Set([userId]);
@@ -788,7 +825,7 @@ export function useMeetSocket({
         videoTrack.contentHint = "detail";
       }
 
-      const screenNetworkProfile = getBrowserPublishNetworkProfile();
+      const screenNetworkProfile = getPublishNetworkProfile();
       await applyScreenShareTrackNetworkProfile(videoTrack, screenNetworkProfile);
       const preferredScreenShareCodec = getPreferredScreenShareCodec(
         deviceRef.current,
@@ -889,6 +926,7 @@ export function useMeetSocket({
       deviceRef,
       emitCloseProducer,
       flushPendingScreenProducerCloses,
+      getPublishNetworkProfile,
       producerTransportRef,
       screenAudioProducerRef,
       screenProducerRef,
@@ -2113,7 +2151,7 @@ export function useMeetSocket({
           const audioProducer = await transport.produce({
             track: audioTrack,
             codecOptions: buildMicrophoneOpusCodecOptions(
-              getBrowserPublishNetworkProfile(),
+              getPublishNetworkProfile(),
             ),
             stopTracks: false,
             appData: {
@@ -2193,7 +2231,7 @@ export function useMeetSocket({
             transport,
             track: videoTrack,
             quality,
-            networkProfile: getBrowserPublishNetworkProfile(),
+            networkProfile: getPublishNetworkProfile(),
             paused: shouldPauseVideo,
             preferredCodec: preferredWebcamCodec,
           });
@@ -2248,7 +2286,7 @@ export function useMeetSocket({
                 transport,
                 track: rawFallbackTrack,
                 quality,
-                networkProfile: getBrowserPublishNetworkProfile(),
+                networkProfile: getPublishNetworkProfile(),
                 paused: shouldPauseVideo,
                 preferredCodec: preferredWebcamCodec,
               });
@@ -2324,6 +2362,7 @@ export function useMeetSocket({
       videoQualityRef,
       deviceRef,
       getVideoPublishTrack,
+      getPublishNetworkProfile,
       onPreferredVideoPublishTrackRejected,
       dropVideoTracksForCameraOff,
       refs.processedVideoTrackRef,
@@ -2367,6 +2406,7 @@ export function useMeetSocket({
               preferHighWebcamLayer:
                 joinMode === "webinar_attendee" ||
                 existingWebcamVideoConsumerCount < 4,
+              networkProfile: getReceiveNetworkProfile(),
             }),
           },
           async (response: ConsumeResponse | { error: string }) => {
@@ -2626,6 +2666,7 @@ export function useMeetSocket({
       producerMapRef,
       dispatchParticipants,
       handleProducerClosed,
+      getReceiveNetworkProfile,
       joinMode,
       queueProducerConsumeRetry,
       setActiveScreenShareId,

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -2238,8 +2238,17 @@ export function useMeetSocket({
         } catch (err) {
           console.error("[Meets] Failed to produce audio:", err);
           if (mediaIntent.isMicOn) {
-            publicationWarnings.push("microphone publish failed");
-            setIsMuted(true);
+            if (audioTrack.readyState === "live") {
+              publicationWarnings.push("microphone publish retry scheduled");
+              audioTrack.enabled = true;
+              isMutedRef.current = false;
+              setIsMuted(false);
+              requestAudioProducerRecovery();
+            } else {
+              publicationWarnings.push("microphone publish failed");
+              isMutedRef.current = true;
+              setIsMuted(true);
+            }
           }
         }
       } else if (mediaIntent.isMicOn) {
@@ -2255,6 +2264,7 @@ export function useMeetSocket({
         } else {
           publicationWarnings.push("microphone track missing");
         }
+        isMutedRef.current = true;
         setIsMuted(true);
       }
 

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -1363,6 +1363,12 @@ export function useMeetSocket({
         status.state === "reconnected" &&
         !visibleParticipantReconnectingIdsRef.current.has(targetUserId)
       ) {
+        clearParticipantConnectionStatusTimer(targetUserId);
+        dispatchParticipants({
+          type: "UPDATE_CONNECTION_STATUS",
+          userId: targetUserId,
+          status: null,
+        });
         return;
       }
 

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -1518,6 +1518,47 @@ export function useMeetSocket({
     [producerMapRef, setProducerPausedState],
   );
 
+  const closeConsumerForSameProducerReconsume = useCallback(
+    (producerId: string) => {
+      pendingProducersRef.current.delete(producerId);
+      consumeRetryAttemptsRef.current.delete(producerId);
+      const scheduledRecoveryTimeout =
+        videoStallRecoveryTimeoutsRef.current.get(producerId);
+      if (scheduledRecoveryTimeout != null) {
+        window.clearTimeout(scheduledRecoveryTimeout);
+        videoStallRecoveryTimeoutsRef.current.delete(producerId);
+      }
+      clearStaleConsumerRecoveryTimeout(producerId);
+      clearStaleReplacementCleanupTimeout(producerId);
+      mutedConsumerSinceRef.current.delete(producerId);
+      adaptivelyPausedConsumerProducerIdsRef.current.delete(producerId);
+      consumerTelemetryRef.current.delete(producerId);
+      videoFreezeStatsRef.current.delete(producerId);
+
+      const consumer = consumersRef.current.get(producerId);
+      if (!consumer) return;
+      try {
+        consumer.track.onmute = null;
+        consumer.track.onunmute = null;
+        consumer.track.stop();
+        consumer.close();
+      } catch {}
+      consumersRef.current.delete(producerId);
+    },
+    [
+      adaptivelyPausedConsumerProducerIdsRef,
+      clearStaleConsumerRecoveryTimeout,
+      clearStaleReplacementCleanupTimeout,
+      consumeRetryAttemptsRef,
+      consumerTelemetryRef,
+      consumersRef,
+      mutedConsumerSinceRef,
+      pendingProducersRef,
+      videoFreezeStatsRef,
+      videoStallRecoveryTimeoutsRef,
+    ],
+  );
+
   const handleProducerClosed = useCallback(
     (producerId: string) => {
       pendingProducersRef.current.delete(producerId);
@@ -2724,7 +2765,7 @@ export function useMeetSocket({
         console.warn(
           `[Meets] Recovering stale ${producerInfo.kind} consumer ${producerInfo.producerId}: ${reason}`,
         );
-        handleProducerClosed(producerInfo.producerId);
+        closeConsumerForSameProducerReconsume(producerInfo.producerId);
         await consumeProducer(producerInfo);
       } catch (error) {
         console.error(
@@ -2740,7 +2781,7 @@ export function useMeetSocket({
       consumerRecoveryInFlightRef,
       socketRef,
       consumerTransportRef,
-      handleProducerClosed,
+      closeConsumerForSameProducerReconsume,
       consumeProducer,
       queueProducerConsumeRetry,
     ],

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -923,11 +923,15 @@ export function useMeetSocket({
         window.clearTimeout(timeoutId);
       }
       videoStallRecoveryTimeoutsRef.current.clear();
-      for (const timeoutId of participantConnectionStatusTimeoutsRef.current.values()) {
-        window.clearTimeout(timeoutId);
+      if (!preserveMeetingState) {
+        const statusTimeouts =
+          participantConnectionStatusTimeoutsRef.current.values();
+        for (const timeoutId of statusTimeouts) {
+          window.clearTimeout(timeoutId);
+        }
+        participantConnectionStatusTimeoutsRef.current.clear();
+        visibleParticipantReconnectingIdsRef.current.clear();
       }
-      participantConnectionStatusTimeoutsRef.current.clear();
-      visibleParticipantReconnectingIdsRef.current.clear();
       for (const timeoutId of staleConsumerRecoveryTimeoutsRef.current.values()) {
         window.clearTimeout(timeoutId);
       }
@@ -1463,7 +1467,6 @@ export function useMeetSocket({
 
   const handleProducerClosed = useCallback(
     (producerId: string) => {
-      clearStaleReplacementCleanupTimeout(producerId);
       pendingProducersRef.current.delete(producerId);
       consumeRetryAttemptsRef.current.delete(producerId);
       const scheduledRecoveryTimeout =
@@ -1494,6 +1497,7 @@ export function useMeetSocket({
 
       const info = producerMapRef.current.get(producerId);
       if (info) {
+        clearStaleReplacementCleanupTimeout(producerId);
         const getMatchingReplacementState = () => {
           const hasConsumedReplacement = Array.from(
             producerMapRef.current.entries(),
@@ -1531,6 +1535,10 @@ export function useMeetSocket({
             producerId: producerId,
           });
 
+          if (info.kind === "video" && info.type === "screen") {
+            setActiveScreenShareId(null);
+          }
+
           if (!hasPendingReplacement) {
             if (info.kind === "video" && info.type === "webcam") {
               dispatchParticipants({
@@ -1544,8 +1552,6 @@ export function useMeetSocket({
                 userId: info.userId,
                 muted: true,
               });
-            } else if (info.type === "screen" && info.kind === "video") {
-              setActiveScreenShareId(null);
             }
           }
         };

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -4762,6 +4762,7 @@ export function useMeetSocket({
             attempt: reconnectAttemptsRef.current,
             usingTurnFallback: useTurnFallbackRef.current,
           });
+          reconnectAttemptsRef.current = 0;
           return;
         } catch (_err) {
           // retry

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -87,6 +87,7 @@ const RESTART_ICE_ACK_TIMEOUT_MS = 5000;
 const PARTICIPANT_RECONNECTING_STATUS_FALLBACK_MS = 30000;
 const PARTICIPANT_RECONNECTING_STATUS_BUFFER_MS = 5000;
 const PARTICIPANT_RECONNECTED_STATUS_MS = 4500;
+const STALE_REPLACEMENT_CLEANUP_DELAY_MS = 5000;
 const TURN_URL_PATTERN = /^turns?:/i;
 const TRANSPORT_CC_FEEDBACK_TYPE = "transport-cc";
 
@@ -579,7 +580,11 @@ export function useMeetSocket({
   const participantConnectionStatusTimeoutsRef = useRef<Map<string, number>>(
     new Map(),
   );
+  const visibleParticipantReconnectingIdsRef = useRef<Set<string>>(new Set());
   const staleConsumerRecoveryTimeoutsRef = useRef<Map<string, number>>(
+    new Map(),
+  );
+  const staleReplacementCleanupTimeoutsRef = useRef<Map<string, number>>(
     new Map(),
   );
   const mutedConsumerSinceRef = useRef<Map<string, number>>(new Map());
@@ -921,10 +926,15 @@ export function useMeetSocket({
         window.clearTimeout(timeoutId);
       }
       participantConnectionStatusTimeoutsRef.current.clear();
+      visibleParticipantReconnectingIdsRef.current.clear();
       for (const timeoutId of staleConsumerRecoveryTimeoutsRef.current.values()) {
         window.clearTimeout(timeoutId);
       }
       staleConsumerRecoveryTimeoutsRef.current.clear();
+      for (const timeoutId of staleReplacementCleanupTimeoutsRef.current.values()) {
+        window.clearTimeout(timeoutId);
+      }
+      staleReplacementCleanupTimeoutsRef.current.clear();
       mutedConsumerSinceRef.current.clear();
       producerPausedStateRef.current.clear();
       videoFreezeStatsRef.current.clear();
@@ -1305,7 +1315,19 @@ export function useMeetSocket({
 
   const applyParticipantConnectionStatus = useCallback(
     (targetUserId: string, status: ParticipantConnectionStatus) => {
+      if (
+        status.state === "reconnected" &&
+        !visibleParticipantReconnectingIdsRef.current.has(targetUserId)
+      ) {
+        return;
+      }
+
       clearParticipantConnectionStatusTimer(targetUserId);
+      if (status.state === "reconnecting") {
+        visibleParticipantReconnectingIdsRef.current.add(targetUserId);
+      } else {
+        visibleParticipantReconnectingIdsRef.current.delete(targetUserId);
+      }
       dispatchParticipants({
         type: "UPDATE_CONNECTION_STATUS",
         userId: targetUserId,
@@ -1314,6 +1336,7 @@ export function useMeetSocket({
 
       const clearStatus = () => {
         participantConnectionStatusTimeoutsRef.current.delete(targetUserId);
+        visibleParticipantReconnectingIdsRef.current.delete(targetUserId);
         dispatchParticipants({
           type: "UPDATE_CONNECTION_STATUS",
           userId: targetUserId,
@@ -1356,6 +1379,17 @@ export function useMeetSocket({
     window.clearTimeout(timeoutId);
     staleConsumerRecoveryTimeoutsRef.current.delete(producerId);
   }, []);
+
+  const clearStaleReplacementCleanupTimeout = useCallback(
+    (producerId: string) => {
+      const timeoutId =
+        staleReplacementCleanupTimeoutsRef.current.get(producerId);
+      if (timeoutId == null) return;
+      window.clearTimeout(timeoutId);
+      staleReplacementCleanupTimeoutsRef.current.delete(producerId);
+    },
+    [],
+  );
 
   const setProducerPausedState = useCallback(
     (producerId: string, paused: boolean) => {
@@ -1428,6 +1462,7 @@ export function useMeetSocket({
 
   const handleProducerClosed = useCallback(
     (producerId: string) => {
+      clearStaleReplacementCleanupTimeout(producerId);
       pendingProducersRef.current.delete(producerId);
       consumeRetryAttemptsRef.current.delete(producerId);
       const scheduledRecoveryTimeout =
@@ -1458,14 +1493,15 @@ export function useMeetSocket({
 
       const info = producerMapRef.current.get(producerId);
       if (info) {
-        const hasReplacementProducer =
+        const hasLiveReplacementProducer =
           Array.from(producerMapRef.current.entries()).some(
             ([otherProducerId, otherInfo]) =>
               otherProducerId !== producerId &&
               otherInfo.userId === info.userId &&
               otherInfo.kind === info.kind &&
               otherInfo.type === info.type,
-          ) ||
+          );
+        const hasAnnouncedReplacementProducer =
           Array.from(announcedRemoteProducersRef.current.entries()).some(
             ([otherProducerId, otherInfo]) =>
               otherProducerId !== producerId &&
@@ -1473,6 +1509,8 @@ export function useMeetSocket({
               otherInfo.kind === info.kind &&
               otherInfo.type === info.type,
           );
+        const hasReplacementProducer =
+          hasLiveReplacementProducer || hasAnnouncedReplacementProducer;
 
         if (!hasReplacementProducer) {
           dispatchParticipants({
@@ -1511,6 +1549,60 @@ export function useMeetSocket({
           setActiveScreenShareId(null);
         }
 
+        if (hasReplacementProducer && !hasLiveReplacementProducer) {
+          const timeoutId = window.setTimeout(() => {
+            staleReplacementCleanupTimeoutsRef.current.delete(producerId);
+            const hasConsumedReplacement = Array.from(
+              producerMapRef.current.entries(),
+            ).some(
+              ([otherProducerId, otherInfo]) =>
+                otherProducerId !== producerId &&
+                otherInfo.userId === info.userId &&
+                otherInfo.kind === info.kind &&
+                otherInfo.type === info.type,
+            );
+            if (hasConsumedReplacement) return;
+
+            const hasPendingReplacement = Array.from(
+              announcedRemoteProducersRef.current.entries(),
+            ).some(
+              ([otherProducerId, otherInfo]) =>
+                otherProducerId !== producerId &&
+                otherInfo.producerUserId === info.userId &&
+                otherInfo.kind === info.kind &&
+                otherInfo.type === info.type,
+            );
+
+            dispatchParticipants({
+              type: "UPDATE_STREAM",
+              userId: info.userId,
+              kind: info.kind,
+              streamType: info.type,
+              stream: null,
+              producerId,
+            });
+
+            if (!hasPendingReplacement) {
+              if (info.kind === "video" && info.type === "webcam") {
+                dispatchParticipants({
+                  type: "UPDATE_CAMERA_OFF",
+                  userId: info.userId,
+                  cameraOff: true,
+                });
+              } else if (info.kind === "audio" && info.type === "webcam") {
+                dispatchParticipants({
+                  type: "UPDATE_MUTED",
+                  userId: info.userId,
+                  muted: true,
+                });
+              } else if (info.type === "screen" && info.kind === "video") {
+                setActiveScreenShareId(null);
+              }
+            }
+          }, STALE_REPLACEMENT_CLEANUP_DELAY_MS);
+          staleReplacementCleanupTimeoutsRef.current.set(producerId, timeoutId);
+        }
+
         producerMapRef.current.delete(producerId);
       }
       announcedRemoteProducersRef.current.delete(producerId);
@@ -1529,6 +1621,7 @@ export function useMeetSocket({
       consumerRecoveryInFlightRef,
       producerMapRef,
       announcedRemoteProducersRef,
+      clearStaleReplacementCleanupTimeout,
       setActiveScreenShareId,
     ],
   );
@@ -3686,6 +3779,7 @@ export function useMeetSocket({
                   return next;
                 });
                 clearParticipantConnectionStatusTimer(leftUserId);
+                visibleParticipantReconnectingIdsRef.current.delete(leftUserId);
 
                 const producersToClose = Array.from(
                   producerMapRef.current.entries(),

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -87,6 +87,7 @@ const RESTART_ICE_ACK_TIMEOUT_MS = 5000;
 const PARTICIPANT_RECONNECTING_STATUS_FALLBACK_MS = 30000;
 const PARTICIPANT_RECONNECTING_STATUS_BUFFER_MS = 5000;
 const PARTICIPANT_RECONNECTED_STATUS_MS = 4500;
+const PRODUCER_CLOSE_REPLACEMENT_GRACE_MS = 1500;
 const STALE_REPLACEMENT_CLEANUP_DELAY_MS = 5000;
 const TURN_URL_PATTERN = /^turns?:/i;
 const TRANSPORT_CC_FEEDBACK_TYPE = "transport-cc";
@@ -1493,26 +1494,34 @@ export function useMeetSocket({
 
       const info = producerMapRef.current.get(producerId);
       if (info) {
-        const hasLiveReplacementProducer =
-          Array.from(producerMapRef.current.entries()).some(
+        const getMatchingReplacementState = () => {
+          const hasConsumedReplacement = Array.from(
+            producerMapRef.current.entries(),
+          ).some(
             ([otherProducerId, otherInfo]) =>
               otherProducerId !== producerId &&
               otherInfo.userId === info.userId &&
               otherInfo.kind === info.kind &&
               otherInfo.type === info.type,
           );
-        const hasAnnouncedReplacementProducer =
-          Array.from(announcedRemoteProducersRef.current.entries()).some(
+          const hasPendingReplacement = Array.from(
+            announcedRemoteProducersRef.current.entries(),
+          ).some(
             ([otherProducerId, otherInfo]) =>
               otherProducerId !== producerId &&
               otherInfo.producerUserId === info.userId &&
               otherInfo.kind === info.kind &&
               otherInfo.type === info.type,
           );
-        const hasReplacementProducer =
-          hasLiveReplacementProducer || hasAnnouncedReplacementProducer;
+          return {
+            hasConsumedReplacement,
+            hasPendingReplacement,
+            hasReplacementProducer:
+              hasConsumedReplacement || hasPendingReplacement,
+          };
+        };
 
-        if (!hasReplacementProducer) {
+        const clearClosedProducerState = (hasPendingReplacement: boolean) => {
           dispatchParticipants({
             type: "UPDATE_STREAM",
             userId: info.userId,
@@ -1521,84 +1530,46 @@ export function useMeetSocket({
             stream: null,
             producerId: producerId,
           });
-        }
 
-        if (info.kind === "video" && info.type === "webcam") {
-          if (!hasReplacementProducer) {
-            dispatchParticipants({
-              type: "UPDATE_CAMERA_OFF",
-              userId: info.userId,
-              cameraOff: true,
-            });
+          if (!hasPendingReplacement) {
+            if (info.kind === "video" && info.type === "webcam") {
+              dispatchParticipants({
+                type: "UPDATE_CAMERA_OFF",
+                userId: info.userId,
+                cameraOff: true,
+              });
+            } else if (info.kind === "audio" && info.type === "webcam") {
+              dispatchParticipants({
+                type: "UPDATE_MUTED",
+                userId: info.userId,
+                muted: true,
+              });
+            } else if (info.type === "screen" && info.kind === "video") {
+              setActiveScreenShareId(null);
+            }
           }
-        } else if (info.kind === "audio" && info.type === "webcam") {
-          if (!hasReplacementProducer) {
-            dispatchParticipants({
-              type: "UPDATE_MUTED",
-              userId: info.userId,
-              muted: true,
-            });
-          }
-        }
+        };
 
-        if (
-          info.type === "screen" &&
-          info.kind === "video" &&
-          !hasReplacementProducer
-        ) {
-          setActiveScreenShareId(null);
-        }
-
-        if (hasReplacementProducer && !hasLiveReplacementProducer) {
+        const replacementState = getMatchingReplacementState();
+        if (!replacementState.hasReplacementProducer) {
           const timeoutId = window.setTimeout(() => {
             staleReplacementCleanupTimeoutsRef.current.delete(producerId);
-            const hasConsumedReplacement = Array.from(
-              producerMapRef.current.entries(),
-            ).some(
-              ([otherProducerId, otherInfo]) =>
-                otherProducerId !== producerId &&
-                otherInfo.userId === info.userId &&
-                otherInfo.kind === info.kind &&
-                otherInfo.type === info.type,
+            const latestReplacementState = getMatchingReplacementState();
+            if (latestReplacementState.hasConsumedReplacement) return;
+            clearClosedProducerState(
+              latestReplacementState.hasPendingReplacement,
             );
-            if (hasConsumedReplacement) return;
+          }, PRODUCER_CLOSE_REPLACEMENT_GRACE_MS);
+          staleReplacementCleanupTimeoutsRef.current.set(producerId, timeoutId);
+        } else if (!replacementState.hasConsumedReplacement) {
+          const timeoutId = window.setTimeout(() => {
+            staleReplacementCleanupTimeoutsRef.current.delete(producerId);
+            const latestReplacementState = getMatchingReplacementState();
+            if (latestReplacementState.hasConsumedReplacement) return;
 
-            const hasPendingReplacement = Array.from(
-              announcedRemoteProducersRef.current.entries(),
-            ).some(
-              ([otherProducerId, otherInfo]) =>
-                otherProducerId !== producerId &&
-                otherInfo.producerUserId === info.userId &&
-                otherInfo.kind === info.kind &&
-                otherInfo.type === info.type,
+            clearClosedProducerState(
+              latestReplacementState.hasPendingReplacement,
             );
-
-            dispatchParticipants({
-              type: "UPDATE_STREAM",
-              userId: info.userId,
-              kind: info.kind,
-              streamType: info.type,
-              stream: null,
-              producerId,
-            });
-
-            if (!hasPendingReplacement) {
-              if (info.kind === "video" && info.type === "webcam") {
-                dispatchParticipants({
-                  type: "UPDATE_CAMERA_OFF",
-                  userId: info.userId,
-                  cameraOff: true,
-                });
-              } else if (info.kind === "audio" && info.type === "webcam") {
-                dispatchParticipants({
-                  type: "UPDATE_MUTED",
-                  userId: info.userId,
-                  muted: true,
-                });
-              } else if (info.type === "screen" && info.kind === "video") {
-                setActiveScreenShareId(null);
-              }
-            }
           }, STALE_REPLACEMENT_CLEANUP_DELAY_MS);
           staleReplacementCleanupTimeoutsRef.current.set(producerId, timeoutId);
         }

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -1499,33 +1499,44 @@ export function useMeetSocket({
       if (info) {
         clearStaleReplacementCleanupTimeout(producerId);
         const getMatchingReplacementState = () => {
-          const hasConsumedReplacement = Array.from(
+          const consumedReplacement = Array.from(
             producerMapRef.current.entries(),
-          ).some(
+          ).find(
             ([otherProducerId, otherInfo]) =>
               otherProducerId !== producerId &&
               otherInfo.userId === info.userId &&
               otherInfo.kind === info.kind &&
               otherInfo.type === info.type,
           );
-          const hasPendingReplacement = Array.from(
+          const pendingReplacement = Array.from(
             announcedRemoteProducersRef.current.entries(),
-          ).some(
+          ).find(
             ([otherProducerId, otherInfo]) =>
               otherProducerId !== producerId &&
               otherInfo.producerUserId === info.userId &&
               otherInfo.kind === info.kind &&
               otherInfo.type === info.type,
           );
+          const hasConsumedReplacement = Boolean(consumedReplacement);
+          const hasPendingReplacement = Boolean(pendingReplacement);
           return {
             hasConsumedReplacement,
             hasPendingReplacement,
             hasReplacementProducer:
               hasConsumedReplacement || hasPendingReplacement,
+            pendingReplacementProducerId: pendingReplacement?.[0] ?? null,
           };
         };
 
-        const clearClosedProducerState = (hasPendingReplacement: boolean) => {
+        const clearClosedProducerState = ({
+          hasPendingReplacement,
+          pendingReplacementProducerId,
+          preservePendingScreenShare,
+        }: {
+          hasPendingReplacement: boolean;
+          pendingReplacementProducerId: string | null;
+          preservePendingScreenShare: boolean;
+        }) => {
           dispatchParticipants({
             type: "UPDATE_STREAM",
             userId: info.userId,
@@ -1536,7 +1547,11 @@ export function useMeetSocket({
           });
 
           if (info.kind === "video" && info.type === "screen") {
-            setActiveScreenShareId(null);
+            setActiveScreenShareId(
+              preservePendingScreenShare && pendingReplacementProducerId
+                ? pendingReplacementProducerId
+                : null,
+            );
           }
 
           if (!hasPendingReplacement) {
@@ -1556,28 +1571,48 @@ export function useMeetSocket({
           }
         };
 
+        const scheduleStaleReplacementCleanup = () => {
+          const timeoutId = window.setTimeout(() => {
+            staleReplacementCleanupTimeoutsRef.current.delete(producerId);
+            const latestReplacementState = getMatchingReplacementState();
+            if (latestReplacementState.hasConsumedReplacement) return;
+
+            clearClosedProducerState({
+              hasPendingReplacement: latestReplacementState.hasPendingReplacement,
+              pendingReplacementProducerId:
+                latestReplacementState.pendingReplacementProducerId,
+              preservePendingScreenShare: false,
+            });
+          }, STALE_REPLACEMENT_CLEANUP_DELAY_MS);
+          staleReplacementCleanupTimeoutsRef.current.set(producerId, timeoutId);
+        };
+
         const replacementState = getMatchingReplacementState();
         if (!replacementState.hasReplacementProducer) {
           const timeoutId = window.setTimeout(() => {
             staleReplacementCleanupTimeoutsRef.current.delete(producerId);
             const latestReplacementState = getMatchingReplacementState();
             if (latestReplacementState.hasConsumedReplacement) return;
-            clearClosedProducerState(
-              latestReplacementState.hasPendingReplacement,
-            );
+            clearClosedProducerState({
+              hasPendingReplacement: latestReplacementState.hasPendingReplacement,
+              pendingReplacementProducerId:
+                latestReplacementState.pendingReplacementProducerId,
+              preservePendingScreenShare: true,
+            });
+            if (latestReplacementState.hasPendingReplacement) {
+              scheduleStaleReplacementCleanup();
+            }
           }, PRODUCER_CLOSE_REPLACEMENT_GRACE_MS);
           staleReplacementCleanupTimeoutsRef.current.set(producerId, timeoutId);
         } else if (!replacementState.hasConsumedReplacement) {
-          const timeoutId = window.setTimeout(() => {
-            staleReplacementCleanupTimeoutsRef.current.delete(producerId);
-            const latestReplacementState = getMatchingReplacementState();
-            if (latestReplacementState.hasConsumedReplacement) return;
-
-            clearClosedProducerState(
-              latestReplacementState.hasPendingReplacement,
-            );
-          }, STALE_REPLACEMENT_CLEANUP_DELAY_MS);
-          staleReplacementCleanupTimeoutsRef.current.set(producerId, timeoutId);
+          if (
+            info.kind === "video" &&
+            info.type === "screen" &&
+            replacementState.pendingReplacementProducerId
+          ) {
+            setActiveScreenShareId(replacementState.pendingReplacementProducerId);
+          }
+          scheduleStaleReplacementCleanup();
         }
 
         producerMapRef.current.delete(producerId);

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -3713,10 +3713,11 @@ export function useMeetSocket({
                     const liveAudioTrack = getFirstLiveTrack(
                       localStreamRef.current?.getAudioTracks() ?? [],
                     );
-                    const shouldRecoverAudio =
-                      !isMutedRef.current && liveAudioTrack !== null;
-                    if (shouldRecoverAudio && liveAudioTrack) {
-                      liveAudioTrack.enabled = true;
+                    const shouldRecoverAudio = !isMutedRef.current;
+                    if (shouldRecoverAudio) {
+                      if (liveAudioTrack) {
+                        liveAudioTrack.enabled = true;
+                      }
                       isMutedRef.current = false;
                       setIsMuted(false);
                       requestAudioProducerRecovery();
@@ -3747,8 +3748,11 @@ export function useMeetSocket({
                             currentStream?.getVideoTracks() ?? [],
                           );
                     const shouldRecoverCamera =
-                      !isCameraOffRef.current && Boolean(liveVideoTrack);
+                      !isCameraOffRef.current;
                     if (shouldRecoverCamera) {
+                      if (liveVideoTrack) {
+                        liveVideoTrack.enabled = true;
+                      }
                       isCameraOffRef.current = false;
                       setIsCameraOff(false);
                       requestCameraProducerRecovery();

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -93,6 +93,7 @@ const PARTICIPANT_RECONNECTING_STATUS_BUFFER_MS = 5000;
 const PARTICIPANT_RECONNECTED_STATUS_MS = 4500;
 const PRODUCER_CLOSE_REPLACEMENT_GRACE_MS = 1500;
 const STALE_REPLACEMENT_CLEANUP_DELAY_MS = 5000;
+const SCREEN_SHARE_STALE_REPLACEMENT_CLEANUP_DELAY_MS = 1500;
 const TURN_URL_PATTERN = /^turns?:/i;
 const TRANSPORT_CC_FEEDBACK_TYPE = "transport-cc";
 
@@ -1610,6 +1611,10 @@ export function useMeetSocket({
         };
 
         const scheduleStaleReplacementCleanup = () => {
+          const cleanupDelayMs =
+            info.kind === "video" && info.type === "screen"
+              ? SCREEN_SHARE_STALE_REPLACEMENT_CLEANUP_DELAY_MS
+              : STALE_REPLACEMENT_CLEANUP_DELAY_MS;
           const timeoutId = window.setTimeout(() => {
             staleReplacementCleanupTimeoutsRef.current.delete(producerId);
             const latestReplacementState = getMatchingReplacementState();
@@ -1621,7 +1626,7 @@ export function useMeetSocket({
                 latestReplacementState.pendingReplacementProducerId,
               preservePendingScreenShare: false,
             });
-          }, STALE_REPLACEMENT_CLEANUP_DELAY_MS);
+          }, cleanupDelayMs);
           staleReplacementCleanupTimeoutsRef.current.set(producerId, timeoutId);
         };
 

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -622,7 +622,15 @@ export function useMeetSocket({
   // effect below — this catches a frozen decoder that `track.muted` never fires
   // for (RTP keeps flowing, the decoder is stuck on a stale reference frame).
   const videoFreezeStatsRef = useRef<
-    Map<string, { frames: number; bytes: number; stalls: number }>
+    Map<
+      string,
+      {
+        frames: number;
+        bytes: number;
+        stalls: number;
+        lastKeyFrameRequestAt: number;
+      }
+    >
   >(new Map());
   const consumerRecoveryInFlightRef = useRef<Set<string>>(new Set());
   const announcedRemoteProducersRef = useRef<Map<string, ProducerInfo>>(
@@ -2745,13 +2753,14 @@ export function useMeetSocket({
   // never fires. Poll each remote VIDEO consumer's getStats every ~2s: if
   // framesDecoded stops advancing while bytesReceived keeps climbing and the
   // producer isn't paused, the decoder is stuck — request a fresh keyframe (PLI)
-  // so it un-freezes. Conservative: needs 2 consecutive stalled samples (~4s)
-  // before a PLI, and resets after each PLI to avoid keyframe storms in lossy
-  // rooms. Persistent failures still fall through to the existing stale-consumer
-  // / producer-sync recovery.
+  // so it un-freezes. One confirmed stalled sample is enough (~2s) because the
+  // byte-delta gate proves media is still arriving; a per-consumer cooldown
+  // avoids keyframe storms in lossy rooms. Persistent failures still fall
+  // through to the existing stale-consumer / producer-sync recovery.
   useEffect(() => {
     const FREEZE_CHECK_MS = 2000;
-    const STALL_SAMPLES_BEFORE_PLI = 2;
+    const STALL_SAMPLES_BEFORE_PLI = 1;
+    const KEYFRAME_REQUEST_COOLDOWN_MS = 3500;
     // Only treat a flat frame count as a freeze when REAL media is still
     // arriving (>~32kbps over the 2s window). A truly frozen decoder still
     // receives full-bitrate RTP from the sender, so a real freeze easily clears
@@ -2817,6 +2826,7 @@ export function useMeetSocket({
 
             const prev = stats.get(producerId);
             let stalls = 0;
+            let lastKeyFrameRequestAt = prev?.lastKeyFrameRequestAt ?? 0;
             if (prev) {
               const decoderStuck =
                 decodedNow === prev.frames &&
@@ -2824,7 +2834,11 @@ export function useMeetSocket({
               stalls = decoderStuck ? prev.stalls + 1 : 0;
             }
 
-            if (stalls >= STALL_SAMPLES_BEFORE_PLI) {
+            const sampleNow = Date.now();
+            if (
+              stalls >= STALL_SAMPLES_BEFORE_PLI &&
+              sampleNow - lastKeyFrameRequestAt >= KEYFRAME_REQUEST_COOLDOWN_MS
+            ) {
               // Decoder is frozen but real media is flowing → force a keyframe.
               const socket2 = socketRef.current;
               if (socket2?.connected) {
@@ -2834,6 +2848,7 @@ export function useMeetSocket({
                   () => {},
                 );
               }
+              lastKeyFrameRequestAt = sampleNow;
               stalls = 0; // give the PLI time to land before re-requesting
             }
 
@@ -2841,6 +2856,7 @@ export function useMeetSocket({
               frames: decodedNow,
               bytes: bytesNow,
               stalls,
+              lastKeyFrameRequestAt,
             });
           })
           .catch(() => {});

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -2074,6 +2074,7 @@ export function useMeetSocket({
             codecOptions: buildMicrophoneOpusCodecOptions(
               getBrowserPublishNetworkProfile(),
             ),
+            stopTracks: false,
             appData: {
               type: "webcam" as ProducerType,
               paused: shouldPauseAudio,
@@ -4652,7 +4653,15 @@ export function useMeetSocket({
         // otherwise we'd briefly re-enter the call and then clobber the terminal
         // notice ("The host ended the meeting.") with "Failed to reconnect".
         if (intentionalDisconnectRef.current) return;
-        setConnectionState("reconnecting");
+        const shouldSurfaceReconnectState =
+          !shouldDeferTransportRecoveryUntilVisible();
+        if (shouldSurfaceReconnectState) {
+          setConnectionState("reconnecting");
+        } else {
+          console.info(
+            "[Meets] Background reconnect in progress; preserving joined UI state.",
+          );
+        }
         reconnectAttemptsRef.current++;
         const delay =
           RECONNECT_DELAY_MS * 2 ** (reconnectAttemptsRef.current - 1);

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -21,6 +21,7 @@ import type {
   ChatHistorySnapshot,
   ChatMessage,
   ConnectionState,
+  Consumer,
   ConsumeResponse,
   HandRaisedNotification,
   HandRaisedSnapshot,
@@ -74,6 +75,10 @@ type ConsumerTelemetryPayload = Omit<
   ConsumerTelemetrySnapshot,
   "receivedAt"
 >;
+
+type ConsumeProducerOptions = {
+  replaceExisting?: boolean;
+};
 
 type JoinInfo = {
   token: string;
@@ -638,7 +643,7 @@ export function useMeetSocket({
   );
   const pendingScreenProducerCloseIdsRef = useRef<Set<string>>(new Set());
   const consumeProducerRef = useRef<
-    (producerInfo: ProducerInfo) => Promise<void>
+    (producerInfo: ProducerInfo, options?: ConsumeProducerOptions) => Promise<void>
   >(async () => {});
   const recoverStaleConsumerRef = useRef<
     (producerInfo: ProducerInfo, reason: string) => Promise<void>
@@ -1519,7 +1524,7 @@ export function useMeetSocket({
   );
 
   const closeConsumerForSameProducerReconsume = useCallback(
-    (producerId: string) => {
+    (producerId: string, consumerToClose?: Consumer | null) => {
       pendingProducersRef.current.delete(producerId);
       consumeRetryAttemptsRef.current.delete(producerId);
       const scheduledRecoveryTimeout =
@@ -1535,7 +1540,7 @@ export function useMeetSocket({
       consumerTelemetryRef.current.delete(producerId);
       videoFreezeStatsRef.current.delete(producerId);
 
-      const consumer = consumersRef.current.get(producerId);
+      const consumer = consumerToClose ?? consumersRef.current.get(producerId);
       if (!consumer) return;
       try {
         consumer.track.onmute = null;
@@ -1543,7 +1548,9 @@ export function useMeetSocket({
         consumer.track.stop();
         consumer.close();
       } catch {}
-      consumersRef.current.delete(producerId);
+      if (consumersRef.current.get(producerId)?.id === consumer.id) {
+        consumersRef.current.delete(producerId);
+      }
     },
     [
       adaptivelyPausedConsumerProducerIdsRef,
@@ -2443,11 +2450,15 @@ export function useMeetSocket({
   );
 
   const consumeProducer = useCallback(
-    async (producerInfo: ProducerInfo): Promise<void> => {
+    async (
+      producerInfo: ProducerInfo,
+      options: ConsumeProducerOptions = {},
+    ): Promise<void> => {
       if (producerInfo.producerUserId === userId) {
         return;
       }
-      if (consumersRef.current.has(producerInfo.producerId)) {
+      const existingConsumer = consumersRef.current.get(producerInfo.producerId);
+      if (existingConsumer && !options.replaceExisting) {
         consumeRetryAttemptsRef.current.delete(producerInfo.producerId);
         return;
       }
@@ -2696,6 +2707,13 @@ export function useMeetSocket({
                 setActiveScreenShareId(producerInfo.producerId);
               }
 
+              if (existingConsumer && existingConsumer.id !== consumer.id) {
+                closeConsumerForSameProducerReconsume(
+                  producerInfo.producerId,
+                  existingConsumer,
+                );
+              }
+
               if (producerInfo.paused) {
                 if (isWebcamAudio) {
                   updateMutedState(true);
@@ -2736,6 +2754,7 @@ export function useMeetSocket({
       producerMapRef,
       dispatchParticipants,
       handleProducerClosed,
+      closeConsumerForSameProducerReconsume,
       getReceiveNetworkProfile,
       joinMode,
       queueProducerConsumeRetry,
@@ -2775,8 +2794,7 @@ export function useMeetSocket({
         console.warn(
           `[Meets] Recovering stale ${producerInfo.kind} consumer ${producerInfo.producerId}: ${reason}`,
         );
-        closeConsumerForSameProducerReconsume(producerInfo.producerId);
-        await consumeProducer(producerInfo);
+        await consumeProducer(producerInfo, { replaceExisting: true });
       } catch (error) {
         console.error(
           `[Meets] Failed to recover stale consumer ${producerInfo.producerId}:`,
@@ -2791,7 +2809,6 @@ export function useMeetSocket({
       consumerRecoveryInFlightRef,
       socketRef,
       consumerTransportRef,
-      closeConsumerForSameProducerReconsume,
       consumeProducer,
       queueProducerConsumeRetry,
     ],

--- a/apps/web/src/app/hooks/useVideoEffects.ts
+++ b/apps/web/src/app/hooks/useVideoEffects.ts
@@ -10962,6 +10962,7 @@ export function useVideoEffects({
     });
     let loopTimerId: number | null = null;
     let effectChangeFramePumpTimerId: number | null = null;
+    let processedOutputStaleCheckIntervalId: number | null = null;
     let effectChangeFramePumpGeneration = 0;
     let effectChangeFramePumpDrainFramesRemaining = 0;
     let videoFrameCallbackId: number | null = null;
@@ -11175,6 +11176,10 @@ export function useVideoEffects({
     let latestOutputFrameDispatchAt = 0;
     let latestOutputFrameAt = 0;
     let lastHiddenStaleOutputPreserveLogAt = 0;
+    let hiddenStaleOutputKeepaliveInFlight = false;
+    let hiddenStaleOutputKeepaliveCount = 0;
+    let hiddenStaleOutputKeepaliveFailureCount = 0;
+    let lastHiddenStaleOutputKeepaliveLogAt = 0;
     let latestOutputFrameVisible = false;
     let latestOutputProbe: CanvasVisibilityProbe = {
       averageLuma: 0,
@@ -13094,6 +13099,19 @@ export function useVideoEffects({
       }
     };
 
+    const getLatestOutputFrameAgeMs = (sampleNow = performance.now()) =>
+      latestOutputFrameAt > 0
+        ? Math.max(0, sampleNow - latestOutputFrameAt)
+        : Number.POSITIVE_INFINITY;
+
+    const isHiddenStaleProcessedOutput = (sampleNow = performance.now()) =>
+      outputTrackPublished &&
+      !cancelled &&
+      track.readyState === "live" &&
+      active &&
+      document.visibilityState !== "visible" &&
+      getLatestOutputFrameAgeMs(sampleNow) >= PROCESSED_OUTPUT_STALE_RELEASE_MS;
+
     const releaseStaleProcessedOutputIfNeeded = (
       reason: string,
       sampleNow = performance.now(),
@@ -13101,10 +13119,7 @@ export function useVideoEffects({
       if (!outputTrackPublished || cancelled || track.readyState !== "live") {
         return false;
       }
-      const latestOutputFrameAgeMs =
-        latestOutputFrameAt > 0
-          ? Math.max(0, sampleNow - latestOutputFrameAt)
-          : Number.POSITIVE_INFINITY;
+      const latestOutputFrameAgeMs = getLatestOutputFrameAgeMs(sampleNow);
       if (latestOutputFrameAgeMs < PROCESSED_OUTPUT_STALE_RELEASE_MS) {
         return false;
       }
@@ -13148,9 +13163,6 @@ export function useVideoEffects({
       releaseOutputTrackToRaw(reason);
       return true;
     };
-    const processedOutputStaleCheckIntervalId = window.setInterval(() => {
-      releaseStaleProcessedOutputIfNeeded("processed output stale heartbeat");
-    }, PROCESSED_OUTPUT_STALE_CHECK_MS);
 
     const recordOutputWriterFrameFailure = (err: unknown, phase: string) => {
       outputWriterWriteFailures += 1;
@@ -13498,6 +13510,95 @@ export function useVideoEffects({
         } catch {}
       }
     };
+
+    const keepHiddenStaleProcessedOutputAlive = async (
+      reason: string,
+      sampleNow = performance.now(),
+    ) => {
+      if (
+        hiddenStaleOutputKeepaliveInFlight ||
+        !isHiddenStaleProcessedOutput(sampleNow)
+      ) {
+        return false;
+      }
+
+      hiddenStaleOutputKeepaliveInFlight = true;
+      const latestOutputFrameAgeMs = getLatestOutputFrameAgeMs(sampleNow);
+      try {
+        if (!latestOutputProbe.visible) {
+          const restoredProbe = restoreLastVisibleOutputFrame(
+            "hidden-stale-output-keepalive",
+            latestOutputProbe,
+          );
+          if (restoredProbe?.visible) {
+            latestOutputProbe = restoredProbe;
+            latestOutputFrameVisible = true;
+          }
+        }
+
+        const outputDelivered = await deliverOutputFrame(sampleNow);
+        if (outputDelivered) {
+          hiddenStaleOutputKeepaliveCount += 1;
+          hiddenStaleOutputKeepaliveFailureCount = 0;
+          if (
+            hiddenStaleOutputKeepaliveCount <= 3 ||
+            sampleNow - lastHiddenStaleOutputKeepaliveLogAt >= 5000
+          ) {
+            lastHiddenStaleOutputKeepaliveLogAt = sampleNow;
+            logVideoEffects(debugId, "hidden_stale_output_keepalive", {
+              reason,
+              keepaliveCount: hiddenStaleOutputKeepaliveCount,
+              latestOutputFrameAgeMs: Number.isFinite(latestOutputFrameAgeMs)
+                ? Math.round(latestOutputFrameAgeMs)
+                : null,
+              outputMode,
+              outputWriterMode,
+              outputFramesWritten,
+              outputFrameSequence,
+              outputTrack: getTrackDebugSnapshot(track),
+              sourceTrack: getTrackDebugSnapshot(sourceVideoTrack),
+            });
+          }
+          return true;
+        }
+
+        hiddenStaleOutputKeepaliveFailureCount += 1;
+        if (
+          hiddenStaleOutputKeepaliveFailureCount <= 3 ||
+          hiddenStaleOutputKeepaliveFailureCount % 5 === 0
+        ) {
+          warnVideoEffects(debugId, "hidden_stale_output_keepalive_failed", {
+            reason,
+            failureCount: hiddenStaleOutputKeepaliveFailureCount,
+            latestOutputFrameAgeMs: Number.isFinite(latestOutputFrameAgeMs)
+              ? Math.round(latestOutputFrameAgeMs)
+              : null,
+            outputMode,
+            outputWriterMode,
+            outputFramesWritten,
+            outputFrameSequence,
+            outputTrack: getTrackDebugSnapshot(track),
+            sourceTrack: getTrackDebugSnapshot(sourceVideoTrack),
+          });
+        }
+        return false;
+      } finally {
+        hiddenStaleOutputKeepaliveInFlight = false;
+      }
+    };
+
+    processedOutputStaleCheckIntervalId = window.setInterval(() => {
+      const sampleNow = performance.now();
+      const released = releaseStaleProcessedOutputIfNeeded(
+        "processed output stale heartbeat",
+        sampleNow,
+      );
+      if (released) return;
+      void keepHiddenStaleProcessedOutputAlive(
+        "processed output hidden stale heartbeat",
+        sampleNow,
+      );
+    }, PROCESSED_OUTPUT_STALE_CHECK_MS);
 
     const setRuntimeStatus = (
       nextStatus: VideoEffectsRuntimeStatus,
@@ -17835,7 +17936,10 @@ export function useVideoEffects({
         window.clearTimeout(effectChangeFramePumpTimerId);
         effectChangeFramePumpTimerId = null;
       }
-      window.clearInterval(processedOutputStaleCheckIntervalId);
+      if (processedOutputStaleCheckIntervalId !== null) {
+        window.clearInterval(processedOutputStaleCheckIntervalId);
+        processedOutputStaleCheckIntervalId = null;
+      }
       if (loopTimerId !== null) {
         window.clearTimeout(loopTimerId);
         loopTimerId = null;

--- a/apps/web/src/app/hooks/useVideoEffects.ts
+++ b/apps/web/src/app/hooks/useVideoEffects.ts
@@ -232,6 +232,7 @@ const OUTPUT_WRITER_FAILURE_RELEASE_THRESHOLD = 3;
 const DUPLICATE_OUTPUT_HEARTBEAT_MS = 900;
 const PROCESSED_OUTPUT_STALE_RELEASE_MS = 2500;
 const PROCESSED_OUTPUT_STALE_CHECK_MS = 1000;
+const HIDDEN_STALE_OUTPUT_REPUBLISH_RETRY_MS = 5000;
 const SEGMENTATION_PROCESSOR_FRAME_TIMEOUT_MS = 6000;
 const SEGMENTATION_PROCESSOR_INITIAL_FRAME_TIMEOUT_MS = 16000;
 const FACE_PROCESSOR_FRAME_TIMEOUT_MS = 6000;
@@ -11180,6 +11181,7 @@ export function useVideoEffects({
     let hiddenStaleOutputKeepaliveCount = 0;
     let hiddenStaleOutputKeepaliveFailureCount = 0;
     let lastHiddenStaleOutputKeepaliveLogAt = 0;
+    let lastHiddenStaleOutputVersionBumpAt = 0;
     let latestOutputFrameVisible = false;
     let latestOutputProbe: CanvasVisibilityProbe = {
       averageLuma: 0,
@@ -13038,6 +13040,26 @@ export function useVideoEffects({
     });
     prestartNeededProcessorWorkers("startup", effectsRef.current);
 
+    const bumpProcessedTrackVersionForFreshOutput = (
+      reason: string,
+      sampleNow = performance.now(),
+    ) => {
+      if (cancelled || track.readyState !== "live") return;
+      setProcessedTrackVersion((version) => version + 1);
+      logVideoEffects(debugId, "processed_track_fresh_output_version", {
+        reason,
+        outputMode,
+        outputWriterMode,
+        outputFramesWritten,
+        outputFrameSequence,
+        outputTrack: getTrackDebugSnapshot(track),
+        ageMs:
+          latestOutputFrameAt > 0
+            ? Math.round(Math.max(0, sampleNow - latestOutputFrameAt))
+            : null,
+      });
+    };
+
     const publishOutputTrack = () => {
       if (outputTrackPublished || cancelled || track.readyState !== "live") return;
       if (
@@ -13065,6 +13087,7 @@ export function useVideoEffects({
         outputTrack: getTrackDebugSnapshot(track),
       });
       setProcessedTrack(track);
+      bumpProcessedTrackVersionForFreshOutput("publish-processed-track");
     };
 
     const releaseOutputTrackToRaw = (
@@ -13540,6 +13563,18 @@ export function useVideoEffects({
         if (outputDelivered) {
           hiddenStaleOutputKeepaliveCount += 1;
           hiddenStaleOutputKeepaliveFailureCount = 0;
+          if (
+            lastHiddenStaleOutputVersionBumpAt <= 0 ||
+            sampleNow - lastHiddenStaleOutputVersionBumpAt >=
+              HIDDEN_STALE_OUTPUT_REPUBLISH_RETRY_MS
+          ) {
+            lastHiddenStaleOutputVersionBumpAt = sampleNow;
+            setProcessedTrackReady(true);
+            bumpProcessedTrackVersionForFreshOutput(
+              "hidden-stale-output-keepalive",
+              sampleNow,
+            );
+          }
           if (
             hiddenStaleOutputKeepaliveCount <= 3 ||
             sampleNow - lastHiddenStaleOutputKeepaliveLogAt >= 5000

--- a/apps/web/src/app/hooks/useVideoEffects.ts
+++ b/apps/web/src/app/hooks/useVideoEffects.ts
@@ -229,6 +229,7 @@ const OUTPUT_WRITER_BACKPRESSURE_DRAIN_TIMEOUT_MS = 36;
 const OUTPUT_WRITER_PENDING_PRESSURE_MS = 75;
 const OUTPUT_WRITER_FRAME_TIMEOUT_MS = 3000;
 const OUTPUT_WRITER_FAILURE_RELEASE_THRESHOLD = 3;
+const DUPLICATE_OUTPUT_HEARTBEAT_MS = 900;
 const PROCESSED_OUTPUT_STALE_RELEASE_MS = 2500;
 const PROCESSED_OUTPUT_STALE_CHECK_MS = 1000;
 const SEGMENTATION_PROCESSOR_FRAME_TIMEOUT_MS = 6000;
@@ -11173,6 +11174,7 @@ export function useVideoEffects({
     let outputFramesWritten = 0;
     let latestOutputFrameDispatchAt = 0;
     let latestOutputFrameAt = 0;
+    let lastHiddenStaleOutputPreserveLogAt = 0;
     let latestOutputFrameVisible = false;
     let latestOutputProbe: CanvasVisibilityProbe = {
       averageLuma: 0,
@@ -13104,6 +13106,29 @@ export function useVideoEffects({
           ? Math.max(0, sampleNow - latestOutputFrameAt)
           : Number.POSITIVE_INFINITY;
       if (latestOutputFrameAgeMs < PROCESSED_OUTPUT_STALE_RELEASE_MS) {
+        return false;
+      }
+
+      if (active && document.visibilityState !== "visible") {
+        if (
+          lastHiddenStaleOutputPreserveLogAt <= 0 ||
+          sampleNow - lastHiddenStaleOutputPreserveLogAt >= 5000
+        ) {
+          lastHiddenStaleOutputPreserveLogAt = sampleNow;
+          logVideoEffects(debugId, "preserve_processed_track_hidden_stale", {
+            reason,
+            latestOutputFrameAgeMs: Number.isFinite(latestOutputFrameAgeMs)
+              ? Math.round(latestOutputFrameAgeMs)
+              : null,
+            thresholdMs: PROCESSED_OUTPUT_STALE_RELEASE_MS,
+            outputMode,
+            outputWriterMode,
+            outputFramesWritten,
+            outputFrameSequence,
+            outputTrack: getTrackDebugSnapshot(track),
+            sourceTrack: getTrackDebugSnapshot(sourceVideoTrack),
+          });
+        }
         return false;
       }
 
@@ -16042,6 +16067,10 @@ export function useVideoEffects({
       const hasNewModelResult =
         latestSegmentationMaskAt > lastRenderedSegmentationMaskAt ||
         latestFaceLandmarksAt > lastRenderedFaceLandmarksAt;
+      const duplicateOutputHeartbeatDue =
+        outputTrackPublished &&
+        latestOutputFrameAt > 0 &&
+        loopStartedAt - latestOutputFrameAt >= DUPLICATE_OUTPUT_HEARTBEAT_MS;
       const shouldSkipDuplicateFrame =
         (frameSource.source === "video" ||
           frameSource.source === "track-processor") &&
@@ -16051,7 +16080,8 @@ export function useVideoEffects({
         !hasNewModelResult &&
         outputTrackPublished &&
         latestOutputFrameAt > 0 &&
-        track.readyState === "live";
+        track.readyState === "live" &&
+        !duplicateOutputHeartbeatDue;
       if (shouldSkipDuplicateFrame) {
         duplicateFrameSkipCount += 1;
         lastDuplicateVideoFrameKey = latestVideoFrameKey;

--- a/apps/web/src/app/hooks/useVideoEffects.ts
+++ b/apps/web/src/app/hooks/useVideoEffects.ts
@@ -222,6 +222,7 @@ const VIDEO_FRAME_CALLBACK_WATCHDOG_MS = 450;
 const VIDEO_FRAME_CALLBACK_TRANSITION_WATCHDOG_MS = 48;
 const VIDEO_FRAME_CALLBACK_EFFECT_CHANGE_PUMP_MS = 320;
 const VIDEO_FRAME_CALLBACK_EFFECT_CHANGE_DRAIN_FRAMES = 4;
+const HIDDEN_VIDEO_REARM_INTERVAL_MS = 5000;
 const OUTPUT_WRITER_STEADY_MAX_PENDING_FRAMES = 1;
 const OUTPUT_WRITER_TRANSITION_MAX_PENDING_FRAMES = 1;
 const OUTPUT_WRITER_TRANSITION_BURST_MS = 900;
@@ -10964,6 +10965,7 @@ export function useVideoEffects({
     let loopTimerId: number | null = null;
     let effectChangeFramePumpTimerId: number | null = null;
     let processedOutputStaleCheckIntervalId: number | null = null;
+    let hiddenVideoRearmIntervalId: number | null = null;
     let effectChangeFramePumpGeneration = 0;
     let effectChangeFramePumpDrainFramesRemaining = 0;
     let videoFrameCallbackId: number | null = null;
@@ -14624,6 +14626,18 @@ export function useVideoEffects({
         });
     };
 
+    const handleDocumentVisibilityChange = () => {
+      if (cancelled) return;
+      const reason =
+        document.visibilityState === "visible"
+          ? "document-visible"
+          : "document-hidden";
+      rearmHiddenVideoPlayback(reason);
+      if (document.visibilityState !== "visible") {
+        void keepHiddenStaleProcessedOutputAlive(reason);
+      }
+    };
+
     const handleHiddenVideoMediaEvent = (event: Event) => {
       if (cancelled) return;
       hiddenVideoMediaEventCount += 1;
@@ -14643,10 +14657,26 @@ export function useVideoEffects({
       schedule();
     };
 
+    const handleHiddenVideoPlaybackStall = (event: Event) => {
+      if (cancelled) return;
+      rearmHiddenVideoPlayback(`hidden-video-${event.type}`);
+    };
+
     video.addEventListener("loadedmetadata", handleHiddenVideoMediaEvent);
     video.addEventListener("loadeddata", handleHiddenVideoMediaEvent);
     video.addEventListener("canplay", handleHiddenVideoMediaEvent);
     video.addEventListener("playing", handleHiddenVideoMediaEvent);
+    video.addEventListener("pause", handleHiddenVideoPlaybackStall);
+    video.addEventListener("stalled", handleHiddenVideoPlaybackStall);
+    video.addEventListener("suspend", handleHiddenVideoPlaybackStall);
+    video.addEventListener("waiting", handleHiddenVideoPlaybackStall);
+    document.addEventListener("visibilitychange", handleDocumentVisibilityChange);
+    window.addEventListener("pageshow", handleDocumentVisibilityChange);
+    hiddenVideoRearmIntervalId = window.setInterval(() => {
+      if (cancelled || document.visibilityState === "visible") return;
+      rearmHiddenVideoPlayback("hidden-video-keepalive");
+      void keepHiddenStaleProcessedOutputAlive("hidden-video-keepalive");
+    }, HIDDEN_VIDEO_REARM_INTERVAL_MS);
 
     const getAdaptationRecordOptions = (sampleNow = performance.now()) => {
       const warmupHeld =
@@ -17975,6 +18005,10 @@ export function useVideoEffects({
         window.clearInterval(processedOutputStaleCheckIntervalId);
         processedOutputStaleCheckIntervalId = null;
       }
+      if (hiddenVideoRearmIntervalId !== null) {
+        window.clearInterval(hiddenVideoRearmIntervalId);
+        hiddenVideoRearmIntervalId = null;
+      }
       if (loopTimerId !== null) {
         window.clearTimeout(loopTimerId);
         loopTimerId = null;
@@ -18023,6 +18057,15 @@ export function useVideoEffects({
       video.removeEventListener("loadeddata", handleHiddenVideoMediaEvent);
       video.removeEventListener("canplay", handleHiddenVideoMediaEvent);
       video.removeEventListener("playing", handleHiddenVideoMediaEvent);
+      video.removeEventListener("pause", handleHiddenVideoPlaybackStall);
+      video.removeEventListener("stalled", handleHiddenVideoPlaybackStall);
+      video.removeEventListener("suspend", handleHiddenVideoPlaybackStall);
+      video.removeEventListener("waiting", handleHiddenVideoPlaybackStall);
+      document.removeEventListener(
+        "visibilitychange",
+        handleDocumentVisibilityChange,
+      );
+      window.removeEventListener("pageshow", handleDocumentVisibilityChange);
       video.pause();
       video.srcObject = null;
       video.remove();

--- a/apps/web/src/app/lib/klipy-gifs.ts
+++ b/apps/web/src/app/lib/klipy-gifs.ts
@@ -1,0 +1,24 @@
+import type { ChatGifAttachment } from "./types";
+
+export interface KlipyGifResult extends ChatGifAttachment {
+  previewUrl: string;
+}
+
+export interface KlipyGifSearchResponse {
+  gifs: KlipyGifResult[];
+  page: number;
+  hasNext: boolean;
+}
+
+export const klipyGifResultToAttachment = (
+  gif: KlipyGifResult,
+): ChatGifAttachment => ({
+  id: gif.id,
+  title: gif.title,
+  url: gif.url,
+  previewUrl: gif.previewUrl,
+  pageUrl: gif.pageUrl,
+  width: gif.width,
+  height: gif.height,
+  source: "klipy",
+});

--- a/apps/web/src/app/lib/network-information.ts
+++ b/apps/web/src/app/lib/network-information.ts
@@ -204,19 +204,3 @@ export function shouldDeferBandwidthHeavyPreload(
     quality === "poor"
   );
 }
-
-export function shouldSuppressBandwidthHeavyVideoEffects(
-  connection = getBrowserNetworkInformation(),
-): boolean {
-  if (typeof navigator !== "undefined" && navigator.onLine === false) {
-    return true;
-  }
-  if (!connection) return false;
-  if (connection.saveData === true) return true;
-  const quality = classifyBrowserNetworkQuality(connection);
-  return (
-    isEmergencyBrowserNetwork(connection) ||
-    quality === "fair" ||
-    quality === "poor"
-  );
-}

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -1102,6 +1102,7 @@ export default function MeetsClient({
     intentionalTrackStopsRef: refs.intentionalTrackStopsRef,
     permissionHintTimeoutRef: refs.permissionHintTimeoutRef,
     audioContextRef: refs.audioContextRef,
+    mediaRecoveryBlockedRef: refs.reconnectInFlightRef,
   });
 
   // Record the picked camera so the dropdown reflects the selection, then run

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -2064,6 +2064,7 @@ export default function MeetsClient({
     setActiveScreenShareId,
     setNetworkManagedVideoQuality,
     videoQualityRef: refs.videoQualityRef,
+    connectionQualityRef: connectionQualityDebugRef,
     updateVideoQualityRef,
     requestMediaPermissions,
     requestAudioProducerRecovery,

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -995,6 +995,7 @@ export default function MeetsClient({
     setChatInput,
     toggleChat,
     sendChat,
+    sendChatGif,
     isChatOpenRef,
   } = useMeetChat({
     socketRef: refs.socketRef,
@@ -2750,6 +2751,7 @@ export default function MeetsClient({
           chatInput={chatInput}
           setChatInput={setChatInput}
           sendChat={sendChat}
+          sendChatGif={sendChatGif}
           chatOverlayMessages={chatOverlayMessages}
           setChatOverlayMessages={setChatOverlayMessages}
           socket={refs.socketRef.current}
@@ -2910,6 +2912,7 @@ export default function MeetsClient({
         chatInput={chatInput}
         setChatInput={setChatInput}
         sendChat={sendChat}
+        sendChatGif={sendChatGif}
         chatOverlayMessages={chatOverlayMessages}
         setChatOverlayMessages={setChatOverlayMessages}
         socket={refs.socketRef.current}

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -42,7 +42,6 @@ import { useMeetTts } from "./hooks/useMeetTts";
 import { MeetVolumeProvider } from "./hooks/useMeetVolume";
 import {
   useBandwidthHeavyPreloadDeferred,
-  useBandwidthHeavyVideoEffectsSuppressed,
 } from "./hooks/useBandwidthHeavyPreloadDeferred";
 import {
   useAdaptiveConsumerPreferences,
@@ -579,11 +578,7 @@ export default function MeetsClient({
   );
   const shouldDeferVideoEffectsPreload =
     useBandwidthHeavyPreloadDeferred();
-  const shouldSuppressVideoEffectsForBandwidth =
-    useBandwidthHeavyVideoEffectsSuppressed();
-  const shouldRunVisualVideoEffects =
-    activeVideoEffectsCount > 0 &&
-    !shouldSuppressVideoEffectsForBandwidth;
+  const shouldRunVisualVideoEffects = activeVideoEffectsCount > 0;
   const [videoEffectsBridgeState, setVideoEffectsBridgeState] =
     useState<VideoEffectsBridgeState>(VIDEO_EFFECTS_OFF_STATE);
   const handleVideoEffectsBridgeStateChange = useCallback(
@@ -637,7 +632,7 @@ export default function MeetsClient({
       if (cancelled) return;
       if (activeVideoEffectsCount <= 0) return;
       if (!isDocumentVisible) return;
-      if (shouldSuppressVideoEffectsForBandwidth) return;
+      if (shouldDeferVideoEffectsPreload) return;
       void prewarmVideoEffectsRuntimeDeferred({
         reason: "meet-shell-runtime",
         outputWriter: true,
@@ -670,7 +665,7 @@ export default function MeetsClient({
   }, [
     activeVideoEffectsCount,
     isDocumentVisible,
-    shouldSuppressVideoEffectsForBandwidth,
+    shouldDeferVideoEffectsPreload,
   ]);
 
   useEffect(() => {
@@ -750,7 +745,7 @@ export default function MeetsClient({
     }
     if (restoredVideoEffectsPrewarmDoneRef.current) return;
     if (!isDocumentVisible) return;
-    if (shouldSuppressVideoEffectsForBandwidth) return;
+    if (shouldDeferVideoEffectsPreload) return;
     restoredVideoEffectsPrewarmDoneRef.current = true;
     const backgroundNeedsSegmentation =
       videoEffects.background !== "none" &&
@@ -772,14 +767,14 @@ export default function MeetsClient({
       backgrounds,
       reason: "restored-effects-state",
     });
-  }, [isDocumentVisible, shouldSuppressVideoEffectsForBandwidth, videoEffects]);
+  }, [isDocumentVisible, shouldDeferVideoEffectsPreload, videoEffects]);
 
   useEffect(() => {
     if (cameraLiveEffectsPrewarmDoneRef.current) return;
     if (activeVideoEffectsCount <= 0) return;
     if (isCameraOff || !hasLiveVideoTrack(localStream)) return;
     if (!isDocumentVisible) return;
-    if (shouldSuppressVideoEffectsForBandwidth) return;
+    if (shouldDeferVideoEffectsPreload) return;
 
     cameraLiveEffectsPrewarmDoneRef.current = true;
     void prewarmVideoEffectsAssetsDeferred({
@@ -792,7 +787,7 @@ export default function MeetsClient({
     isDocumentVisible,
     isCameraOff,
     localStream,
-    shouldSuppressVideoEffectsForBandwidth,
+    shouldDeferVideoEffectsPreload,
   ]);
 
   const [browserAudioNeedsGesture, setBrowserAudioNeedsGesture] =
@@ -1557,7 +1552,7 @@ export default function MeetsClient({
         ),
         isDocumentVisible,
         activeVideoEffectsCount,
-        shouldSuppressVideoEffectsForBandwidth,
+        shouldDeferVideoEffectsPreload,
         shouldRunVideoEffects,
         videoEffects: getMeetVideoEffectsDebugSnapshot(videoEffects),
         videoEffectsStatus,
@@ -1626,7 +1621,7 @@ export default function MeetsClient({
       refs.videoProducerRef,
       shouldPublishProcessedVideo,
       shouldRunVideoEffects,
-      shouldSuppressVideoEffectsForBandwidth,
+      shouldDeferVideoEffectsPreload,
       videoEffects,
       videoEffectsError,
       videoEffectsDebugStats,

--- a/packages/meeting-core/src/participant-reducer.ts
+++ b/packages/meeting-core/src/participant-reducer.ts
@@ -225,6 +225,8 @@ export function participantReducer(
     }
     case "UPDATE_CONNECTION_STATUS": {
       const participant = state.get(action.userId);
+      if (!participant && !action.status) return state;
+
       const previous = participant?.connectionStatus;
       const previousGraceMs =
         previous?.state === "reconnecting" ? previous.graceMs : undefined;

--- a/packages/meeting-core/src/types.ts
+++ b/packages/meeting-core/src/types.ts
@@ -44,9 +44,21 @@ export interface ChatMessage {
   displayName: string;
   content: string;
   timestamp: number;
+  gif?: ChatGifAttachment;
   isDirect?: boolean;
   dmTargetUserId?: string;
   dmTargetDisplayName?: string;
+}
+
+export interface ChatGifAttachment {
+  id: string;
+  title: string;
+  url: string;
+  previewUrl?: string;
+  pageUrl?: string;
+  width?: number;
+  height?: number;
+  source: "klipy";
 }
 
 export interface ReactionNotification {

--- a/packages/meeting-core/test/participant-reducer.test.ts
+++ b/packages/meeting-core/test/participant-reducer.test.ts
@@ -423,6 +423,20 @@ describe("participantReducer — mute / camera / hand transitions", () => {
   });
 });
 
+describe("participantReducer — connection status transitions", () => {
+  it("UPDATE_CONNECTION_STATUS clear does not materialize an absent participant", () => {
+    const state = seed("a");
+    const next = participantReducer(state, {
+      type: "UPDATE_CONNECTION_STATUS",
+      userId: "missing",
+      status: null,
+    });
+
+    expect(next).toBe(state);
+    expect(next.has("missing")).toBe(false);
+  });
+});
+
 describe("participantReducer — CLEAR_ALL & fallthrough", () => {
   it("clears a populated map", () => {
     let state = seed("a");

--- a/packages/sfu/config/classes/Client.ts
+++ b/packages/sfu/config/classes/Client.ts
@@ -128,13 +128,14 @@ export class Client {
   addConsumer(
     consumer: Consumer,
     metadata?: { producerUserId?: string; type?: ProducerType },
-  ): void {
+  ): Consumer | null {
     const previousConsumer = this.consumers.get(consumer.producerId);
-    if (previousConsumer && previousConsumer.id !== consumer.id) {
-      try {
-        this.consumerProducerIdsById.delete(previousConsumer.id);
-        previousConsumer.close();
-      } catch {}
+    const displacedConsumer =
+      previousConsumer && previousConsumer.id !== consumer.id
+        ? previousConsumer
+        : null;
+    if (displacedConsumer) {
+      this.consumerProducerIdsById.delete(displacedConsumer.id);
     }
 
     this.consumers.set(consumer.producerId, consumer);
@@ -168,6 +169,8 @@ export class Client {
     consumer.on("transportclose", cleanup);
     consumer.on("producerclose", cleanup);
     consumer.observer.on("close", cleanup);
+
+    return displacedConsumer;
   }
 
   getProducer(

--- a/packages/sfu/config/config.ts
+++ b/packages/sfu/config/config.ts
@@ -44,6 +44,9 @@ const sfuSecretFingerprint = (() => {
   const value = sfuSecret;
   return createHash("sha256").update(value).digest("hex").slice(0, 12);
 })();
+// Hidden/mobile browsers can suspend socket timers while WebRTC media is still
+// viable. Keep producers warm long enough for low-bandwidth recovery by default.
+const BACKGROUND_SOCKET_RECOVERY_WINDOW_MS = 120000;
 
 if (process.env.SFU_DEBUG_SECRET !== "0") {
   console.log(
@@ -319,12 +322,12 @@ export const config = {
     }),
     disconnectGraceMs: toNumber(
       process.env.SFU_SOCKET_DISCONNECT_GRACE_MS,
-      30000,
+      BACKGROUND_SOCKET_RECOVERY_WINDOW_MS,
       { min: 0 },
     ),
     recoveryMaxDisconnectionMs: toNumber(
       process.env.SFU_SOCKET_RECOVERY_MAX_MS,
-      30000,
+      BACKGROUND_SOCKET_RECOVERY_WINDOW_MS,
       { min: 0 },
     ),
     redisUrl: socketRedisUrl,

--- a/packages/sfu/server/socket/handlers/adminHandlers.ts
+++ b/packages/sfu/server/socket/handlers/adminHandlers.ts
@@ -20,6 +20,7 @@ import { forceCloseRoom, markRoomEnded } from "../../rooms.js";
 import type { ConnectionContext } from "../context.js";
 import { RATE_LIMITS, takeToken } from "../rateLimit.js";
 import { respond } from "./ack.js";
+import { emitChatHistorySnapshot } from "./chatHistory.js";
 
 const DEFAULT_END_ROOM_MESSAGE =
   "This meeting has been ended by the host.";
@@ -338,6 +339,7 @@ const activatePromotedAdmin = (
     users: toPendingUserSnapshots(context.currentRoom),
     roomId,
   });
+  emitChatHistorySnapshot(promoted.socket, context.currentRoom);
 
   promoted.socket.emit("admin:roomStateChanged", {
     roomId,

--- a/packages/sfu/server/socket/handlers/chatHandlers.ts
+++ b/packages/sfu/server/socket/handlers/chatHandlers.ts
@@ -1,4 +1,8 @@
-import type { ChatMessage, SendChatData } from "../../../types.js";
+import type {
+  ChatGifAttachment,
+  ChatMessage,
+  SendChatData,
+} from "../../../types.js";
 import { Admin } from "../../../config/classes/Admin.js";
 import { Logger } from "../../../utilities/loggers.js";
 import type Room from "../../../config/classes/Room.js";
@@ -11,12 +15,83 @@ const DM_COMMAND_PATTERN = /^\/dm\s+(\S+)\s+([\s\S]+)$/i;
 const TRAILING_MENTION_PUNCTUATION_PATTERN = /[,:;.!?]+$/;
 const DIRECT_MESSAGE_USAGE_ERROR =
   "Use private messages as @username <message> or /dm <username> <message>.";
+const MAX_GIF_TITLE_LENGTH = 140;
+const MAX_GIF_URL_LENGTH = 2048;
+const KLIPY_MEDIA_HOSTS = new Set(["static.klipy.com"]);
+const KLIPY_PAGE_HOSTS = new Set(["klipy.com", "www.klipy.com"]);
 
 const fallbackDisplayNameFromUserId = (userId: string): string =>
   userId.split("#")[0]?.split("@")[0] || userId;
 
 const normalizeLookupToken = (value: string): string =>
   value.trim().toLowerCase().replace(/[^a-z0-9._-]/g, "");
+
+const normalizeHttpsUrl = (
+  value: unknown,
+  allowedHosts: Set<string>,
+): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_GIF_URL_LENGTH) return null;
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "https:" || !allowedHosts.has(url.hostname)) {
+      return null;
+    }
+    return url.href;
+  } catch {
+    return null;
+  }
+};
+
+const normalizeGifDimension = (value: unknown): number | undefined => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const rounded = Math.round(value);
+  return rounded > 0 && rounded <= 4096 ? rounded : undefined;
+};
+
+const normalizeChatGifAttachment = (
+  value: unknown,
+): ChatGifAttachment | { error: string } | null => {
+  if (!value) return null;
+  if (typeof value !== "object") {
+    return { error: "Invalid GIF attachment." };
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (candidate.source !== "klipy") {
+    return { error: "Unsupported GIF provider." };
+  }
+
+  const url = normalizeHttpsUrl(candidate.url, KLIPY_MEDIA_HOSTS);
+  if (!url) {
+    return { error: "Invalid GIF URL." };
+  }
+
+  const previewUrl =
+    normalizeHttpsUrl(candidate.previewUrl, KLIPY_MEDIA_HOSTS) ?? undefined;
+  const pageUrl =
+    normalizeHttpsUrl(candidate.pageUrl, KLIPY_PAGE_HOSTS) ?? undefined;
+  const rawId = typeof candidate.id === "string" ? candidate.id.trim() : "";
+  const id = rawId.slice(0, 120) || url;
+  const rawTitle =
+    typeof candidate.title === "string" ? candidate.title.trim() : "";
+  const title = (rawTitle || "GIF").slice(0, MAX_GIF_TITLE_LENGTH);
+  const width = normalizeGifDimension(candidate.width);
+  const height = normalizeGifDimension(candidate.height);
+
+  return {
+    id,
+    title,
+    url,
+    ...(previewUrl ? { previewUrl } : {}),
+    ...(pageUrl ? { pageUrl } : {}),
+    ...(width ? { width } : {}),
+    ...(height ? { height } : {}),
+    source: "klipy",
+  };
+};
 
 interface DirectMessageTargetCandidate {
   userId: string;
@@ -209,8 +284,16 @@ export const registerChatHandlers = (context: ConnectionContext): void => {
           return;
         }
 
-        const content = data.content?.trim();
-        if (!content || content.length === 0) {
+        const normalizedGif = normalizeChatGifAttachment(data.gif);
+        if (normalizedGif && "error" in normalizedGif) {
+          respond(callback, { error: normalizedGif.error });
+          return;
+        }
+
+        const gif = normalizedGif ?? undefined;
+        const content =
+          typeof data.content === "string" ? data.content.trim() : "";
+        if (!content && !gif) {
           respond(callback, { error: "Message cannot be empty" });
           return;
         }
@@ -242,9 +325,12 @@ export const registerChatHandlers = (context: ConnectionContext): void => {
           dmTarget = resolvedTarget;
         }
 
-        const messageContent = directMessageIntent
+        let messageContent = directMessageIntent
           ? directMessageIntent.messageBody
           : content;
+        if (!messageContent && gif) {
+          messageContent = gif.title;
+        }
 
         if (
           !directMessageIntent &&
@@ -277,6 +363,7 @@ export const registerChatHandlers = (context: ConnectionContext): void => {
           displayName,
           content: messageContent,
           timestamp: Date.now(),
+          ...(gif ? { gif } : {}),
           isDirect: Boolean(dmTarget),
           dmTargetUserId: dmTarget?.userId,
           dmTargetDisplayName: dmTarget?.displayName,

--- a/packages/sfu/server/socket/handlers/chatHistory.ts
+++ b/packages/sfu/server/socket/handlers/chatHistory.ts
@@ -1,0 +1,10 @@
+import type { Socket } from "socket.io";
+import type Room from "../../../config/classes/Room.js";
+import type { ChatHistorySnapshot } from "../../../types.js";
+
+export const emitChatHistorySnapshot = (socket: Socket, room: Room): void => {
+  socket.emit("chatHistorySnapshot", {
+    messages: room.getChatHistorySnapshot(),
+    roomId: room.id,
+  } satisfies ChatHistorySnapshot);
+};

--- a/packages/sfu/server/socket/handlers/disconnectHandlers.ts
+++ b/packages/sfu/server/socket/handlers/disconnectHandlers.ts
@@ -10,6 +10,7 @@ import {
   emitWebinarFeedChanged,
 } from "../../webinarNotifications.js";
 import type { ConnectionContext } from "../context.js";
+import { emitChatHistorySnapshot } from "./chatHistory.js";
 import { registerAdminHandlers } from "./adminHandlers.js";
 
 const promoteNextAdmin = (room: Room): Admin | null => {
@@ -114,6 +115,7 @@ export const registerDisconnectHandlers = (
                 users: pendingUsers,
                 roomId,
               });
+              emitChatHistorySnapshot(promoted.socket, activeRoom);
               promoted.socket.emit("roomLockChanged", {
                 locked: activeRoom.isLocked,
                 roomId,

--- a/packages/sfu/server/socket/handlers/joinRoom.ts
+++ b/packages/sfu/server/socket/handlers/joinRoom.ts
@@ -3,7 +3,6 @@ import { Client } from "../../../config/classes/Client.js";
 import { config } from "../../../config/config.js";
 import type {
   AppsAwarenessData,
-  ChatHistorySnapshot,
   HandRaisedSnapshot,
   JoinRoomData,
   JoinRoomErrorResponse,
@@ -51,6 +50,7 @@ import { ensureWebinarRoomConfig } from "../../scheduledWebinarScheduler.js";
 import type { ConnectionContext } from "../context.js";
 import { registerAdminHandlers } from "./adminHandlers.js";
 import { respond } from "./ack.js";
+import { emitChatHistorySnapshot } from "./chatHistory.js";
 import {
   clearBrowserState,
   getBrowserState,
@@ -775,10 +775,9 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           roomId: context.currentRoom.id,
         } satisfies HandRaisedSnapshot & { roomId: string });
 
-        socket.emit("chatHistorySnapshot", {
-          messages: context.currentRoom.getChatHistorySnapshot(),
-          roomId: context.currentRoom.id,
-        } satisfies ChatHistorySnapshot);
+        if (context.currentClient instanceof Admin) {
+          emitChatHistorySnapshot(socket, context.currentRoom);
+        }
 
         socket.emit("roomLockChanged", {
           locked: context.currentRoom.isLocked,

--- a/packages/sfu/server/socket/handlers/mediaHandlers.ts
+++ b/packages/sfu/server/socket/handlers/mediaHandlers.ts
@@ -24,6 +24,7 @@ const MAX_CONSUMER_LAYER = 10;
 const MIN_CONSUMER_PRIORITY = 0;
 const MAX_CONSUMER_PRIORITY = 255;
 const MAX_MEDIA_ID_LENGTH = 256;
+const DISPLACED_CONSUMER_CLOSE_DELAY_MS = 3000;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -545,7 +546,7 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
           paused: true,
         });
 
-        currentClient.addConsumer(consumer, {
+        const displacedConsumer = currentClient.addConsumer(consumer, {
           producerUserId: producerInfo.producerUserId,
           type: producerInfo.type,
         });
@@ -609,6 +610,16 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
           currentLayers: consumer.currentLayers,
           priority: consumer.priority,
         });
+
+        if (displacedConsumer && !displacedConsumer.closed) {
+          setTimeout(() => {
+            try {
+              if (!displacedConsumer.closed) {
+                displacedConsumer.close();
+              }
+            } catch {}
+          }, DISPLACED_CONSUMER_CLOSE_DELAY_MS).unref?.();
+        }
       } catch (error) {
         Logger.error("Error consuming:", error);
         respond(callback, { error: (error as Error).message });

--- a/packages/sfu/types.ts
+++ b/packages/sfu/types.ts
@@ -405,13 +405,26 @@ export interface ChatMessage {
   displayName: string;
   content: string;
   timestamp: number;
+  gif?: ChatGifAttachment;
   isDirect?: boolean;
   dmTargetUserId?: string;
   dmTargetDisplayName?: string;
 }
 
+export interface ChatGifAttachment {
+  id: string;
+  title: string;
+  url: string;
+  previewUrl?: string;
+  pageUrl?: string;
+  width?: number;
+  height?: number;
+  source: "klipy";
+}
+
 export interface SendChatData {
-  content: string;
+  content?: string;
+  gif?: ChatGifAttachment;
 }
 
 export interface ChatMessageNotification extends ChatMessage {}

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1088,8 +1088,8 @@ for (const [context, label] of [
   );
   assertRegex(
     "webMeetMedia",
-    /When frame counters exist, byte trickle alone is not video progress[\s\S]*previous\.frames !== null[\s\S]*sample\.frames !== null[\s\S]*return sample\.frames > previous\.frames;[\s\S]*sample\.bytes - previous\.bytes >= MIN_OUTBOUND_VIDEO_BYTE_DELTA_FOR_PROGRESS/,
-    "web camera sender watchdog must not treat byte trickle as frame progress",
+    /framesPerSecond: number \| null[\s\S]*currentFramesPerSecond = getRtcStatsNumber\(stat, "framesPerSecond"\)[\s\S]*When frame counters exist, flat frames alone are not enough to prove a[\s\S]*sample\.frames > previous\.frames[\s\S]*sample\.framesPerSecond !== null[\s\S]*sample\.bytes - previous\.bytes >= MIN_OUTBOUND_VIDEO_BYTE_DELTA_FOR_PROGRESS[\s\S]*return false;[\s\S]*return true;/,
+    "web camera sender watchdog must not recreate producers from quiet/static frame counters",
   );
   assertRegex(
     "webMeetMedia",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1514,10 +1514,23 @@ assertRegex(
   const end = text.indexOf("recoverStaleConsumerRef.current", start);
   if (start < 0 || end < 0) {
     failures.push("web stale consumer recovery section missing");
-  } else if (text.slice(start, end).includes("handleReconnectRef.current")) {
-    failures.push(
-      "web stale consumer recovery must not trigger full meeting reconnect",
-    );
+  } else {
+    const section = text.slice(start, end);
+    if (section.includes("handleReconnectRef.current")) {
+      failures.push(
+        "web stale consumer recovery must not trigger full meeting reconnect",
+      );
+    }
+    if (
+      section.includes("handleProducerClosed(producerInfo.producerId)") ||
+      !section.includes(
+        "closeConsumerForSameProducerReconsume(producerInfo.producerId)",
+      )
+    ) {
+      failures.push(
+        "web stale consumer recovery must not schedule stream cleanup while re-consuming the same producer",
+      );
+    }
   }
 }
 {
@@ -2029,6 +2042,31 @@ assertRegex(
     ) {
       failures.push(
         "web screen-share replacements must move active state to pending replacements and clear never-consumed replacements",
+      );
+    }
+  }
+}
+{
+  const text = source.webMeetSocket;
+  const start = text.indexOf(
+    "const closeConsumerForSameProducerReconsume = useCallback(",
+  );
+  const end = text.indexOf("const handleProducerClosed = useCallback", start);
+  if (start < 0 || end < 0) {
+    failures.push("web same-producer consumer reconsume cleanup helper missing");
+  } else {
+    const section = text.slice(start, end);
+    if (
+      !section.includes("clearStaleReplacementCleanupTimeout(producerId);") ||
+      !section.includes("consumer.track.onmute = null;") ||
+      !section.includes("consumer.track.onunmute = null;") ||
+      !section.includes("consumer.track.stop();") ||
+      !section.includes("consumersRef.current.delete(producerId);") ||
+      section.includes('type: "UPDATE_STREAM"') ||
+      section.includes("producerMapRef.current.delete(producerId)")
+    ) {
+      failures.push(
+        "web same-producer consumer reconsume must close only stale consumer resources without clearing participant streams",
       );
     }
   }

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -427,6 +427,11 @@ assertIncludes(
   "isVisible || isFocus ? bounds.maxTemporalLayer : 1",
   "web visible fair-link tiles keep max temporal layer",
 );
+assertRegex(
+  "webAdaptiveConsumerPreferences",
+  /const isConsumerLayerUpgrade =[\s\S]*next\.spatialLayer > previous\.spatialLayer[\s\S]*next\.temporalLayer[\s\S]*previous\.temporalLayer[\s\S]*requestKeyFrame =[\s\S]*isConsumerLayerUpgrade\(previousLayers, preferredLayers!\)/,
+  "web receive layer upgrades request keyframes for temporal recovery",
+);
 assertIncludes(
   "webAdaptiveConsumerPreferences",
   "priority: quality === \"poor\" ? 10 : 25,\n      paused: false,",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -741,6 +741,16 @@ for (const [context, label] of [
     if (!section.includes("await ensureProducerTransportRef?.current?.()")) {
       failures.push("web audio producer recovery must rebuild failed transports");
     }
+    if (
+      !section.includes("hadLiveAudioTrackBeforeRecovery") ||
+      !section.includes("if (createdTrack)") ||
+      !section.includes("if (!hadLiveAudioTrackBeforeRecovery)") ||
+      section.includes("existingAudioTracks.forEach((track) =>")
+    ) {
+      failures.push(
+        "web audio producer recovery failure must preserve existing live mic capture",
+      );
+    }
     const transportSectionEnd = section.indexOf("let audioTrack");
     const transportSection =
       transportSectionEnd >= 0 ? section.slice(0, transportSectionEnd) : section;

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1481,8 +1481,8 @@ assertRegex(
 );
 assertRegex(
   "webMeetSocket",
-  /status\.state === "reconnected"[\s\S]*!visibleParticipantReconnectingIdsRef\.current\.has\(targetUserId\)[\s\S]*return;[\s\S]*status\.state === "reconnecting"[\s\S]*visibleParticipantReconnectingIdsRef\.current\.add\(targetUserId\)/,
-  "web reconnected badges only show after a visible reconnecting state",
+  /status\.state === "reconnected"[\s\S]*!visibleParticipantReconnectingIdsRef\.current\.has\(targetUserId\)[\s\S]*clearParticipantConnectionStatusTimer\(targetUserId\)[\s\S]*UPDATE_CONNECTION_STATUS[\s\S]*status: null[\s\S]*return;[\s\S]*status\.state === "reconnecting"[\s\S]*visibleParticipantReconnectingIdsRef\.current\.add\(targetUserId\)/,
+  "web unmatched reconnected events clear stale peer badges without showing a new one",
 );
 assertRegex(
   "webMeetSocket",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -730,6 +730,11 @@ for (const [context, label] of [
     }
   }
 }
+assertRegex(
+  "webMeetMedia",
+  /const recoverAudioProducer = async \(\) => \{[\s\S]*const removeCreatedTrackFromLocalStream = \(\) => \{[\s\S]*stopLocalTrack\(createdTrack\);[\s\S]*createdTrack = null;[\s\S]*if \(cancelled\) \{[\s\S]*audioProducer\.close\(\);[\s\S]*removeCreatedTrackFromLocalStream\(\);[\s\S]*catch \(err\) \{[\s\S]*removeCreatedTrackFromLocalStream\(\);/,
+  "web cancelled audio recovery stops recovery-created mic tracks",
+);
 {
   const text = source.webMeetMedia;
   const start = text.indexOf("const handleLocalTrackEnded = useCallback(");
@@ -852,7 +857,7 @@ for (const [context, label] of [
     if (!text.includes("audioProducerRecoveryPulse,")) {
       failures.push("web audio producer recovery must be pulse-triggered");
     }
-    if (!section.includes("setAudioProducerRecoveryPulse((value) => value + 1)")) {
+    if (!section.includes("requestAudioProducerRecovery();")) {
       failures.push(
         "web audio producer transport close must trigger producer recovery",
       );
@@ -909,6 +914,27 @@ for (const [context, label] of [
   if (!source.webMeetClient.includes("requestCameraProducerRecovery,")) {
     failures.push(
       "web meet client must pass camera producer recovery pulse to socket hook",
+    );
+  }
+  if (
+    !mediaText.includes("mediaRecoveryBlockedRef?: React.MutableRefObject<boolean>") ||
+    !mediaText.includes("const isMediaRecoveryBlocked = useCallback(") ||
+    !source.webMeetClient.includes(
+      "mediaRecoveryBlockedRef: refs.reconnectInFlightRef",
+    )
+  ) {
+    failures.push(
+      "web media recovery must be blocked by the internal reconnect-in-flight ref",
+    );
+  }
+  if (
+    !mediaText.includes("if (isMediaRecoveryBlocked()) return;") ||
+    !/if \(isMediaRecoveryBlocked\(\)\) \{\s*removeCreatedTrackFromLocalStream\(\);\s*return;/.test(
+      mediaText,
+    )
+  ) {
+    failures.push(
+      "web media recovery must stop rebuilding producers once reconnect cleanup starts",
     );
   }
 
@@ -1084,6 +1110,7 @@ for (const [context, label] of [
     const recreateIndex = section.indexOf(
       "closeLocalVideoProducerForReplacement(producer);",
     );
+    const hiddenGuardIndex = section.indexOf("if (!allowProducerRecreate)");
     if (
       rawRepairIndex >= 0 &&
       recreateIndex >= 0 &&
@@ -1091,6 +1118,24 @@ for (const [context, label] of [
     ) {
       failures.push(
         "web stalled camera sender recovery must try raw-track repair before producer recreation",
+      );
+    }
+    if (
+      rawRepairIndex >= 0 &&
+      hiddenGuardIndex >= 0 &&
+      rawRepairIndex < hiddenGuardIndex
+    ) {
+      failures.push(
+        "web hidden-tab camera stalls must hit the no-recreate guard before raw-track repair",
+      );
+    }
+    if (
+      !section.includes(
+        "!isMediaRecoveryBlocked() &&\n          videoProducerRef.current?.id === producer.id",
+      )
+    ) {
+      failures.push(
+        "web stalled camera sender recovery failure must honor reconnect recovery block",
       );
     }
   }
@@ -1128,6 +1173,11 @@ for (const [context, label] of [
     "webMeetMedia",
     /onPreferredVideoPublishTrackRejected[\s\S]*producer\.replaceTrack\(\{ track: rawCameraTrack \}\);[\s\S]*onPreferredVideoPublishTrackRejected\?\.[\s\S]*camera-outbound-stall-raw-repair/,
     "web raw camera repair suppresses the rejected processed publish track",
+  );
+  assertRegex(
+    "webMeetMedia",
+    /const recoverCameraProducer = async \(\) => \{[\s\S]*const removeCreatedTrackFromLocalStream = \(\) => \{[\s\S]*stopLocalTrack\(createdTrack\);[\s\S]*createdTrack = null;[\s\S]*if \(cancelled\) \{[\s\S]*recoveredProducer\.close\(\);[\s\S]*removeCreatedTrackFromLocalStream\(\);[\s\S]*catch \(err\) \{[\s\S]*removeCreatedTrackFromLocalStream\(\);/,
+    "web cancelled camera recovery stops recovery-created camera tracks",
   );
   assertRegex(
     "webMeetMedia",
@@ -1379,6 +1429,11 @@ assertRegex(
   "webMeetSocket",
   /status\.state === "reconnected"[\s\S]*!visibleParticipantReconnectingIdsRef\.current\.has\(targetUserId\)[\s\S]*return;[\s\S]*status\.state === "reconnecting"[\s\S]*visibleParticipantReconnectingIdsRef\.current\.add\(targetUserId\)/,
   "web reconnected badges only show after a visible reconnecting state",
+);
+assertRegex(
+  "webMeetSocket",
+  /if \(!preserveMeetingState\) \{[\s\S]*participantConnectionStatusTimeoutsRef\.current\.values\(\)[\s\S]*participantConnectionStatusTimeoutsRef\.current\.clear\(\);[\s\S]*visibleParticipantReconnectingIdsRef\.current\.clear\(\);[\s\S]*\}[\s\S]*staleConsumerRecoveryTimeoutsRef/,
+  "web state-preserving reconnect cleanup keeps peer reconnect status timers",
 );
 assertRegex(
   "webMeetSocket",
@@ -1752,6 +1807,36 @@ assertRegex(
   /STALE_REPLACEMENT_CLEANUP_DELAY_MS[\s\S]*else if \(!replacementState\.hasConsumedReplacement\)[\s\S]*window\.setTimeout[\s\S]*latestReplacementState = getMatchingReplacementState\(\)[\s\S]*latestReplacementState\.hasConsumedReplacement[\s\S]*clearClosedProducerState\([\s\S]*latestReplacementState\.hasPendingReplacement/,
   "web stale producer replacement cleanup clears frozen old streams if the replacement never consumes",
 );
+{
+  const text = source.webMeetSocket;
+  const start = text.indexOf("const handleProducerClosed = useCallback(");
+  const end = text.indexOf("const queueProducerConsumeRetry = useCallback", start);
+  if (start < 0 || end < 0) {
+    failures.push("web producer-close replacement cleanup section missing");
+  } else {
+    const section = text.slice(start, end);
+    const infoIndex = section.indexOf(
+      "const info = producerMapRef.current.get(producerId);",
+    );
+    const clearIndex = section.indexOf(
+      "clearStaleReplacementCleanupTimeout(producerId);",
+    );
+    if (infoIndex < 0 || clearIndex < 0 || clearIndex < infoIndex) {
+      failures.push(
+        "web duplicate producerClosed events must not cancel pending replacement cleanup after producer info is gone",
+      );
+    }
+    if (
+      !/const clearClosedProducerState = \(hasPendingReplacement: boolean\) => \{[\s\S]*UPDATE_STREAM[\s\S]*if \(info\.kind === "video" && info\.type === "screen"\) \{[\s\S]*setActiveScreenShareId\(null\);[\s\S]*if \(!hasPendingReplacement\)/.test(
+        section,
+      )
+    ) {
+      failures.push(
+        "web stale screen-share replacements must clear active screen share even while a replacement is pending",
+      );
+    }
+  }
+}
 assertRegex(
   "sfuClient",
   /addProducer\(producer: Producer\): Producer \| null[\s\S]*const displacedProducer =[\s\S]*return displacedProducer;/,

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -586,6 +586,31 @@ assertRegex(
   /publishEmergencyMode: selfPublishEmergencyMode,[\s\S]*receiveEmergencyMode: selfReceiveEmergencyMode,[\s\S]*useAdaptiveConsumerPreferences\(\{[\s\S]*connectionQuality: selfReceiveQuality,[\s\S]*emergencyMode: selfReceiveEmergencyMode,[\s\S]*useAdaptivePublishQuality\(\{[\s\S]*connectionQuality: selfPublishQuality,[\s\S]*emergencyMode: selfPublishEmergencyMode,/,
   "web publish and receive adaptation use direction-specific emergency signals",
 );
+assertRegex(
+  "webMeetSocket",
+  /connectionQualityRef\?: React\.MutableRefObject<ConnectionQualityStats \| null>[\s\S]*const getPublishNetworkProfile = useCallback\([\s\S]*getConnectionStatsNetworkProfile\(connectionQualityRef\?\.current, "publish"\)[\s\S]*const getReceiveNetworkProfile = useCallback\([\s\S]*getConnectionStatsNetworkProfile\(connectionQualityRef\?\.current, "receive"\)/,
+  "web socket publish and receive setup uses measured directional network profiles",
+);
+assertRegex(
+  "webMeetSocket",
+  /const screenNetworkProfile = getPublishNetworkProfile\(\);[\s\S]*buildMicrophoneOpusCodecOptions\(\s*getPublishNetworkProfile\(\),\s*\)[\s\S]*networkProfile: getPublishNetworkProfile\(\)[\s\S]*networkProfile: getPublishNetworkProfile\(\)/,
+  "web socket publish paths use measured publish profile for recreated producers",
+);
+assertRegex(
+  "webMeetSocket",
+  /getInitialConsumerPreferences\(producerInfo, \{[\s\S]*preferHighWebcamLayer:[\s\S]*networkProfile: getReceiveNetworkProfile\(\)/,
+  "web initial consumer preferences use measured receive profile",
+);
+assertRegex(
+  "webMeetClient",
+  /useMeetSocket\(\{[\s\S]*videoQualityRef: refs\.videoQualityRef,[\s\S]*connectionQualityRef: connectionQualityDebugRef,/,
+  "web meet client passes measured connection stats to socket hook",
+);
+assertNotIncludes(
+  "webMeetSocket",
+  "getBrowserPublishNetworkProfile",
+  "web socket must not use raw browser-only startup hints for producer caps",
+);
 assertNotIncludes(
   "webAdaptivePublishQuality",
   'if (connectionQuality === "poor") {\n          void applyLiveProducerProfile(emergencyMode ? "emergency" : "poor");\n        }',

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1148,6 +1148,28 @@ assertRegex(
       );
     }
   }
+
+  const produceStart = socketText.indexOf("const produce = useCallback(");
+  const produceEnd = socketText.indexOf(
+    "const consumeProducer = useCallback",
+    produceStart,
+  );
+  if (produceStart < 0 || produceEnd < 0) {
+    failures.push("web local producer publish helper missing");
+  } else {
+    const section = socketText.slice(produceStart, produceEnd);
+    if (
+      !section.includes("microphone publish retry scheduled") ||
+      !section.includes("audioTrack.enabled = true;") ||
+      !section.includes("isMutedRef.current = false;") ||
+      !section.includes("setIsMuted(false);") ||
+      !section.includes("requestAudioProducerRecovery();")
+    ) {
+      failures.push(
+        "web reconnect join audio publish failures must preserve unmuted intent and queue producer recovery",
+      );
+    }
+  }
 }
 {
   const text = source.webMeetMedia;
@@ -2000,6 +2022,11 @@ assertRegex(
   "meetingParticipantReducer",
   /if \(!action\.stream\) \{[\s\S]*currentProducerId[\s\S]*currentProducerId !== action\.producerId[\s\S]*return state;/,
   "shared participant reducer ignores stale producer close events",
+);
+assertRegex(
+  "meetingParticipantReducer",
+  /case "UPDATE_CONNECTION_STATUS":[\s\S]*const participant = state\.get\(action\.userId\);[\s\S]*if \(!participant && !action\.status\) return state;/,
+  "shared participant reducer ignores stale connection-status clears for missing participants",
 );
 assertRegex(
   "webMeetSocket",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1573,12 +1573,15 @@ assertRegex(
     }
     if (
       section.includes("handleProducerClosed(producerInfo.producerId)") ||
+      section.includes(
+        "closeConsumerForSameProducerReconsume(producerInfo.producerId);",
+      ) ||
       !section.includes(
-        "closeConsumerForSameProducerReconsume(producerInfo.producerId)",
+        "await consumeProducer(producerInfo, { replaceExisting: true });",
       )
     ) {
       failures.push(
-        "web stale consumer recovery must not schedule stream cleanup while re-consuming the same producer",
+        "web stale consumer recovery must keep the old stream rendered until replacement consume succeeds",
       );
     }
   }
@@ -2127,10 +2130,12 @@ assertRegex(
   } else {
     const section = text.slice(start, end);
     if (
+      !section.includes("consumerToClose?: Consumer | null") ||
       !section.includes("clearStaleReplacementCleanupTimeout(producerId);") ||
       !section.includes("consumer.track.onmute = null;") ||
       !section.includes("consumer.track.onunmute = null;") ||
       !section.includes("consumer.track.stop();") ||
+      !section.includes("consumersRef.current.get(producerId)?.id === consumer.id") ||
       !section.includes("consumersRef.current.delete(producerId);") ||
       section.includes('type: "UPDATE_STREAM"') ||
       section.includes("producerMapRef.current.delete(producerId)")
@@ -2141,10 +2146,40 @@ assertRegex(
     }
   }
 }
+{
+  const text = source.webMeetSocket;
+  const start = text.indexOf("const consumeProducer = useCallback(");
+  const end = text.indexOf("consumeProducerRef.current = consumeProducer", start);
+  if (start < 0 || end < 0) {
+    failures.push("web consume producer section missing");
+  } else {
+    const section = text.slice(start, end);
+    const dispatchIndex = section.indexOf('type: "UPDATE_STREAM"');
+    const closeIndex = section.indexOf(
+      "closeConsumerForSameProducerReconsume(\n                  producerInfo.producerId,\n                  existingConsumer,",
+    );
+    if (
+      !section.includes("options: ConsumeProducerOptions = {}") ||
+      !section.includes("existingConsumer && !options.replaceExisting") ||
+      dispatchIndex < 0 ||
+      closeIndex < 0 ||
+      closeIndex < dispatchIndex
+    ) {
+      failures.push(
+        "web replacement consumer handoff must dispatch the new stream before closing the old consumer",
+      );
+    }
+  }
+}
 assertRegex(
   "sfuClient",
   /addProducer\(producer: Producer\): Producer \| null[\s\S]*const displacedProducer =[\s\S]*return displacedProducer;/,
   "SFU client returns displaced producer instead of closing it inline",
+);
+assertRegex(
+  "sfuClient",
+  /addConsumer\([\s\S]*\): Consumer \| null[\s\S]*const displacedConsumer =[\s\S]*this\.consumerProducerIdsById\.delete\(displacedConsumer\.id\)[\s\S]*return displacedConsumer;/,
+  "SFU client returns displaced consumer instead of closing it inline",
 );
 {
   const text = source.sfuMediaHandlers;
@@ -2156,6 +2191,11 @@ assertRegex(
     );
   }
 }
+assertRegex(
+  "sfuMediaHandlers",
+  /const displacedConsumer = currentClient\.addConsumer[\s\S]*respond\(callback, \{[\s\S]*priority: consumer\.priority,[\s\S]*if \(displacedConsumer && !displacedConsumer\.closed\) \{[\s\S]*DISPLACED_CONSUMER_CLOSE_DELAY_MS/,
+  "SFU same-producer consumer replacement must respond before closing the displaced consumer",
+);
 
 // Native receive adaptation must keep audio crisp, preserve screen shares, and
 // pause extra webcam video only in emergency mode.

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -804,7 +804,9 @@ assertRegex(
       !section.includes("const previousAudioTracks =") ||
       !section.includes("const currentAudioProducer = audioProducerRef.current;") ||
       !section.includes("currentAudioProducer?.closed") ||
-      !section.includes("resetAudioProducer(currentAudioProducer);") ||
+      !section.includes(
+        "closeLocalAudioProducerForReplacement(currentAudioProducer);",
+      ) ||
       !section.includes("requestAudioProducerRecovery();") ||
       !section.includes("commitLocalStream(nextStream);") ||
       !section.includes("committedNewAudioTrack = newAudioTrack;") ||
@@ -1596,6 +1598,11 @@ assertIncludes(
   "webMeetMedia",
   "intentionalLocalProducerCloseIdsRef.current.add(producer.id)",
   "web camera recovery marks replacement closes as intentional",
+);
+assertRegex(
+  "webMeetMedia",
+  /const closeLocalAudioProducerForReplacement = useCallback\([\s\S]*intentionalLocalProducerCloseIdsRef\.current\.add\(producer\.id\)[\s\S]*socketRef\.current\?\.emit\([\s\S]*"closeProducer"[\s\S]*producerId: producer\.id[\s\S]*producer\.close\(\)[\s\S]*audioProducerRef\.current = null;/,
+  "web audio producer replacement closes are intentional and notify the SFU",
 );
 assertIncludes(
   "iosWebrtc",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1918,12 +1918,17 @@ assertRegex(
 );
 assertRegex(
   "webVideoEffects",
-  /const releaseStaleProcessedOutputIfNeeded =[\s\S]*latestOutputFrameAt[\s\S]*PROCESSED_OUTPUT_STALE_RELEASE_MS[\s\S]*document\.visibilityState !== "visible"[\s\S]*preserve_processed_track_hidden_stale[\s\S]*return false;[\s\S]*releaseOutputTrackToRaw\(reason\);/,
+  /const getLatestOutputFrameAgeMs =[\s\S]*latestOutputFrameAt[\s\S]*const isHiddenStaleProcessedOutput =[\s\S]*document\.visibilityState !== "visible"[\s\S]*PROCESSED_OUTPUT_STALE_RELEASE_MS[\s\S]*const releaseStaleProcessedOutputIfNeeded =[\s\S]*preserve_processed_track_hidden_stale[\s\S]*return false;[\s\S]*releaseOutputTrackToRaw\(reason\);/,
   "web hidden-tab stale processed effects output preserves effects instead of raw fallback",
 );
 assertRegex(
   "webVideoEffects",
-  /const processedOutputStaleCheckIntervalId = window\.setInterval\(\(\) => \{[\s\S]*releaseStaleProcessedOutputIfNeeded\("processed output stale heartbeat"\);[\s\S]*PROCESSED_OUTPUT_STALE_CHECK_MS[\s\S]*window\.clearInterval\(processedOutputStaleCheckIntervalId\);/,
+  /const keepHiddenStaleProcessedOutputAlive = async[\s\S]*isHiddenStaleProcessedOutput\(sampleNow\)[\s\S]*restoreLastVisibleOutputFrame\(\s*"hidden-stale-output-keepalive"[\s\S]*await deliverOutputFrame\(sampleNow\)[\s\S]*"hidden_stale_output_keepalive"/,
+  "web hidden stale processed effects output sends keepalive frames instead of going inert",
+);
+assertRegex(
+  "webVideoEffects",
+  /processedOutputStaleCheckIntervalId = window\.setInterval\(\(\) => \{[\s\S]*releaseStaleProcessedOutputIfNeeded\(\s*"processed output stale heartbeat",\s*sampleNow,\s*\);[\s\S]*keepHiddenStaleProcessedOutputAlive\([\s\S]*PROCESSED_OUTPUT_STALE_CHECK_MS[\s\S]*window\.clearInterval\(processedOutputStaleCheckIntervalId\);/,
   "web stale processed effects output heartbeat survives stalled effects loops",
 );
 assertRegex(

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -709,7 +709,7 @@ for (const [context, label] of [
         "web unexpected audio track ends must preserve mic intent in joined meetings",
       );
     }
-    if (!section.includes("setAudioProducerRecoveryPulse((value) => value + 1)")) {
+    if (!section.includes("requestAudioProducerRecovery();")) {
       failures.push(
         "web unexpected audio track ends must trigger producer recovery",
       );
@@ -723,7 +723,7 @@ for (const [context, label] of [
         "web unexpected camera track ends must preserve camera intent in joined meetings",
       );
     }
-    if (!section.includes("setCameraProducerRecoveryPulse((value) => value + 1)")) {
+    if (!section.includes("requestCameraProducerRecovery();")) {
       failures.push(
         "web unexpected camera track ends must trigger producer recovery",
       );
@@ -937,6 +937,35 @@ assertRegex(
       "web media recovery must stop rebuilding producers once reconnect cleanup starts",
     );
   }
+  if (
+    !/pendingAudioProducerRecoveryRef[\s\S]*pendingCameraProducerRecoveryRef[\s\S]*blockedProducerRecoveryFlushPulse[\s\S]*flushQueuedProducerRecoveries[\s\S]*window\.setInterval\(\(\) => \{[\s\S]*if \(isMediaRecoveryBlocked\(\)\) return;[\s\S]*flushQueuedProducerRecoveries\(\);/.test(
+      mediaText,
+    )
+  ) {
+    failures.push(
+      "web blocked reconnect recovery pulses must be queued and replayed after reconnect unblocks",
+    );
+  }
+  if (
+    !/const requestAudioProducerRecovery = useCallback\(\(\) => \{[\s\S]*if \(isMediaRecoveryBlocked\(\)\) \{[\s\S]*queueBlockedProducerRecovery\("audio"\);[\s\S]*setAudioProducerRecoveryPulse/.test(
+      mediaText,
+    ) ||
+    !/const requestCameraProducerRecovery = useCallback\(\(\) => \{[\s\S]*if \(isMediaRecoveryBlocked\(\)\) \{[\s\S]*queueBlockedProducerRecovery\("camera"\);[\s\S]*setCameraProducerRecoveryPulse/.test(
+      mediaText,
+    )
+  ) {
+    failures.push(
+      "web explicit audio/camera recovery requests must queue while reconnect cleanup blocks recovery",
+    );
+  }
+  if (
+    /transportclose"[\s\S]{0,400}setAudioProducerRecoveryPulse/.test(mediaText) ||
+    /transportclose"[\s\S]{0,400}setCameraProducerRecoveryPulse/.test(mediaText)
+  ) {
+    failures.push(
+      "web producer transport-close handlers must use queued recovery requests, not raw pulses",
+    );
+  }
 
   const socketText = source.webMeetSocket;
   const start = socketText.indexOf('"producerClosed"');
@@ -1130,12 +1159,12 @@ assertRegex(
       );
     }
     if (
-      !section.includes(
-        "!isMediaRecoveryBlocked() &&\n          videoProducerRef.current?.id === producer.id",
+      !/!allowProducerRecreate \|\|[\s\S]*isMediaRecoveryBlocked\(\)[\s\S]*Stalled camera sender recovery failed; keeping producer open/.test(
+        section,
       )
     ) {
       failures.push(
-        "web stalled camera sender recovery failure must honor reconnect recovery block",
+        "web stalled camera sender recovery failure must honor hidden-tab and reconnect no-recreate guards",
       );
     }
   }
@@ -1794,17 +1823,17 @@ assertRegex(
 );
 assertRegex(
   "webMeetSocket",
-  /getMatchingReplacementState[\s\S]*producerMapRef\.current\.entries\(\)[\s\S]*announcedRemoteProducersRef\.current\.entries\(\)[\s\S]*hasReplacementProducer:[\s\S]*hasConsumedReplacement \|\| hasPendingReplacement[\s\S]*clearClosedProducerState[\s\S]*UPDATE_STREAM[\s\S]*stream: null[\s\S]*if \(!hasPendingReplacement\)[\s\S]*UPDATE_CAMERA_OFF[\s\S]*announcedRemoteProducersRef\.current\.set\(data\.producerId, data\)/,
+  /getMatchingReplacementState[\s\S]*producerMapRef\.current\.entries\(\)[\s\S]*announcedRemoteProducersRef\.current\.entries\(\)[\s\S]*hasReplacementProducer:[\s\S]*hasConsumedReplacement \|\| hasPendingReplacement[\s\S]*pendingReplacementProducerId[\s\S]*clearClosedProducerState[\s\S]*UPDATE_STREAM[\s\S]*stream: null[\s\S]*if \(!hasPendingReplacement\)[\s\S]*UPDATE_CAMERA_OFF[\s\S]*announcedRemoteProducersRef\.current\.set\(data\.producerId, data\)/,
   "web producer replacement announcements suppress transient stream and camera-off clears",
 );
 assertRegex(
   "webMeetSocket",
-  /PRODUCER_CLOSE_REPLACEMENT_GRACE_MS[\s\S]*if \(!replacementState\.hasReplacementProducer\)[\s\S]*window\.setTimeout[\s\S]*latestReplacementState = getMatchingReplacementState\(\)[\s\S]*latestReplacementState\.hasConsumedReplacement[\s\S]*clearClosedProducerState\([\s\S]*latestReplacementState\.hasPendingReplacement/,
+  /PRODUCER_CLOSE_REPLACEMENT_GRACE_MS[\s\S]*if \(!replacementState\.hasReplacementProducer\)[\s\S]*window\.setTimeout[\s\S]*latestReplacementState = getMatchingReplacementState\(\)[\s\S]*latestReplacementState\.hasConsumedReplacement[\s\S]*clearClosedProducerState\(\{[\s\S]*latestReplacementState\.hasPendingReplacement[\s\S]*preservePendingScreenShare: true/,
   "web unannounced producer closes wait briefly for reconnect replacement before clearing streams",
 );
 assertRegex(
   "webMeetSocket",
-  /STALE_REPLACEMENT_CLEANUP_DELAY_MS[\s\S]*else if \(!replacementState\.hasConsumedReplacement\)[\s\S]*window\.setTimeout[\s\S]*latestReplacementState = getMatchingReplacementState\(\)[\s\S]*latestReplacementState\.hasConsumedReplacement[\s\S]*clearClosedProducerState\([\s\S]*latestReplacementState\.hasPendingReplacement/,
+  /const scheduleStaleReplacementCleanup = \(\) => \{[\s\S]*clearClosedProducerState\(\{[\s\S]*latestReplacementState\.hasPendingReplacement[\s\S]*preservePendingScreenShare: false[\s\S]*STALE_REPLACEMENT_CLEANUP_DELAY_MS[\s\S]*else if \(!replacementState\.hasConsumedReplacement\)[\s\S]*scheduleStaleReplacementCleanup\(\);/,
   "web stale producer replacement cleanup clears frozen old streams if the replacement never consumes",
 );
 {
@@ -1827,12 +1856,12 @@ assertRegex(
       );
     }
     if (
-      !/const clearClosedProducerState = \(hasPendingReplacement: boolean\) => \{[\s\S]*UPDATE_STREAM[\s\S]*if \(info\.kind === "video" && info\.type === "screen"\) \{[\s\S]*setActiveScreenShareId\(null\);[\s\S]*if \(!hasPendingReplacement\)/.test(
+      !/pendingReplacementProducerId[\s\S]*setActiveScreenShareId\([\s\S]*preservePendingScreenShare && pendingReplacementProducerId[\s\S]*scheduleStaleReplacementCleanup[\s\S]*preservePendingScreenShare: false[\s\S]*replacementState\.pendingReplacementProducerId[\s\S]*setActiveScreenShareId\(replacementState\.pendingReplacementProducerId\)/.test(
         section,
       )
     ) {
       failures.push(
-        "web stale screen-share replacements must clear active screen share even while a replacement is pending",
+        "web screen-share replacements must move active state to pending replacements and clear never-consumed replacements",
       );
     }
   }

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -802,6 +802,7 @@ assertRegex(
       !section.includes("acquiredAudioTracks = newStream.getAudioTracks();") ||
       !section.includes("const previousStream = localStreamRef.current;") ||
       !section.includes("const previousAudioTracks =") ||
+      !section.includes("requestAudioProducerRecovery();") ||
       !section.includes("commitLocalStream(nextStream);") ||
       !section.includes("committedNewAudioTrack = newAudioTrack;") ||
       !section.includes("stopTracksExcept(previousAudioTracks, [newAudioTrack]);") ||
@@ -810,7 +811,7 @@ assertRegex(
       section.includes("prev.addTrack(newAudioTrack)")
     ) {
       failures.push(
-        "web audio input device changes must sync local stream refs and clean up failed mic captures",
+        "web audio input device changes must sync refs, recover missing producers, and clean up failed mic captures",
       );
     }
   }

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -21,6 +21,8 @@ const files = {
   webMobileParticipantVideo:
     "apps/web/src/app/components/mobile/MobileParticipantVideo.tsx",
   webGridLayout: "apps/web/src/app/components/GridLayout.tsx",
+  webMobileGridLayout:
+    "apps/web/src/app/components/mobile/MobileGridLayout.tsx",
   webPresentationLayout: "apps/web/src/app/components/PresentationLayout.tsx",
   webMobilePresentationLayout:
     "apps/web/src/app/components/mobile/MobilePresentationLayout.tsx",
@@ -339,6 +341,16 @@ assertRegex(
   "webMobileParticipantVideo",
   /<video[\s\S]*autoPlay[\s\S]*muted[\s\S]*playsInline/,
   "web mobile participant video is muted for autoplay reliability",
+);
+assertRegex(
+  "webMobileGridLayout",
+  /const ParticipantTile = memo[\s\S]*createPlaybackRecoveryScheduler[\s\S]*shouldAttemptAnimationFrameReplay[\s\S]*video\.addEventListener\("stalled", scheduleReplay\)[\s\S]*document\.addEventListener\("visibilitychange", handleVisibilityChange\)[\s\S]*window\.addEventListener\("orientationchange", handleOrientationChange\)/,
+  "web mobile grid visible remote video retries stalled playback",
+);
+assertRegex(
+  "webMobileGridLayout",
+  /function WarmRemoteVideo[\s\S]*createPlaybackRecoveryScheduler[\s\S]*shouldAttemptAnimationFrameReplay[\s\S]*video\.addEventListener\("stalled", scheduleReplay\)[\s\S]*document\.addEventListener\("visibilitychange", handleVisibilityChange\)[\s\S]*window\.addEventListener\("orientationchange", handleOrientationChange\)/,
+  "web mobile grid warm remote video keeps decoder playback live",
 );
 assertRegex(
   "webAdaptiveConsumerPreferences",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -116,9 +116,12 @@ assertRegex(
     source.webMeetMedia.match(
       /track: audioTrack,[\s\S]*?buildMicrophoneOpusCodecOptions\([\s\S]*?stopTracks: false,[\s\S]*?type: "webcam" as ProducerType/g,
     ) ?? [];
-  if (mediaAudioProduceMatches.length < 2) {
+  if (
+    mediaAudioProduceMatches.length < 1 ||
+    !source.webMeetMedia.includes("requestAudioProducerRecovery();\n      return;")
+  ) {
     failures.push(
-      "web mute and audio recovery microphone producers must preserve capture tracks during producer cleanup",
+      "web audio recovery microphone producers must preserve capture tracks and unmute must use recovery instead of cold publish",
     );
   }
 }
@@ -879,11 +882,14 @@ assertRegex(
       !text.includes("isMutedRef.current") ||
       !section.includes("setMutedIntent(false);") ||
       !section.includes("confirmAudioProducerUnmuted(producer.id);") ||
+      !section.includes("requestAudioProducerRecovery();") ||
       !section.includes("return;") ||
-      section.includes("const retry = await emitToggleMute(producer.id, false)")
+      section.includes("const retry = await emitToggleMute(producer.id, false)") ||
+      section.includes("transport.produce({") ||
+      section.includes('throw new Error("Audio transport unavailable")')
     ) {
       failures.push(
-        "web unmute must return after local producer resume and confirm SFU state in the background",
+        "web unmute must return after local producer resume and never wait for cold producer creation",
       );
     }
   }
@@ -947,7 +953,11 @@ assertRegex(
     }
     if (
       !section.includes("hadLiveAudioTrackBeforeRecovery") ||
+      !section.includes("const shouldStartPaused = isMutedRef.current;") ||
       !section.includes("let audioTrack = getFirstLiveTrack(") ||
+      !section.includes("if (shouldStartPaused)") ||
+      !section.includes("audioTrack.enabled = !shouldStartPaused;") ||
+      !section.includes("paused: shouldStartPaused") ||
       !section.includes("if (createdTrack)") ||
       !section.includes("localStreamRef.current = nextStream;") ||
       !section.includes("setLocalStream(nextStream);") ||
@@ -992,7 +1002,7 @@ assertRegex(
 }
 {
   const text = source.webMeetMedia;
-  const start = text.indexOf('"[Meets] Audio producer recovery triggered:"');
+  const start = text.indexOf("const getReusableAudioTrack =");
   const end = text.indexOf("const recoverAudioProducer = async () => {", start);
   if (start < 0 || end < 0) {
     failures.push("web audio producer recovery watchdog missing");
@@ -1008,9 +1018,13 @@ assertRegex(
         "web audio producer watchdog must only run in joined meetings",
       );
     }
-    if (!section.includes("if (isMuted) return;")) {
+    if (
+      !section.includes("getReusableAudioTrack") ||
+      !section.includes("if (isMuted && !getReusableAudioTrack()) return;") ||
+      !section.includes("if (isMutedRef.current && !liveAudioTrack) return;")
+    ) {
       failures.push(
-        "web audio producer watchdog must preserve muted intent",
+        "web audio producer watchdog must keep muted producers warm without opening cold mic capture",
       );
     }
     if (!section.includes("window.setInterval(")) {

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -26,6 +26,8 @@ const files = {
   webPresentationLayout: "apps/web/src/app/components/PresentationLayout.tsx",
   webMobilePresentationLayout:
     "apps/web/src/app/components/mobile/MobilePresentationLayout.tsx",
+  webMobileBrowserLayout:
+    "apps/web/src/app/components/mobile/MobileBrowserLayout.tsx",
   webMeetClient: "apps/web/src/app/meets-client.tsx",
   webMeetMedia: "apps/web/src/app/hooks/useMeetMedia.ts",
   webMeetSocket: "apps/web/src/app/hooks/useMeetSocket.ts",
@@ -331,6 +333,7 @@ for (const [key, label] of [
   ["webGridLayout", "grid video"],
   ["webPresentationLayout", "presentation video"],
   ["webMobilePresentationLayout", "mobile presentation video"],
+  ["webMobileBrowserLayout", "mobile browser video"],
 ]) {
   assertNotIncludes(
     key,
@@ -367,6 +370,21 @@ assertRegex(
   "webMobileGridLayout",
   /function WarmRemoteVideo[\s\S]*createPlaybackRecoveryScheduler[\s\S]*shouldAttemptAnimationFrameReplay[\s\S]*video\.addEventListener\("stalled", scheduleReplay\)[\s\S]*document\.addEventListener\("visibilitychange", handleVisibilityChange\)[\s\S]*window\.addEventListener\("orientationchange", handleOrientationChange\)/,
   "web mobile grid warm remote video keeps decoder playback live",
+);
+assertRegex(
+  "webGridLayout",
+  /const OverflowGalleryTile = memo\(function OverflowGalleryTile[\s\S]*createPlaybackRecoveryScheduler[\s\S]*shouldAttemptAnimationFrameReplay[\s\S]*video\.addEventListener\("stalled", scheduleReplay\)[\s\S]*document\.addEventListener\("visibilitychange", handleVisibilityChange\)[\s\S]*window\.addEventListener\("orientationchange", handleWindowChange\)/,
+  "web overflow gallery remote video keeps decoder playback live",
+);
+assertRegex(
+  "webMobilePresentationLayout",
+  /const VideoThumbnail = memo\(function VideoThumbnail[\s\S]*createPlaybackRecoveryScheduler[\s\S]*shouldAttemptAnimationFrameReplay[\s\S]*video\.addEventListener\("stalled", scheduleReplay\)[\s\S]*document\.addEventListener\("visibilitychange", handleVisibilityChange\)[\s\S]*window\.addEventListener\("orientationchange", handleWindowChange\)/,
+  "web mobile presentation thumbnails keep decoder playback live",
+);
+assertRegex(
+  "webMobileBrowserLayout",
+  /const VideoThumbnail = memo\(function VideoThumbnail[\s\S]*createPlaybackRecoveryScheduler[\s\S]*shouldAttemptAnimationFrameReplay[\s\S]*video\.addEventListener\("stalled", scheduleReplay\)[\s\S]*document\.addEventListener\("visibilitychange", handleVisibilityChange\)[\s\S]*window\.addEventListener\("orientationchange", handleWindowChange\)/,
+  "web mobile browser thumbnails keep decoder playback live",
 );
 assertRegex(
   "webAdaptiveConsumerPreferences",
@@ -1531,9 +1549,8 @@ assertRegex(
   "Android fair bandwidth quality hint",
 );
 
-// Bandwidth-heavy video effects assets must not auto-load on constrained links.
-// Camera/screen publishing should stay raw and cheap unless the user has enough
-// bandwidth and real effects are active.
+// Bandwidth-heavy video effects assets must not auto-load on constrained links,
+// but selected effects must stay active once the user asks for them.
 assertIncludes(
   "webNetworkInformation",
   "export function shouldDeferBandwidthHeavyPreload",
@@ -1544,15 +1561,25 @@ assertIncludes(
   "if (!connection) return isLikelyMobileOrTabletNavigator();",
   "web mobile no-NetworkInformation preload deferral",
 );
-assertIncludes(
+assertNotIncludes(
+  "webNetworkInformation",
+  "shouldSuppressBandwidthHeavyVideoEffects",
+  "web network hints must not expose an effects disable gate",
+);
+assertNotIncludes(
   "webMeetClient",
-  "const shouldSuppressVideoEffectsForBandwidth =\n    useBandwidthHeavyVideoEffectsSuppressed();",
-  "web meet-shell video effects bandwidth suppression",
+  "useBandwidthHeavyVideoEffectsSuppressed",
+  "web meet-shell must not import an effects suppression hook",
+);
+assertNotIncludes(
+  "webMeetClient",
+  "shouldSuppressVideoEffectsForBandwidth",
+  "web meet-shell must not disable selected video effects for bandwidth",
 );
 assertRegex(
   "webMeetClient",
-  /const shouldRunVisualVideoEffects =\s*activeVideoEffectsCount > 0 &&\s*!shouldSuppressVideoEffectsForBandwidth;[\s\S]*const shouldRunVideoEffects = shouldRunVisualVideoEffects;[\s\S]*const shouldPublishProcessedVideo = shouldRunVisualVideoEffects;/,
-  "web meet-shell effects stay active across visibility changes unless constrained",
+  /const shouldRunVisualVideoEffects = activeVideoEffectsCount > 0;[\s\S]*const shouldRunVideoEffects = shouldRunVisualVideoEffects;[\s\S]*const shouldPublishProcessedVideo = shouldRunVisualVideoEffects;/,
+  "web meet-shell effects stay active across visibility and bandwidth changes",
 );
 assertNotIncludes(
   "webMeetClient",
@@ -1616,17 +1643,17 @@ assertRegex(
 );
 assertRegex(
   "webMeetClient",
-  /if \(activeVideoEffectsCount <= 0\) return;[\s\S]*if \(!isDocumentVisible\) return;[\s\S]*if \(shouldSuppressVideoEffectsForBandwidth\) return;[\s\S]*prewarmVideoEffectsRuntimeDeferred/,
+  /if \(activeVideoEffectsCount <= 0\) return;[\s\S]*if \(!isDocumentVisible\) return;[\s\S]*if \(shouldDeferVideoEffectsPreload\) return;[\s\S]*prewarmVideoEffectsRuntimeDeferred/,
   "web meet-shell runtime prewarm constrained-link guard",
 );
 assertRegex(
   "webMeetClient",
-  /if \(restoredVideoEffectsPrewarmDoneRef\.current\) return;[\s\S]*if \(!isDocumentVisible\) return;[\s\S]*if \(shouldSuppressVideoEffectsForBandwidth\) return;[\s\S]*reason: "restored-effects-state"/,
+  /if \(restoredVideoEffectsPrewarmDoneRef\.current\) return;[\s\S]*if \(!isDocumentVisible\) return;[\s\S]*if \(shouldDeferVideoEffectsPreload\) return;[\s\S]*reason: "restored-effects-state"/,
   "web restored-effects asset prewarm constrained-link guard",
 );
 assertRegex(
   "webMeetClient",
-  /if \(activeVideoEffectsCount <= 0\) return;[\s\S]*if \(isCameraOff \|\| !hasLiveVideoTrack\(localStream\)\) return;[\s\S]*if \(!isDocumentVisible\) return;[\s\S]*if \(shouldSuppressVideoEffectsForBandwidth\) return;[\s\S]*reason: "camera-live"/,
+  /if \(activeVideoEffectsCount <= 0\) return;[\s\S]*if \(isCameraOff \|\| !hasLiveVideoTrack\(localStream\)\) return;[\s\S]*if \(!isDocumentVisible\) return;[\s\S]*if \(shouldDeferVideoEffectsPreload\) return;[\s\S]*reason: "camera-live"/,
   "web live-camera asset prewarm constrained-link guard",
 );
 assertRegex(
@@ -1645,8 +1672,8 @@ for (const [key, label] of [
 ]) {
   assertRegex(
     key,
-    /const shouldRunPreviewVideoEffects =\s*activeVideoEffectsCount > 0 &&\s*!shouldSuppressPreviewVideoEffectsForBandwidth;/,
-    `${label} effects only run when active and not constrained`,
+    /const shouldRunPreviewVideoEffects = activeVideoEffectsCount > 0;/,
+    `${label} effects run whenever selected`,
   );
   assertRegex(
     key,

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1337,6 +1337,9 @@ assertRegex(
     const rawRepairIndex = section.indexOf(
       "producer.replaceTrack({ track: rawCameraTrack });",
     );
+    const rawRepairConditionIndex = section.indexOf(
+      "const shouldTryRawRepair = !state.rawRepairAttempted;",
+    );
     const recreateIndex = section.indexOf(
       "closeLocalVideoProducerForReplacement(producer);",
     );
@@ -1348,6 +1351,15 @@ assertRegex(
     ) {
       failures.push(
         "web stalled camera sender recovery must try raw-track repair before producer recreation",
+      );
+    }
+    if (
+      rawRepairConditionIndex < 0 ||
+      !section.includes("if (producerTrack.id !== rawCameraTrack.id)") ||
+      !section.includes("Refreshed stalled camera sender with raw camera track")
+    ) {
+      failures.push(
+        "web stalled camera sender recovery must soft-refresh raw camera before any destructive producer recreation",
       );
     }
     if (

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -872,6 +872,20 @@ assertRegex(
         "web mute toggle must apply intent to all live mic tracks and unmute a live track",
       );
     }
+    if (
+      !text.includes("const confirmAudioProducerUnmuted = useCallback(") ||
+      !text.includes("TOGGLE_MUTE_FAST_ACK_TIMEOUT_MS") ||
+      !text.includes("TOGGLE_MUTE_BACKGROUND_ACK_TIMEOUT_MS") ||
+      !text.includes("isMutedRef.current") ||
+      !section.includes("setMutedIntent(false);") ||
+      !section.includes("confirmAudioProducerUnmuted(producer.id);") ||
+      !section.includes("return;") ||
+      section.includes("const retry = await emitToggleMute(producer.id, false)")
+    ) {
+      failures.push(
+        "web unmute must return after local producer resume and confirm SFU state in the background",
+      );
+    }
   }
 }
 {

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1858,8 +1858,8 @@ assertRegex(
 );
 assertRegex(
   "webMeetSocket",
-  /const scheduleStaleReplacementCleanup = \(\) => \{[\s\S]*clearClosedProducerState\(\{[\s\S]*latestReplacementState\.hasPendingReplacement[\s\S]*preservePendingScreenShare: false[\s\S]*STALE_REPLACEMENT_CLEANUP_DELAY_MS[\s\S]*else if \(!replacementState\.hasConsumedReplacement\)[\s\S]*scheduleStaleReplacementCleanup\(\);/,
-  "web stale producer replacement cleanup clears frozen old streams if the replacement never consumes",
+  /SCREEN_SHARE_STALE_REPLACEMENT_CLEANUP_DELAY_MS[\s\S]*const scheduleStaleReplacementCleanup = \(\) => \{[\s\S]*const cleanupDelayMs =[\s\S]*info\.kind === "video" && info\.type === "screen"[\s\S]*SCREEN_SHARE_STALE_REPLACEMENT_CLEANUP_DELAY_MS[\s\S]*STALE_REPLACEMENT_CLEANUP_DELAY_MS[\s\S]*clearClosedProducerState\(\{[\s\S]*latestReplacementState\.hasPendingReplacement[\s\S]*preservePendingScreenShare: false[\s\S]*cleanupDelayMs[\s\S]*else if \(!replacementState\.hasConsumedReplacement\)[\s\S]*setActiveScreenShareId\(replacementState\.pendingReplacementProducerId\)[\s\S]*scheduleStaleReplacementCleanup\(\);/,
+  "web stale producer replacement cleanup quickly clears failed screen shares while preserving pending replacements",
 );
 {
   const text = source.webMeetSocket;

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1432,6 +1432,11 @@ assertIncludes(
   "if (consumer.paused || shouldRequestKeyFrame)",
   "web producer sync avoids no-op consumer resumes",
 );
+assertRegex(
+  "webMeetSocket",
+  /STALL_SAMPLES_BEFORE_PLI = 1[\s\S]*KEYFRAME_REQUEST_COOLDOWN_MS = 3500[\s\S]*bytesNow - prev\.bytes >= MIN_STALL_BYTE_DELTA[\s\S]*sampleNow - lastKeyFrameRequestAt >= KEYFRAME_REQUEST_COOLDOWN_MS[\s\S]*requestKeyFrame: true[\s\S]*lastKeyFrameRequestAt = sampleNow/,
+  "web frozen remote video decoders request keyframes after one stalled decode sample with cooldown",
+);
 {
   const text = source.webMeetSocket;
   const start = text.indexOf("const handleTrackMuted = () => {");

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1550,13 +1550,23 @@ assertIncludes(
 );
 assertIncludes(
   "webVideoEffects",
+  "const DUPLICATE_OUTPUT_HEARTBEAT_MS = 900;",
+  "web processed effects duplicate-frame heartbeat cadence",
+);
+assertIncludes(
+  "webVideoEffects",
   "const PROCESSED_OUTPUT_STALE_CHECK_MS = 1000;",
   "web stale processed effects output heartbeat interval",
 );
 assertRegex(
   "webVideoEffects",
-  /const releaseStaleProcessedOutputIfNeeded =[\s\S]*latestOutputFrameAt[\s\S]*PROCESSED_OUTPUT_STALE_RELEASE_MS[\s\S]*releaseOutputTrackToRaw\(reason\);/,
-  "web live-but-stale processed effects output releases to raw publish track",
+  /const duplicateOutputHeartbeatDue =[\s\S]*DUPLICATE_OUTPUT_HEARTBEAT_MS[\s\S]*!duplicateOutputHeartbeatDue/,
+  "web duplicate processed effects frames still heartbeat before stale release",
+);
+assertRegex(
+  "webVideoEffects",
+  /const releaseStaleProcessedOutputIfNeeded =[\s\S]*latestOutputFrameAt[\s\S]*PROCESSED_OUTPUT_STALE_RELEASE_MS[\s\S]*document\.visibilityState !== "visible"[\s\S]*preserve_processed_track_hidden_stale[\s\S]*return false;[\s\S]*releaseOutputTrackToRaw\(reason\);/,
+  "web hidden-tab stale processed effects output preserves effects instead of raw fallback",
 );
 assertRegex(
   "webVideoEffects",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1244,6 +1244,11 @@ assertRegex(
   /status\.state === "reconnected"[\s\S]*!visibleParticipantReconnectingIdsRef\.current\.has\(targetUserId\)[\s\S]*return;[\s\S]*status\.state === "reconnecting"[\s\S]*visibleParticipantReconnectingIdsRef\.current\.add\(targetUserId\)/,
   "web reconnected badges only show after a visible reconnecting state",
 );
+assertRegex(
+  "webMeetSocket",
+  /meet_reconnect_success[\s\S]*attempt: reconnectAttemptsRef\.current[\s\S]*reconnectAttemptsRef\.current = 0;[\s\S]*return;/,
+  "web successful reconnect resets retry attempts after reused-socket rejoins",
+);
 assertIncludes(
   "sfuConfig",
   "30000",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -698,6 +698,49 @@ for (const [context, label] of [
 }
 {
   const text = source.webMeetMedia;
+  const start = text.indexOf("const handleLocalTrackEnded = useCallback(");
+  const end = text.indexOf("const requestMediaPermissions = useCallback", start);
+  if (start < 0 || end < 0) {
+    failures.push("web local track-ended handler section missing");
+  } else {
+    const section = text.slice(start, end);
+    if (
+      !text.includes("const commitLocalStream = useCallback(") ||
+      !section.includes("const currentStream = localStreamRef.current;") ||
+      !section.includes("hasCurrentLocalTrack") ||
+      !section.includes("hasCurrentProducerTrack") ||
+      !section.includes("Ignoring ended stale local track") ||
+      !section.includes("commitLocalStream(new MediaStream(remaining));") ||
+      section.includes(".filter((t) => t.kind !== kind)")
+    ) {
+      failures.push(
+        "web local track-ended handler must ignore stale ended tracks and sync stream refs",
+      );
+    }
+  }
+}
+{
+  const text = source.webMeetMedia;
+  const start = text.indexOf("const handleAudioInputDeviceChange = useCallback(");
+  const end = text.indexOf("const handleVideoInputDeviceChange = useCallback", start);
+  if (start < 0 || end < 0) {
+    failures.push("web audio input device-change section missing");
+  } else {
+    const section = text.slice(start, end);
+    if (
+      !section.includes("const previousStream = localStreamRef.current;") ||
+      !section.includes("commitLocalStream(nextStream);") ||
+      section.includes("prev.removeTrack(oldAudioTrack)") ||
+      section.includes("prev.addTrack(newAudioTrack)")
+    ) {
+      failures.push(
+        "web audio input device changes must sync local stream refs without mutating stale streams",
+      );
+    }
+  }
+}
+{
+  const text = source.webMeetMedia;
   const start = text.indexOf("const updateVideoQuality = useCallback(");
   const end = text.indexOf(
     "useEffect(() => {\n    updateVideoQualityRef.current = updateVideoQuality;",
@@ -888,6 +931,16 @@ for (const [context, label] of [
     if (!section.includes("requestCameraProducerRecovery();")) {
       failures.push(
         "web camera-toggle video producer transport close must pulse camera recovery",
+      );
+    }
+    if (
+      !section.includes("const previousStream = localStreamRef.current;") ||
+      !section.includes("commitLocalStream(new MediaStream(remainingTracks));") ||
+      !section.includes("if (currentStream?.getTracks().includes(createdTrack))") ||
+      !section.includes("commitLocalStream(new MediaStream(remaining));")
+    ) {
+      failures.push(
+        "web camera toggle cleanup must keep local stream ref synchronized",
       );
     }
   }

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -879,13 +879,15 @@ assertRegex(
       );
     }
     if (
+      !section.includes("const currentStream = localStreamRef.current ?? localStream;") ||
+      !section.includes("if (!currentStream) return;") ||
       !section.includes("const currentTrack = getFirstLiveTrack(") ||
       !section.includes("let nextVideoTrack = getFirstLiveTrack(") ||
       !section.includes("let oldVideoTracksToStop: MediaStreamTrack[] = [];") ||
       !section.includes("stopTracksExcept(oldVideoTracksToStop, [")
     ) {
       failures.push(
-        "web video-quality recovery must prefer live tracks and stop all replaced camera tracks",
+        "web video-quality recovery must prefer ref-backed live tracks and stop all replaced camera tracks",
       );
     }
   }

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1002,6 +1002,21 @@ for (const [context, label] of [
   );
   assertRegex(
     "webMeetMedia",
+    /When frame counters exist, byte trickle alone is not video progress[\s\S]*previous\.frames !== null[\s\S]*sample\.frames !== null[\s\S]*return sample\.frames > previous\.frames;[\s\S]*sample\.bytes - previous\.bytes >= MIN_OUTBOUND_VIDEO_BYTE_DELTA_FOR_PROGRESS/,
+    "web camera sender watchdog must not treat byte trickle as frame progress",
+  );
+  assertRegex(
+    "webMeetMedia",
+    /allowProducerRecreate: boolean[\s\S]*if \(!allowProducerRecreate\) \{[\s\S]*Camera sender stalled in background; keeping producer open/,
+    "web hidden camera sender watchdog repairs raw tracks without background producer recreation",
+  );
+  assertRegex(
+    "webMeetMedia",
+    /const allowProducerRecreate =[\s\S]*document\.visibilityState === "visible"[\s\S]*recoverStalledProducer\(\{[\s\S]*allowProducerRecreate/,
+    "web camera sender watchdog passes foreground state to stalled recovery",
+  );
+  assertRegex(
+    "webMeetMedia",
     /qualityLimitationReason[\s\S]*isEncoderLimitedOutboundSample[\s\S]*qualityLimitationReason === "bandwidth"[\s\S]*qualityLimitationReason === "cpu"[\s\S]*stalledSamples < CAMERA_OUTBOUND_STALL_SAMPLES_BEFORE_RECOVERY \|\|[\s\S]*isEncoderLimitedOutboundSample\(sample\)/,
     "web camera sender watchdog must not recreate producers for encoder-limited stalls",
   );

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1167,8 +1167,13 @@ assertIncludes(
 }
 assertRegex(
   "webAdaptivePublishQuality",
-  /const restoreStandardCaptureIfNeeded = useCallback[\s\S]*videoQualityRef\.current !== "standard"[\s\S]*webcamTrack\?\.readyState !== "live"[\s\S]*await updateVideoQualityRef\.current\("standard", "good"\)[\s\S]*lastStandardCaptureRestoreSignatureRef\.current = signature/,
-  "web adaptive good-link restore refreshes standard capture without reopening camera",
+  /needsStandardCaptureRestore[\s\S]*STANDARD_CAPTURE_MIN_WIDTH[\s\S]*STANDARD_CAPTURE_MIN_HEIGHT[\s\S]*STANDARD_CAPTURE_MIN_FRAMERATE/,
+  "web adaptive good-link restore only refreshes undersized camera capture",
+);
+assertRegex(
+  "webAdaptivePublishQuality",
+  /const restoreStandardCaptureIfNeeded = useCallback[\s\S]*videoQualityRef\.current !== "standard"[\s\S]*webcamTrack\?\.readyState !== "live"[\s\S]*if \(needsStandardCaptureRestore\(webcamTrack\)\) \{[\s\S]*await updateVideoQualityRef\.current\("standard", "good"\)[\s\S]*\} else \{[\s\S]*await applyWebcamProducerNetworkProfile\(webcamProducer, "standard", "good"\);[\s\S]*lastStandardCaptureRestoreSignatureRef\.current = signature/,
+  "web adaptive good-link restore avoids camera constraint churn when capture is already standard",
 );
 assertRegex(
   "webAdaptivePublishQuality",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -760,6 +760,11 @@ assertRegex(
   /const recoverAudioProducer = async \(\) => \{[\s\S]*const removeCreatedTrackFromLocalStream = \(\) => \{[\s\S]*stopLocalTrack\(createdTrack\);[\s\S]*createdTrack = null;[\s\S]*if \(cancelled\) \{[\s\S]*audioProducer\.close\(\);[\s\S]*removeCreatedTrackFromLocalStream\(\);[\s\S]*catch \(err\) \{[\s\S]*removeCreatedTrackFromLocalStream\(\);/,
   "web cancelled audio recovery stops recovery-created mic tracks",
 );
+assertRegex(
+  "webMeetMedia",
+  /const stopTracksExcept = useCallback\([\s\S]*keepTrackIds[\s\S]*for \(const track of tracks\)[\s\S]*stopLocalTrack\(track\);/,
+  "web replaced local capture tracks are stopped as a complete set",
+);
 {
   const text = source.webMeetMedia;
   const start = text.indexOf("const handleLocalTrackEnded = useCallback(");
@@ -793,12 +798,53 @@ assertRegex(
     const section = text.slice(start, end);
     if (
       !section.includes("const previousStream = localStreamRef.current;") ||
+      !section.includes("const previousAudioTracks =") ||
       !section.includes("commitLocalStream(nextStream);") ||
+      !section.includes("stopTracksExcept(previousAudioTracks, [newAudioTrack]);") ||
       section.includes("prev.removeTrack(oldAudioTrack)") ||
       section.includes("prev.addTrack(newAudioTrack)")
     ) {
       failures.push(
-        "web audio input device changes must sync local stream refs without mutating stale streams",
+        "web audio input device changes must sync local stream refs and stop all replaced mic tracks",
+      );
+    }
+  }
+}
+{
+  const text = source.webMeetMedia;
+  const start = text.indexOf("const handleVideoInputDeviceChange = useCallback(");
+  const end = text.indexOf("const updateVideoQuality = useCallback", start);
+  if (start < 0 || end < 0) {
+    failures.push("web video input device-change section missing");
+  } else {
+    const section = text.slice(start, end);
+    if (
+      !section.includes("const previousVideoTracks =") ||
+      !section.includes("stopTracksExcept(previousVideoTracks, [") ||
+      !section.includes("videoProducerRef.current?.track ?? null")
+    ) {
+      failures.push(
+        "web video input device changes must stop all replaced camera tracks",
+      );
+    }
+  }
+}
+{
+  const text = source.webMeetMedia;
+  const start = text.indexOf("const toggleMute = useCallback(");
+  const end = text.indexOf("useEffect(() => {\n    if (ghostEnabled || isObserverMode) return;", start);
+  if (start < 0 || end < 0) {
+    failures.push("web mute toggle section missing");
+  } else {
+    const section = text.slice(start, end);
+    if (
+      !section.includes("const currentAudioTracks =") ||
+      !section.includes("const liveAudioTracks = currentAudioTracks.filter(") ||
+      !section.includes("liveAudioTracks.forEach((track) => {") ||
+      !section.includes("let audioTrack = getFirstLiveTrack(")
+    ) {
+      failures.push(
+        "web mute toggle must apply intent to all live mic tracks and unmute a live track",
       );
     }
   }
@@ -832,6 +878,16 @@ assertRegex(
         "web video-quality producer recreation must skip intentional mobile/H264 single-layer webcam producers",
       );
     }
+    if (
+      !section.includes("const currentTrack = getFirstLiveTrack(") ||
+      !section.includes("let nextVideoTrack = getFirstLiveTrack(") ||
+      !section.includes("let oldVideoTracksToStop: MediaStreamTrack[] = [];") ||
+      !section.includes("stopTracksExcept(oldVideoTracksToStop, [")
+    ) {
+      failures.push(
+        "web video-quality recovery must prefer live tracks and stop all replaced camera tracks",
+      );
+    }
   }
 }
 {
@@ -850,6 +906,7 @@ assertRegex(
     }
     if (
       !section.includes("hadLiveAudioTrackBeforeRecovery") ||
+      !section.includes("let audioTrack = getFirstLiveTrack(") ||
       !section.includes("if (createdTrack)") ||
       !section.includes("localStreamRef.current = nextStream;") ||
       !section.includes("setLocalStream(nextStream);") ||
@@ -1277,6 +1334,7 @@ assertRegex(
       !section.includes(
         "const recoveryCodecOverride = cameraRecoveryCodecOverrideRef.current",
       ) ||
+      !section.includes("let videoTrack = getFirstLiveTrack(") ||
       !section.includes("recoveryCodecOverride ??") ||
       !section.includes("forceSingleLayer,") ||
       !section.includes("consumedRecoveryPublishOverride") ||

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -744,6 +744,8 @@ for (const [context, label] of [
     if (
       !section.includes("hadLiveAudioTrackBeforeRecovery") ||
       !section.includes("if (createdTrack)") ||
+      !section.includes("localStreamRef.current = nextStream;") ||
+      !section.includes("setLocalStream(nextStream);") ||
       !section.includes("if (!hadLiveAudioTrackBeforeRecovery)") ||
       section.includes("existingAudioTracks.forEach((track) =>")
     ) {

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1172,7 +1172,12 @@ assertRegex(
 );
 assertRegex(
   "webAdaptivePublishQuality",
-  /const restoreStandardCaptureIfNeeded = useCallback[\s\S]*videoQualityRef\.current !== "standard"[\s\S]*webcamTrack\?\.readyState !== "live"[\s\S]*if \(needsStandardCaptureRestore\(webcamTrack\)\) \{[\s\S]*await updateVideoQualityRef\.current\("standard", "good"\)[\s\S]*\} else \{[\s\S]*await applyWebcamProducerNetworkProfile\(webcamProducer, "standard", "good"\);[\s\S]*lastStandardCaptureRestoreSignatureRef\.current = signature/,
+  /getStandardCaptureRestoreSignature[\s\S]*settings\.width[\s\S]*settings\.height[\s\S]*settings\.frameRate[\s\S]*const signature = getStandardCaptureRestoreSignature\([\s\S]*webcamProducer\.id,[\s\S]*webcamTrack/,
+  "web adaptive good-link restore signature tracks live capture settings",
+);
+assertRegex(
+  "webAdaptivePublishQuality",
+  /const restoreStandardCaptureIfNeeded = useCallback[\s\S]*videoQualityRef\.current !== "standard"[\s\S]*webcamTrack\?\.readyState !== "live"[\s\S]*if \(needsStandardCaptureRestore\(webcamTrack\)\) \{[\s\S]*await updateVideoQualityRef\.current\("standard", "good"\)[\s\S]*\} else \{[\s\S]*await applyWebcamProducerNetworkProfile\([\s\S]*webcamProducer,[\s\S]*"standard",[\s\S]*"good",[\s\S]*\);[\s\S]*lastStandardCaptureRestoreSignatureRef\.current = signature/,
   "web adaptive good-link restore avoids camera constraint churn when capture is already standard",
 );
 assertRegex(

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -104,6 +104,22 @@ assertRegex(
   /ConnectionQuality\.emergency -> 18_000[\s\S]*ConnectionQuality\.poor -> 24_000[\s\S]*ConnectionQuality\.fair -> 32_000/,
   "Android microphone Opus constrained ladder",
 );
+assertRegex(
+  "webMeetSocket",
+  /track: audioTrack,[\s\S]*buildMicrophoneOpusCodecOptions\([\s\S]*stopTracks: false,[\s\S]*type: "webcam" as ProducerType/,
+  "web initial microphone producer must preserve capture tracks during producer cleanup",
+);
+{
+  const mediaAudioProduceMatches =
+    source.webMeetMedia.match(
+      /track: audioTrack,[\s\S]*?buildMicrophoneOpusCodecOptions\([\s\S]*?stopTracks: false,[\s\S]*?type: "webcam" as ProducerType/g,
+    ) ?? [];
+  if (mediaAudioProduceMatches.length < 2) {
+    failures.push(
+      "web mute and audio recovery microphone producers must preserve capture tracks during producer cleanup",
+    );
+  }
+}
 
 // Codec preference should not globally force VP8: Safari/iOS/Android benefit
 // from H264 hardware acceleration, while desktop browsers can still prefer VP8
@@ -1340,6 +1356,11 @@ assertRegex(
   "webMeetSocket",
   /status\.state === "reconnected"[\s\S]*!visibleParticipantReconnectingIdsRef\.current\.has\(targetUserId\)[\s\S]*return;[\s\S]*status\.state === "reconnecting"[\s\S]*visibleParticipantReconnectingIdsRef\.current\.add\(targetUserId\)/,
   "web reconnected badges only show after a visible reconnecting state",
+);
+assertRegex(
+  "webMeetSocket",
+  /const shouldSurfaceReconnectState =[\s\S]*!shouldDeferTransportRecoveryUntilVisible\(\);[\s\S]*if \(shouldSurfaceReconnectState\) \{[\s\S]*setConnectionState\("reconnecting"\);[\s\S]*Background reconnect in progress; preserving joined UI state/,
+  "web hidden-tab reconnect attempts must not surface reconnecting UI state",
 );
 assertRegex(
   "webMeetSocket",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1342,6 +1342,11 @@ assertIncludes(
   "Browser background throttling",
   "SFU documents why grace-window reconnect badges are suppressed",
 );
+assertRegex(
+  "sfuConfig",
+  /const BACKGROUND_SOCKET_RECOVERY_WINDOW_MS = 120000;[\s\S]*disconnectGraceMs: toNumber\([\s\S]*SFU_SOCKET_DISCONNECT_GRACE_MS[\s\S]*BACKGROUND_SOCKET_RECOVERY_WINDOW_MS[\s\S]*recoveryMaxDisconnectionMs: toNumber\([\s\S]*SFU_SOCKET_RECOVERY_MAX_MS[\s\S]*BACKGROUND_SOCKET_RECOVERY_WINDOW_MS/,
+  "SFU default socket recovery and disconnect grace stay aligned for background clients",
+);
 assertIncludes(
   "webMeetSocket",
   "const PARTICIPANT_RECONNECTING_STATUS_FALLBACK_MS = 30000;",
@@ -1369,7 +1374,7 @@ assertRegex(
 );
 assertIncludes(
   "sfuConfig",
-  "30000",
+  "BACKGROUND_SOCKET_RECOVERY_WINDOW_MS = 120000",
   "SFU socket disconnect grace tolerates backgrounded tabs",
 );
 assertIncludes(

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1039,12 +1039,16 @@ for (const [context, label] of [
       failures.push("web camera producer recovery must rebuild failed transports");
     }
     if (
-      !section.includes("cameraRecoveryCodecOverrideRef.current ??") ||
+      !section.includes(
+        "const recoveryCodecOverride = cameraRecoveryCodecOverrideRef.current",
+      ) ||
+      !section.includes("recoveryCodecOverride ??") ||
       !section.includes("forceSingleLayer,") ||
+      !section.includes("consumedRecoveryPublishOverride") ||
       !section.includes("cameraRecoveryForceSingleLayerRef.current = false")
     ) {
       failures.push(
-        "web camera producer recovery must consume and clear single-layer codec fallback",
+        "web camera producer recovery must consume and clear single-layer codec fallback after attempted publish",
       );
     }
     const transportSectionEnd = section.indexOf("let videoTrack");
@@ -1168,6 +1172,11 @@ assertRegex(
 );
 assertRegex(
   "webAdaptivePublishQuality",
+  /STANDARD_CAPTURE_RESTORE_RETRY_MS[\s\S]*standardCaptureRestoreRetryTimeoutRef[\s\S]*scheduleRestoreRetry[\s\S]*updateInFlightRef\.current[\s\S]*scheduleRestoreRetry\(\)[\s\S]*Adaptive standard camera capture restore failed[\s\S]*scheduleRestoreRetry\(\)/,
+  "web adaptive good-link standard capture restore retries after in-flight or failed restore",
+);
+assertRegex(
+  "webAdaptivePublishQuality",
   /shouldRestoreStableStandardCapture[\s\S]*capRecoveryQuality === "good"[\s\S]*capRecoveryElapsedMs >= GOOD_LIVE_RESTORE_AFTER_MS[\s\S]*currentPublishQuality === "standard"[\s\S]*void restoreStandardCaptureIfNeeded\(\)\.finally\(\(\) => \{[\s\S]*applyLiveProducerProfile\("good"\)[\s\S]*\} else \{[\s\S]*applyStableLiveProfile\(\);/,
   "web adaptive good-link capture restore also restores good publish profiles",
 );
@@ -1219,6 +1228,11 @@ assertRegex(
   "webMeetSocket",
   /status\.state === "reconnected"[\s\S]*PARTICIPANT_RECONNECTED_STATUS_MS[\s\S]*PARTICIPANT_RECONNECTING_STATUS_FALLBACK_MS[\s\S]*PARTICIPANT_RECONNECTING_STATUS_BUFFER_MS/,
   "web reconnecting participant badges expire even if recovery event is missed",
+);
+assertRegex(
+  "webMeetSocket",
+  /status\.state === "reconnected"[\s\S]*!visibleParticipantReconnectingIdsRef\.current\.has\(targetUserId\)[\s\S]*return;[\s\S]*status\.state === "reconnecting"[\s\S]*visibleParticipantReconnectingIdsRef\.current\.add\(targetUserId\)/,
+  "web reconnected badges only show after a visible reconnecting state",
 );
 assertIncludes(
   "sfuConfig",
@@ -1550,8 +1564,13 @@ assertRegex(
 );
 assertRegex(
   "webMeetSocket",
-  /announcedRemoteProducersRef[\s\S]*hasReplacementProducer[\s\S]*announcedRemoteProducersRef\.current\.entries\(\)[\s\S]*if \(!hasReplacementProducer\) \{[\s\S]*UPDATE_STREAM[\s\S]*stream: null[\s\S]*if \(info\.kind === "video" && info\.type === "webcam"\) \{[\s\S]*if \(!hasReplacementProducer\)[\s\S]*UPDATE_CAMERA_OFF[\s\S]*announcedRemoteProducersRef\.current\.set\(data\.producerId, data\)/,
+  /hasLiveReplacementProducer[\s\S]*producerMapRef\.current\.entries\(\)[\s\S]*hasAnnouncedReplacementProducer[\s\S]*announcedRemoteProducersRef\.current\.entries\(\)[\s\S]*const hasReplacementProducer =[\s\S]*hasLiveReplacementProducer \|\| hasAnnouncedReplacementProducer[\s\S]*if \(!hasReplacementProducer\) \{[\s\S]*UPDATE_STREAM[\s\S]*stream: null[\s\S]*if \(info\.kind === "video" && info\.type === "webcam"\) \{[\s\S]*if \(!hasReplacementProducer\)[\s\S]*UPDATE_CAMERA_OFF[\s\S]*announcedRemoteProducersRef\.current\.set\(data\.producerId, data\)/,
   "web producer replacement announcements suppress transient stream and camera-off clears",
+);
+assertRegex(
+  "webMeetSocket",
+  /STALE_REPLACEMENT_CLEANUP_DELAY_MS[\s\S]*staleReplacementCleanupTimeoutsRef[\s\S]*hasConsumedReplacement[\s\S]*if \(hasConsumedReplacement\) return;[\s\S]*hasPendingReplacement[\s\S]*UPDATE_STREAM[\s\S]*stream: null[\s\S]*if \(!hasPendingReplacement\)/,
+  "web stale producer replacement cleanup clears frozen old streams if the replacement never consumes",
 );
 assertRegex(
   "sfuClient",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -757,7 +757,7 @@ for (const [context, label] of [
 }
 assertRegex(
   "webMeetMedia",
-  /const recoverAudioProducer = async \(\) => \{[\s\S]*const removeCreatedTrackFromLocalStream = \(\) => \{[\s\S]*stopLocalTrack\(createdTrack\);[\s\S]*createdTrack = null;[\s\S]*if \(cancelled\) \{[\s\S]*audioProducer\.close\(\);[\s\S]*removeCreatedTrackFromLocalStream\(\);[\s\S]*catch \(err\) \{[\s\S]*removeCreatedTrackFromLocalStream\(\);/,
+  /let createdTrack: MediaStreamTrack \| null = null;[\s\S]*const removeCreatedTrackFromLocalStream = \(\) => \{[\s\S]*stopLocalTrack\(createdTrack\);[\s\S]*createdTrack = null;[\s\S]*audioRecoveryInFlightRef\.current = true;[\s\S]*const recoverAudioProducer = async \(\) => \{[\s\S]*if \(cancelled\) \{[\s\S]*audioProducer\.close\(\);[\s\S]*removeCreatedTrackFromLocalStream\(\);[\s\S]*catch \(err\) \{[\s\S]*removeCreatedTrackFromLocalStream\(\);[\s\S]*return \(\) => \{[\s\S]*cancelled = true;[\s\S]*removeCreatedTrackFromLocalStream\(\);/,
   "web cancelled audio recovery stops recovery-created mic tracks",
 );
 assertRegex(
@@ -937,7 +937,10 @@ assertRegex(
       !section.includes("if (createdTrack)") ||
       !section.includes("localStreamRef.current = nextStream;") ||
       !section.includes("setLocalStream(nextStream);") ||
-      !section.includes("if (!hadLiveAudioTrackBeforeRecovery)") ||
+      !section.includes("!hadLiveAudioTrackBeforeRecovery &&") ||
+      !section.includes(
+        "shouldDisableMediaIntentAfterRecoveryFailure(err, meetErr)",
+      ) ||
       section.includes("existingAudioTracks.forEach((track) =>")
     ) {
       failures.push(
@@ -1073,6 +1076,33 @@ assertRegex(
   ) {
     failures.push(
       "web producer transport-close handlers must use queued recovery requests, not raw pulses",
+    );
+  }
+  if (
+    !/let createdTrack: MediaStreamTrack \| null = null;[\s\S]*const removeCreatedTrackFromLocalStream = \(\) => \{[\s\S]*audioRecoveryInFlightRef\.current = true;[\s\S]*const recoverAudioProducer = async \(\) => \{[\s\S]*const audioProducer = await transport\.produce[\s\S]*if \(cancelled\) \{[\s\S]*removeCreatedTrackFromLocalStream\(\);[\s\S]*audioProducerRef\.current = audioProducer;[\s\S]*createdTrack = null;[\s\S]*return \(\) => \{[\s\S]*cancelled = true;[\s\S]*removeCreatedTrackFromLocalStream\(\);/.test(
+      mediaText,
+    )
+  ) {
+    failures.push(
+      "web audio recovery must stop recovery-created mic tracks immediately on effect cancellation",
+    );
+  }
+  if (
+    !/let createdTrack: MediaStreamTrack \| null = null;[\s\S]*const removeCreatedTrackFromLocalStream = \(\) => \{[\s\S]*cameraRecoveryInFlightRef\.current = true;[\s\S]*const recoverCameraProducer = async \(\) => \{[\s\S]*const recoveredProducer = await produceCameraTrackWithRawFallback[\s\S]*if \(cancelled\) \{[\s\S]*removeCreatedTrackFromLocalStream\(\);[\s\S]*videoProducerRef\.current = recoveredProducer;[\s\S]*createdTrack = null;[\s\S]*return \(\) => \{[\s\S]*cancelled = true;[\s\S]*removeCreatedTrackFromLocalStream\(\);/.test(
+      mediaText,
+    )
+  ) {
+    failures.push(
+      "web camera recovery must stop recovery-created video tracks immediately on effect cancellation",
+    );
+  }
+  if (
+    !/shouldDisableMediaIntentAfterRecoveryFailure[\s\S]*meetError\.code === "PERMISSION_DENIED"[\s\S]*NotFoundError[\s\S]*Audio producer recovery failed[\s\S]*const meetErr = createMeetError\(err, "MEDIA_ERROR"\);[\s\S]*!hadLiveAudioTrackBeforeRecovery &&[\s\S]*shouldDisableMediaIntentAfterRecoveryFailure\(err, meetErr\)[\s\S]*setIsMuted\(true\);[\s\S]*Camera producer recovery failed[\s\S]*const meetErr = createMeetError\(err, "MEDIA_ERROR"\);[\s\S]*!hadLiveCameraTrackBeforeRecovery &&[\s\S]*shouldDisableMediaIntentAfterRecoveryFailure\(err, meetErr\)[\s\S]*setIsCameraOff\(true\);/.test(
+      mediaText,
+    )
+  ) {
+    failures.push(
+      "web media recovery must preserve mic/camera intent on transient producer failures",
     );
   }
 
@@ -1301,8 +1331,8 @@ assertRegex(
   );
   assertRegex(
     "webMeetMedia",
-    /framesPerSecond: number \| null[\s\S]*currentFramesPerSecond = getRtcStatsNumber\(stat, "framesPerSecond"\)[\s\S]*When frame counters exist, flat frames alone are not enough to prove a[\s\S]*sample\.frames > previous\.frames[\s\S]*sample\.framesPerSecond !== null[\s\S]*sample\.bytes - previous\.bytes >= MIN_OUTBOUND_VIDEO_BYTE_DELTA_FOR_PROGRESS[\s\S]*return false;[\s\S]*return true;/,
-    "web camera sender watchdog must not recreate producers from quiet/static frame counters",
+    /framesPerSecond: number \| null[\s\S]*currentFramesPerSecond = getRtcStatsNumber\(stat, "framesPerSecond"\)[\s\S]*When frame counters exist, they are the strongest signal[\s\S]*sample\.frames > previous\.frames[\s\S]*sample\.framesPerSecond !== null[\s\S]*return true;[\s\S]*return false;[\s\S]*previous\.bytes !== null[\s\S]*sample\.bytes - previous\.bytes >= MIN_OUTBOUND_VIDEO_BYTE_DELTA_FOR_PROGRESS[\s\S]*return true;/,
+    "web camera sender watchdog must treat flat frame counters as stalled video",
   );
   assertRegex(
     "webMeetMedia",
@@ -1326,7 +1356,7 @@ assertRegex(
   );
   assertRegex(
     "webMeetMedia",
-    /const recoverCameraProducer = async \(\) => \{[\s\S]*const removeCreatedTrackFromLocalStream = \(\) => \{[\s\S]*stopLocalTrack\(createdTrack\);[\s\S]*createdTrack = null;[\s\S]*if \(cancelled\) \{[\s\S]*recoveredProducer\.close\(\);[\s\S]*removeCreatedTrackFromLocalStream\(\);[\s\S]*catch \(err\) \{[\s\S]*removeCreatedTrackFromLocalStream\(\);/,
+    /let createdTrack: MediaStreamTrack \| null = null;[\s\S]*const removeCreatedTrackFromLocalStream = \(\) => \{[\s\S]*stopLocalTrack\(createdTrack\);[\s\S]*createdTrack = null;[\s\S]*cameraRecoveryInFlightRef\.current = true;[\s\S]*const recoverCameraProducer = async \(\) => \{[\s\S]*if \(cancelled\) \{[\s\S]*recoveredProducer\.close\(\);[\s\S]*removeCreatedTrackFromLocalStream\(\);[\s\S]*catch \(err\) \{[\s\S]*removeCreatedTrackFromLocalStream\(\);[\s\S]*return \(\) => \{[\s\S]*cancelled = true;[\s\S]*removeCreatedTrackFromLocalStream\(\);/,
     "web cancelled camera recovery stops recovery-created camera tracks",
   );
   assertRegex(
@@ -1595,6 +1625,11 @@ assertRegex(
   "webMeetSocket",
   /const shouldSurfaceReconnectState =[\s\S]*!shouldDeferTransportRecoveryUntilVisible\(\);[\s\S]*if \(shouldSurfaceReconnectState\) \{[\s\S]*setConnectionState\("reconnecting"\);[\s\S]*Background reconnect in progress; preserving joined UI state/,
   "web hidden-tab reconnect attempts must not surface reconnecting UI state",
+);
+assertRegex(
+  "webMeetSocket",
+  /const handleReconnect = useCallback\(async \(\) => \{[\s\S]*reconnectInFlightRef\.current = true;[\s\S]*const shouldSurfaceReconnectState =[\s\S]*cleanupRoomResources\(\{[\s\S]*preserveMeetingState: true[\s\S]*await joinRoomInternal[\s\S]*\} finally \{[\s\S]*reconnectInFlightRef\.current = false;/,
+  "web hidden-tab reconnect keeps internal media recovery blocked across cleanup and rejoin",
 );
 assertRegex(
   "webMeetSocket",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1324,21 +1324,22 @@ assertRegex(
   } else {
     const section = text.slice(start, end);
     if (
-      !section.includes("producer.replaceTrack({ track: rawCameraTrack });") ||
+      !section.includes("producer.replaceTrack({ track: publishTrack });") ||
+      !section.includes("waitForPreferredVideoPublishTrack(") ||
       !section.includes("closeLocalVideoProducerForReplacement(producer);") ||
       !section.includes("requestCameraProducerRecovery();") ||
       !section.includes("cameraRecoveryForceSingleLayerRef.current = true") ||
       !section.includes("getFallbackWebcamCodec(device, currentCodec)")
     ) {
       failures.push(
-        "web stalled camera sender recovery must repair with raw camera and then recreate with single-layer codec fallback",
+        "web stalled camera sender recovery must repair with preferred camera track and then recreate with single-layer codec fallback",
       );
     }
     const rawRepairIndex = section.indexOf(
-      "producer.replaceTrack({ track: rawCameraTrack });",
+      "producer.replaceTrack({ track: publishTrack });",
     );
     const rawRepairConditionIndex = section.indexOf(
-      "const shouldTryRawRepair = !state.rawRepairAttempted;",
+      "const shouldTryPreferredRepair = !state.rawRepairAttempted;",
     );
     const recreateIndex = section.indexOf(
       "closeLocalVideoProducerForReplacement(producer);",
@@ -1355,20 +1356,22 @@ assertRegex(
     }
     if (
       rawRepairConditionIndex < 0 ||
-      !section.includes("if (producerTrack.id !== rawCameraTrack.id)") ||
-      !section.includes("Refreshed stalled camera sender with raw camera track")
+      !section.includes("publishTrack.id === rawCameraTrack.id") ||
+      !section.includes(
+        "Refreshed stalled camera sender with preferred camera track",
+      )
     ) {
       failures.push(
-        "web stalled camera sender recovery must soft-refresh raw camera before any destructive producer recreation",
+        "web stalled camera sender recovery must soft-refresh preferred camera before any destructive producer recreation",
       );
     }
     if (
       rawRepairIndex >= 0 &&
       hiddenGuardIndex >= 0 &&
-      rawRepairIndex < hiddenGuardIndex
+      hiddenGuardIndex < rawRepairIndex
     ) {
       failures.push(
-        "web hidden-tab camera stalls must hit the no-recreate guard before raw-track repair",
+        "web hidden-tab camera stalls must try preferred-track repair before the no-recreate guard",
       );
     }
     if (
@@ -1399,7 +1402,7 @@ assertRegex(
   assertRegex(
     "webMeetMedia",
     /allowProducerRecreate: boolean[\s\S]*if \(!allowProducerRecreate\) \{[\s\S]*Camera sender stalled in background; keeping producer open/,
-    "web hidden camera sender watchdog repairs raw tracks without background producer recreation",
+    "web hidden camera sender watchdog repairs preferred tracks without background producer recreation",
   );
   assertRegex(
     "webMeetMedia",
@@ -1413,7 +1416,7 @@ assertRegex(
   );
   assertRegex(
     "webMeetMedia",
-    /onPreferredVideoPublishTrackRejected[\s\S]*producer\.replaceTrack\(\{ track: rawCameraTrack \}\);[\s\S]*onPreferredVideoPublishTrackRejected\?\.[\s\S]*camera-outbound-stall-raw-repair/,
+    /producer\.replaceTrack\(\{ track: publishTrack \}\);[\s\S]*publishTrack\.id === rawCameraTrack\.id[\s\S]*onPreferredVideoPublishTrackRejected\?\.[\s\S]*camera-outbound-stall-raw-repair/,
     "web raw camera repair suppresses the rejected processed publish track",
   );
   assertRegex(
@@ -1945,6 +1948,11 @@ assertIncludes(
   "const HIDDEN_STALE_OUTPUT_REPUBLISH_RETRY_MS = 5000;",
   "web hidden processed effects republish retry cadence",
 );
+assertIncludes(
+  "webVideoEffects",
+  "const HIDDEN_VIDEO_REARM_INTERVAL_MS = 5000;",
+  "web hidden effects source video rearm cadence",
+);
 assertRegex(
   "webVideoEffects",
   /const duplicateOutputHeartbeatDue =[\s\S]*DUPLICATE_OUTPUT_HEARTBEAT_MS[\s\S]*!duplicateOutputHeartbeatDue/,
@@ -1959,6 +1967,11 @@ assertRegex(
   "webVideoEffects",
   /const keepHiddenStaleProcessedOutputAlive = async[\s\S]*isHiddenStaleProcessedOutput\(sampleNow\)[\s\S]*restoreLastVisibleOutputFrame\(\s*"hidden-stale-output-keepalive"[\s\S]*await deliverOutputFrame\(sampleNow\)[\s\S]*HIDDEN_STALE_OUTPUT_REPUBLISH_RETRY_MS[\s\S]*setProcessedTrackReady\(true\);[\s\S]*bumpProcessedTrackVersionForFreshOutput\([\s\S]*"hidden-stale-output-keepalive"[\s\S]*"hidden_stale_output_keepalive"/,
   "web hidden stale processed effects output sends keepalive frames instead of going inert",
+);
+assertRegex(
+  "webVideoEffects",
+  /const handleDocumentVisibilityChange = \(\) => \{[\s\S]*rearmHiddenVideoPlayback\(reason\)[\s\S]*keepHiddenStaleProcessedOutputAlive\(reason\)[\s\S]*video\.addEventListener\("pause", handleHiddenVideoPlaybackStall\)[\s\S]*video\.addEventListener\("stalled", handleHiddenVideoPlaybackStall\)[\s\S]*document\.addEventListener\("visibilitychange", handleDocumentVisibilityChange\)[\s\S]*hiddenVideoRearmIntervalId = window\.setInterval/,
+  "web hidden effects pipeline actively rearms background video playback",
 );
 assertRegex(
   "webVideoEffects",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1579,12 +1579,17 @@ assertRegex(
 );
 assertRegex(
   "webMeetSocket",
-  /hasLiveReplacementProducer[\s\S]*producerMapRef\.current\.entries\(\)[\s\S]*hasAnnouncedReplacementProducer[\s\S]*announcedRemoteProducersRef\.current\.entries\(\)[\s\S]*const hasReplacementProducer =[\s\S]*hasLiveReplacementProducer \|\| hasAnnouncedReplacementProducer[\s\S]*if \(!hasReplacementProducer\) \{[\s\S]*UPDATE_STREAM[\s\S]*stream: null[\s\S]*if \(info\.kind === "video" && info\.type === "webcam"\) \{[\s\S]*if \(!hasReplacementProducer\)[\s\S]*UPDATE_CAMERA_OFF[\s\S]*announcedRemoteProducersRef\.current\.set\(data\.producerId, data\)/,
+  /getMatchingReplacementState[\s\S]*producerMapRef\.current\.entries\(\)[\s\S]*announcedRemoteProducersRef\.current\.entries\(\)[\s\S]*hasReplacementProducer:[\s\S]*hasConsumedReplacement \|\| hasPendingReplacement[\s\S]*clearClosedProducerState[\s\S]*UPDATE_STREAM[\s\S]*stream: null[\s\S]*if \(!hasPendingReplacement\)[\s\S]*UPDATE_CAMERA_OFF[\s\S]*announcedRemoteProducersRef\.current\.set\(data\.producerId, data\)/,
   "web producer replacement announcements suppress transient stream and camera-off clears",
 );
 assertRegex(
   "webMeetSocket",
-  /STALE_REPLACEMENT_CLEANUP_DELAY_MS[\s\S]*staleReplacementCleanupTimeoutsRef[\s\S]*hasConsumedReplacement[\s\S]*if \(hasConsumedReplacement\) return;[\s\S]*hasPendingReplacement[\s\S]*UPDATE_STREAM[\s\S]*stream: null[\s\S]*if \(!hasPendingReplacement\)/,
+  /PRODUCER_CLOSE_REPLACEMENT_GRACE_MS[\s\S]*if \(!replacementState\.hasReplacementProducer\)[\s\S]*window\.setTimeout[\s\S]*latestReplacementState = getMatchingReplacementState\(\)[\s\S]*latestReplacementState\.hasConsumedReplacement[\s\S]*clearClosedProducerState\([\s\S]*latestReplacementState\.hasPendingReplacement/,
+  "web unannounced producer closes wait briefly for reconnect replacement before clearing streams",
+);
+assertRegex(
+  "webMeetSocket",
+  /STALE_REPLACEMENT_CLEANUP_DELAY_MS[\s\S]*else if \(!replacementState\.hasConsumedReplacement\)[\s\S]*window\.setTimeout[\s\S]*latestReplacementState = getMatchingReplacementState\(\)[\s\S]*latestReplacementState\.hasConsumedReplacement[\s\S]*clearClosedProducerState\([\s\S]*latestReplacementState\.hasPendingReplacement/,
   "web stale producer replacement cleanup clears frozen old streams if the replacement never consumes",
 );
 assertRegex(

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -802,6 +802,9 @@ assertRegex(
       !section.includes("acquiredAudioTracks = newStream.getAudioTracks();") ||
       !section.includes("const previousStream = localStreamRef.current;") ||
       !section.includes("const previousAudioTracks =") ||
+      !section.includes("const currentAudioProducer = audioProducerRef.current;") ||
+      !section.includes("currentAudioProducer?.closed") ||
+      !section.includes("resetAudioProducer(currentAudioProducer);") ||
       !section.includes("requestAudioProducerRecovery();") ||
       !section.includes("commitLocalStream(nextStream);") ||
       !section.includes("committedNewAudioTrack = newAudioTrack;") ||
@@ -811,7 +814,7 @@ assertRegex(
       section.includes("prev.addTrack(newAudioTrack)")
     ) {
       failures.push(
-        "web audio input device changes must sync refs, recover missing producers, and clean up failed mic captures",
+        "web audio input device changes must sync refs, clear dead producers, recover missing producers, and clean up failed mic captures",
       );
     }
   }
@@ -824,13 +827,16 @@ assertRegex(
     failures.push("web video input device-change section missing");
   } else {
     const section = text.slice(start, end);
-    const replaceIndex = section.indexOf("await videoProducerRef.current.replaceTrack");
+    const replaceIndex = section.indexOf("await videoProducer.replaceTrack");
     const commitIndex = section.indexOf("localStreamRef.current = nextStream;");
     if (
       !section.includes("let acquiredVideoTracks: MediaStreamTrack[] = [];") ||
       !section.includes("let committedNewVideoTrack: MediaStreamTrack | null = null;") ||
       !section.includes("acquiredVideoTracks = newStream.getVideoTracks();") ||
       !section.includes("const previousVideoTracks =") ||
+      !section.includes("const currentVideoProducer = videoProducerRef.current;") ||
+      !section.includes("currentVideoProducer?.closed") ||
+      !section.includes("closeLocalVideoProducerForReplacement(currentVideoProducer);") ||
       replaceIndex < 0 ||
       commitIndex < 0 ||
       commitIndex < replaceIndex ||
@@ -841,7 +847,7 @@ assertRegex(
       !section.includes("videoProducerRef.current?.track ?? null")
     ) {
       failures.push(
-        "web video input device changes must commit after publish replacement and clean up failed camera captures",
+        "web video input device changes must clear dead producers, commit after publish replacement, and clean up failed camera captures",
       );
     }
   }

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -797,15 +797,20 @@ assertRegex(
   } else {
     const section = text.slice(start, end);
     if (
+      !section.includes("let acquiredAudioTracks: MediaStreamTrack[] = [];") ||
+      !section.includes("let committedNewAudioTrack: MediaStreamTrack | null = null;") ||
+      !section.includes("acquiredAudioTracks = newStream.getAudioTracks();") ||
       !section.includes("const previousStream = localStreamRef.current;") ||
       !section.includes("const previousAudioTracks =") ||
       !section.includes("commitLocalStream(nextStream);") ||
+      !section.includes("committedNewAudioTrack = newAudioTrack;") ||
       !section.includes("stopTracksExcept(previousAudioTracks, [newAudioTrack]);") ||
+      !section.includes("stopTracksExcept(acquiredAudioTracks, [committedNewAudioTrack]);") ||
       section.includes("prev.removeTrack(oldAudioTrack)") ||
       section.includes("prev.addTrack(newAudioTrack)")
     ) {
       failures.push(
-        "web audio input device changes must sync local stream refs and stop all replaced mic tracks",
+        "web audio input device changes must sync local stream refs and clean up failed mic captures",
       );
     }
   }
@@ -818,13 +823,24 @@ assertRegex(
     failures.push("web video input device-change section missing");
   } else {
     const section = text.slice(start, end);
+    const replaceIndex = section.indexOf("await videoProducerRef.current.replaceTrack");
+    const commitIndex = section.indexOf("localStreamRef.current = nextStream;");
     if (
+      !section.includes("let acquiredVideoTracks: MediaStreamTrack[] = [];") ||
+      !section.includes("let committedNewVideoTrack: MediaStreamTrack | null = null;") ||
+      !section.includes("acquiredVideoTracks = newStream.getVideoTracks();") ||
       !section.includes("const previousVideoTracks =") ||
+      replaceIndex < 0 ||
+      commitIndex < 0 ||
+      commitIndex < replaceIndex ||
+      !section.includes("committedNewVideoTrack = newVideoTrack;") ||
       !section.includes("stopTracksExcept(previousVideoTracks, [") ||
+      !section.includes("stopTracksExcept(acquiredVideoTracks, [committedNewVideoTrack]);") ||
+      !section.includes("requestCameraProducerRecovery();") ||
       !section.includes("videoProducerRef.current?.track ?? null")
     ) {
       failures.push(
-        "web video input device changes must stop all replaced camera tracks",
+        "web video input device changes must commit after publish replacement and clean up failed camera captures",
       );
     }
   }

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1911,6 +1911,11 @@ assertIncludes(
   "const PROCESSED_OUTPUT_STALE_CHECK_MS = 1000;",
   "web stale processed effects output heartbeat interval",
 );
+assertIncludes(
+  "webVideoEffects",
+  "const HIDDEN_STALE_OUTPUT_REPUBLISH_RETRY_MS = 5000;",
+  "web hidden processed effects republish retry cadence",
+);
 assertRegex(
   "webVideoEffects",
   /const duplicateOutputHeartbeatDue =[\s\S]*DUPLICATE_OUTPUT_HEARTBEAT_MS[\s\S]*!duplicateOutputHeartbeatDue/,
@@ -1923,8 +1928,13 @@ assertRegex(
 );
 assertRegex(
   "webVideoEffects",
-  /const keepHiddenStaleProcessedOutputAlive = async[\s\S]*isHiddenStaleProcessedOutput\(sampleNow\)[\s\S]*restoreLastVisibleOutputFrame\(\s*"hidden-stale-output-keepalive"[\s\S]*await deliverOutputFrame\(sampleNow\)[\s\S]*"hidden_stale_output_keepalive"/,
+  /const keepHiddenStaleProcessedOutputAlive = async[\s\S]*isHiddenStaleProcessedOutput\(sampleNow\)[\s\S]*restoreLastVisibleOutputFrame\(\s*"hidden-stale-output-keepalive"[\s\S]*await deliverOutputFrame\(sampleNow\)[\s\S]*HIDDEN_STALE_OUTPUT_REPUBLISH_RETRY_MS[\s\S]*setProcessedTrackReady\(true\);[\s\S]*bumpProcessedTrackVersionForFreshOutput\([\s\S]*"hidden-stale-output-keepalive"[\s\S]*"hidden_stale_output_keepalive"/,
   "web hidden stale processed effects output sends keepalive frames instead of going inert",
+);
+assertRegex(
+  "webVideoEffects",
+  /const publishOutputTrack = \(\) => \{[\s\S]*setProcessedTrack\(track\);[\s\S]*bumpProcessedTrackVersionForFreshOutput\("publish-processed-track"\);/,
+  "web processed effects publish bumps version so raw fallback suppression can retry",
 );
 assertRegex(
   "webVideoEffects",

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -1089,10 +1089,22 @@ assertRegex(
       );
     }
     if (
-      !section.includes("!isMutedRef.current && liveAudioTrack !== null")
+      !section.includes("const shouldRecoverAudio = !isMutedRef.current;") ||
+      !section.includes("if (liveAudioTrack) {") ||
+      !section.includes("liveAudioTrack.enabled = true;")
     ) {
       failures.push(
-        "web local audio producer-close recovery must preserve unmuted mic intent",
+        "web local audio producer-close recovery must preserve unmuted mic intent even before a live mic track is visible",
+      );
+    }
+    if (
+      !section.includes("const shouldRecoverCamera =") ||
+      !section.includes("!isCameraOffRef.current;") ||
+      !section.includes("if (liveVideoTrack) {") ||
+      !section.includes("liveVideoTrack.enabled = true;")
+    ) {
+      failures.push(
+        "web local camera producer-close recovery must preserve camera intent even before a live camera track is visible",
       );
     }
     if (!section.includes("requestAudioProducerRecovery();")) {


### PR DESCRIPTION
## Summary
- Keep microphone capture tracks alive when audio producers are closed or recreated during reconnect, mute recovery, and audio recovery.
- Avoid surfacing a local reconnecting state while hidden-tab transport recovery is intentionally deferred, preserving joined UI/camera/effects state during background socket blips.
- Extend the low-bandwidth verifier to guard these media preservation paths.

## Impacted surfaces
- apps/web

## Validation
- node scripts/check-low-bandwidth-profiles.mjs
- pnpm -C apps/web exec tsc --noEmit
- pnpm -C apps/web run lint
- pnpm -C apps/web run build
- pnpm -C packages/sfu run typecheck
- git diff --check

Note: the web build still prints the existing Better Auth baseURL warning in this local environment.

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR hardens WebRTC media continuity across background socket reconnects and producer lifecycle events. The central fix passes `stopTracks: false` in all audio producer creation paths and replaces the old `resetAudioProducer` helper with `closeLocalAudioProducerForReplacement`, which marks the close as intentional so the SFU does not advertise it as a disconnect.

- **Queued recovery**: `mediaRecoveryBlockedRef` (aliased to `reconnectInFlightRef`) gates immediate recovery; a 250 ms polling interval flushes pending audio/camera recovery pulses once the reconnect completes.
- **Background reconnect state**: `handleReconnect` now skips `setConnectionState("reconnecting")` when the tab is hidden, preserving joined UI and effects state during background socket blips. A prior review comment notes that `joinRoomInternal` still unconditionally sets `"joining"` inside that path.
- **Consumer replacement**: `closeConsumerForSameProducerReconsume` cleanly displaces old consumers during re-consume without a full teardown cycle; the SFU mirrors this with a 3-second delayed close of displaced consumers.
- **Stall detection**: `framesPerSecond` is now tracked alongside frame counters to distinguish live but flat senders from dead ones, and `isConsumerLayerUpgrade` requests keyframes on temporal-layer upgrades (not only spatial).

<h3>Confidence Score: 4/5</h3>

- Safe to merge with the understanding that the background-tab reconnect path still briefly transitions through "joining" state via joinRoomInternal, which was flagged in a prior review and remains unresolved.
- The core media-preservation logic is well-structured: stopTracks:false is consistently applied, the queued-recovery flush mechanism handles blocked recovery correctly, and the SFU-side delayed consumer close gives clients enough time to switch streams. The two open questions are (1) the joinRoomInternal unconditionally setting "joining" during hidden-tab reconnect (previously noted, unaddressed) and (2) minor edge cases in confirmAudioProducerUnmuted and closeConsumerForSameProducerReconsume that don't cause data loss but could produce spurious producer teardowns under specific timing. No data-loss or security concerns were found.
- apps/web/src/app/hooks/useMeetMedia.ts (confirmAudioProducerUnmuted non-timeout error path) and apps/web/src/app/hooks/useMeetSocket.ts (joinRoomInternal state transition and closeConsumerForSameProducerReconsume consumerRecoveryInFlightRef cleanup)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/hooks/useMeetMedia.ts | Core media hook heavily refactored: adds stopTracks:false to all audio producer paths, introduces blocked-recovery queuing with 250ms polling, isMutedRef for async-safe mute state, confirmAudioProducerUnmuted with a two-phase ack, and framesPerSecond-based stall detection. Changes are complex but mostly correct; recovery flush interval and dual isMutedRef tracking (one per hook) should be verified under high reconnect frequency. |
| apps/web/src/app/hooks/useMeetSocket.ts | Background reconnect avoids surfacing "reconnecting" state, but joinRoomInternal still unconditionally sets "joining" (tracked in prior review). Producer replacement now uses closeConsumerForSameProducerReconsume instead of teardown-first, and visibleParticipantReconnectingIdsRef suppresses spurious reconnect banners. The getConnectionStatsNetworkProfile helper properly scopes publish vs receive quality signals. |
| packages/sfu/server/socket/handlers/mediaHandlers.ts | addConsumer now returns the displaced consumer instead of immediately closing it; a 3-second delayed close gives the client time to switch streams before the old consumer's track terminates. Looks correct. |
| packages/sfu/server/socket/handlers/joinRoom.ts | Chat history snapshot now only sent to admins on join, which was flagged in a prior review thread; the developer indicated this is intentional. New emitChatHistorySnapshot helper is correctly injected on admin promotion in disconnectHandlers. |
| packages/meeting-core/src/participant-reducer.ts | Adds an early-return guard preventing phantom participant creation when UPDATE_CONNECTION_STATUS is dispatched for an unknown user with null status. Safe change. |
| apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts | isConsumerLayerUpgrade now requests keyframes on temporal-layer upgrades (not only spatial), fixing a gap where the decoder wasn't recovering after temporal-only layer changes. |
| apps/web/src/app/meets-client.tsx | mediaRecoveryBlockedRef wired to reconnectInFlightRef to gate recovery during reconnect; shouldSuppressBandwidthHeavyVideoEffects removed (effects now always run when enabled, preloading remains deferred); connectionQualityRef plumbed into useMeetSocket for direction-specific network profiles. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Tab as Hidden Tab
    participant Socket as Socket.IO
    participant handleReconnect
    participant joinRoomInternal
    participant produce
    participant useMeetMedia

    Tab->>Socket: disconnect (background)
    Socket->>handleReconnect: trigger reconnect
    Note over handleReconnect: shouldDeferTransportRecoveryUntilVisible() = true<br/>skip setConnectionState("reconnecting")
    handleReconnect->>joinRoomInternal: await joinRoomInternal()
    Note over joinRoomInternal: setConnectionState("joining") — unconditional
    joinRoomInternal->>produce: produce(stream)
    produce-->>useMeetMedia: audio publish fails → track still live
    Note over produce: isMutedRef.current=false, setIsMuted(false)<br/>requestAudioProducerRecovery()
    Note over useMeetMedia: isMediaRecoveryBlocked()=true (reconnectInFlight)<br/>→ queueBlockedProducerRecovery("audio")
    joinRoomInternal-->>handleReconnect: joined
    handleReconnect->>handleReconnect: "reconnectInFlightRef = false"
    Note over useMeetMedia: 250ms poll detects unblocked<br/>→ flushQueuedProducerRecoveries()<br/>→ audio producer recreated
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Tab as Hidden Tab
    participant Socket as Socket.IO
    participant handleReconnect
    participant joinRoomInternal
    participant produce
    participant useMeetMedia

    Tab->>Socket: disconnect (background)
    Socket->>handleReconnect: trigger reconnect
    Note over handleReconnect: shouldDeferTransportRecoveryUntilVisible() = true<br/>skip setConnectionState("reconnecting")
    handleReconnect->>joinRoomInternal: await joinRoomInternal()
    Note over joinRoomInternal: setConnectionState("joining") — unconditional
    joinRoomInternal->>produce: produce(stream)
    produce-->>useMeetMedia: audio publish fails → track still live
    Note over produce: isMutedRef.current=false, setIsMuted(false)<br/>requestAudioProducerRecovery()
    Note over useMeetMedia: isMediaRecoveryBlocked()=true (reconnectInFlight)<br/>→ queueBlockedProducerRecovery("audio")
    joinRoomInternal-->>handleReconnect: joined
    handleReconnect->>handleReconnect: "reconnectInFlightRef = false"
    Note over useMeetMedia: 250ms poll detects unblocked<br/>→ flushQueuedProducerRecoveries()<br/>→ audio producer recreated
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/app/hooks/useMeetSocket.ts`, line 3070-3072 ([link](https://github.com/acm-vit/conclave/blob/c7ab1c91d43d3683ad4937eab46332974f89c07f/apps/web/src/app/hooks/useMeetSocket.ts#L3070-L3072)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Hidden reconnect changes state**

   The reconnect loop avoids setting `reconnecting` while recovery is deferred in a hidden tab, but it still calls `joinRoomInternal`, which unconditionally sets the connection state to `joining`. That makes `connectionState === "joined"` false during the hidden-tab recovery and can disable joined-only UI/media hooks, which breaks the intended preservation of joined UI/camera/effects state during background socket blips.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused hidden reconnect state harness](https://app.greptile.com/trex/artifacts/5050d3d0-c424-4f6e-b071-06d56314c100)**

   - Contains supporting evidence from the run (text/javascript; charset=utf-8).

   **[Stack trace captured during the T-Rex run](https://app.greptile.com/trex/artifacts/3fbb97b5-a1e8-47d1-9db9-de7dbde7bf53)**

   - Keeps the raw stack trace available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11739706/artifacts?artifact=5050d3d0-c424-4f6e-b071-06d56314c100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%0ALine%3A%203070-3072%0A%0AComment%3A%0A**Hidden%20reconnect%20changes%20state**%0A%0AThe%20reconnect%20loop%20avoids%20setting%20%60reconnecting%60%20while%20recovery%20is%20deferred%20in%20a%20hidden%20tab%2C%20but%20it%20still%20calls%20%60joinRoomInternal%60%2C%20which%20unconditionally%20sets%20the%20connection%20state%20to%20%60joining%60.%20That%20makes%20%60connectionState%20%3D%3D%3D%20%22joined%22%60%20false%20during%20the%20hidden-tab%20recovery%20and%20can%20disable%20joined-only%20UI%2Fmedia%20hooks%2C%20which%20breaks%20the%20intended%20preservation%20of%20joined%20UI%2Fcamera%2Feffects%20state%20during%20background%20socket%20blips.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%0ALine%3A%203070-3072%0A%0AComment%3A%0A**Hidden%20reconnect%20changes%20state**%0A%0AThe%20reconnect%20loop%20avoids%20setting%20%60reconnecting%60%20while%20recovery%20is%20deferred%20in%20a%20hidden%20tab%2C%20but%20it%20still%20calls%20%60joinRoomInternal%60%2C%20which%20unconditionally%20sets%20the%20connection%20state%20to%20%60joining%60.%20That%20makes%20%60connectionState%20%3D%3D%3D%20%22joined%22%60%20false%20during%20the%20hidden-tab%20recovery%20and%20can%20disable%20joined-only%20UI%2Fmedia%20hooks%2C%20which%20breaks%20the%20intended%20preservation%20of%20joined%20UI%2Fcamera%2Feffects%20state%20during%20background%20socket%20blips.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%0ALine%3A%203070-3072%0A%0AComment%3A%0A**Hidden%20reconnect%20changes%20state**%0A%0AThe%20reconnect%20loop%20avoids%20setting%20%60reconnecting%60%20while%20recovery%20is%20deferred%20in%20a%20hidden%20tab%2C%20but%20it%20still%20calls%20%60joinRoomInternal%60%2C%20which%20unconditionally%20sets%20the%20connection%20state%20to%20%60joining%60.%20That%20makes%20%60connectionState%20%3D%3D%3D%20%22joined%22%60%20false%20during%20the%20hidden-tab%20recovery%20and%20can%20disable%20joined-only%20UI%2Fmedia%20hooks%2C%20which%20breaks%20the%20intended%20preservation%20of%20joined%20UI%2Fcamera%2Feffects%20state%20during%20background%20socket%20blips.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A618-673%0A**%60confirmAudioProducerUnmuted%60%20closes%20producer%20on%20non-timeout%20socket%20error**%0A%0AWhen%20%60emitToggleMute%60%20returns%20%60%7B%20ok%3A%20false%2C%20error%3A%20%22Socket%20not%20connected%22%20%7D%60%20%28socket%20momentarily%20unavailable%29%2C%20the%20code%20skips%20the%20retry%20branch%20and%20falls%20through%20to%20%60closeLocalAudioProducerForReplacement%60%20%2B%20%60requestAudioProducerRecovery%60.%20If%20a%20reconnect%20is%20already%20in%20flight%2C%20the%20queued%20recovery%20will%20be%20flushed%20once%20the%20transport%20is%20back%20%E2%80%94%20but%20the%20fresh%20producer%20created%20by%20%60joinRoomInternal%60%20%E2%86%92%20%60produce%28%29%60%20would%20have%20already%20been%20set%20on%20%60audioProducerRef%60.%20The%20subsequent%20recovery%20effect%20would%20early-return%20correctly%20%28%60needsRecovery%20%3D%3D%3D%20false%60%29%2C%20so%20no%20duplicate%20producer%20is%20created.%20However%2C%20a%20socket-disconnect%20error%20that%20isn't%20a%20reconnect%20%28e.g.%2C%20brief%20send%20failure%20before%20the%20disconnect%20is%20surfaced%29%20would%20still%20tear%20down%20a%20healthy%20producer%20unnecessarily.%20Consider%20early-returning%20on%20%60%22Socket%20not%20connected%22%60%20in%20the%20same%20way%20%60isMutedRef.current%60%20checks%20guard%20against%20stale%20calls.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%3A269-310%0A**%60closeConsumerForSameProducerReconsume%60%20does%20not%20clear%20%60consumerRecoveryInFlightRef%60**%0A%0A%60handleProducerClosed%60%20deletes%20the%20producerId%20from%20%60consumerRecoveryInFlightRef.current%60%20before%20cleaning%20up%20the%20consumer.%20%60closeConsumerForSameProducerReconsume%60%20does%20not.%20In%20the%20path%20that%20goes%20through%20%60recoverStaleConsumer%60%20%E2%86%92%20%60consumeProducer%28%7B%20replaceExisting%3A%20true%20%7D%29%60%20this%20is%20fine%20because%20%60recoverStaleConsumer%60's%20%60finally%60%20block%20clears%20the%20entry.%20However%2C%20if%20the%20displaced%20consumer%20was%20previously%20tracked%20in%20%60consumerRecoveryInFlightRef%60%20via%20a%20code%20path%20that%20doesn't%20call%20%60recoverStaleConsumer%60%2C%20the%20stale%20entry%20would%20block%20a%20future%20call%20to%20%60recoverStaleConsumer%60%20for%20that%20producerId%20until%20a%20full%20cleanup%20cycle.%20Consider%20adding%20%60consumerRecoveryInFlightRef.current.delete%28producerId%29%60%20alongside%20the%20other%20cleanup%20calls.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FchatHistory.ts%3A1-9%0A**Commit%20message%20style**%0A%0AOne%20commit%20in%20this%20PR%20%28%6029bc741%20fix%20chat%20history%60%29%20doesn't%20match%20the%20conventional%20commits%20format%20%28%60type%28scope%29%3A%20description%60%29%20used%20by%20every%20other%20commit%20in%20the%20branch.%20Something%20like%20%60fix%28sfu%29%3A%20restrict%20chat%20history%20snapshot%20to%20reconnecting%20admins%60%20would%20be%20easier%20to%20scan%20in%20%60git%20log%20--oneline%60%20and%20keeps%20the%20history%20consistent.%0A%0A&repo=acm-vit%2Fconclave&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A618-673%0A**%60confirmAudioProducerUnmuted%60%20closes%20producer%20on%20non-timeout%20socket%20error**%0A%0AWhen%20%60emitToggleMute%60%20returns%20%60%7B%20ok%3A%20false%2C%20error%3A%20%22Socket%20not%20connected%22%20%7D%60%20%28socket%20momentarily%20unavailable%29%2C%20the%20code%20skips%20the%20retry%20branch%20and%20falls%20through%20to%20%60closeLocalAudioProducerForReplacement%60%20%2B%20%60requestAudioProducerRecovery%60.%20If%20a%20reconnect%20is%20already%20in%20flight%2C%20the%20queued%20recovery%20will%20be%20flushed%20once%20the%20transport%20is%20back%20%E2%80%94%20but%20the%20fresh%20producer%20created%20by%20%60joinRoomInternal%60%20%E2%86%92%20%60produce%28%29%60%20would%20have%20already%20been%20set%20on%20%60audioProducerRef%60.%20The%20subsequent%20recovery%20effect%20would%20early-return%20correctly%20%28%60needsRecovery%20%3D%3D%3D%20false%60%29%2C%20so%20no%20duplicate%20producer%20is%20created.%20However%2C%20a%20socket-disconnect%20error%20that%20isn't%20a%20reconnect%20%28e.g.%2C%20brief%20send%20failure%20before%20the%20disconnect%20is%20surfaced%29%20would%20still%20tear%20down%20a%20healthy%20producer%20unnecessarily.%20Consider%20early-returning%20on%20%60%22Socket%20not%20connected%22%60%20in%20the%20same%20way%20%60isMutedRef.current%60%20checks%20guard%20against%20stale%20calls.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%3A269-310%0A**%60closeConsumerForSameProducerReconsume%60%20does%20not%20clear%20%60consumerRecoveryInFlightRef%60**%0A%0A%60handleProducerClosed%60%20deletes%20the%20producerId%20from%20%60consumerRecoveryInFlightRef.current%60%20before%20cleaning%20up%20the%20consumer.%20%60closeConsumerForSameProducerReconsume%60%20does%20not.%20In%20the%20path%20that%20goes%20through%20%60recoverStaleConsumer%60%20%E2%86%92%20%60consumeProducer%28%7B%20replaceExisting%3A%20true%20%7D%29%60%20this%20is%20fine%20because%20%60recoverStaleConsumer%60's%20%60finally%60%20block%20clears%20the%20entry.%20However%2C%20if%20the%20displaced%20consumer%20was%20previously%20tracked%20in%20%60consumerRecoveryInFlightRef%60%20via%20a%20code%20path%20that%20doesn't%20call%20%60recoverStaleConsumer%60%2C%20the%20stale%20entry%20would%20block%20a%20future%20call%20to%20%60recoverStaleConsumer%60%20for%20that%20producerId%20until%20a%20full%20cleanup%20cycle.%20Consider%20adding%20%60consumerRecoveryInFlightRef.current.delete%28producerId%29%60%20alongside%20the%20other%20cleanup%20calls.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FchatHistory.ts%3A1-9%0A**Commit%20message%20style**%0A%0AOne%20commit%20in%20this%20PR%20%28%6029bc741%20fix%20chat%20history%60%29%20doesn't%20match%20the%20conventional%20commits%20format%20%28%60type%28scope%29%3A%20description%60%29%20used%20by%20every%20other%20commit%20in%20the%20branch.%20Something%20like%20%60fix%28sfu%29%3A%20restrict%20chat%20history%20snapshot%20to%20reconnecting%20admins%60%20would%20be%20easier%20to%20scan%20in%20%60git%20log%20--oneline%60%20and%20keeps%20the%20history%20consistent.%0A%0A&repo=acm-vit%2Fconclave&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A618-673%0A**%60confirmAudioProducerUnmuted%60%20closes%20producer%20on%20non-timeout%20socket%20error**%0A%0AWhen%20%60emitToggleMute%60%20returns%20%60%7B%20ok%3A%20false%2C%20error%3A%20%22Socket%20not%20connected%22%20%7D%60%20%28socket%20momentarily%20unavailable%29%2C%20the%20code%20skips%20the%20retry%20branch%20and%20falls%20through%20to%20%60closeLocalAudioProducerForReplacement%60%20%2B%20%60requestAudioProducerRecovery%60.%20If%20a%20reconnect%20is%20already%20in%20flight%2C%20the%20queued%20recovery%20will%20be%20flushed%20once%20the%20transport%20is%20back%20%E2%80%94%20but%20the%20fresh%20producer%20created%20by%20%60joinRoomInternal%60%20%E2%86%92%20%60produce%28%29%60%20would%20have%20already%20been%20set%20on%20%60audioProducerRef%60.%20The%20subsequent%20recovery%20effect%20would%20early-return%20correctly%20%28%60needsRecovery%20%3D%3D%3D%20false%60%29%2C%20so%20no%20duplicate%20producer%20is%20created.%20However%2C%20a%20socket-disconnect%20error%20that%20isn't%20a%20reconnect%20%28e.g.%2C%20brief%20send%20failure%20before%20the%20disconnect%20is%20surfaced%29%20would%20still%20tear%20down%20a%20healthy%20producer%20unnecessarily.%20Consider%20early-returning%20on%20%60%22Socket%20not%20connected%22%60%20in%20the%20same%20way%20%60isMutedRef.current%60%20checks%20guard%20against%20stale%20calls.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%3A269-310%0A**%60closeConsumerForSameProducerReconsume%60%20does%20not%20clear%20%60consumerRecoveryInFlightRef%60**%0A%0A%60handleProducerClosed%60%20deletes%20the%20producerId%20from%20%60consumerRecoveryInFlightRef.current%60%20before%20cleaning%20up%20the%20consumer.%20%60closeConsumerForSameProducerReconsume%60%20does%20not.%20In%20the%20path%20that%20goes%20through%20%60recoverStaleConsumer%60%20%E2%86%92%20%60consumeProducer%28%7B%20replaceExisting%3A%20true%20%7D%29%60%20this%20is%20fine%20because%20%60recoverStaleConsumer%60's%20%60finally%60%20block%20clears%20the%20entry.%20However%2C%20if%20the%20displaced%20consumer%20was%20previously%20tracked%20in%20%60consumerRecoveryInFlightRef%60%20via%20a%20code%20path%20that%20doesn't%20call%20%60recoverStaleConsumer%60%2C%20the%20stale%20entry%20would%20block%20a%20future%20call%20to%20%60recoverStaleConsumer%60%20for%20that%20producerId%20until%20a%20full%20cleanup%20cycle.%20Consider%20adding%20%60consumerRecoveryInFlightRef.current.delete%28producerId%29%60%20alongside%20the%20other%20cleanup%20calls.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FchatHistory.ts%3A1-9%0A**Commit%20message%20style**%0A%0AOne%20commit%20in%20this%20PR%20%28%6029bc741%20fix%20chat%20history%60%29%20doesn't%20match%20the%20conventional%20commits%20format%20%28%60type%28scope%29%3A%20description%60%29%20used%20by%20every%20other%20commit%20in%20the%20branch.%20Something%20like%20%60fix%28sfu%29%3A%20restrict%20chat%20history%20snapshot%20to%20reconnecting%20admins%60%20would%20be%20easier%20to%20scan%20in%20%60git%20log%20--oneline%60%20and%20keeps%20the%20history%20consistent.%0A%0A&pr=91&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix: keep hidden camera effects publishi..."](https://github.com/acm-vit/conclave/commit/d9b5ef3de0debf05cbf45bfb5755e8b077dcb6e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38832394)</sub>

**Context used:**

- Context used - Encourage people to write better commit messages ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->