### PR TITLE
Staging

### DIFF
--- a/apps/web/src/app/components/GridLayout.tsx
+++ b/apps/web/src/app/components/GridLayout.tsx
@@ -45,6 +45,7 @@ import {
   computeGridLayout,
   computeStageRailLayout,
   type GridTilePosition,
+  type GridLayoutResult,
 } from "@conclave/meeting-core";
 import {
   clampMeetViewTiles,
@@ -120,6 +121,112 @@ const STAGE_RAIL_TILE_HEIGHT = 112;
 const SIDE_BY_SIDE_RAIL_HEIGHT_RATIO = 0.35;
 const AUTO_GRID_MIN_TILE_WIDTH = 176;
 const AUTO_GRID_MIN_TILE_HEIGHT = 99;
+// On a portrait phone the desktop "fit everyone into the viewport" packer is the
+// wrong model: with many people it either squashes tiles into short 16:9
+// "capsules" (wasted height) or shrinks square tiles to nothing (wasted width).
+// Phones instead get a fixed-size, vertically-SCROLLING 2-up gallery — the
+// standard mobile video-call layout (Meet/Zoom). Tiles fill the column width,
+// stay a usable size, and you scroll when there are more than fit. See
+// computeMobilePortraitGridLayout below. A landscape phone keeps the 16:9
+// packer but with a lower column cap.
+const MOBILE_PORTRAIT_COLS = 2;
+// Tiles are square by default; for small calls that fit on screen they grow
+// taller (up to this width-multiple) to fill the viewport instead of leaving a
+// gap below.
+const MOBILE_PORTRAIT_MAX_TILE_ASPECT = 1.5; // height up to 1.5× width
+const MOBILE_LANDSCAPE_MAX_COLS = 4;
+
+/**
+ * Device-/orientation-aware packing parameters for the desktop/landscape Meet
+ * grid (the 16:9 optimal packer). Portrait phones bypass this entirely and use
+ * computeMobilePortraitGridLayout instead.
+ */
+const getGridPackingParams = (isMobile: boolean) => ({
+  maxCols: isMobile ? MOBILE_LANDSCAPE_MAX_COLS : GRID_MAX_COLS,
+  targetAspect: 16 / 9,
+  minTileWidth: AUTO_GRID_MIN_TILE_WIDTH,
+  minTileHeight: AUTO_GRID_MIN_TILE_HEIGHT,
+});
+
+const isMobilePortrait = (isMobile: boolean, width: number, height: number) =>
+  isMobile && height >= width;
+
+/**
+ * Fixed-size, vertically-scrolling 2-column gallery for portrait phones.
+ *
+ * Unlike the desktop packer (computeGridLayout), this does NOT shrink tiles to
+ * cram everyone into the viewport. Each tile fills half the width; height is
+ * square by default. When the whole grid fits with room to spare (small calls)
+ * tiles grow taller to fill the screen; when it doesn't (many people) tiles keep
+ * their size and the grid overflows so the container scrolls. Returns the same
+ * GridLayoutResult shape the renderer/FLIP already consume.
+ */
+const computeMobilePortraitGridLayout = (
+  count: number,
+  width: number,
+  height: number,
+  gap: number,
+  maxTilesPerPage: number,
+): GridLayoutResult => {
+  const total = Math.max(1, Math.floor(count));
+  const perPage = Math.min(total, Math.max(1, Math.floor(maxTilesPerPage)));
+  const pages = Math.ceil(total / perPage);
+  const cols = Math.min(perPage, MOBILE_PORTRAIT_COLS);
+  const rows = Math.ceil(perPage / cols);
+  const tileWidth = Math.max(0, Math.floor((width - (cols - 1) * gap) / cols));
+
+  // Square by default; grow to fill the viewport height only if the whole grid
+  // already fits, capped so tiles never become absurdly tall.
+  let tileHeight = tileWidth;
+  const squareContentHeight = rows * tileHeight + (rows - 1) * gap;
+  if (squareContentHeight < height) {
+    const fitHeight = Math.floor((height - (rows - 1) * gap) / rows);
+    const maxHeight = Math.floor(tileWidth * MOBILE_PORTRAIT_MAX_TILE_ASPECT);
+    tileHeight = Math.max(tileWidth, Math.min(fitHeight, maxHeight));
+  }
+  tileHeight = Math.max(0, tileHeight);
+
+  const contentWidth = cols * tileWidth + Math.max(0, cols - 1) * gap;
+  const contentHeight = rows * tileHeight + Math.max(0, rows - 1) * gap;
+  const offsetX = Math.max(0, (width - contentWidth) / 2);
+  // Center vertically when it fits; pin to the top when it overflows (scroll).
+  const offsetY = contentHeight <= height ? Math.max(0, (height - contentHeight) / 2) : 0;
+
+  const positions: GridTilePosition[] = [];
+  for (let index = 0; index < perPage; index += 1) {
+    const row = Math.floor(index / cols);
+    const rowStartIndex = row * cols;
+    const rowCount = Math.min(cols, perPage - rowStartIndex);
+    const rowWidth = rowCount * tileWidth + Math.max(0, rowCount - 1) * gap;
+    const rowOffsetX = offsetX + Math.max(0, (contentWidth - rowWidth) / 2);
+    const col = index - rowStartIndex;
+    positions.push({
+      index,
+      row,
+      col: col + Math.max(0, cols - rowCount) / 2,
+      x: rowOffsetX + col * (tileWidth + gap),
+      y: offsetY + row * (tileHeight + gap),
+      width: tileWidth,
+      height: tileHeight,
+    });
+  }
+
+  const lastRowCount = perPage - (rows - 1) * cols;
+  return {
+    cols,
+    rows,
+    tileWidth,
+    tileHeight,
+    lastRowCount: Math.max(1, lastRowCount),
+    pages,
+    perPage,
+    contentWidth,
+    contentHeight,
+    offsetX,
+    offsetY,
+    positions,
+  };
+};
 const ROOM_TILING_METADATA_INTERVAL_MS = 200;
 const ROOM_TILING_PROMOTE_DELAY_MS = 220;
 const ROOM_TILING_MIN_SWITCH_INTERVAL_MS = 2200;
@@ -610,6 +717,7 @@ const computeMeetAutoTileLimit = (
   requestedMaxTiles: number,
   gridWidth: number,
   gridHeight: number,
+  isMobile = false,
 ) => {
   const usableWidth = Math.max(0, gridWidth - GRID_PADDING * 2);
   const usableHeight = Math.max(0, gridHeight - GRID_PADDING * 2);
@@ -618,6 +726,16 @@ const computeMeetAutoTileLimit = (
     return requestedMaxTiles;
   }
 
+  // Portrait phones use a fixed-size scrolling gallery — tiles never shrink to
+  // fit, so the cram-to-fit reduction doesn't apply. Show up to the requested
+  // cap and let the rest spill into the overflow tile / scroll.
+  if (isMobilePortrait(isMobile, usableWidth, usableHeight)) {
+    return requestedMaxTiles;
+  }
+
+  const { maxCols, targetAspect, minTileWidth, minTileHeight } =
+    getGridPackingParams(isMobile);
+
   for (
     let tileCount = requestedMaxTiles;
     tileCount >= MEET_VIEW_MIN_TILES;
@@ -625,13 +743,13 @@ const computeMeetAutoTileLimit = (
   ) {
     const candidate = computeGridLayout(tileCount, usableWidth, usableHeight, {
       gap: GRID_GAP,
-      maxCols: GRID_MAX_COLS,
+      maxCols,
       maxTilesPerPage: tileCount,
-      targetAspect: 16 / 9,
+      targetAspect,
     });
     if (
-      candidate.tileWidth >= AUTO_GRID_MIN_TILE_WIDTH &&
-      candidate.tileHeight >= AUTO_GRID_MIN_TILE_HEIGHT
+      candidate.tileWidth >= minTileWidth &&
+      candidate.tileHeight >= minTileHeight
     ) {
       return tileCount;
     }
@@ -1122,11 +1240,13 @@ function GridLayout({
             requestedMaxTiles,
             gridSize.width,
             gridSize.height,
+            isMobile,
           )
         : requestedMaxTiles,
     [
       gridSize.height,
       gridSize.width,
+      isMobile,
       renderedViewMode,
       requestedMaxTiles,
       viewSettings.mode,
@@ -1808,21 +1928,26 @@ function GridLayout({
   // Optimal-packing grid (shared @conclave/meeting-core engine — same logic web,
   // RN, and the Swift port use). Tiles are sized and placed exactly by the core
   // packer so every renderer gets the same centered rows and group offsets.
-  const layout = useMemo(
-    () =>
-      computeGridLayout(
+  const layout = useMemo(() => {
+    const usableWidth = Math.max(0, gridSize.width - GRID_PADDING * 2);
+    const usableHeight = Math.max(0, gridSize.height - GRID_PADDING * 2);
+    if (isMobilePortrait(isMobile, usableWidth, usableHeight)) {
+      return computeMobilePortraitGridLayout(
         totalParticipants,
-        Math.max(0, gridSize.width - GRID_PADDING * 2),
-        Math.max(0, gridSize.height - GRID_PADDING * 2),
-        {
-          gap: GRID_GAP,
-          maxCols: GRID_MAX_COLS,
-          maxTilesPerPage: maxGridTiles,
-          targetAspect: 16 / 9,
-        }
-      ),
-    [totalParticipants, gridSize.width, gridSize.height, maxGridTiles]
-  );
+        usableWidth,
+        usableHeight,
+        GRID_GAP,
+        maxGridTiles,
+      );
+    }
+    const { maxCols, targetAspect } = getGridPackingParams(isMobile);
+    return computeGridLayout(totalParticipants, usableWidth, usableHeight, {
+      gap: GRID_GAP,
+      maxCols,
+      maxTilesPerPage: maxGridTiles,
+      targetAspect,
+    });
+  }, [totalParticipants, gridSize.width, gridSize.height, maxGridTiles, isMobile]);
   const tiledGridTileIds = useMemo(() => {
     if (usesStageLayout) return [];
     const ids: string[] = [];
@@ -1876,6 +2001,16 @@ function GridLayout({
   const tileClass = layout.tileWidth > 0
     ? "absolute will-change-transform"
     : "relative h-full w-full will-change-transform";
+  // Portrait-phone tiled view is a fixed-size, vertically-scrolling gallery
+  // (see computeMobilePortraitGridLayout) — let the grid container scroll when
+  // the tiles overflow instead of clipping them.
+  const usesMobileScrollGrid =
+    !usesStageLayout &&
+    isMobilePortrait(
+      isMobile,
+      Math.max(0, gridSize.width - GRID_PADDING * 2),
+      Math.max(0, gridSize.height - GRID_PADDING * 2),
+    );
   // Include the measured stage size so a panel toggle that shifts tile POSITION
   // (the centered group re-centers) WITHOUT changing tile SIZE still re-runs the
   // FLIP effect on the settle commit — otherwise the pending reflow would be
@@ -2459,7 +2594,11 @@ function GridLayout({
         data-meet-room-tiling-warm-hold={RECENTLY_VISIBLE_WARM_HOLD_MS}
         data-meet-room-tiling-warm-reasons={roomTilingWarmReasonsJson}
         data-meet-room-tiling-scores={roomTilingScoresJson}
-        className={`relative flex flex-1 min-h-0 overflow-hidden p-4 ${
+        className={`relative flex flex-1 min-h-0 p-4 ${
+          usesMobileScrollGrid
+            ? "overflow-y-auto overflow-x-hidden"
+            : "overflow-hidden"
+        } ${
           usesStageLayout ? "flex-wrap content-center justify-center" : ""
         } ${
           hasMeasuredGrid ? "opacity-100" : "opacity-0"

--- a/apps/web/src/app/components/JoinScreen.tsx
+++ b/apps/web/src/app/components/JoinScreen.tsx
@@ -772,9 +772,9 @@ function JoinScreen({
 
   return (
     <div className="relative min-h-screen w-full bg-[#0a0a0b] text-[#fafafa]">
-      <main className="flex min-h-screen w-full items-center justify-center px-4 py-10">
-        <div className="animate-fade-in w-full max-w-4xl overflow-hidden rounded-2xl border border-white/10 bg-[#0e0e10] md:grid md:grid-cols-2">
-          <div className="relative aspect-video bg-[#121214] md:aspect-auto md:min-h-[440px]">
+      <main className="flex min-h-dvh w-full flex-col items-center justify-start px-0 pb-8 pt-32 sm:justify-center sm:px-4 sm:py-10">
+        <div className="animate-fade-in w-full overflow-hidden bg-[#0e0e10] sm:max-w-4xl sm:rounded-2xl sm:border sm:border-white/10 md:grid md:grid-cols-2">
+          <div className="relative aspect-[4/3] bg-[#121214] sm:aspect-video md:aspect-auto md:min-h-[440px]">
                 <video
                   ref={videoRef}
                   autoPlay
@@ -867,7 +867,7 @@ function JoinScreen({
                 </div>
               </div>
 
-          <div className="flex flex-col justify-center gap-4 p-6 sm:p-8">
+          <div className="safe-area-pb flex flex-col justify-center gap-4 p-5 sm:p-8">
             <div className="space-y-1.5">
               <h1
                 className="text-[22px] leading-tight text-[#fafafa]"


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR ships two mobile UI improvements: a new portrait-phone grid layout for the in-meeting view and a responsive layout polish pass for the pre-join screen.

- **GridLayout**: Introduces `computeMobilePortraitGridLayout`, a fixed-size 2-column vertically-scrolling gallery for portrait phones (matching the Meet/Zoom pattern). The grid container switches from `overflow-hidden` to `overflow-y-auto` via the new `usesMobileScrollGrid` flag, and the tile-limit reduction logic is bypassed in portrait mode since tiles no longer shrink to fit.
- **JoinScreen**: Removes border/rounding below the `sm:` breakpoint, switches to `min-h-dvh`, adjusts top padding, and changes the preview aspect ratio to `4/3` on mobile for a more natural look.

<h3>Confidence Score: 4/5</h3>

The changes are well-scoped and additive — the new mobile portrait path is cleanly gated behind isMobilePortrait so desktop and landscape-phone behaviour is unchanged.

The new computeMobilePortraitGridLayout function handles the common cases correctly, math for last-row centering checks out, and the overflow-y-auto switch is consistent with how absolute positioning creates scroll overflow. The only noteworthy gap is the count=0 clamp that returns a phantom 1-tile layout instead of an empty one, which is inconsistent with the desktop path. JoinScreen changes are pure styling with no logic risk.

GridLayout.tsx — specifically the computeMobilePortraitGridLayout zero-participant edge case.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/components/GridLayout.tsx | Adds a new computeMobilePortraitGridLayout helper and wires it into the existing layout useMemo and tile-limit logic; introduces usesMobileScrollGrid to switch the grid container from overflow-hidden to overflow-y-auto on portrait phones. Minor edge case: count=0 is clamped to 1 inside the new function, which is inconsistent with the desktop path. |
| apps/web/src/app/components/JoinScreen.tsx | Responsive layout polish for mobile: switches to min-h-dvh, adds flex-col/justify-start on small screens, drops border/rounding until sm: breakpoint, changes the preview aspect ratio to 4/3 on mobile, and adds safe-area-pb (an existing utility class) to the form panel. No logic changes. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GridLayout renders] --> B{isMobile && height >= width?}
    B -->|Yes — portrait phone| C[computeMobilePortraitGridLayout]
    B -->|No — desktop / landscape| D[computeGridLayout]
    C --> E[2-col fixed-size tiles\nscrolling gallery]
    D --> F[Optimal-packing 16:9 tiles\nfit-to-viewport]
    E --> G{usesMobileScrollGrid?}
    F --> H[overflow-hidden container]
    G -->|true| I[overflow-y-auto container\ntiles scroll vertically]
    G -->|false| H
    I --> J[Render absolute-positioned tiles]
    H --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[GridLayout renders] --> B{isMobile && height >= width?}
    B -->|Yes — portrait phone| C[computeMobilePortraitGridLayout]
    B -->|No — desktop / landscape| D[computeGridLayout]
    C --> E[2-col fixed-size tiles\nscrolling gallery]
    D --> F[Optimal-packing 16:9 tiles\nfit-to-viewport]
    E --> G{usesMobileScrollGrid?}
    F --> H[overflow-hidden container]
    G -->|true| I[overflow-y-auto container\ntiles scroll vertically]
    G -->|false| H
    I --> J[Render absolute-positioned tiles]
    H --> J
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FGridLayout.tsx%3A124-232%0A**Commit%20and%20PR%20naming%20don't%20describe%20the%20change**%0A%0AThe%20PR%20is%20titled%20%22Staging%22%20and%20both%20commits%20are%20prefixed%20%60fix%3A%60%20%E2%80%94%20e.g.%20%22fix%3A%20implement%20mobile%20portrait%20grid%20layout%20for%20improved%20video%20call%20experience%22.%20Adding%20an%20entirely%20new%20layout%20path%20for%20portrait%20phones%20is%20a%20feature%2C%20not%20a%20fix.%20A%20more%20accurate%20prefix%20would%20be%20%60feat%3A%60%20%28or%20%60chore%3A%60%2F%60refactor%3A%60%20for%20the%20JoinScreen%20layout%20tweak%29.%20Future%20readers%20and%20automated%20changelogs%20will%20misclassify%20these%20changes.%20Consider%20adopting%20conventional%20commits%20more%20precisely%3A%20%60feat%28grid%29%3A%20mobile%20portrait%202-column%20scrolling%20gallery%60%20and%20%60feat%28join%29%3A%20responsive%20mobile%20layout%20adjustments%60%20would%20make%20the%20history%20much%20clearer.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FGridLayout.tsx%3A163%0A**%60count%20%3D%200%60%20silently%20produces%20a%201-tile%20layout**%0A%0A%60Math.max%281%2C%20Math.floor%28count%29%29%60%20clamps%20zero%20participants%20to%20%601%60%2C%20which%20means%20%60computeMobilePortraitGridLayout%60%20returns%20a%20layout%20with%20one%20computed%20position%20even%20when%20there%20are%20no%20participants.%20The%20desktop%20path%20%28%60computeGridLayout%60%29%20handles%20zero%20cleanly.%20In%20practice%20the%20caller%20passes%20%60totalParticipants%60%20%28which%20counts%20rendered%20tile%20IDs%29%20so%20this%20is%20usually%20benign%2C%20but%20if%20the%20meeting%20state%20ever%20reaches%200%20participants%20while%20in%20portrait%20mode%20the%20function%20will%20return%20a%20phantom%20tile%20position.%20Using%20%60Math.max%280%2C%20...%29%60%20and%20adding%20an%20early-return%20guard%20for%20%60total%20%3D%3D%3D%200%60%20would%20make%20the%20edge%20case%20explicit%20and%20consistent%20with%20the%20desktop%20path.%0A%0A&repo=acm-vit%2Fconclave&pr=93&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FGridLayout.tsx%3A124-232%0A**Commit%20and%20PR%20naming%20don't%20describe%20the%20change**%0A%0AThe%20PR%20is%20titled%20%22Staging%22%20and%20both%20commits%20are%20prefixed%20%60fix%3A%60%20%E2%80%94%20e.g.%20%22fix%3A%20implement%20mobile%20portrait%20grid%20layout%20for%20improved%20video%20call%20experience%22.%20Adding%20an%20entirely%20new%20layout%20path%20for%20portrait%20phones%20is%20a%20feature%2C%20not%20a%20fix.%20A%20more%20accurate%20prefix%20would%20be%20%60feat%3A%60%20%28or%20%60chore%3A%60%2F%60refactor%3A%60%20for%20the%20JoinScreen%20layout%20tweak%29.%20Future%20readers%20and%20automated%20changelogs%20will%20misclassify%20these%20changes.%20Consider%20adopting%20conventional%20commits%20more%20precisely%3A%20%60feat%28grid%29%3A%20mobile%20portrait%202-column%20scrolling%20gallery%60%20and%20%60feat%28join%29%3A%20responsive%20mobile%20layout%20adjustments%60%20would%20make%20the%20history%20much%20clearer.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FGridLayout.tsx%3A163%0A**%60count%20%3D%200%60%20silently%20produces%20a%201-tile%20layout**%0A%0A%60Math.max%281%2C%20Math.floor%28count%29%29%60%20clamps%20zero%20participants%20to%20%601%60%2C%20which%20means%20%60computeMobilePortraitGridLayout%60%20returns%20a%20layout%20with%20one%20computed%20position%20even%20when%20there%20are%20no%20participants.%20The%20desktop%20path%20%28%60computeGridLayout%60%29%20handles%20zero%20cleanly.%20In%20practice%20the%20caller%20passes%20%60totalParticipants%60%20%28which%20counts%20rendered%20tile%20IDs%29%20so%20this%20is%20usually%20benign%2C%20but%20if%20the%20meeting%20state%20ever%20reaches%200%20participants%20while%20in%20portrait%20mode%20the%20function%20will%20return%20a%20phantom%20tile%20position.%20Using%20%60Math.max%280%2C%20...%29%60%20and%20adding%20an%20early-return%20guard%20for%20%60total%20%3D%3D%3D%200%60%20would%20make%20the%20edge%20case%20explicit%20and%20consistent%20with%20the%20desktop%20path.%0A%0A&repo=acm-vit%2Fconclave&pr=93&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FGridLayout.tsx%3A124-232%0A**Commit%20and%20PR%20naming%20don't%20describe%20the%20change**%0A%0AThe%20PR%20is%20titled%20%22Staging%22%20and%20both%20commits%20are%20prefixed%20%60fix%3A%60%20%E2%80%94%20e.g.%20%22fix%3A%20implement%20mobile%20portrait%20grid%20layout%20for%20improved%20video%20call%20experience%22.%20Adding%20an%20entirely%20new%20layout%20path%20for%20portrait%20phones%20is%20a%20feature%2C%20not%20a%20fix.%20A%20more%20accurate%20prefix%20would%20be%20%60feat%3A%60%20%28or%20%60chore%3A%60%2F%60refactor%3A%60%20for%20the%20JoinScreen%20layout%20tweak%29.%20Future%20readers%20and%20automated%20changelogs%20will%20misclassify%20these%20changes.%20Consider%20adopting%20conventional%20commits%20more%20precisely%3A%20%60feat%28grid%29%3A%20mobile%20portrait%202-column%20scrolling%20gallery%60%20and%20%60feat%28join%29%3A%20responsive%20mobile%20layout%20adjustments%60%20would%20make%20the%20history%20much%20clearer.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FGridLayout.tsx%3A163%0A**%60count%20%3D%200%60%20silently%20produces%20a%201-tile%20layout**%0A%0A%60Math.max%281%2C%20Math.floor%28count%29%29%60%20clamps%20zero%20participants%20to%20%601%60%2C%20which%20means%20%60computeMobilePortraitGridLayout%60%20returns%20a%20layout%20with%20one%20computed%20position%20even%20when%20there%20are%20no%20participants.%20The%20desktop%20path%20%28%60computeGridLayout%60%29%20handles%20zero%20cleanly.%20In%20practice%20the%20caller%20passes%20%60totalParticipants%60%20%28which%20counts%20rendered%20tile%20IDs%29%20so%20this%20is%20usually%20benign%2C%20but%20if%20the%20meeting%20state%20ever%20reaches%200%20participants%20while%20in%20portrait%20mode%20the%20function%20will%20return%20a%20phantom%20tile%20position.%20Using%20%60Math.max%280%2C%20...%29%60%20and%20adding%20an%20early-return%20guard%20for%20%60total%20%3D%3D%3D%200%60%20would%20make%20the%20edge%20case%20explicit%20and%20consistent%20with%20the%20desktop%20path.%0A%0A&pr=93&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: implement mobile portrait grid layo..."](https://github.com/acm-vit/conclave/commit/4f53259c15f8500f4d648d42e14fb64118dcb852) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38880154)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - Encourage people to write better commit messages ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->