### PR TITLE
feat: manage departed participants in meeting socket

### DIFF
--- a/apps/web/src/app/api/klipy/gifs/route.ts
+++ b/apps/web/src/app/api/klipy/gifs/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
-import type {
-  KlipyGifResult,
-  KlipyGifSearchResponse,
+import {
+  KLIPY_ATTACHMENT_KIND,
+  type KlipyMediaKind,
+  type KlipyMediaResult,
+  type KlipyMediaSearchResponse,
 } from "../../../lib/klipy-gifs";
 
 export const runtime = "nodejs";
@@ -13,10 +15,35 @@ const DEFAULT_PER_PAGE = 16;
 const MAX_PER_PAGE = 32;
 const MAX_QUERY_LENGTH = 80;
 const RATING = "pg";
-const GIF_SIZE_PREFERENCE = ["md", "sm", "hd", "xs"] as const;
+
+const MEDIA_KINDS: readonly KlipyMediaKind[] = ["gifs", "stickers", "clips"];
+
+// Size/format preferences for the catalogs that return nested renditions
+// (gifs + stickers). Clips return a flat file object handled separately.
+const NESTED_SIZE_PREFERENCE = ["md", "sm", "hd", "xs"] as const;
 const PREVIEW_SIZE_PREFERENCE = ["sm", "xs", "md", "hd"] as const;
-const GIF_FORMAT_PREFERENCE = ["gif"] as const;
-const PREVIEW_FORMAT_PREFERENCE = ["webp", "gif", "jpg"] as const;
+
+interface NestedMediaConfig {
+  // Animated formats for the sent media. GIF is preferred so transparency and
+  // animation survive on every client (including native ones that can't render
+  // animated WebP).
+  urlFormats: readonly string[];
+  previewFormats: readonly string[];
+  pagePath: string;
+}
+
+const NESTED_MEDIA_CONFIG: Record<"gifs" | "stickers", NestedMediaConfig> = {
+  gifs: {
+    urlFormats: ["gif"],
+    previewFormats: ["webp", "gif", "jpg"],
+    pagePath: "gifs",
+  },
+  stickers: {
+    urlFormats: ["gif", "webp"],
+    previewFormats: ["webp", "gif"],
+    pagePath: "stickers",
+  },
+};
 
 interface KlipyRendition {
   url: string;
@@ -46,6 +73,11 @@ const asDimension = (value: unknown): number | undefined => {
   const rounded = Math.round(value);
   return rounded > 0 && rounded <= 4096 ? rounded : undefined;
 };
+
+const parseMediaKind = (value: string | null): KlipyMediaKind =>
+  MEDIA_KINDS.includes(value as KlipyMediaKind)
+    ? (value as KlipyMediaKind)
+    : "gifs";
 
 const normalizeKlipyMediaUrl = (value: unknown): string | null => {
   const raw = asString(value);
@@ -92,39 +124,99 @@ const findRendition = (
   return null;
 };
 
-const normalizeKlipyGif = (value: unknown): KlipyGifResult | null => {
+const buildPageUrl = (path: string, slug: string | null): string | undefined =>
+  slug ? `https://klipy.com/${path}/${encodeURIComponent(slug)}` : undefined;
+
+// gifs + stickers: `file` is `{ [size]: { [format]: { url, width, height } } }`.
+const normalizeNestedItem = (
+  value: unknown,
+  media: "gifs" | "stickers",
+): KlipyMediaResult | null => {
   const item = asRecord(value);
   if (!item) return null;
 
-  const gif = findRendition(
+  const config = NESTED_MEDIA_CONFIG[media];
+  const main = findRendition(
     item.file,
-    GIF_SIZE_PREFERENCE,
-    GIF_FORMAT_PREFERENCE,
+    NESTED_SIZE_PREFERENCE,
+    config.urlFormats,
   );
+  if (!main) return null;
   const preview = findRendition(
     item.file,
     PREVIEW_SIZE_PREFERENCE,
-    PREVIEW_FORMAT_PREFERENCE,
+    config.previewFormats,
   );
-  if (!gif) return null;
 
-  const rawId = asString(item.slug) ?? asString(item.id) ?? gif.url;
-  const title = (asString(item.title) ?? "GIF").slice(0, 140);
   const slug = asString(item.slug);
+  const rawId = slug ?? asString(item.id) ?? main.url;
+  const title = (asString(item.title) ?? "GIF").slice(0, 140);
+  const width = main.width ?? preview?.width;
+  const height = main.height ?? preview?.height;
+  const pageUrl = buildPageUrl(config.pagePath, slug);
 
   return {
     id: rawId.slice(0, 120),
     title,
-    url: gif.url,
-    previewUrl: preview?.url ?? gif.url,
-    ...(slug ? { pageUrl: `https://klipy.com/gifs/${encodeURIComponent(slug)}` } : {}),
-    ...(gif.width ?? preview?.width ? { width: gif.width ?? preview?.width } : {}),
-    ...(gif.height ?? preview?.height
-      ? { height: gif.height ?? preview?.height }
-      : {}),
+    url: main.url,
+    previewUrl: preview?.url ?? main.url,
+    ...(pageUrl ? { pageUrl } : {}),
+    ...(width ? { width } : {}),
+    ...(height ? { height } : {}),
+    kind: KLIPY_ATTACHMENT_KIND[media],
     source: "klipy",
   };
 };
+
+// clips: `file` is a flat `{ mp4, gif, webp }` map of URLs, with dimensions in
+// a sibling `file_meta` map keyed by the same format names.
+const normalizeClipItem = (value: unknown): KlipyMediaResult | null => {
+  const item = asRecord(value);
+  if (!item) return null;
+
+  const file = asRecord(item.file);
+  if (!file) return null;
+  const fileMeta = asRecord(item.file_meta);
+
+  const videoUrl = normalizeKlipyMediaUrl(file.mp4);
+  if (!videoUrl) return null;
+
+  // The GIF (preferred) or WebP rendition is the image fallback that ships in
+  // `url`, so clients that don't play the MP4 still show the animation.
+  const imageUrl =
+    normalizeKlipyMediaUrl(file.gif) ?? normalizeKlipyMediaUrl(file.webp);
+  if (!imageUrl) return null;
+
+  const imageMeta = asRecord(fileMeta?.gif) ?? asRecord(fileMeta?.webp);
+  const width = asDimension(imageMeta?.width);
+  const height = asDimension(imageMeta?.height);
+
+  const slug = asString(item.slug);
+  const rawId = slug ?? asString(item.id) ?? videoUrl;
+  const title = (asString(item.title) ?? "Clip").slice(0, 140);
+  const pageUrl = buildPageUrl("clips", slug);
+
+  return {
+    id: rawId.slice(0, 120),
+    title,
+    url: imageUrl,
+    previewUrl: imageUrl,
+    videoUrl,
+    ...(pageUrl ? { pageUrl } : {}),
+    ...(width ? { width } : {}),
+    ...(height ? { height } : {}),
+    kind: "clip",
+    source: "klipy",
+  };
+};
+
+const normalizeItem = (
+  value: unknown,
+  media: KlipyMediaKind,
+): KlipyMediaResult | null =>
+  media === "clips"
+    ? normalizeClipItem(value)
+    : normalizeNestedItem(value, media);
 
 export async function GET(request: Request) {
   const apiKey = process.env.KLIPY_API_KEY?.trim();
@@ -136,6 +228,9 @@ export async function GET(request: Request) {
   }
 
   const { searchParams } = new URL(request.url);
+  const media = parseMediaKind(
+    searchParams.get("media") ?? searchParams.get("type"),
+  );
   const query = (searchParams.get("q") ?? searchParams.get("query") ?? "")
     .trim()
     .slice(0, MAX_QUERY_LENGTH);
@@ -149,7 +244,7 @@ export async function GET(request: Request) {
 
   const endpoint = query ? "search" : "trending";
   const url = new URL(
-    `${KLIPY_API_BASE_URL}/${encodeURIComponent(apiKey)}/gifs/${endpoint}`,
+    `${KLIPY_API_BASE_URL}/${encodeURIComponent(apiKey)}/${media}/${endpoint}`,
   );
   url.searchParams.set("page", String(page));
   url.searchParams.set("per_page", String(perPage));
@@ -172,12 +267,12 @@ export async function GET(request: Request) {
   const body = await response.json();
   const data = asRecord(asRecord(body)?.data);
   const rawItems = Array.isArray(data?.data) ? data.data : [];
-  const gifs = rawItems
-    .map((item) => normalizeKlipyGif(item))
-    .filter((item): item is KlipyGifResult => Boolean(item));
+  const items = rawItems
+    .map((item) => normalizeItem(item, media))
+    .filter((item): item is KlipyMediaResult => Boolean(item));
 
-  const payload: KlipyGifSearchResponse = {
-    gifs,
+  const payload: KlipyMediaSearchResponse = {
+    items,
     page: typeof data?.current_page === "number" ? data.current_page : page,
     hasNext: data?.has_next === true,
   };

--- a/apps/web/src/app/components/ChatGifAttachmentView.tsx
+++ b/apps/web/src/app/components/ChatGifAttachmentView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type { CSSProperties } from "react";
+import { Volume2, VolumeX } from "lucide-react";
+import { useRef, useState, type CSSProperties } from "react";
 import type { ChatGifAttachment } from "../lib/types";
 
 interface ChatGifAttachmentViewProps {
@@ -17,6 +18,72 @@ function getGifStyle(gif: ChatGifAttachment): CSSProperties | undefined {
   };
 }
 
+const Watermark = () => (
+  <img
+    src="/KLIPY%20TEXT%20LIGHT.svg"
+    alt=""
+    aria-hidden="true"
+    className="pointer-events-none absolute bottom-2 left-2 h-3 w-auto max-w-[34%] opacity-70 drop-shadow-[0_1px_2px_rgba(0,0,0,0.55)]"
+  />
+);
+
+// Clips ship as muted autoplay loops (browsers block autoplay with sound), and
+// can be unmuted with a tap — the speaker badge doubles as the affordance.
+function ClipAttachment({
+  gif,
+  baseClassName,
+  sizeClassName,
+}: {
+  gif: ChatGifAttachment;
+  baseClassName: string;
+  sizeClassName: string;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [muted, setMuted] = useState(true);
+
+  const toggleAudio = () => {
+    const video = videoRef.current;
+    if (!video) return;
+    const next = !muted;
+    video.muted = next;
+    setMuted(next);
+    if (!next) {
+      void video.play().catch(() => {});
+    }
+  };
+
+  return (
+    <div className={baseClassName} style={getGifStyle(gif)} title={gif.title}>
+      <video
+        ref={videoRef}
+        src={gif.videoUrl}
+        poster={gif.previewUrl ?? gif.url}
+        muted
+        loop
+        autoPlay
+        playsInline
+        preload="metadata"
+        aria-label={gif.title || "Clip"}
+        onClick={toggleAudio}
+        className={`${sizeClassName} cursor-pointer`}
+      />
+      <button
+        type="button"
+        onClick={toggleAudio}
+        aria-label={muted ? "Unmute clip" : "Mute clip"}
+        className="absolute bottom-2 right-2 inline-flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white backdrop-blur-sm transition-colors hover:bg-black/70"
+      >
+        {muted ? (
+          <VolumeX size={15} strokeWidth={1.75} />
+        ) : (
+          <Volume2 size={15} strokeWidth={1.75} />
+        )}
+      </button>
+      <Watermark />
+    </div>
+  );
+}
+
 export default function ChatGifAttachmentView({
   gif,
   className = "",
@@ -24,24 +91,32 @@ export default function ChatGifAttachmentView({
   widthClassName = "w-[240px]",
 }: ChatGifAttachmentViewProps) {
   const hasRatio = Boolean(gif.width && gif.height);
+  const sizeClassName = `${hasRatio ? "h-full" : "h-auto"} w-full object-contain ${imageClassName}`;
+  // Stickers are transparent, so they float on the chat surface without the
+  // dark media card that gifs/clips sit on.
+  const isSticker = gif.kind === "sticker";
+  const baseClassName = `relative block ${widthClassName} max-w-full overflow-hidden rounded-[16px] ${
+    isSticker ? "" : "bg-black/25"
+  } ${className}`;
+
+  if (gif.kind === "clip" && gif.videoUrl) {
+    return (
+      <ClipAttachment
+        gif={gif}
+        baseClassName={baseClassName}
+        sizeClassName={sizeClassName}
+      />
+    );
+  }
+
   const content = (
     <img
       src={gif.url}
       alt={gif.title || "GIF"}
       loading="lazy"
-      className={`${hasRatio ? "h-full" : "h-auto"} w-full object-contain ${imageClassName}`}
+      className={sizeClassName}
     />
   );
-  const watermark = (
-    <img
-      src="/KLIPY%20TEXT%20LIGHT.svg"
-      alt=""
-      aria-hidden="true"
-      className="pointer-events-none absolute bottom-2 left-2 h-3 w-auto max-w-[34%] opacity-70 drop-shadow-[0_1px_2px_rgba(0,0,0,0.55)]"
-    />
-  );
-
-  const baseClassName = `relative block ${widthClassName} max-w-full overflow-hidden rounded-[16px] bg-black/25 ${className}`;
 
   if (gif.pageUrl) {
     return (
@@ -54,7 +129,7 @@ export default function ChatGifAttachmentView({
         title={gif.title}
       >
         {content}
-        {watermark}
+        <Watermark />
       </a>
     );
   }
@@ -62,7 +137,7 @@ export default function ChatGifAttachmentView({
   return (
     <div className={baseClassName} style={getGifStyle(gif)} title={gif.title}>
       {content}
-      {watermark}
+      <Watermark />
     </div>
   );
 }

--- a/apps/web/src/app/components/ChatPanel.tsx
+++ b/apps/web/src/app/components/ChatPanel.tsx
@@ -716,9 +716,11 @@ function ChatPanel({
                     >
                       <div
                         className={`inline-block min-w-0 max-w-full overflow-hidden rounded-[18px] ${
-                          isOwn
-                            ? "bg-[#F95F4A] text-white"
-                            : "bg-white/[0.05] text-[#fafafa]"
+                          msg.gif
+                            ? "text-white"
+                            : isOwn
+                              ? "bg-[#F95F4A] text-white"
+                              : "bg-white/[0.05] text-[#fafafa]"
                         } ${
                           isOwn && groupedWithPrevious ? "rounded-tr-md" : ""
                         } ${

--- a/apps/web/src/app/components/GifPicker.tsx
+++ b/apps/web/src/app/components/GifPicker.tsx
@@ -11,10 +11,13 @@ import {
 } from "react";
 import type { ChatGifAttachment } from "../lib/types";
 import {
-  klipyGifResultToAttachment,
-  type KlipyGifResult,
-  type KlipyGifSearchResponse,
+  klipyMediaResultToAttachment,
+  type KlipyMediaKind,
+  type KlipyMediaResult,
+  type KlipyMediaSearchResponse,
 } from "../lib/klipy-gifs";
+import Coachmark from "./Coachmark";
+import { useOneTimeHint } from "../hooks/useOneTimeHint";
 
 interface GifPickerProps {
   disabled?: boolean;
@@ -23,7 +26,17 @@ interface GifPickerProps {
 }
 
 const SEARCH_DEBOUNCE_MS = 250;
-const GIFS_PER_PAGE = 16;
+const ITEMS_PER_PAGE = 16;
+
+const MEDIA_TABS: ReadonlyArray<{
+  kind: KlipyMediaKind;
+  label: string;
+  noun: string;
+}> = [
+  { kind: "gifs", label: "GIFs", noun: "GIFs" },
+  { kind: "stickers", label: "Stickers", noun: "stickers" },
+  { kind: "clips", label: "Clips", noun: "clips" },
+];
 
 function GifPicker({
   disabled = false,
@@ -33,14 +46,27 @@ function GifPicker({
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [isOpen, setIsOpen] = useState(false);
+  const [mediaKind, setMediaKind] = useState<KlipyMediaKind>("gifs");
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
-  const [gifs, setGifs] = useState<KlipyGifResult[]>([]);
+  const [items, setItems] = useState<KlipyMediaResult[]>([]);
   const [page, setPage] = useState(1);
   const [hasNext, setHasNext] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const noun = useMemo(
+    () => MEDIA_TABS.find((tab) => tab.kind === mediaKind)?.noun ?? "results",
+    [mediaKind],
+  );
+
+  // Announce the newly added stickers + clips catalogs on the picker itself, so
+  // even people who already dismissed the original "GIFs are here" tip see it.
+  const stickersClipsTip = useOneTimeHint("chat-stickers-clips", {
+    enabled: !disabled && !isOpen,
+    delay: 900,
+  });
 
   useEffect(() => {
     if (!disabled) return;
@@ -88,13 +114,14 @@ function GifPicker({
     if (!isOpen) return;
 
     const controller = new AbortController();
-    const loadGifs = async () => {
+    const loadItems = async () => {
       setIsLoading(true);
       setError(null);
       try {
         const params = new URLSearchParams({
+          media: mediaKind,
           page: "1",
-          limit: String(GIFS_PER_PAGE),
+          limit: String(ITEMS_PER_PAGE),
         });
         if (debouncedQuery) {
           params.set("q", debouncedQuery);
@@ -104,18 +131,20 @@ function GifPicker({
           signal: controller.signal,
         });
         if (!response.ok) {
-          throw new Error("GIF search failed.");
+          throw new Error(`${noun} search failed.`);
         }
-        const body = (await response.json()) as KlipyGifSearchResponse;
-        setGifs(body.gifs);
+        const body = (await response.json()) as KlipyMediaSearchResponse;
+        setItems(body.items);
         setPage(body.page);
         setHasNext(body.hasNext);
       } catch (loadError) {
         if (controller.signal.aborted) return;
-        setGifs([]);
+        setItems([]);
         setHasNext(false);
         setError(
-          loadError instanceof Error ? loadError.message : "GIF search failed.",
+          loadError instanceof Error
+            ? loadError.message
+            : `${noun} search failed.`,
         );
       } finally {
         if (!controller.signal.aborted) {
@@ -124,9 +153,9 @@ function GifPicker({
       }
     };
 
-    void loadGifs();
+    void loadItems();
     return () => controller.abort();
-  }, [debouncedQuery, isOpen]);
+  }, [debouncedQuery, isOpen, mediaKind, noun]);
 
   const loadMore = useCallback(async () => {
     if (isLoading || isLoadingMore || !hasNext) return;
@@ -135,8 +164,9 @@ function GifPicker({
     setError(null);
     try {
       const params = new URLSearchParams({
+        media: mediaKind,
         page: String(page + 1),
-        limit: String(GIFS_PER_PAGE),
+        limit: String(ITEMS_PER_PAGE),
       });
       if (debouncedQuery) {
         params.set("q", debouncedQuery);
@@ -144,22 +174,22 @@ function GifPicker({
 
       const response = await fetch(`/api/klipy/gifs?${params.toString()}`);
       if (!response.ok) {
-        throw new Error("More GIFs failed to load.");
+        throw new Error(`More ${noun} failed to load.`);
       }
-      const body = (await response.json()) as KlipyGifSearchResponse;
-      setGifs((prev) => [...prev, ...body.gifs]);
+      const body = (await response.json()) as KlipyMediaSearchResponse;
+      setItems((prev) => [...prev, ...body.items]);
       setPage(body.page);
       setHasNext(body.hasNext);
     } catch (loadError) {
       setError(
         loadError instanceof Error
           ? loadError.message
-          : "More GIFs failed to load.",
+          : `More ${noun} failed to load.`,
       );
     } finally {
       setIsLoadingMore(false);
     }
-  }, [debouncedQuery, hasNext, isLoading, isLoadingMore, page]);
+  }, [debouncedQuery, hasNext, isLoading, isLoadingMore, mediaKind, noun, page]);
 
   const panelClassName = useMemo(
     () =>
@@ -169,10 +199,19 @@ function GifPicker({
     [variant],
   );
 
-  const handleSelect = (gif: KlipyGifResult) => {
-    onSelect(klipyGifResultToAttachment(gif));
+  const handleSelectMedia = (item: KlipyMediaResult) => {
+    onSelect(klipyMediaResultToAttachment(item));
     setIsOpen(false);
     setQuery("");
+  };
+
+  const handleSelectTab = (kind: KlipyMediaKind) => {
+    if (kind === mediaKind) return;
+    setMediaKind(kind);
+    setItems([]);
+    setPage(1);
+    setHasNext(false);
+    setError(null);
   };
 
   return (
@@ -180,10 +219,13 @@ function GifPicker({
       <button
         type="button"
         disabled={disabled}
-        onClick={() => setIsOpen((prev) => !prev)}
-        aria-label="Search GIFs"
+        onClick={() => {
+          if (!isOpen) stickersClipsTip.dismiss();
+          setIsOpen((prev) => !prev);
+        }}
+        aria-label="GIFs, stickers, and clips"
         aria-expanded={isOpen}
-        title="Search GIFs"
+        title="GIFs, stickers, and clips"
         className={`inline-flex h-8 w-8 items-center justify-center rounded-lg transition-[background-color,color,opacity] ${
           isOpen
             ? "bg-white/[0.12] text-[#fafafa]"
@@ -192,6 +234,16 @@ function GifPicker({
       >
         <Images size={18} strokeWidth={1.75} />
       </button>
+
+      {stickersClipsTip.visible && !isOpen ? (
+        <Coachmark
+          title="Stickers & clips, too"
+          description="Browse Klipy stickers and short video clips right here."
+          onDismiss={stickersClipsTip.dismiss}
+          arrowLeft="1rem"
+          className="!left-0 !translate-x-0"
+        />
+      ) : null}
 
       {isOpen ? (
         <div
@@ -217,7 +269,7 @@ function GifPicker({
                 ref={inputRef}
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
-                aria-label="Search Klipy GIFs"
+                aria-label={`Search Klipy ${noun}`}
                 className="w-full bg-transparent text-[13px] text-[#fafafa] focus:outline-none"
               />
             </div>
@@ -225,7 +277,7 @@ function GifPicker({
               <button
                 type="button"
                 onClick={() => setQuery("")}
-                aria-label="Clear GIF search"
+                aria-label="Clear search"
                 className="inline-flex h-6 w-6 items-center justify-center rounded-md text-[#a1a1aa] transition-colors hover:bg-white/[0.08] hover:text-[#fafafa]"
               >
                 <X size={14} strokeWidth={1.75} />
@@ -233,35 +285,79 @@ function GifPicker({
             ) : null}
           </div>
 
-          <div className="max-h-[18rem] overflow-y-auto p-2">
+          <div
+            role="tablist"
+            aria-label="Media type"
+            className="flex items-center gap-1 border-b border-white/10 px-2 py-1.5"
+          >
+            {MEDIA_TABS.map((tab) => {
+              const isActive = tab.kind === mediaKind;
+              return (
+                <button
+                  key={tab.kind}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => handleSelectTab(tab.kind)}
+                  className={`inline-flex h-7 flex-1 items-center justify-center rounded-md text-[12px] font-medium transition-colors ${
+                    isActive
+                      ? "bg-white/[0.12] text-[#fafafa]"
+                      : "text-[#a1a1aa] hover:bg-white/[0.06] hover:text-[#fafafa]"
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="h-[18rem] overflow-y-auto p-2">
             {isLoading ? (
-              <div className="flex h-32 items-center justify-center text-[#a1a1aa]">
+              <div className="flex h-full items-center justify-center text-[#a1a1aa]">
                 <Loader2 size={20} strokeWidth={1.75} className="animate-spin" />
               </div>
             ) : error ? (
-              <div className="flex h-32 items-center justify-center px-4 text-center text-[13px] text-[#a1a1aa]">
+              <div className="flex h-full items-center justify-center px-4 text-center text-[13px] text-[#a1a1aa]">
                 {error}
               </div>
-            ) : gifs.length === 0 ? (
-              <div className="flex h-32 items-center justify-center px-4 text-center text-[13px] text-[#a1a1aa]">
-                No GIFs found
+            ) : items.length === 0 ? (
+              <div className="flex h-full items-center justify-center px-4 text-center text-[13px] text-[#a1a1aa]">
+                No {noun} found
               </div>
             ) : (
               <div className="grid grid-cols-2 gap-1.5">
-                {gifs.map((gif) => (
+                {items.map((item) => (
                   <button
-                    key={`${gif.id}-${gif.url}`}
+                    key={`${item.id}-${item.url}`}
                     type="button"
-                    onClick={() => handleSelect(gif)}
+                    onClick={() => handleSelectMedia(item)}
                     className="group relative aspect-[4/3] overflow-hidden rounded-lg bg-black/30 outline-none ring-1 ring-white/[0.06] transition-[filter,ring-color] hover:brightness-110 hover:ring-white/20 focus-visible:ring-2 focus-visible:ring-[#F95F4A]"
-                    title={gif.title}
+                    title={item.title}
                   >
-                    <img
-                      src={gif.previewUrl}
-                      alt={gif.title}
-                      loading="lazy"
-                      className="h-full w-full object-cover"
-                    />
+                    {item.kind === "clip" && item.videoUrl ? (
+                      <video
+                        src={item.videoUrl}
+                        poster={item.previewUrl}
+                        muted
+                        loop
+                        autoPlay
+                        playsInline
+                        preload="metadata"
+                        aria-label={item.title}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <img
+                        src={item.previewUrl}
+                        alt={item.title}
+                        loading="lazy"
+                        className={`h-full w-full ${
+                          item.kind === "sticker"
+                            ? "object-contain"
+                            : "object-cover"
+                        }`}
+                      />
+                    )}
                   </button>
                 ))}
               </div>

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -103,6 +103,7 @@ const STALE_REPLACEMENT_CLEANUP_DELAY_MS = 5000;
 const SCREEN_SHARE_STALE_REPLACEMENT_CLEANUP_DELAY_MS = 1500;
 const CLOSE_CONSUMER_RETRY_DELAY_MS = 500;
 const CLOSE_CONSUMER_MAX_ATTEMPTS = 4;
+const CLOSE_CONSUMER_RETRY_WINDOW_MS = 30000;
 const TURN_URL_PATTERN = /^turns?:/i;
 const TRANSPORT_CC_FEEDBACK_TYPE = "transport-cc";
 
@@ -1956,7 +1957,16 @@ export function useMeetSocket({
         closeConsumerRetryTimeoutsRef.current.delete(consumerId);
       }
 
+      const retryStartedAt = Date.now();
       const scheduleCloseRetry = (attempt: number) => {
+        if (Date.now() - retryStartedAt >= CLOSE_CONSUMER_RETRY_WINDOW_MS) {
+          closeConsumerRetryTimeoutsRef.current.delete(consumerId);
+          console.warn("[Meets] Gave up closing server consumer after retry window:", {
+            consumerId,
+          });
+          return;
+        }
+
         const timeoutId = window.setTimeout(() => {
           closeConsumerRetryTimeoutsRef.current.delete(consumerId);
           closeWithRetry(attempt);

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -101,6 +101,8 @@ const PARTICIPANT_RECONNECTED_STATUS_MS = 4500;
 const PRODUCER_CLOSE_REPLACEMENT_GRACE_MS = 1500;
 const STALE_REPLACEMENT_CLEANUP_DELAY_MS = 5000;
 const SCREEN_SHARE_STALE_REPLACEMENT_CLEANUP_DELAY_MS = 1500;
+const CLOSE_CONSUMER_RETRY_DELAY_MS = 500;
+const CLOSE_CONSUMER_MAX_ATTEMPTS = 4;
 const TURN_URL_PATTERN = /^turns?:/i;
 const TRANSPORT_CC_FEEDBACK_TYPE = "transport-cc";
 
@@ -699,6 +701,7 @@ export function useMeetSocket({
   const staleReplacementCleanupTimeoutsRef = useRef<Map<string, number>>(
     new Map(),
   );
+  const closeConsumerRetryTimeoutsRef = useRef<Map<string, number>>(new Map());
   const mutedConsumerSinceRef = useRef<Map<string, number>>(new Map());
   const producerPausedStateRef = useRef<Map<string, boolean>>(new Map());
   // Per-video-consumer decode progress for the freeze watchdog: last
@@ -1133,6 +1136,10 @@ export function useMeetSocket({
         window.clearTimeout(timeoutId);
       }
       staleReplacementCleanupTimeoutsRef.current.clear();
+      for (const timeoutId of closeConsumerRetryTimeoutsRef.current.values()) {
+        window.clearTimeout(timeoutId);
+      }
+      closeConsumerRetryTimeoutsRef.current.clear();
       mutedConsumerSinceRef.current.clear();
       producerPausedStateRef.current.clear();
       videoFreezeStatsRef.current.clear();
@@ -1282,6 +1289,7 @@ export function useMeetSocket({
       consumeRetryAttemptsRef,
       videoStallRecoveryTimeoutsRef,
       staleConsumerRecoveryTimeoutsRef,
+      closeConsumerRetryTimeoutsRef,
       mutedConsumerSinceRef,
       producerPausedStateRef,
       consumerRecoveryInFlightRef,
@@ -1928,11 +1936,50 @@ export function useMeetSocket({
   const closeServerConsumer = useCallback(
     (consumerId?: string | null) => {
       if (!consumerId) return;
-      const socket = socketRef.current;
-      if (!socket?.connected) return;
-      socket.emit("closeConsumer", { consumerId }, () => {});
+
+      const existingTimeout =
+        closeConsumerRetryTimeoutsRef.current.get(consumerId);
+      if (existingTimeout != null) {
+        window.clearTimeout(existingTimeout);
+        closeConsumerRetryTimeoutsRef.current.delete(consumerId);
+      }
+
+      const closeWithRetry = (attempt: number) => {
+        const socket = socketRef.current;
+        if (!socket?.connected) return;
+
+        socket.emit(
+          "closeConsumer",
+          { consumerId },
+          (response: { success: boolean } | { error: string }) => {
+            closeConsumerRetryTimeoutsRef.current.delete(consumerId);
+            if (!("error" in response)) return;
+
+            if (
+              attempt + 1 >= CLOSE_CONSUMER_MAX_ATTEMPTS ||
+              !/too many consumer control requests|retry shortly/i.test(
+                response.error,
+              )
+            ) {
+              console.warn("[Meets] Failed to close server consumer:", {
+                consumerId,
+                error: response.error,
+              });
+              return;
+            }
+
+            const timeoutId = window.setTimeout(() => {
+              closeConsumerRetryTimeoutsRef.current.delete(consumerId);
+              closeWithRetry(attempt + 1);
+            }, CLOSE_CONSUMER_RETRY_DELAY_MS);
+            closeConsumerRetryTimeoutsRef.current.set(consumerId, timeoutId);
+          },
+        );
+      };
+
+      closeWithRetry(0);
     },
-    [socketRef],
+    [closeConsumerRetryTimeoutsRef, socketRef],
   );
 
   const dropDepartedProducer = useCallback(

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -3335,10 +3335,6 @@ export function useMeetSocket({
 
   const applyWebinarFeedProducers = useCallback(
     async (producers: ProducerInfo[]) => {
-      for (const producer of producers) {
-        markRemoteParticipantPresent(producer.producerUserId);
-      }
-
       const serverProducerIds = new Set(
         producers.map((producer) => producer.producerId),
       );
@@ -3349,12 +3345,7 @@ export function useMeetSocket({
       }
       await Promise.all(producers.map((producer) => consumeProducer(producer)));
     },
-    [
-      consumeProducer,
-      handleProducerClosed,
-      markRemoteParticipantPresent,
-      producerMapRef,
-    ],
+    [consumeProducer, handleProducerClosed, producerMapRef],
   );
 
   const startProducerSync = useCallback(() => {

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -3422,11 +3422,13 @@ export function useMeetSocket({
 
   const applyWebinarFeedProducers = useCallback(
     async (producers: ProducerInfo[]) => {
+      const departedProducerIds = new Set<string>();
       const activeProducers = producers.filter((producer) => {
         const isDeparted = shouldIgnoreDepartedParticipant(
           producer.producerUserId,
         );
         if (isDeparted) {
+          departedProducerIds.add(producer.producerId);
           dropDepartedProducer(producer);
         }
         return !isDeparted;
@@ -3435,6 +3437,7 @@ export function useMeetSocket({
         activeProducers.map((producer) => producer.producerId),
       );
       for (const producerId of producerMapRef.current.keys()) {
+        if (departedProducerIds.has(producerId)) continue;
         if (!serverProducerIds.has(producerId)) {
           handleProducerClosed(producerId);
         }

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -3335,6 +3335,10 @@ export function useMeetSocket({
 
   const applyWebinarFeedProducers = useCallback(
     async (producers: ProducerInfo[]) => {
+      for (const producer of producers) {
+        markRemoteParticipantPresent(producer.producerUserId);
+      }
+
       const serverProducerIds = new Set(
         producers.map((producer) => producer.producerId),
       );
@@ -3345,7 +3349,12 @@ export function useMeetSocket({
       }
       await Promise.all(producers.map((producer) => consumeProducer(producer)));
     },
-    [consumeProducer, handleProducerClosed, producerMapRef],
+    [
+      consumeProducer,
+      handleProducerClosed,
+      markRemoteParticipantPresent,
+      producerMapRef,
+    ],
   );
 
   const startProducerSync = useCallback(() => {

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -3197,6 +3197,12 @@ export function useMeetSocket({
 
       for (const producerInfo of producers) {
         if (shouldIgnoreDepartedParticipant(producerInfo.producerUserId)) {
+          if (
+            consumersRef.current.has(producerInfo.producerId) ||
+            producerMapRef.current.has(producerInfo.producerId)
+          ) {
+            handleProducerClosed(producerInfo.producerId);
+          }
           announcedRemoteProducersRef.current.delete(producerInfo.producerId);
           pendingProducersRef.current.delete(producerInfo.producerId);
           continue;

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -5044,6 +5044,7 @@ export function useMeetSocket({
                 dispatchParticipants({
                   type: "ADD_PARTICIPANT",
                   userId: notification.userId,
+                  addIfMissing: false,
                 });
                 if (clearedDepartedParticipant) {
                   void syncProducers();

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -104,7 +104,6 @@ const SCREEN_SHARE_STALE_REPLACEMENT_CLEANUP_DELAY_MS = 1500;
 const CLOSE_CONSUMER_RETRY_DELAY_MS = 500;
 const CLOSE_CONSUMER_MAX_ATTEMPTS = 4;
 const CLOSE_CONSUMER_RETRY_WINDOW_MS = 30000;
-const WEBINAR_FEED_JOIN_SYNC_DELAY_MS = 300;
 const TURN_URL_PATTERN = /^turns?:/i;
 const TRANSPORT_CC_FEEDBACK_TYPE = "transport-cc";
 
@@ -706,7 +705,6 @@ export function useMeetSocket({
     new Map(),
   );
   const closeConsumerRetryTimeoutsRef = useRef<Map<string, number>>(new Map());
-  const webinarFeedJoinSyncTimeoutRef = useRef<number | null>(null);
   const mutedConsumerSinceRef = useRef<Map<string, number>>(new Map());
   const producerPausedStateRef = useRef<Map<string, boolean>>(new Map());
   // Per-video-consumer decode progress for the freeze watchdog: last
@@ -1116,10 +1114,6 @@ export function useMeetSocket({
         window.clearTimeout(pendingProducerRetryTimeoutRef.current);
         pendingProducerRetryTimeoutRef.current = null;
       }
-      if (webinarFeedJoinSyncTimeoutRef.current != null) {
-        window.clearTimeout(webinarFeedJoinSyncTimeoutRef.current);
-        webinarFeedJoinSyncTimeoutRef.current = null;
-      }
 
       consumersRef.current.forEach((consumer) => {
         try {
@@ -1303,7 +1297,6 @@ export function useMeetSocket({
       producerTransportDisconnectTimeoutRef,
       consumerTransportDisconnectTimeoutRef,
       pendingProducerRetryTimeoutRef,
-      webinarFeedJoinSyncTimeoutRef,
       prejoinMediaIntentRef,
       producerSyncIntervalRef,
       consumeRetryAttemptsRef,
@@ -1558,6 +1551,40 @@ export function useMeetSocket({
       });
     },
     [clearParticipantConnectionStatusTimer, dispatchParticipants],
+  );
+
+  const restoreWebinarFeedParticipant = useCallback(
+    (targetUserId: string, displayName?: string) => {
+      const clearedDepartedParticipant =
+        markRemoteParticipantPresent(targetUserId);
+      if (displayName) {
+        setDisplayNames((prev) => {
+          const next = new Map(prev);
+          next.set(targetUserId, displayName);
+          return next;
+        });
+      }
+      const leaveTimeout = leaveTimeoutsRef.current.get(targetUserId);
+      if (leaveTimeout) {
+        window.clearTimeout(leaveTimeout);
+        leaveTimeoutsRef.current.delete(targetUserId);
+      }
+      clearParticipantConnectionStatus(targetUserId);
+      dispatchParticipants({
+        type: "ADD_PARTICIPANT",
+        userId: targetUserId,
+        addIfMissing: false,
+        reviveIfPresent: true,
+      });
+      return clearedDepartedParticipant;
+    },
+    [
+      clearParticipantConnectionStatus,
+      dispatchParticipants,
+      leaveTimeoutsRef,
+      markRemoteParticipantPresent,
+      setDisplayNames,
+    ],
   );
 
   const clearExpiredParticipantConnectionStatuses = useCallback(() => {
@@ -3322,8 +3349,17 @@ export function useMeetSocket({
 
       for (const producerInfo of producers) {
         if (shouldIgnoreDepartedParticipant(producerInfo.producerUserId)) {
-          dropDepartedProducer(producerInfo);
-          continue;
+          if (
+            joinMode === "webinar_attendee" &&
+            webinarJoinedParticipantIdsRef.current.has(
+              producerInfo.producerUserId,
+            )
+          ) {
+            restoreWebinarFeedParticipant(producerInfo.producerUserId);
+          } else {
+            dropDepartedProducer(producerInfo);
+            continue;
+          }
         }
         setProducerPausedState(
           producerInfo.producerId,
@@ -3450,6 +3486,8 @@ export function useMeetSocket({
     consumeProducer,
     dropDepartedProducer,
     handleProducerClosed,
+    joinMode,
+    restoreWebinarFeedParticipant,
     setProducerPausedState,
     shouldIgnoreDepartedParticipant,
     adaptivelyPausedConsumerProducerIdsRef,
@@ -3468,6 +3506,12 @@ export function useMeetSocket({
         );
         if (isDeparted) {
           departedProducerIds.add(producer.producerId);
+          if (
+            webinarJoinedParticipantIdsRef.current.has(producer.producerUserId)
+          ) {
+            restoreWebinarFeedParticipant(producer.producerUserId);
+            return true;
+          }
           dropDepartedProducer(producer);
         }
         return !isDeparted;
@@ -3490,6 +3534,7 @@ export function useMeetSocket({
       dropDepartedProducer,
       handleProducerClosed,
       producerMapRef,
+      restoreWebinarFeedParticipant,
       shouldIgnoreDepartedParticipant,
     ],
   );
@@ -5127,39 +5172,22 @@ export function useMeetSocket({
                 if (!isRoomEvent(notification.roomId)) return;
                 if (notification.userId === userId) return;
 
-                webinarJoinedParticipantIdsRef.current.add(notification.userId);
-                if (
-                  !webinarVisibleParticipantIdsRef.current.has(
-                    notification.userId,
-                  )
-                ) {
-                  return;
-                }
-
-                const clearedDepartedParticipant =
-                  markRemoteParticipantPresent(notification.userId);
                 const displayName = notification.displayName;
                 if (displayName) {
                   setDisplayNames((prev) => {
+                    if (prev.get(notification.userId) === displayName) {
+                      return prev;
+                    }
                     const next = new Map(prev);
                     next.set(notification.userId, displayName);
                     return next;
                   });
                 }
-                const leaveTimeout = leaveTimeoutsRef.current.get(
-                  notification.userId,
-                );
-                if (leaveTimeout) {
-                  window.clearTimeout(leaveTimeout);
-                  leaveTimeoutsRef.current.delete(notification.userId);
-                }
-                clearParticipantConnectionStatus(notification.userId);
-                dispatchParticipants({
-                  type: "ADD_PARTICIPANT",
-                  userId: notification.userId,
-                  addIfMissing: false,
-                });
-                if (clearedDepartedParticipant) {
+                webinarJoinedParticipantIdsRef.current.add(notification.userId);
+                if (
+                  shouldIgnoreDepartedParticipant(notification.userId) ||
+                  webinarVisibleParticipantIdsRef.current.has(notification.userId)
+                ) {
                   void syncProducers();
                 }
               },
@@ -5171,72 +5199,34 @@ export function useMeetSocket({
                 if (joinMode !== "webinar_attendee") return;
                 if (!isRoomEvent(notification.roomId)) return;
                 const nextVisibleParticipantIds = new Set<string>();
-                const restoredVisibleParticipantIds = new Set<string>();
-                let clearedDepartedParticipant = false;
-                let sawDepartedFeedProducerWithoutJoinSignal = false;
                 for (const producer of notification.producers) {
-                  const producerUserId = producer.producerUserId;
-                  const hasJoinedSignal =
-                    webinarJoinedParticipantIdsRef.current.has(producerUserId);
-                  if (
-                    shouldIgnoreDepartedParticipant(producerUserId) &&
-                    !hasJoinedSignal
-                  ) {
-                    sawDepartedFeedProducerWithoutJoinSignal = true;
-                    continue;
-                  }
-
-                  nextVisibleParticipantIds.add(producerUserId);
-                  if (
-                    hasJoinedSignal &&
-                    shouldIgnoreDepartedParticipant(producerUserId) &&
-                    !restoredVisibleParticipantIds.has(producerUserId)
-                  ) {
-                    restoredVisibleParticipantIds.add(producerUserId);
-                    clearedDepartedParticipant =
-                      markRemoteParticipantPresent(producerUserId) ||
-                      clearedDepartedParticipant;
-                    const leaveTimeout =
-                      leaveTimeoutsRef.current.get(producerUserId);
-                    if (leaveTimeout) {
-                      window.clearTimeout(leaveTimeout);
-                      leaveTimeoutsRef.current.delete(producerUserId);
-                    }
-                    clearParticipantConnectionStatus(producerUserId);
-                    dispatchParticipants({
-                      type: "ADD_PARTICIPANT",
-                      userId: producerUserId,
-                      addIfMissing: false,
-                    });
-                  }
+                  nextVisibleParticipantIds.add(producer.producerUserId);
                 }
                 webinarVisibleParticipantIdsRef.current =
                   nextVisibleParticipantIds;
                 const activeFeedProducers = notification.producers.filter(
-                  (producer) =>
-                    nextVisibleParticipantIds.has(producer.producerUserId) &&
-                    !shouldIgnoreDepartedParticipant(producer.producerUserId),
+                  (producer) => {
+                    const producerUserId = producer.producerUserId;
+                    return (
+                      nextVisibleParticipantIds.has(producerUserId) &&
+                      (!shouldIgnoreDepartedParticipant(producerUserId) ||
+                        webinarJoinedParticipantIdsRef.current.has(producerUserId))
+                    );
+                  },
                 );
                 setWebinarSpeakerUserId(
                   notification.speakerUserId &&
                     nextVisibleParticipantIds.has(notification.speakerUserId) &&
-                    !shouldIgnoreDepartedParticipant(notification.speakerUserId)
+                    (!shouldIgnoreDepartedParticipant(notification.speakerUserId) ||
+                      webinarJoinedParticipantIdsRef.current.has(
+                        notification.speakerUserId,
+                      ))
                     ? notification.speakerUserId
                     : activeFeedProducers[0]?.producerUserId ??
                     null,
                 );
                 void applyWebinarFeedProducers(notification.producers).finally(() => {
-                  if (clearedDepartedParticipant) {
-                    void syncProducers();
-                  } else if (sawDepartedFeedProducerWithoutJoinSignal) {
-                    if (webinarFeedJoinSyncTimeoutRef.current != null) {
-                      window.clearTimeout(webinarFeedJoinSyncTimeoutRef.current);
-                    }
-                    webinarFeedJoinSyncTimeoutRef.current = window.setTimeout(() => {
-                      webinarFeedJoinSyncTimeoutRef.current = null;
-                      void syncProducers();
-                    }, WEBINAR_FEED_JOIN_SYNC_DELAY_MS);
-                  }
+                  void syncProducers();
                 });
               },
             );
@@ -5300,6 +5290,7 @@ export function useMeetSocket({
       requestAudioProducerRecovery,
       requestCameraProducerRecovery,
       reconnectAttemptsRef,
+      restoreWebinarFeedParticipant,
       screenAudioProducerRef,
       screenProducerRef,
       setActiveScreenShareId,

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -4969,7 +4969,18 @@ export function useMeetSocket({
                     return next;
                   });
                 }
+                const leaveTimeout = leaveTimeoutsRef.current.get(
+                  notification.userId,
+                );
+                if (leaveTimeout) {
+                  window.clearTimeout(leaveTimeout);
+                  leaveTimeoutsRef.current.delete(notification.userId);
+                }
                 clearParticipantConnectionStatus(notification.userId);
+                dispatchParticipants({
+                  type: "ADD_PARTICIPANT",
+                  userId: notification.userId,
+                });
               },
             );
 

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -668,6 +668,7 @@ export function useMeetSocket({
   bypassMediaPermissions = false,
 }: UseMeetSocketOptions) {
   const participantIdsRef = useRef<Set<string>>(new Set([userId]));
+  const departedParticipantIdsRef = useRef<Set<string>>(new Set());
   const isMutedRef = useRef(isMuted);
   const isCameraOffRef = useRef(isCameraOff);
   const serverRoomIdRef = useRef<string | null>(null);
@@ -826,7 +827,26 @@ export function useMeetSocket({
 
   useEffect(() => {
     participantIdsRef.current = new Set([userId]);
+    departedParticipantIdsRef.current.clear();
   }, [userId]);
+
+  const markRemoteParticipantPresent = useCallback((targetUserId: string) => {
+    departedParticipantIdsRef.current.delete(targetUserId);
+  }, []);
+
+  const markRemoteParticipantDeparted = useCallback(
+    (targetUserId: string) => {
+      if (targetUserId === userId) return;
+      departedParticipantIdsRef.current.add(targetUserId);
+    },
+    [userId],
+  );
+
+  const shouldIgnoreDepartedParticipant = useCallback(
+    (targetUserId: string): boolean =>
+      targetUserId !== userId && departedParticipantIdsRef.current.has(targetUserId),
+    [userId],
+  );
 
   useEffect(() => {
     isMutedRef.current = isMuted;
@@ -1135,6 +1155,7 @@ export function useMeetSocket({
         setWebinarRole(null);
         setWebinarSpeakerUserId(null);
         participantIdsRef.current = new Set([userId]);
+        departedParticipantIdsRef.current.clear();
         serverRoomIdRef.current = null;
       }
 
@@ -1523,6 +1544,8 @@ export function useMeetSocket({
 
   const applyParticipantConnectionStatus = useCallback(
     (targetUserId: string, status: ParticipantConnectionStatus) => {
+      if (shouldIgnoreDepartedParticipant(targetUserId)) return;
+
       if (
         status.state === "reconnected" &&
         !visibleParticipantReconnectingIdsRef.current.has(targetUserId)
@@ -1576,6 +1599,7 @@ export function useMeetSocket({
       clearParticipantConnectionStatus,
       clearParticipantConnectionStatusTimer,
       dispatchParticipants,
+      shouldIgnoreDepartedParticipant,
     ],
   );
 
@@ -2611,7 +2635,10 @@ export function useMeetSocket({
       producerInfo: ProducerInfo,
       options: ConsumeProducerOptions = {},
     ): Promise<void> => {
-      if (producerInfo.producerUserId === userId) {
+      if (
+        producerInfo.producerUserId === userId ||
+        shouldIgnoreDepartedParticipant(producerInfo.producerUserId)
+      ) {
         return;
       }
       const existingConsumer = consumersRef.current.get(producerInfo.producerId);
@@ -2648,6 +2675,14 @@ export function useMeetSocket({
             }),
           },
           async (response: ConsumeResponse | { error: string }) => {
+            if (shouldIgnoreDepartedParticipant(producerInfo.producerUserId)) {
+              announcedRemoteProducersRef.current.delete(producerInfo.producerId);
+              pendingProducersRef.current.delete(producerInfo.producerId);
+              consumeRetryAttemptsRef.current.delete(producerInfo.producerId);
+              resolve();
+              return;
+            }
+
             if ("error" in response) {
               console.error("[Meets] Consume error:", response.error);
               queueProducerConsumeRetry(producerInfo, 300);
@@ -2665,6 +2700,21 @@ export function useMeetSocket({
                     response.rtpParameters,
                   ),
               });
+              if (shouldIgnoreDepartedParticipant(producerInfo.producerUserId)) {
+                try {
+                  consumer.track.onmute = null;
+                  consumer.track.onunmute = null;
+                  consumer.track.stop();
+                  consumer.close();
+                } catch {}
+                announcedRemoteProducersRef.current.delete(
+                  producerInfo.producerId,
+                );
+                pendingProducersRef.current.delete(producerInfo.producerId);
+                consumeRetryAttemptsRef.current.delete(producerInfo.producerId);
+                resolve();
+                return;
+              }
 
               consumersRef.current.set(producerInfo.producerId, consumer);
               announcedRemoteProducersRef.current.delete(
@@ -2916,6 +2966,7 @@ export function useMeetSocket({
       joinMode,
       queueProducerConsumeRetry,
       setActiveScreenShareId,
+      shouldIgnoreDepartedParticipant,
       videoStallRecoveryTimeoutsRef,
       staleConsumerRecoveryTimeoutsRef,
       adaptivelyPausedConsumerProducerIdsRef,
@@ -3144,6 +3195,11 @@ export function useMeetSocket({
       }
 
       for (const producerInfo of producers) {
+        if (shouldIgnoreDepartedParticipant(producerInfo.producerUserId)) {
+          announcedRemoteProducersRef.current.delete(producerInfo.producerId);
+          pendingProducersRef.current.delete(producerInfo.producerId);
+          continue;
+        }
         setProducerPausedState(
           producerInfo.producerId,
           Boolean(producerInfo.paused),
@@ -3269,6 +3325,7 @@ export function useMeetSocket({
     consumeProducer,
     handleProducerClosed,
     setProducerPausedState,
+    shouldIgnoreDepartedParticipant,
     adaptivelyPausedConsumerProducerIdsRef,
     mutedConsumerSinceRef,
     clearStaleConsumerRecoveryTimeout,
@@ -3876,6 +3933,12 @@ export function useMeetSocket({
 
             socket.on("newProducer", async (data: ProducerInfo) => {
               console.log("[Meets] New producer:", data);
+              if (shouldIgnoreDepartedParticipant(data.producerUserId)) {
+                announcedRemoteProducersRef.current.delete(data.producerId);
+                pendingProducersRef.current.delete(data.producerId);
+                consumeRetryAttemptsRef.current.delete(data.producerId);
+                return;
+              }
               setProducerPausedState(data.producerId, Boolean(data.paused));
               if (data.producerUserId === userId) {
                 return;
@@ -4053,6 +4116,7 @@ export function useMeetSocket({
                 if (joinedUserId === userId) {
                   return;
                 }
+                markRemoteParticipantPresent(joinedUserId);
                 if (shouldPlayJoinLeaveSound("join", joinedUserId)) {
                   playNotificationSound("join");
                 }
@@ -4081,6 +4145,7 @@ export function useMeetSocket({
               "userLeft",
               ({ userId: leftUserId }: { userId: string }) => {
                 console.log("[Meets] User left:", leftUserId);
+                markRemoteParticipantDeparted(leftUserId);
                 if (
                   leftUserId !== userId &&
                   shouldPlayJoinLeaveSound("leave", leftUserId)
@@ -4189,6 +4254,7 @@ export function useMeetSocket({
                       snapshot.set(snapshotUserId, displayName);
                     }
                     if (snapshotUserId !== userId) {
+                      markRemoteParticipantPresent(snapshotUserId);
                       if (!isSystemUserId(snapshotUserId)) {
                         nextParticipantIds.add(snapshotUserId);
                       }
@@ -4214,6 +4280,7 @@ export function useMeetSocket({
                     continue;
                   }
                   const leaveTimeout = leaveTimeoutsRef.current.get(previousUserId);
+                  markRemoteParticipantDeparted(previousUserId);
                   if (leaveTimeout) {
                     window.clearTimeout(leaveTimeout);
                     leaveTimeoutsRef.current.delete(previousUserId);
@@ -4251,6 +4318,7 @@ export function useMeetSocket({
                     setIsHandRaised(raised);
                     return;
                   }
+                  if (shouldIgnoreDepartedParticipant(raisedUserId)) return;
                   dispatchParticipants({
                     type: "UPDATE_HAND_RAISED",
                     userId: raisedUserId,
@@ -4325,6 +4393,7 @@ export function useMeetSocket({
                   setIsMuted(muted);
                   return;
                 }
+                if (shouldIgnoreDepartedParticipant(mutedUserId)) return;
                 dispatchParticipants({
                   type: "UPDATE_MUTED",
                   userId: mutedUserId,
@@ -4350,6 +4419,7 @@ export function useMeetSocket({
                   setIsCameraOff(cameraOff);
                   return;
                 }
+                if (shouldIgnoreDepartedParticipant(camUserId)) return;
                 dispatchParticipants({
                   type: "UPDATE_CAMERA_OFF",
                   userId: camUserId,
@@ -4557,6 +4627,7 @@ export function useMeetSocket({
                   setIsHandRaised(raised);
                   return;
                 }
+                if (shouldIgnoreDepartedParticipant(raisedUserId)) return;
                 dispatchParticipants({
                   type: "UPDATE_HAND_RAISED",
                   userId: raisedUserId,
@@ -4935,6 +5006,8 @@ export function useMeetSocket({
       joinOptionsRef,
       joinRoomInternal,
       leaveTimeoutsRef,
+      markRemoteParticipantDeparted,
+      markRemoteParticipantPresent,
       clearParticipantConnectionStatus,
       localStream,
       localStreamRef,
@@ -4942,6 +5015,7 @@ export function useMeetSocket({
       pendingProducersRef,
       playNotificationSound,
       shouldPlayJoinLeaveSound,
+      shouldIgnoreDepartedParticipant,
       applyWebinarFeedProducers,
       producerMapRef,
       requestAudioProducerRecovery,

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -672,6 +672,8 @@ export function useMeetSocket({
 }: UseMeetSocketOptions) {
   const participantIdsRef = useRef<Set<string>>(new Set([userId]));
   const departedParticipantIdsRef = useRef<Set<string>>(new Set());
+  const webinarJoinedParticipantIdsRef = useRef<Set<string>>(new Set());
+  const webinarVisibleParticipantIdsRef = useRef<Set<string>>(new Set());
   const isMutedRef = useRef(isMuted);
   const isCameraOffRef = useRef(isCameraOff);
   const serverRoomIdRef = useRef<string | null>(null);
@@ -832,6 +834,8 @@ export function useMeetSocket({
   useEffect(() => {
     participantIdsRef.current = new Set([userId]);
     departedParticipantIdsRef.current.clear();
+    webinarJoinedParticipantIdsRef.current.clear();
+    webinarVisibleParticipantIdsRef.current.clear();
   }, [userId]);
 
   const markRemoteParticipantPresent = useCallback((targetUserId: string) => {
@@ -842,6 +846,8 @@ export function useMeetSocket({
     (targetUserId: string) => {
       if (targetUserId === userId) return;
       departedParticipantIdsRef.current.add(targetUserId);
+      webinarJoinedParticipantIdsRef.current.delete(targetUserId);
+      webinarVisibleParticipantIdsRef.current.delete(targetUserId);
     },
     [userId],
   );
@@ -1136,10 +1142,12 @@ export function useMeetSocket({
         window.clearTimeout(timeoutId);
       }
       staleReplacementCleanupTimeoutsRef.current.clear();
-      for (const timeoutId of closeConsumerRetryTimeoutsRef.current.values()) {
-        window.clearTimeout(timeoutId);
+      if (!preserveMeetingState) {
+        for (const timeoutId of closeConsumerRetryTimeoutsRef.current.values()) {
+          window.clearTimeout(timeoutId);
+        }
+        closeConsumerRetryTimeoutsRef.current.clear();
       }
-      closeConsumerRetryTimeoutsRef.current.clear();
       mutedConsumerSinceRef.current.clear();
       producerPausedStateRef.current.clear();
       videoFreezeStatsRef.current.clear();
@@ -1164,8 +1172,12 @@ export function useMeetSocket({
         setWebinarSpeakerUserId(null);
         participantIdsRef.current = new Set([userId]);
         departedParticipantIdsRef.current.clear();
+        webinarJoinedParticipantIdsRef.current.clear();
+        webinarVisibleParticipantIdsRef.current.clear();
         serverRoomIdRef.current = null;
       }
+      webinarJoinedParticipantIdsRef.current.clear();
+      webinarVisibleParticipantIdsRef.current.clear();
 
       const shouldPreserveScreenShare =
         preserveMeetingState &&
@@ -1944,9 +1956,20 @@ export function useMeetSocket({
         closeConsumerRetryTimeoutsRef.current.delete(consumerId);
       }
 
+      const scheduleCloseRetry = (attempt: number) => {
+        const timeoutId = window.setTimeout(() => {
+          closeConsumerRetryTimeoutsRef.current.delete(consumerId);
+          closeWithRetry(attempt);
+        }, CLOSE_CONSUMER_RETRY_DELAY_MS);
+        closeConsumerRetryTimeoutsRef.current.set(consumerId, timeoutId);
+      };
+
       const closeWithRetry = (attempt: number) => {
         const socket = socketRef.current;
-        if (!socket?.connected) return;
+        if (!socket?.connected) {
+          scheduleCloseRetry(attempt);
+          return;
+        }
 
         socket.emit(
           "closeConsumer",
@@ -1968,11 +1991,7 @@ export function useMeetSocket({
               return;
             }
 
-            const timeoutId = window.setTimeout(() => {
-              closeConsumerRetryTimeoutsRef.current.delete(consumerId);
-              closeWithRetry(attempt + 1);
-            }, CLOSE_CONSUMER_RETRY_DELAY_MS);
-            closeConsumerRetryTimeoutsRef.current.set(consumerId, timeoutId);
+            scheduleCloseRetry(attempt + 1);
           },
         );
       };
@@ -5074,6 +5093,15 @@ export function useMeetSocket({
                 if (!isRoomEvent(notification.roomId)) return;
                 if (notification.userId === userId) return;
 
+                webinarJoinedParticipantIdsRef.current.add(notification.userId);
+                if (
+                  !webinarVisibleParticipantIdsRef.current.has(
+                    notification.userId,
+                  )
+                ) {
+                  return;
+                }
+
                 const clearedDepartedParticipant =
                   markRemoteParticipantPresent(notification.userId);
                 const displayName = notification.displayName;
@@ -5108,19 +5136,63 @@ export function useMeetSocket({
               (notification: WebinarFeedChangedNotification) => {
                 if (joinMode !== "webinar_attendee") return;
                 if (!isRoomEvent(notification.roomId)) return;
+                const nextVisibleParticipantIds = new Set<string>();
+                const restoredVisibleParticipantIds = new Set<string>();
+                let clearedDepartedParticipant = false;
+                for (const producer of notification.producers) {
+                  const producerUserId = producer.producerUserId;
+                  const hasJoinedSignal =
+                    webinarJoinedParticipantIdsRef.current.has(producerUserId);
+                  if (
+                    shouldIgnoreDepartedParticipant(producerUserId) &&
+                    !hasJoinedSignal
+                  ) {
+                    continue;
+                  }
+
+                  nextVisibleParticipantIds.add(producerUserId);
+                  if (
+                    hasJoinedSignal &&
+                    shouldIgnoreDepartedParticipant(producerUserId) &&
+                    !restoredVisibleParticipantIds.has(producerUserId)
+                  ) {
+                    restoredVisibleParticipantIds.add(producerUserId);
+                    clearedDepartedParticipant =
+                      markRemoteParticipantPresent(producerUserId) ||
+                      clearedDepartedParticipant;
+                    const leaveTimeout =
+                      leaveTimeoutsRef.current.get(producerUserId);
+                    if (leaveTimeout) {
+                      window.clearTimeout(leaveTimeout);
+                      leaveTimeoutsRef.current.delete(producerUserId);
+                    }
+                    clearParticipantConnectionStatus(producerUserId);
+                    dispatchParticipants({
+                      type: "ADD_PARTICIPANT",
+                      userId: producerUserId,
+                      addIfMissing: false,
+                    });
+                  }
+                }
+                webinarVisibleParticipantIdsRef.current =
+                  nextVisibleParticipantIds;
                 const activeFeedProducers = notification.producers.filter(
                   (producer) =>
+                    nextVisibleParticipantIds.has(producer.producerUserId) &&
                     !shouldIgnoreDepartedParticipant(producer.producerUserId),
                 );
                 setWebinarSpeakerUserId(
                   notification.speakerUserId &&
+                    nextVisibleParticipantIds.has(notification.speakerUserId) &&
                     !shouldIgnoreDepartedParticipant(notification.speakerUserId)
                     ? notification.speakerUserId
                     : activeFeedProducers[0]?.producerUserId ??
                     null,
                 );
                 void applyWebinarFeedProducers(notification.producers).finally(() => {
-                  void syncProducers();
+                  if (clearedDepartedParticipant) {
+                    void syncProducers();
+                  }
                 });
               },
             );

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -3579,6 +3579,8 @@ export function useMeetSocket({
               return;
             }
 
+            departedParticipantIdsRef.current.clear();
+
             if (response.status === "waiting") {
               setConnectionState("waiting");
               setHostUserId(response.hostUserId ?? null);
@@ -3629,7 +3631,6 @@ export function useMeetSocket({
               );
               currentRoomIdRef.current = targetRoomId;
               serverRoomIdRef.current = response.roomId ?? targetRoomId;
-              departedParticipantIdsRef.current.clear();
               setIsRoomLocked(response.isLocked ?? false);
               setMeetingRequiresInviteCode(
                 response.meetingRequiresInviteCode ?? false,

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -47,6 +47,7 @@ import type {
   WebinarConfigSnapshot,
   WebinarFeedChangedNotification,
   WebinarLinkResponse,
+  WebinarParticipantJoinedNotification,
   ServerRestartNotification,
   WebinarUpdateRequest,
 } from "../lib/types";
@@ -4943,6 +4944,26 @@ export function useMeetSocket({
                   linkSlug: previous?.linkSlug ?? null,
                   feedMode: previous?.feedMode ?? "active-speaker",
                 }));
+              },
+            );
+
+            socket.on(
+              "webinar:participantJoined",
+              (notification: WebinarParticipantJoinedNotification) => {
+                if (joinMode !== "webinar_attendee") return;
+                if (!isRoomEvent(notification.roomId)) return;
+                if (notification.userId === userId) return;
+
+                markRemoteParticipantPresent(notification.userId);
+                const displayName = notification.displayName;
+                if (displayName) {
+                  setDisplayNames((prev) => {
+                    const next = new Map(prev);
+                    next.set(notification.userId, displayName);
+                    return next;
+                  });
+                }
+                clearParticipantConnectionStatus(notification.userId);
               },
             );
 

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -104,6 +104,7 @@ const SCREEN_SHARE_STALE_REPLACEMENT_CLEANUP_DELAY_MS = 1500;
 const CLOSE_CONSUMER_RETRY_DELAY_MS = 500;
 const CLOSE_CONSUMER_MAX_ATTEMPTS = 4;
 const CLOSE_CONSUMER_RETRY_WINDOW_MS = 30000;
+const WEBINAR_FEED_JOIN_SYNC_DELAY_MS = 300;
 const TURN_URL_PATTERN = /^turns?:/i;
 const TRANSPORT_CC_FEEDBACK_TYPE = "transport-cc";
 
@@ -705,6 +706,7 @@ export function useMeetSocket({
     new Map(),
   );
   const closeConsumerRetryTimeoutsRef = useRef<Map<string, number>>(new Map());
+  const webinarFeedJoinSyncTimeoutRef = useRef<number | null>(null);
   const mutedConsumerSinceRef = useRef<Map<string, number>>(new Map());
   const producerPausedStateRef = useRef<Map<string, boolean>>(new Map());
   // Per-video-consumer decode progress for the freeze watchdog: last
@@ -1114,6 +1116,10 @@ export function useMeetSocket({
         window.clearTimeout(pendingProducerRetryTimeoutRef.current);
         pendingProducerRetryTimeoutRef.current = null;
       }
+      if (webinarFeedJoinSyncTimeoutRef.current != null) {
+        window.clearTimeout(webinarFeedJoinSyncTimeoutRef.current);
+        webinarFeedJoinSyncTimeoutRef.current = null;
+      }
 
       consumersRef.current.forEach((consumer) => {
         try {
@@ -1297,6 +1303,7 @@ export function useMeetSocket({
       producerTransportDisconnectTimeoutRef,
       consumerTransportDisconnectTimeoutRef,
       pendingProducerRetryTimeoutRef,
+      webinarFeedJoinSyncTimeoutRef,
       prejoinMediaIntentRef,
       producerSyncIntervalRef,
       consumeRetryAttemptsRef,
@@ -5166,6 +5173,7 @@ export function useMeetSocket({
                 const nextVisibleParticipantIds = new Set<string>();
                 const restoredVisibleParticipantIds = new Set<string>();
                 let clearedDepartedParticipant = false;
+                let sawDepartedFeedProducerWithoutJoinSignal = false;
                 for (const producer of notification.producers) {
                   const producerUserId = producer.producerUserId;
                   const hasJoinedSignal =
@@ -5174,6 +5182,7 @@ export function useMeetSocket({
                     shouldIgnoreDepartedParticipant(producerUserId) &&
                     !hasJoinedSignal
                   ) {
+                    sawDepartedFeedProducerWithoutJoinSignal = true;
                     continue;
                   }
 
@@ -5219,6 +5228,14 @@ export function useMeetSocket({
                 void applyWebinarFeedProducers(notification.producers).finally(() => {
                   if (clearedDepartedParticipant) {
                     void syncProducers();
+                  } else if (sawDepartedFeedProducerWithoutJoinSignal) {
+                    if (webinarFeedJoinSyncTimeoutRef.current != null) {
+                      window.clearTimeout(webinarFeedJoinSyncTimeoutRef.current);
+                    }
+                    webinarFeedJoinSyncTimeoutRef.current = window.setTimeout(() => {
+                      webinarFeedJoinSyncTimeoutRef.current = null;
+                      void syncProducers();
+                    }, WEBINAR_FEED_JOIN_SYNC_DELAY_MS);
                   }
                 });
               },

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -832,7 +832,7 @@ export function useMeetSocket({
   }, [userId]);
 
   const markRemoteParticipantPresent = useCallback((targetUserId: string) => {
-    departedParticipantIdsRef.current.delete(targetUserId);
+    return departedParticipantIdsRef.current.delete(targetUserId);
   }, []);
 
   const markRemoteParticipantDeparted = useCallback(
@@ -4172,7 +4172,8 @@ export function useMeetSocket({
                 if (joinedUserId === userId) {
                   return;
                 }
-                markRemoteParticipantPresent(joinedUserId);
+                const clearedDepartedParticipant =
+                  markRemoteParticipantPresent(joinedUserId);
                 if (shouldPlayJoinLeaveSound("join", joinedUserId)) {
                   playNotificationSound("join");
                 }
@@ -4194,6 +4195,9 @@ export function useMeetSocket({
                   userId: joinedUserId,
                   isGhost,
                 });
+                if (clearedDepartedParticipant) {
+                  void syncProducers();
+                }
               },
             );
 
@@ -4306,13 +4310,16 @@ export function useMeetSocket({
                 const snapshot = new Map<string, string>();
                 const nextParticipantIds = new Set<string>([userId]);
                 const previousParticipantIds = participantIdsRef.current;
+                let clearedDepartedParticipant = false;
                 (users || []).forEach(
                   ({ userId: snapshotUserId, displayName }) => {
                     if (displayName) {
                       snapshot.set(snapshotUserId, displayName);
                     }
                     if (snapshotUserId !== userId) {
-                      markRemoteParticipantPresent(snapshotUserId);
+                      clearedDepartedParticipant =
+                        markRemoteParticipantPresent(snapshotUserId) ||
+                        clearedDepartedParticipant;
                       if (!isSystemUserId(snapshotUserId)) {
                         nextParticipantIds.add(snapshotUserId);
                       }
@@ -4366,6 +4373,9 @@ export function useMeetSocket({
                 }
                 participantIdsRef.current = nextParticipantIds;
                 setDisplayNames(snapshot);
+                if (clearedDepartedParticipant) {
+                  void syncProducers();
+                }
               },
             );
 
@@ -5013,7 +5023,8 @@ export function useMeetSocket({
                 if (!isRoomEvent(notification.roomId)) return;
                 if (notification.userId === userId) return;
 
-                markRemoteParticipantPresent(notification.userId);
+                const clearedDepartedParticipant =
+                  markRemoteParticipantPresent(notification.userId);
                 const displayName = notification.displayName;
                 if (displayName) {
                   setDisplayNames((prev) => {
@@ -5034,6 +5045,9 @@ export function useMeetSocket({
                   type: "ADD_PARTICIPANT",
                   userId: notification.userId,
                 });
+                if (clearedDepartedParticipant) {
+                  void syncProducers();
+                }
               },
             );
 

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -1925,6 +1925,43 @@ export function useMeetSocket({
     ],
   );
 
+  const closeServerConsumer = useCallback(
+    (consumerId?: string | null) => {
+      if (!consumerId) return;
+      const socket = socketRef.current;
+      if (!socket?.connected) return;
+      socket.emit("closeConsumer", { consumerId }, () => {});
+    },
+    [socketRef],
+  );
+
+  const dropDepartedProducer = useCallback(
+    (producerInfo: ProducerInfo) => {
+      const producerId = producerInfo.producerId;
+      if (
+        consumersRef.current.has(producerId) ||
+        producerMapRef.current.has(producerId)
+      ) {
+        handleProducerClosed(producerId);
+        return;
+      }
+
+      announcedRemoteProducersRef.current.delete(producerId);
+      pendingProducersRef.current.delete(producerId);
+      consumeRetryAttemptsRef.current.delete(producerId);
+      producerPausedStateRef.current.delete(producerId);
+    },
+    [
+      announcedRemoteProducersRef,
+      consumeRetryAttemptsRef,
+      consumersRef,
+      handleProducerClosed,
+      pendingProducersRef,
+      producerMapRef,
+      producerPausedStateRef,
+    ],
+  );
+
   const queueProducerConsumeRetry = useCallback(
     (producerInfo: ProducerInfo, delayMs = 300) => {
       const attemptCount =
@@ -2636,10 +2673,11 @@ export function useMeetSocket({
       producerInfo: ProducerInfo,
       options: ConsumeProducerOptions = {},
     ): Promise<void> => {
-      if (
-        producerInfo.producerUserId === userId ||
-        shouldIgnoreDepartedParticipant(producerInfo.producerUserId)
-      ) {
+      if (producerInfo.producerUserId === userId) {
+        return;
+      }
+      if (shouldIgnoreDepartedParticipant(producerInfo.producerUserId)) {
+        dropDepartedProducer(producerInfo);
         return;
       }
       const existingConsumer = consumersRef.current.get(producerInfo.producerId);
@@ -2677,9 +2715,10 @@ export function useMeetSocket({
           },
           async (response: ConsumeResponse | { error: string }) => {
             if (shouldIgnoreDepartedParticipant(producerInfo.producerUserId)) {
-              announcedRemoteProducersRef.current.delete(producerInfo.producerId);
-              pendingProducersRef.current.delete(producerInfo.producerId);
-              consumeRetryAttemptsRef.current.delete(producerInfo.producerId);
+              if (!("error" in response)) {
+                closeServerConsumer(response.id);
+              }
+              dropDepartedProducer(producerInfo);
               resolve();
               return;
             }
@@ -2702,17 +2741,14 @@ export function useMeetSocket({
                   ),
               });
               if (shouldIgnoreDepartedParticipant(producerInfo.producerUserId)) {
+                closeServerConsumer(response.id);
                 try {
                   consumer.track.onmute = null;
                   consumer.track.onunmute = null;
                   consumer.track.stop();
                   consumer.close();
                 } catch {}
-                announcedRemoteProducersRef.current.delete(
-                  producerInfo.producerId,
-                );
-                pendingProducersRef.current.delete(producerInfo.producerId);
-                consumeRetryAttemptsRef.current.delete(producerInfo.producerId);
+                dropDepartedProducer(producerInfo);
                 resolve();
                 return;
               }
@@ -2944,6 +2980,7 @@ export function useMeetSocket({
               );
               resolve();
             } catch (err) {
+              closeServerConsumer(response.id);
               console.error("[Meets] Failed to create consumer:", err);
               queueProducerConsumeRetry(producerInfo, 350);
               resolve();
@@ -2963,6 +3000,8 @@ export function useMeetSocket({
       dispatchParticipants,
       handleProducerClosed,
       closeConsumerForSameProducerReconsume,
+      closeServerConsumer,
+      dropDepartedProducer,
       getReceiveNetworkProfile,
       joinMode,
       queueProducerConsumeRetry,
@@ -3197,14 +3236,7 @@ export function useMeetSocket({
 
       for (const producerInfo of producers) {
         if (shouldIgnoreDepartedParticipant(producerInfo.producerUserId)) {
-          if (
-            consumersRef.current.has(producerInfo.producerId) ||
-            producerMapRef.current.has(producerInfo.producerId)
-          ) {
-            handleProducerClosed(producerInfo.producerId);
-          }
-          announcedRemoteProducersRef.current.delete(producerInfo.producerId);
-          pendingProducersRef.current.delete(producerInfo.producerId);
+          dropDepartedProducer(producerInfo);
           continue;
         }
         setProducerPausedState(
@@ -3330,6 +3362,7 @@ export function useMeetSocket({
     pendingProducersRef,
     dispatchParticipants,
     consumeProducer,
+    dropDepartedProducer,
     handleProducerClosed,
     setProducerPausedState,
     shouldIgnoreDepartedParticipant,
@@ -3342,17 +3375,34 @@ export function useMeetSocket({
 
   const applyWebinarFeedProducers = useCallback(
     async (producers: ProducerInfo[]) => {
+      const activeProducers = producers.filter((producer) => {
+        const isDeparted = shouldIgnoreDepartedParticipant(
+          producer.producerUserId,
+        );
+        if (isDeparted) {
+          dropDepartedProducer(producer);
+        }
+        return !isDeparted;
+      });
       const serverProducerIds = new Set(
-        producers.map((producer) => producer.producerId),
+        activeProducers.map((producer) => producer.producerId),
       );
       for (const producerId of producerMapRef.current.keys()) {
         if (!serverProducerIds.has(producerId)) {
           handleProducerClosed(producerId);
         }
       }
-      await Promise.all(producers.map((producer) => consumeProducer(producer)));
+      await Promise.all(
+        activeProducers.map((producer) => consumeProducer(producer)),
+      );
     },
-    [consumeProducer, handleProducerClosed, producerMapRef],
+    [
+      consumeProducer,
+      dropDepartedProducer,
+      handleProducerClosed,
+      producerMapRef,
+      shouldIgnoreDepartedParticipant,
+    ],
   );
 
   const startProducerSync = useCallback(() => {
@@ -3529,6 +3579,7 @@ export function useMeetSocket({
               );
               currentRoomIdRef.current = targetRoomId;
               serverRoomIdRef.current = response.roomId ?? targetRoomId;
+              departedParticipantIdsRef.current.clear();
               setIsRoomLocked(response.isLocked ?? false);
               setMeetingRequiresInviteCode(
                 response.meetingRequiresInviteCode ?? false,
@@ -3941,9 +3992,7 @@ export function useMeetSocket({
             socket.on("newProducer", async (data: ProducerInfo) => {
               console.log("[Meets] New producer:", data);
               if (shouldIgnoreDepartedParticipant(data.producerUserId)) {
-                announcedRemoteProducersRef.current.delete(data.producerId);
-                pendingProducersRef.current.delete(data.producerId);
-                consumeRetryAttemptsRef.current.delete(data.producerId);
+                dropDepartedProducer(data);
                 return;
               }
               setProducerPausedState(data.producerId, Boolean(data.paused));
@@ -4173,9 +4222,11 @@ export function useMeetSocket({
                   .filter(([, info]) => info.userId === leftUserId)
                   .map(([producerId]) => producerId);
 
-                for (const [producerId, info] of pendingProducersRef.current) {
+                for (const info of Array.from(
+                  pendingProducersRef.current.values(),
+                )) {
                   if (info.producerUserId === leftUserId) {
-                    pendingProducersRef.current.delete(producerId);
+                    dropDepartedProducer(info);
                   }
                 }
 
@@ -4298,9 +4349,11 @@ export function useMeetSocket({
                   )
                     .filter(([, info]) => info.userId === previousUserId)
                     .map(([producerId]) => producerId);
-                  for (const [producerId, info] of pendingProducersRef.current) {
+                  for (const info of Array.from(
+                    pendingProducersRef.current.values(),
+                  )) {
                     if (info.producerUserId === previousUserId) {
-                      pendingProducersRef.current.delete(producerId);
+                      dropDepartedProducer(info);
                     }
                   }
                   for (const producerId of producersToClose) {
@@ -4989,9 +5042,15 @@ export function useMeetSocket({
               (notification: WebinarFeedChangedNotification) => {
                 if (joinMode !== "webinar_attendee") return;
                 if (!isRoomEvent(notification.roomId)) return;
+                const activeFeedProducers = notification.producers.filter(
+                  (producer) =>
+                    !shouldIgnoreDepartedParticipant(producer.producerUserId),
+                );
                 setWebinarSpeakerUserId(
-                  notification.speakerUserId ??
-                    notification.producers?.[0]?.producerUserId ??
+                  notification.speakerUserId &&
+                    !shouldIgnoreDepartedParticipant(notification.speakerUserId)
+                    ? notification.speakerUserId
+                    : activeFeedProducers[0]?.producerUserId ??
                     null,
                 );
                 void applyWebinarFeedProducers(notification.producers).finally(() => {

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -2004,10 +2004,12 @@ export function useMeetSocket({
   const dropDepartedProducer = useCallback(
     (producerInfo: ProducerInfo) => {
       const producerId = producerInfo.producerId;
+      const existingConsumer = consumersRef.current.get(producerId);
       if (
-        consumersRef.current.has(producerId) ||
+        existingConsumer ||
         producerMapRef.current.has(producerId)
       ) {
+        closeServerConsumer(existingConsumer?.id);
         handleProducerClosed(producerId);
         return;
       }
@@ -2020,6 +2022,7 @@ export function useMeetSocket({
     [
       announcedRemoteProducersRef,
       consumeRetryAttemptsRef,
+      closeServerConsumer,
       consumersRef,
       handleProducerClosed,
       pendingProducersRef,
@@ -4294,7 +4297,14 @@ export function useMeetSocket({
                   producerMapRef.current.entries(),
                 )
                   .filter(([, info]) => info.userId === leftUserId)
-                  .map(([producerId]) => producerId);
+                  .map(
+                    ([producerId, info]): ProducerInfo => ({
+                      producerId,
+                      producerUserId: leftUserId,
+                      kind: info.kind,
+                      type: info.type,
+                    }),
+                  );
 
                 for (const info of Array.from(
                   pendingProducersRef.current.values(),
@@ -4304,8 +4314,8 @@ export function useMeetSocket({
                   }
                 }
 
-                for (const producerId of producersToClose) {
-                  handleProducerClosed(producerId);
+                for (const producerInfo of producersToClose) {
+                  dropDepartedProducer(producerInfo);
                 }
 
                 dispatchParticipants({
@@ -4425,7 +4435,14 @@ export function useMeetSocket({
                     producerMapRef.current.entries(),
                   )
                     .filter(([, info]) => info.userId === previousUserId)
-                    .map(([producerId]) => producerId);
+                    .map(
+                      ([producerId, info]): ProducerInfo => ({
+                        producerId,
+                        producerUserId: previousUserId,
+                        kind: info.kind,
+                        type: info.type,
+                      }),
+                    );
                   for (const info of Array.from(
                     pendingProducersRef.current.values(),
                   )) {
@@ -4433,8 +4450,8 @@ export function useMeetSocket({
                       dropDepartedProducer(info);
                     }
                   }
-                  for (const producerId of producersToClose) {
-                    handleProducerClosed(producerId);
+                  for (const producerInfo of producersToClose) {
+                    dropDepartedProducer(producerInfo);
                   }
                   dispatchParticipants({
                     type: "REMOVE_PARTICIPANT",

--- a/apps/web/src/app/lib/klipy-gifs.ts
+++ b/apps/web/src/app/lib/klipy-gifs.ts
@@ -1,24 +1,40 @@
-import type { ChatGifAttachment } from "./types";
+import type { ChatGifAttachment, ChatGifAttachmentKind } from "./types";
 
-export interface KlipyGifResult extends ChatGifAttachment {
+// The Klipy catalogs we surface in the picker. These map to the plural path
+// segments used by the Klipy API (`/gifs`, `/stickers`, `/clips`).
+export type KlipyMediaKind = "gifs" | "stickers" | "clips";
+
+// The singular `ChatGifAttachment.kind` each catalog produces once sent.
+export const KLIPY_ATTACHMENT_KIND: Record<
+  KlipyMediaKind,
+  ChatGifAttachmentKind
+> = {
+  gifs: "gif",
+  stickers: "sticker",
+  clips: "clip",
+};
+
+export interface KlipyMediaResult extends ChatGifAttachment {
   previewUrl: string;
 }
 
-export interface KlipyGifSearchResponse {
-  gifs: KlipyGifResult[];
+export interface KlipyMediaSearchResponse {
+  items: KlipyMediaResult[];
   page: number;
   hasNext: boolean;
 }
 
-export const klipyGifResultToAttachment = (
-  gif: KlipyGifResult,
+export const klipyMediaResultToAttachment = (
+  item: KlipyMediaResult,
 ): ChatGifAttachment => ({
-  id: gif.id,
-  title: gif.title,
-  url: gif.url,
-  previewUrl: gif.previewUrl,
-  pageUrl: gif.pageUrl,
-  width: gif.width,
-  height: gif.height,
+  id: item.id,
+  title: item.title,
+  url: item.url,
+  previewUrl: item.previewUrl,
+  ...(item.pageUrl ? { pageUrl: item.pageUrl } : {}),
+  ...(item.width ? { width: item.width } : {}),
+  ...(item.height ? { height: item.height } : {}),
+  ...(item.kind ? { kind: item.kind } : {}),
+  ...(item.videoUrl ? { videoUrl: item.videoUrl } : {}),
   source: "klipy",
 });

--- a/packages/meeting-core/src/participant-reducer.ts
+++ b/packages/meeting-core/src/participant-reducer.ts
@@ -88,6 +88,7 @@ export function participantReducer(
     case "ADD_PARTICIPANT": {
       const existing = state.get(action.userId);
       if (existing) {
+        if (action.addIfMissing === false && existing.isLeaving) return state;
         const nextGhost = action.isGhost ?? existing.isGhost;
         // Re-add of an already-present, non-leaving participant with the same
         // ghost flag is a no-op (server re-sync) — keep the same reference.

--- a/packages/meeting-core/src/participant-reducer.ts
+++ b/packages/meeting-core/src/participant-reducer.ts
@@ -5,7 +5,12 @@ import type {
 } from "./types";
 
 export type ParticipantAction =
-  | { type: "ADD_PARTICIPANT"; userId: string; isGhost?: boolean }
+  | {
+      type: "ADD_PARTICIPANT";
+      userId: string;
+      isGhost?: boolean;
+      addIfMissing?: boolean;
+    }
   | { type: "REMOVE_PARTICIPANT"; userId: string }
   | { type: "MARK_LEAVING"; userId: string }
   | {
@@ -96,6 +101,7 @@ export function participantReducer(
           connectionStatus: undefined,
         });
       }
+      if (action.addIfMissing === false) return state;
       return withParticipant(
         state,
         action.userId,

--- a/packages/meeting-core/src/participant-reducer.ts
+++ b/packages/meeting-core/src/participant-reducer.ts
@@ -10,6 +10,7 @@ export type ParticipantAction =
       userId: string;
       isGhost?: boolean;
       addIfMissing?: boolean;
+      reviveIfPresent?: boolean;
     }
   | { type: "REMOVE_PARTICIPANT"; userId: string }
   | { type: "MARK_LEAVING"; userId: string }
@@ -88,7 +89,13 @@ export function participantReducer(
     case "ADD_PARTICIPANT": {
       const existing = state.get(action.userId);
       if (existing) {
-        if (action.addIfMissing === false && existing.isLeaving) return state;
+        if (
+          action.addIfMissing === false &&
+          existing.isLeaving &&
+          !action.reviveIfPresent
+        ) {
+          return state;
+        }
         const nextGhost = action.isGhost ?? existing.isGhost;
         // Re-add of an already-present, non-leaving participant with the same
         // ghost flag is a no-op (server re-sync) — keep the same reference.

--- a/packages/meeting-core/src/sfu-events.ts
+++ b/packages/meeting-core/src/sfu-events.ts
@@ -184,6 +184,7 @@ export const SFU_EVENTS = {
 
     // Webinar
     webinarFeedChanged: "webinar:feedChanged",
+    webinarParticipantJoined: "webinar:participantJoined",
     webinarAttendeeCountChanged: "webinar:attendeeCountChanged",
 
     // Meeting / webinar config broadcasts

--- a/packages/meeting-core/src/sfu-events.ts
+++ b/packages/meeting-core/src/sfu-events.ts
@@ -33,6 +33,7 @@ export const SFU_EVENTS = {
     consume: "consume",
     resumeConsumer: "resumeConsumer",
     setConsumerPreferences: "setConsumerPreferences",
+    closeConsumer: "closeConsumer",
     closeProducer: "closeProducer",
     getProducers: "getProducers",
     restartIce: "restartIce",
@@ -134,6 +135,7 @@ export const SFU_EVENTS = {
     producerClosed: "producerClosed",
     participantMuted: "participantMuted",
     participantCameraOff: "participantCameraOff",
+    participantConnectionState: "participantConnectionState",
     setVideoQuality: "setVideoQuality",
     consumerTelemetry: "consumerTelemetry",
 

--- a/packages/meeting-core/src/types.ts
+++ b/packages/meeting-core/src/types.ts
@@ -61,6 +61,8 @@ export interface ChatReplyPreview {
   dmTargetUserId?: string;
 }
 
+export type ChatGifAttachmentKind = "gif" | "sticker" | "clip";
+
 export interface ChatGifAttachment {
   id: string;
   title: string;
@@ -69,6 +71,12 @@ export interface ChatGifAttachment {
   pageUrl?: string;
   width?: number;
   height?: number;
+  // Which Klipy media catalog this came from. Absent on legacy messages,
+  // which should be treated as "gif". Clips additionally carry `videoUrl`.
+  kind?: ChatGifAttachmentKind;
+  // Direct MP4 URL for clips. `url` remains a renderable image (the clip's
+  // animated GIF) so clients that don't understand clips still show something.
+  videoUrl?: string;
   source: "klipy";
 }
 

--- a/packages/meeting-core/src/types.ts
+++ b/packages/meeting-core/src/types.ts
@@ -233,6 +233,12 @@ export interface WebinarFeedChangedNotification {
   producers: ProducerInfo[];
 }
 
+export interface WebinarParticipantJoinedNotification {
+  roomId: string;
+  userId: string;
+  displayName?: string;
+}
+
 export interface ServerRestartNotification {
   roomId?: string;
   message?: string;

--- a/packages/meeting-core/test/participant-reducer.test.ts
+++ b/packages/meeting-core/test/participant-reducer.test.ts
@@ -113,6 +113,35 @@ describe("participantReducer — ADD_PARTICIPANT (join)", () => {
     expect(next.get("a")!.isLeaving).toBe(true);
   });
 
+  it("revives a leaving participant when explicitly restoring an existing one", () => {
+    let state = seed("a");
+    state = participantReducer(state, { type: "MARK_LEAVING", userId: "a" });
+
+    const next = participantReducer(state, {
+      type: "ADD_PARTICIPANT",
+      userId: "a",
+      addIfMissing: false,
+      reviveIfPresent: true,
+    });
+
+    expect(next).not.toBe(state);
+    expect(next.get("a")!.isLeaving).toBe(false);
+  });
+
+  it("does not add a missing participant when reviveIfPresent is true", () => {
+    const state = empty();
+
+    const next = participantReducer(state, {
+      type: "ADD_PARTICIPANT",
+      userId: "hidden",
+      addIfMissing: false,
+      reviveIfPresent: true,
+    });
+
+    expect(next).toBe(state);
+    expect(next.has("hidden")).toBe(false);
+  });
+
   it("promotes a ghost to a real participant on re-add (ghost flag change)", () => {
     const state = seed("a", { isGhost: true });
     const next = participantReducer(state, {

--- a/packages/meeting-core/test/participant-reducer.test.ts
+++ b/packages/meeting-core/test/participant-reducer.test.ts
@@ -87,6 +87,18 @@ describe("participantReducer — ADD_PARTICIPANT (join)", () => {
     expect(next.get("a")!.isLeaving).toBe(false);
   });
 
+  it("does not add a missing participant when addIfMissing is false", () => {
+    const state = empty();
+    const next = participantReducer(state, {
+      type: "ADD_PARTICIPANT",
+      userId: "hidden",
+      addIfMissing: false,
+    });
+
+    expect(next).toBe(state);
+    expect(next.has("hidden")).toBe(false);
+  });
+
   it("promotes a ghost to a real participant on re-add (ghost flag change)", () => {
     const state = seed("a", { isGhost: true });
     const next = participantReducer(state, {

--- a/packages/meeting-core/test/participant-reducer.test.ts
+++ b/packages/meeting-core/test/participant-reducer.test.ts
@@ -99,6 +99,20 @@ describe("participantReducer — ADD_PARTICIPANT (join)", () => {
     expect(next.has("hidden")).toBe(false);
   });
 
+  it("does not revive a leaving participant when addIfMissing is false", () => {
+    let state = seed("a");
+    state = participantReducer(state, { type: "MARK_LEAVING", userId: "a" });
+
+    const next = participantReducer(state, {
+      type: "ADD_PARTICIPANT",
+      userId: "a",
+      addIfMissing: false,
+    });
+
+    expect(next).toBe(state);
+    expect(next.get("a")!.isLeaving).toBe(true);
+  });
+
   it("promotes a ghost to a real participant on re-add (ghost flag change)", () => {
     const state = seed("a", { isGhost: true });
     const next = participantReducer(state, {

--- a/packages/meeting-core/test/sfu-events.test.ts
+++ b/packages/meeting-core/test/sfu-events.test.ts
@@ -28,4 +28,20 @@ describe("SFU_EVENTS", () => {
       ]),
     );
   });
+
+  it("keeps native media lifecycle events in the shared registry", () => {
+    const clientEvents = new Set(Object.values(SFU_EVENTS.clientToServer));
+    const serverEvents = new Set(Object.values(SFU_EVENTS.serverToClient));
+
+    expect(Array.from(clientEvents)).toEqual(
+      expect.arrayContaining(["closeConsumer"]),
+    );
+    expect(Array.from(serverEvents)).toEqual(
+      expect.arrayContaining([
+        "participantConnectionState",
+        "consumerTelemetry",
+        "producerClosed",
+      ]),
+    );
+  });
 });

--- a/packages/sfu/server/socket/handlers/chatHandlers.ts
+++ b/packages/sfu/server/socket/handlers/chatHandlers.ts
@@ -83,6 +83,18 @@ const normalizeChatGifAttachment = (
   const title = (rawTitle || "GIF").slice(0, MAX_GIF_TITLE_LENGTH);
   const width = normalizeGifDimension(candidate.width);
   const height = normalizeGifDimension(candidate.height);
+  const kind =
+    candidate.kind === "sticker" ||
+    candidate.kind === "clip" ||
+    candidate.kind === "gif"
+      ? candidate.kind
+      : undefined;
+  // Clips carry an MP4 alongside the GIF fallback in `url`; only clips may
+  // declare one, and it must live on the same trusted Klipy media host.
+  const videoUrl =
+    kind === "clip"
+      ? (normalizeHttpsUrl(candidate.videoUrl, KLIPY_MEDIA_HOSTS) ?? undefined)
+      : undefined;
 
   return {
     id,
@@ -92,6 +104,8 @@ const normalizeChatGifAttachment = (
     ...(pageUrl ? { pageUrl } : {}),
     ...(width ? { width } : {}),
     ...(height ? { height } : {}),
+    ...(kind ? { kind } : {}),
+    ...(videoUrl ? { videoUrl } : {}),
     source: "klipy",
   };
 };

--- a/packages/sfu/server/socket/handlers/joinRoom.ts
+++ b/packages/sfu/server/socket/handlers/joinRoom.ts
@@ -731,16 +731,9 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
               });
             }
           } else if (!context.currentClient.isWebinarAttendee) {
-            for (const [clientId, client] of context.currentRoom.clients) {
-              if (clientId === userId || client.isWebinarAttendee) {
-                continue;
-              }
-              client.socket.emit("userJoined", {
-                userId,
-                displayName: resolvedDisplayName,
-                roomId: context.currentRoom.id,
-              });
-            }
+            emitUserJoined(context.currentRoom, userId, resolvedDisplayName, {
+              excludeUserId: userId,
+            });
           }
         } else if (wasReconnectNoticeEmitted) {
           Logger.info(`User ${userId} reconnected to room ${roomId}.`);

--- a/packages/sfu/server/socket/handlers/joinRoom.ts
+++ b/packages/sfu/server/socket/handlers/joinRoom.ts
@@ -731,9 +731,24 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
               });
             }
           } else if (!context.currentClient.isWebinarAttendee) {
-            emitUserJoined(context.currentRoom, userId, resolvedDisplayName, {
-              excludeUserId: userId,
-            });
+            for (const [clientId, client] of context.currentRoom.clients) {
+              if (clientId === userId) {
+                continue;
+              }
+              if (client.isWebinarAttendee) {
+                client.socket.emit("webinar:participantJoined", {
+                  userId,
+                  displayName: resolvedDisplayName,
+                  roomId: context.currentRoom.id,
+                });
+                continue;
+              }
+              client.socket.emit("userJoined", {
+                userId,
+                displayName: resolvedDisplayName,
+                roomId: context.currentRoom.id,
+              });
+            }
           }
         } else if (wasReconnectNoticeEmitted) {
           Logger.info(`User ${userId} reconnected to room ${roomId}.`);

--- a/packages/sfu/server/socket/handlers/mediaHandlers.ts
+++ b/packages/sfu/server/socket/handlers/mediaHandlers.ts
@@ -729,6 +729,13 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
           return;
         }
 
+        if (!takeToken(socket, "closeConsumer", RATE_LIMITS.consumerControl)) {
+          respond(callback, {
+            error: "Too many consumer control requests; please retry shortly",
+          });
+          return;
+        }
+
         const consumerId = normalizeMediaId(data?.consumerId);
         if (!consumerId) {
           respond(callback, { error: "Consumer ID is required" });

--- a/packages/sfu/server/socket/handlers/mediaHandlers.ts
+++ b/packages/sfu/server/socket/handlers/mediaHandlers.ts
@@ -1,5 +1,6 @@
 import type { Consumer, ConsumerLayers } from "mediasoup/types";
 import type {
+  CloseConsumerData,
   ConsumeData,
   ConsumeResponse,
   ConsumerTelemetryNotification,
@@ -707,6 +708,41 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
           { room, client: currentClient, consumer },
           wasPaused ? "resume" : "preferences",
         );
+        respond(callback, { success: true });
+      } catch (error) {
+        respond(callback, { error: (error as Error).message });
+      }
+    },
+  );
+
+  socket.on(
+    "closeConsumer",
+    (
+      data: CloseConsumerData,
+      callback: (response: { success: boolean } | { error: string }) => void,
+    ) => {
+      try {
+        const room = context.currentRoom;
+        const currentClient = context.currentClient;
+        if (!room || !currentClient) {
+          respond(callback, { error: "Not in a room" });
+          return;
+        }
+
+        const consumerId = normalizeMediaId(data?.consumerId);
+        if (!consumerId) {
+          respond(callback, { error: "Consumer ID is required" });
+          return;
+        }
+
+        const consumer = currentClient.getConsumerById(consumerId);
+        if (!consumer) {
+          respond(callback, { success: true });
+          return;
+        }
+
+        emitConsumerTelemetry({ room, client: currentClient, consumer }, "closed");
+        consumer.close();
         respond(callback, { success: true });
       } catch (error) {
         respond(callback, { error: (error as Error).message });

--- a/packages/sfu/server/socket/handlers/mediaHandlers.ts
+++ b/packages/sfu/server/socket/handlers/mediaHandlers.ts
@@ -748,8 +748,18 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
           return;
         }
 
-        emitConsumerTelemetry({ room, client: currentClient, consumer }, "closed");
         consumer.close();
+        try {
+          emitConsumerTelemetry({ room, client: currentClient, consumer }, "closed");
+        } catch (telemetryError) {
+          Logger.warn(
+            `Failed to emit close telemetry for consumer ${consumerId}: ${
+              telemetryError instanceof Error
+                ? telemetryError.message
+                : String(telemetryError)
+            }`,
+          );
+        }
         respond(callback, { success: true });
       } catch (error) {
         respond(callback, { error: (error as Error).message });

--- a/packages/sfu/types.ts
+++ b/packages/sfu/types.ts
@@ -432,6 +432,8 @@ export interface ChatReplyPreview {
   dmTargetUserId?: string;
 }
 
+export type ChatGifAttachmentKind = "gif" | "sticker" | "clip";
+
 export interface ChatGifAttachment {
   id: string;
   title: string;
@@ -440,6 +442,12 @@ export interface ChatGifAttachment {
   pageUrl?: string;
   width?: number;
   height?: number;
+  // Which Klipy media catalog this came from. Absent on legacy messages,
+  // which should be treated as "gif". Clips additionally carry `videoUrl`.
+  kind?: ChatGifAttachmentKind;
+  // Direct MP4 URL for clips. `url` remains a renderable image (the clip's
+  // animated GIF) so clients that don't understand clips still show something.
+  videoUrl?: string;
   source: "klipy";
 }
 

--- a/packages/sfu/types.ts
+++ b/packages/sfu/types.ts
@@ -329,6 +329,12 @@ export interface WebinarFeedChangedNotification {
   producers: ProducerInfo[];
 }
 
+export interface WebinarParticipantJoinedNotification {
+  roomId: string;
+  userId: string;
+  displayName?: string;
+}
+
 export interface WebinarAttendeeCountChangedNotification {
   roomId: string;
   attendeeCount: number;

--- a/packages/sfu/types.ts
+++ b/packages/sfu/types.ts
@@ -122,6 +122,10 @@ export interface ConsumeData {
   priority?: number;
 }
 
+export interface CloseConsumerData {
+  consumerId: string;
+}
+
 export interface ConsumeResponse {
   id: string;
   producerId: string;


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR introduces a tombstone mechanism for departed meeting participants — tracking departure via `departedParticipantIdsRef` and restoration via `webinarJoinedParticipantIdsRef` / `webinarVisibleParticipantIdsRef` — and adds a `closeConsumer` server handler with retry logic for cleaning up server-side consumers when a participant leaves mid-consume. It also expands the Klipy media picker to support stickers and video clips alongside GIFs.

- **Departed participant tracking**: `markRemoteParticipantDeparted` / `markRemoteParticipantPresent` helpers gate `consumeProducer`, `applyWebinarFeedProducers`, and connection-status updates; `dropDepartedProducer` replaces bare `handleProducerClosed` calls to also close server consumers and clean bookkeeping refs.
- **`closeConsumer` server handler**: rate-limited, close-before-telemetry ordering, idempotent not-found response; client side adds a capped exponential-backoff retry via `closeConsumerRetryTimeoutsRef`.
- **Webinar attendee flow**: `joinRoom.ts` now emits `webinar:participantJoined` to attendees instead of silently skipping them; the client handler uses this event to populate `webinarJoinedParticipantIdsRef` and gate tombstone restoration in `applyWebinarFeedProducers`.

<h3>Confidence Score: 3/5</h3>

The core tombstone mechanism is well-structured but has a timing gap in the webinar attendee path that can leave a rejoined speaker's feed blank until a subsequent sync fires.

The webinar:feedChanged handler drops producers for tombstoned users unless they are already in webinarJoinedParticipantIdsRef. Because webinar:participantJoined and feed-change events originate from different server code paths, the feed notification can arrive first, causing applyWebinarFeedProducers to call dropDepartedProducer for a legitimately rejoined speaker. The feed self-corrects once the delayed webinar:participantJoined triggers syncProducers, but the window of blank feed is user-visible and recovery depends on event ordering rather than an explicit guarantee.

apps/web/src/app/hooks/useMeetSocket.ts — specifically applyWebinarFeedProducers and the webinar:feedChanged / webinar:participantJoined handler interaction.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/hooks/useMeetSocket.ts | Core departed-participant tracking: adds departedParticipantIdsRef, webinarJoinedParticipantIdsRef, webinarVisibleParticipantIdsRef, closeServerConsumer retry logic, dropDepartedProducer, and restoreWebinarFeedParticipant. Has a potential blank-feed window when feedChanged arrives before participantJoined for a tombstoned speaker. |
| packages/meeting-core/src/participant-reducer.ts | Adds addIfMissing/reviveIfPresent flags to ADD_PARTICIPANT; correctly guards leaving-participant revival; connectionStatus clear on ghost-flag update with addIfMissing is a minor edge case. |
| packages/sfu/server/socket/handlers/mediaHandlers.ts | Adds closeConsumer handler with rate-limit guard, idempotent not-found success response, close-before-telemetry ordering, and swallowed telemetry errors — all correct. |
| packages/sfu/server/socket/handlers/joinRoom.ts | Splits userJoined broadcast: webinar attendees now receive webinar:participantJoined instead of userJoined, correctly differentiating the two presence flows. |
| apps/web/src/app/api/klipy/gifs/route.ts | Expands the Klipy API route to support stickers and clips alongside GIFs, with separate normalisation paths for nested (gifs/stickers) and flat (clips) item formats. |
| apps/web/src/app/components/ChatGifAttachmentView.tsx | Adds ClipAttachment video component with mute toggle and refactors Watermark to a shared component; sticker detection removes dark background appropriately. |
| apps/web/src/app/components/GifPicker.tsx | Adds GIFs/Stickers/Clips tab switcher with state reset on tab change; clips use autoplay video thumbnails; stickers use object-contain instead of object-cover. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Server
    participant Client as Client (useMeetSocket)
    participant Reducer as participantReducer

    Note over Server,Reducer: Participant departs
    Server->>Client: "userLeft {userId}"
    Client->>Client: markRemoteParticipantDeparted(userId)
    Client->>Client: dropDepartedProducer → closeServerConsumer + handleProducerClosed
    Client->>Reducer: "MARK_LEAVING {userId}"

    Note over Server,Reducer: Participant rejoins (regular meeting)
    Server->>Client: "userJoined {userId}"
    Client->>Client: markRemoteParticipantPresent(userId)
    Client->>Client: syncProducers()
    Client->>Reducer: "ADD_PARTICIPANT {userId}"

    Note over Server,Reducer: Participant rejoins (webinar attendee path)
    Server->>Client: "webinar:participantJoined {userId}"
    Client->>Client: webinarJoinedParticipantIdsRef.add(userId)
    Client->>Client: syncProducers() [if departed or visible]

    Server->>Client: "webinar:feedChanged {producers}"
    Client->>Client: "webinarVisibleParticipantIdsRef = new Set(producerUserIds)"
    Client->>Client: applyWebinarFeedProducers(producers)
    alt departed AND in webinarJoinedParticipantIdsRef
        Client->>Client: restoreWebinarFeedParticipant(userId)
        Client->>Reducer: "ADD_PARTICIPANT {addIfMissing:false, reviveIfPresent:true}"
        Client->>Client: consumeProducer(producer)
    else departed AND NOT in webinarJoinedParticipantIdsRef
        Client->>Client: dropDepartedProducer(producer)
    end

    Note over Server,Reducer: In-flight consume for departed producer
    Server-->>Client: "consume ack {consumerId}"
    Client->>Client: shouldIgnoreDepartedParticipant? → closeServerConsumer(consumerId)
    Client->>Client: dropDepartedProducer(producerInfo)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Server
    participant Client as Client (useMeetSocket)
    participant Reducer as participantReducer

    Note over Server,Reducer: Participant departs
    Server->>Client: "userLeft {userId}"
    Client->>Client: markRemoteParticipantDeparted(userId)
    Client->>Client: dropDepartedProducer → closeServerConsumer + handleProducerClosed
    Client->>Reducer: "MARK_LEAVING {userId}"

    Note over Server,Reducer: Participant rejoins (regular meeting)
    Server->>Client: "userJoined {userId}"
    Client->>Client: markRemoteParticipantPresent(userId)
    Client->>Client: syncProducers()
    Client->>Reducer: "ADD_PARTICIPANT {userId}"

    Note over Server,Reducer: Participant rejoins (webinar attendee path)
    Server->>Client: "webinar:participantJoined {userId}"
    Client->>Client: webinarJoinedParticipantIdsRef.add(userId)
    Client->>Client: syncProducers() [if departed or visible]

    Server->>Client: "webinar:feedChanged {producers}"
    Client->>Client: "webinarVisibleParticipantIdsRef = new Set(producerUserIds)"
    Client->>Client: applyWebinarFeedProducers(producers)
    alt departed AND in webinarJoinedParticipantIdsRef
        Client->>Client: restoreWebinarFeedParticipant(userId)
        Client->>Reducer: "ADD_PARTICIPANT {addIfMissing:false, reviveIfPresent:true}"
        Client->>Client: consumeProducer(producer)
    else departed AND NOT in webinarJoinedParticipantIdsRef
        Client->>Client: dropDepartedProducer(producer)
    end

    Note over Server,Reducer: In-flight consume for departed producer
    Server-->>Client: "consume ack {consumerId}"
    Client->>Client: shouldIgnoreDepartedParticipant? → closeServerConsumer(consumerId)
    Client->>Client: dropDepartedProducer(producerInfo)
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (6)</h3></summary>

1. `apps/web/src/app/hooks/useMeetSocket.ts`, line 3587-3589 ([link](https://github.com/acm-vit/conclave/blob/367f9e9a322c2c7421c1c5665913f3dcde311c8e/apps/web/src/app/hooks/useMeetSocket.ts#L3587-L3589)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Clear stale tombstones**

   `joinRoomInternal` consumes `response.existingProducers` before marking those producer users present. During reconnect, `cleanupRoomResources({ preserveMeetingState: true })` preserves `departedParticipantIdsRef`, so a participant who left earlier and rejoined while this client was reconnecting can still be in the departed set. When the join response includes that participant's active producers, `consumeProducer` returns early and the remote audio/video stays missing until another event happens to clear the tombstone.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused runtime harness for stale tombstone join ordering](https://app.greptile.com/trex/artifacts/212eaec9-9771-4f65-b21b-a7a066714201)**

   - Contains supporting evidence from the run (text/javascript; charset=utf-8).

   **[Stack trace captured during the T-Rex run](https://app.greptile.com/trex/artifacts/b20d04dd-a1e9-4a6b-81e8-5d3d16ed7369)**

   - Keeps the raw stack trace available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11801570/artifacts?artifact=212eaec9-9771-4f65-b21b-a7a066714201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%0ALine%3A%203587-3589%0A%0AComment%3A%0A**Clear%20stale%20tombstones**%0A%0A%60joinRoomInternal%60%20consumes%20%60response.existingProducers%60%20before%20marking%20those%20producer%20users%20present.%20During%20reconnect%2C%20%60cleanupRoomResources%28%7B%20preserveMeetingState%3A%20true%20%7D%29%60%20preserves%20%60departedParticipantIdsRef%60%2C%20so%20a%20participant%20who%20left%20earlier%20and%20rejoined%20while%20this%20client%20was%20reconnecting%20can%20still%20be%20in%20the%20departed%20set.%20When%20the%20join%20response%20includes%20that%20participant's%20active%20producers%2C%20%60consumeProducer%60%20returns%20early%20and%20the%20remote%20audio%2Fvideo%20stays%20missing%20until%20another%20event%20happens%20to%20clear%20the%20tombstone.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=95&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%0ALine%3A%203587-3589%0A%0AComment%3A%0A**Clear%20stale%20tombstones**%0A%0A%60joinRoomInternal%60%20consumes%20%60response.existingProducers%60%20before%20marking%20those%20producer%20users%20present.%20During%20reconnect%2C%20%60cleanupRoomResources%28%7B%20preserveMeetingState%3A%20true%20%7D%29%60%20preserves%20%60departedParticipantIdsRef%60%2C%20so%20a%20participant%20who%20left%20earlier%20and%20rejoined%20while%20this%20client%20was%20reconnecting%20can%20still%20be%20in%20the%20departed%20set.%20When%20the%20join%20response%20includes%20that%20participant's%20active%20producers%2C%20%60consumeProducer%60%20returns%20early%20and%20the%20remote%20audio%2Fvideo%20stays%20missing%20until%20another%20event%20happens%20to%20clear%20the%20tombstone.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=95&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%0ALine%3A%203587-3589%0A%0AComment%3A%0A**Clear%20stale%20tombstones**%0A%0A%60joinRoomInternal%60%20consumes%20%60response.existingProducers%60%20before%20marking%20those%20producer%20users%20present.%20During%20reconnect%2C%20%60cleanupRoomResources%28%7B%20preserveMeetingState%3A%20true%20%7D%29%60%20preserves%20%60departedParticipantIdsRef%60%2C%20so%20a%20participant%20who%20left%20earlier%20and%20rejoined%20while%20this%20client%20was%20reconnecting%20can%20still%20be%20in%20the%20departed%20set.%20When%20the%20join%20response%20includes%20that%20participant's%20active%20producers%2C%20%60consumeProducer%60%20returns%20early%20and%20the%20remote%20audio%2Fvideo%20stays%20missing%20until%20another%20event%20happens%20to%20clear%20the%20tombstone.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=95&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `apps/web/src/app/hooks/useMeetSocket.ts`, line 3346 ([link](https://github.com/acm-vit/conclave/blob/367f9e9a322c2c7421c1c5665913f3dcde311c8e/apps/web/src/app/hooks/useMeetSocket.ts#L3346)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Mark feed users present**

   Webinar feed updates pass the server's producer list straight to `consumeProducer`, but departed producer users are still filtered by `shouldIgnoreDepartedParticipant`. If a speaker was previously tombstoned and then becomes the active webinar feed again, the attendee records the new speaker id but skips all of that speaker's producers, leaving the feed blank or stale.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused webinar feed departed producer harness](https://app.greptile.com/trex/artifacts/a18c2d3f-32b5-43c6-8550-ec976b6b15ed)**

   - Contains supporting evidence from the run (text/javascript; charset=utf-8).

   **[Repro: harness output showing skipped consume and blank feed state](https://app.greptile.com/trex/artifacts/8bbd8141-a61f-41ae-810e-aa75f17d1489)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11801570/artifacts?artifact=a18c2d3f-32b5-43c6-8550-ec976b6b15ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%0ALine%3A%203346%0A%0AComment%3A%0A**Mark%20feed%20users%20present**%0A%0AWebinar%20feed%20updates%20pass%20the%20server's%20producer%20list%20straight%20to%20%60consumeProducer%60%2C%20but%20departed%20producer%20users%20are%20still%20filtered%20by%20%60shouldIgnoreDepartedParticipant%60.%20If%20a%20speaker%20was%20previously%20tombstoned%20and%20then%20becomes%20the%20active%20webinar%20feed%20again%2C%20the%20attendee%20records%20the%20new%20speaker%20id%20but%20skips%20all%20of%20that%20speaker's%20producers%2C%20leaving%20the%20feed%20blank%20or%20stale.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=95&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%0ALine%3A%203346%0A%0AComment%3A%0A**Mark%20feed%20users%20present**%0A%0AWebinar%20feed%20updates%20pass%20the%20server's%20producer%20list%20straight%20to%20%60consumeProducer%60%2C%20but%20departed%20producer%20users%20are%20still%20filtered%20by%20%60shouldIgnoreDepartedParticipant%60.%20If%20a%20speaker%20was%20previously%20tombstoned%20and%20then%20becomes%20the%20active%20webinar%20feed%20again%2C%20the%20attendee%20records%20the%20new%20speaker%20id%20but%20skips%20all%20of%20that%20speaker's%20producers%2C%20leaving%20the%20feed%20blank%20or%20stale.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=95&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%0ALine%3A%203346%0A%0AComment%3A%0A**Mark%20feed%20users%20present**%0A%0AWebinar%20feed%20updates%20pass%20the%20server's%20producer%20list%20straight%20to%20%60consumeProducer%60%2C%20but%20departed%20producer%20users%20are%20still%20filtered%20by%20%60shouldIgnoreDepartedParticipant%60.%20If%20a%20speaker%20was%20previously%20tombstoned%20and%20then%20becomes%20the%20active%20webinar%20feed%20again%2C%20the%20attendee%20records%20the%20new%20speaker%20id%20but%20skips%20all%20of%20that%20speaker's%20producers%2C%20leaving%20the%20feed%20blank%20or%20stale.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=95&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale participant connection state is still applied after the participant leaves**

   - **Bug**
     - After userLeft tombstones a remote participant, head still accepts a later participantConnectionState event for that departed user. The executed after log shows `stale connection after leave => applied` and final connection state includes `["remote-a", "reconnecting"]`, even though stale producer and participant media/control state updates are suppressed. This contradicts the requested contract that connection status updates for departed users should be ignored until userJoined or a participant snapshot marks them present again.
   - **Cause**
     - The participantConnectionState socket handler in apps/web/src/app/hooks/useMeetSocket.ts applies `applyParticipantConnectionStatus(targetUserId, ...)` without first checking `shouldIgnoreDepartedParticipant(targetUserId)`. Other nearby handlers added departed-user guards, but this connection-status path was missed.
   - **Fix**
     - In the participantConnectionState handler, after validating `targetUserId` and before reading/applying `state`, add a guard such as `if (shouldIgnoreDepartedParticipant(targetUserId)) return;`. Ensure the handler's callback dependencies include the guard if needed by the surrounding effect.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

4. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Departed remote participants still accept stale mute/camera updates and feed removal does not mark departure**

   - **Bug**
     - The PR contract says departed remote participants should ignore later stale socket/media events, including hand/mute/camera updates, until userJoined or a webinar feed snapshot marks them present again. The head run demonstrates only partial suppression: after userLeft, stale newProducer, connection, and hand events are ignored, but stale participantMuted and participantCameraOff updates are still dispatched. The same harness also shows removal from the feed/snapshot path did not mark the participant departed, so a stale hand update after snapshot removal was still dispatched.
   - **Cause**
     - The departed-user guard is not consistently applied to all relevant useMeetSocket update paths. The affected behavior is visible around apps/web/src/app/hooks/useMeetSocket.ts participantMuted/participantCameraOff handling near lines 4380-4429 and webinar feed producer handling near lines 3336-3348, which does not mark removed feed users departed in the executed extraction.
   - **Fix**
     - Add shouldIgnoreDepartedParticipant checks before dispatching remote participantMuted and participantCameraOff updates, and update webinar feed application/removal logic to mark producer users absent from a fresh feed snapshot as departed while marking included feed users present again. Ensure stale pending/consumer state is cleaned for departed feed users and add regression coverage for leave, stale mute/camera, feed removal, and rejoin/reappear.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

5. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Departed participant connection-state events are still applied before rejoin**

   - **Bug**
     - After B leaves and is marked departed, a stale `participantConnectionState` event for B is still processed. The executed head harness logs `applyParticipantConnectionStatus` for B during the departed window, even though stale producer, hand-raised, and mute events are ignored/dropped. This violates the departed participant lifecycle contract for stale participant state events.
   - **Cause**
     - The `participantConnectionState` socket handler in `apps/web/src/app/hooks/useMeetSocket.ts` validates the room and target user but does not call `shouldIgnoreDepartedParticipant(targetUserId)` before `applyParticipantConnectionStatus(...)` and telemetry capture.
   - **Fix**
     - Add a departed-participant guard in the `participantConnectionState` handler after validating `targetUserId` and before applying status/telemetry, e.g. `if (shouldIgnoreDepartedParticipant(targetUserId)) return;`. Ensure the hook dependency list includes the guard if needed.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

6. `packages/meeting-core/src/participant-reducer.ts`, line 88-104 ([link](https://github.com/acm-vit/conclave/blob/29e31f37fdfbcbf8ee1a5519a5e8d16afbc123ee/packages/meeting-core/src/participant-reducer.ts#L88-L104)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`addIfMissing: false` does not prevent revival of `isLeaving` participants**

   The `addIfMissing` guard is placed after the `if (existing)` branch, so when a participant already exists with `isLeaving: true`, the reducer unconditionally clears `isLeaving` and returns a new state — regardless of the flag value. Any `ADD_PARTICIPANT { addIfMissing: false }` dispatch for a participant mid-leave will cancel the timeout-driven removal. Moving the guard to the top of the `existing` branch limits its effect to new additions only and makes it also prevent leave revival when the caller intends a no-op on missing participants.

   

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fmeeting-core%2Fsrc%2Fparticipant-reducer.ts%0ALine%3A%2088-104%0A%0AComment%3A%0A**%60addIfMissing%3A%20false%60%20does%20not%20prevent%20revival%20of%20%60isLeaving%60%20participants**%0A%0AThe%20%60addIfMissing%60%20guard%20is%20placed%20after%20the%20%60if%20%28existing%29%60%20branch%2C%20so%20when%20a%20participant%20already%20exists%20with%20%60isLeaving%3A%20true%60%2C%20the%20reducer%20unconditionally%20clears%20%60isLeaving%60%20and%20returns%20a%20new%20state%20%E2%80%94%20regardless%20of%20the%20flag%20value.%20Any%20%60ADD_PARTICIPANT%20%7B%20addIfMissing%3A%20false%20%7D%60%20dispatch%20for%20a%20participant%20mid-leave%20will%20cancel%20the%20timeout-driven%20removal.%20Moving%20the%20guard%20to%20the%20top%20of%20the%20%60existing%60%20branch%20limits%20its%20effect%20to%20new%20additions%20only%20and%20makes%20it%20also%20prevent%20leave%20revival%20when%20the%20caller%20intends%20a%20no-op%20on%20missing%20participants.%0A%0A%60%60%60suggestion%0A%20%20%20%20case%20%22ADD_PARTICIPANT%22%3A%20%7B%0A%20%20%20%20%20%20const%20existing%20%3D%20state.get%28action.userId%29%3B%0A%20%20%20%20%20%20if%20%28existing%29%20%7B%0A%20%20%20%20%20%20%20%20if%20%28action.addIfMissing%20%3D%3D%3D%20false%29%20return%20state%3B%0A%20%20%20%20%20%20%20%20const%20nextGhost%20%3D%20action.isGhost%20%3F%3F%20existing.isGhost%3B%0A%20%20%20%20%20%20%20%20%2F%2F%20Re-add%20of%20an%20already-present%2C%20non-leaving%20participant%20with%20the%20same%0A%20%20%20%20%20%20%20%20%2F%2F%20ghost%20flag%20is%20a%20no-op%20%28server%20re-sync%29%20%E2%80%94%20keep%20the%20same%20reference.%0A%20%20%20%20%20%20%20%20if%20%28!existing.isLeaving%20%26%26%20existing.isGhost%20%3D%3D%3D%20nextGhost%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20return%20state%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20withParticipant%28state%2C%20action.userId%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20...existing%2C%0A%20%20%20%20%20%20%20%20%20%20isLeaving%3A%20false%2C%0A%20%20%20%20%20%20%20%20%20%20isGhost%3A%20nextGhost%2C%0A%20%20%20%20%20%20%20%20%20%20connectionStatus%3A%20undefined%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20if%20%28action.addIfMissing%20%3D%3D%3D%20false%29%20return%20state%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=95&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fmeeting-core%2Fsrc%2Fparticipant-reducer.ts%0ALine%3A%2088-104%0A%0AComment%3A%0A**%60addIfMissing%3A%20false%60%20does%20not%20prevent%20revival%20of%20%60isLeaving%60%20participants**%0A%0AThe%20%60addIfMissing%60%20guard%20is%20placed%20after%20the%20%60if%20%28existing%29%60%20branch%2C%20so%20when%20a%20participant%20already%20exists%20with%20%60isLeaving%3A%20true%60%2C%20the%20reducer%20unconditionally%20clears%20%60isLeaving%60%20and%20returns%20a%20new%20state%20%E2%80%94%20regardless%20of%20the%20flag%20value.%20Any%20%60ADD_PARTICIPANT%20%7B%20addIfMissing%3A%20false%20%7D%60%20dispatch%20for%20a%20participant%20mid-leave%20will%20cancel%20the%20timeout-driven%20removal.%20Moving%20the%20guard%20to%20the%20top%20of%20the%20%60existing%60%20branch%20limits%20its%20effect%20to%20new%20additions%20only%20and%20makes%20it%20also%20prevent%20leave%20revival%20when%20the%20caller%20intends%20a%20no-op%20on%20missing%20participants.%0A%0A%60%60%60suggestion%0A%20%20%20%20case%20%22ADD_PARTICIPANT%22%3A%20%7B%0A%20%20%20%20%20%20const%20existing%20%3D%20state.get%28action.userId%29%3B%0A%20%20%20%20%20%20if%20%28existing%29%20%7B%0A%20%20%20%20%20%20%20%20if%20%28action.addIfMissing%20%3D%3D%3D%20false%29%20return%20state%3B%0A%20%20%20%20%20%20%20%20const%20nextGhost%20%3D%20action.isGhost%20%3F%3F%20existing.isGhost%3B%0A%20%20%20%20%20%20%20%20%2F%2F%20Re-add%20of%20an%20already-present%2C%20non-leaving%20participant%20with%20the%20same%0A%20%20%20%20%20%20%20%20%2F%2F%20ghost%20flag%20is%20a%20no-op%20%28server%20re-sync%29%20%E2%80%94%20keep%20the%20same%20reference.%0A%20%20%20%20%20%20%20%20if%20%28!existing.isLeaving%20%26%26%20existing.isGhost%20%3D%3D%3D%20nextGhost%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20return%20state%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20withParticipant%28state%2C%20action.userId%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20...existing%2C%0A%20%20%20%20%20%20%20%20%20%20isLeaving%3A%20false%2C%0A%20%20%20%20%20%20%20%20%20%20isGhost%3A%20nextGhost%2C%0A%20%20%20%20%20%20%20%20%20%20connectionStatus%3A%20undefined%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20if%20%28action.addIfMissing%20%3D%3D%3D%20false%29%20return%20state%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=95&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fmeeting-core%2Fsrc%2Fparticipant-reducer.ts%0ALine%3A%2088-104%0A%0AComment%3A%0A**%60addIfMissing%3A%20false%60%20does%20not%20prevent%20revival%20of%20%60isLeaving%60%20participants**%0A%0AThe%20%60addIfMissing%60%20guard%20is%20placed%20after%20the%20%60if%20%28existing%29%60%20branch%2C%20so%20when%20a%20participant%20already%20exists%20with%20%60isLeaving%3A%20true%60%2C%20the%20reducer%20unconditionally%20clears%20%60isLeaving%60%20and%20returns%20a%20new%20state%20%E2%80%94%20regardless%20of%20the%20flag%20value.%20Any%20%60ADD_PARTICIPANT%20%7B%20addIfMissing%3A%20false%20%7D%60%20dispatch%20for%20a%20participant%20mid-leave%20will%20cancel%20the%20timeout-driven%20removal.%20Moving%20the%20guard%20to%20the%20top%20of%20the%20%60existing%60%20branch%20limits%20its%20effect%20to%20new%20additions%20only%20and%20makes%20it%20also%20prevent%20leave%20revival%20when%20the%20caller%20intends%20a%20no-op%20on%20missing%20participants.%0A%0A%60%60%60suggestion%0A%20%20%20%20case%20%22ADD_PARTICIPANT%22%3A%20%7B%0A%20%20%20%20%20%20const%20existing%20%3D%20state.get%28action.userId%29%3B%0A%20%20%20%20%20%20if%20%28existing%29%20%7B%0A%20%20%20%20%20%20%20%20if%20%28action.addIfMissing%20%3D%3D%3D%20false%29%20return%20state%3B%0A%20%20%20%20%20%20%20%20const%20nextGhost%20%3D%20action.isGhost%20%3F%3F%20existing.isGhost%3B%0A%20%20%20%20%20%20%20%20%2F%2F%20Re-add%20of%20an%20already-present%2C%20non-leaving%20participant%20with%20the%20same%0A%20%20%20%20%20%20%20%20%2F%2F%20ghost%20flag%20is%20a%20no-op%20%28server%20re-sync%29%20%E2%80%94%20keep%20the%20same%20reference.%0A%20%20%20%20%20%20%20%20if%20%28!existing.isLeaving%20%26%26%20existing.isGhost%20%3D%3D%3D%20nextGhost%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20return%20state%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20withParticipant%28state%2C%20action.userId%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20...existing%2C%0A%20%20%20%20%20%20%20%20%20%20isLeaving%3A%20false%2C%0A%20%20%20%20%20%20%20%20%20%20isGhost%3A%20nextGhost%2C%0A%20%20%20%20%20%20%20%20%20%20connectionStatus%3A%20undefined%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20if%20%28action.addIfMissing%20%3D%3D%3D%20false%29%20return%20state%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=95&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (18): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/2d5c064bbd1f7e4e8ac0d1bbcf3aa50cbdb3c3c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38926834)</sub>

**Context used:**

- Context used - Encourage people to write better commit messages ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->