### PR TITLE
fix: add display name snapshot handling to improve participant mgmt

### DIFF
--- a/apps/web/src/app/components/ControlsBar.tsx
+++ b/apps/web/src/app/components/ControlsBar.tsx
@@ -71,6 +71,7 @@ function MeetingClock({ roomId }: { roomId?: string }) {
 }
 
 function BarButton({ d, size = 48 }: { d: ControlDescriptor; size?: number }) {
+  const shouldShowTooltip = Boolean(d.hotkey || d.showTooltipWithoutHotkey);
   const button = (
     <ControlButton
       icon={d.icon}
@@ -83,8 +84,12 @@ function BarButton({ d, size = 48 }: { d: ControlDescriptor; size?: number }) {
       onClick={d.onPress}
     />
   );
-  return d.hotkey ? (
-    <HotkeyTooltip label={d.label} hotkey={d.hotkey}>
+  return shouldShowTooltip ? (
+    <HotkeyTooltip
+      label={d.label}
+      hotkey={d.hotkey}
+      showWithoutHotkey={d.showTooltipWithoutHotkey}
+    >
       {button}
     </HotkeyTooltip>
   ) : (
@@ -133,6 +138,7 @@ function MediaClusterButton({
 function PanelButton({ d }: { d: ControlDescriptor }) {
   const Icon = d.icon;
   const active = d.variant === "active";
+  const shouldShowTooltip = Boolean(d.hotkey || d.showTooltipWithoutHotkey);
   const btn = (
     <button
       type="button"
@@ -157,8 +163,12 @@ function PanelButton({ d }: { d: ControlDescriptor }) {
       ) : null}
     </button>
   );
-  return d.hotkey ? (
-    <HotkeyTooltip label={d.label} hotkey={d.hotkey}>
+  return shouldShowTooltip ? (
+    <HotkeyTooltip
+      label={d.label}
+      hotkey={d.hotkey}
+      showWithoutHotkey={d.showTooltipWithoutHotkey}
+    >
       {btn}
     </HotkeyTooltip>
   ) : (
@@ -245,6 +255,17 @@ function ControlsBar(props: ControlsBarProps) {
   const hasChatControl = config.left.some(
     (row) => row.id === "chat" && !row.disabled,
   );
+  const hasGamesControl = config.left.some(
+    (row) => row.id === "games" && !row.disabled,
+  );
+  const gamesTip = useOneTimeHint("games-launcher", {
+    enabled:
+      !compact &&
+      hasGamesControl &&
+      !props.isGamesOpen &&
+      !props.hasActiveGame,
+    delay: 3000,
+  });
   const gifsTip = useOneTimeHint("chat-gifs", {
     enabled: !compact && hasChatControl && !props.isChatOpen,
     delay: 2400,
@@ -486,6 +507,36 @@ function ControlsBar(props: ControlsBarProps) {
 
       <div className="flex min-w-0 shrink-0 items-center justify-self-end gap-0.5">
         {config.left.map((d) => {
+          if (d.id === "games") {
+            return (
+              <div key={d.id} className="relative flex">
+                <PanelButton
+                  d={{
+                    ...d,
+                    onPress: () => {
+                      gamesTip.dismiss();
+                      d.onPress?.();
+                    },
+                  }}
+                />
+                {gamesTip.visible &&
+                !props.isGamesOpen &&
+                !props.hasActiveGame &&
+                !filtersTip.visible &&
+                !gifsTip.visible &&
+                !moreOpen &&
+                !reactionsOpen &&
+                !browserOpen ? (
+                  <Coachmark
+                    title="Games are here!"
+                    description="Start a quick room game with everyone."
+                    onDismiss={gamesTip.dismiss}
+                  />
+                ) : null}
+              </div>
+            );
+          }
+
           if (d.id !== "chat") {
             return <PanelButton key={d.id} d={d} />;
           }
@@ -504,6 +555,7 @@ function ControlsBar(props: ControlsBarProps) {
               {gifsTip.visible &&
               !props.isChatOpen &&
               !filtersTip.visible &&
+              !gamesTip.visible &&
               !moreOpen &&
               !reactionsOpen &&
               !browserOpen ? (
@@ -520,21 +572,23 @@ function ControlsBar(props: ControlsBarProps) {
         })}
 
         {showHost && onToggleHostControls && (
-          <button
-            type="button"
-            onClick={onToggleHostControls}
-            aria-label="Host controls"
-            aria-pressed={isHostControlsOpen}
-            title="Host controls"
-            className={
-              "inline-flex h-10 w-10 items-center justify-center rounded-full " +
-              "transition-[background-color,color] duration-[120ms] hover:bg-white/[0.08] " +
-              (isHostControlsOpen ? "" : "hover:!text-[#fafafa]")
-            }
-            style={{ color: isHostControlsOpen ? color.accent : color.textMuted }}
-          >
-            <Shield size={ICON} strokeWidth={STROKE} />
-          </button>
+          <HotkeyTooltip label="Host controls" showWithoutHotkey>
+            <button
+              type="button"
+              onClick={onToggleHostControls}
+              aria-label="Host controls"
+              aria-pressed={isHostControlsOpen}
+              title="Host controls"
+              className={
+                "inline-flex h-10 w-10 items-center justify-center rounded-full " +
+                "transition-[background-color,color] duration-[120ms] hover:bg-white/[0.08] " +
+                (isHostControlsOpen ? "" : "hover:!text-[#fafafa]")
+              }
+              style={{ color: isHostControlsOpen ? color.accent : color.textMuted }}
+            >
+              <Shield size={ICON} strokeWidth={STROKE} />
+            </button>
+          </HotkeyTooltip>
         )}
       </div>
     </div>

--- a/apps/web/src/app/components/HotkeyTooltip.tsx
+++ b/apps/web/src/app/components/HotkeyTooltip.tsx
@@ -5,9 +5,10 @@ import type { ReactNode } from "react";
 
 interface HotkeyTooltipProps {
   label: string;
-  hotkey: string;
+  hotkey?: string;
   children: ReactNode;
   className?: string;
+  showWithoutHotkey?: boolean;
 }
 
 export default function HotkeyTooltip({
@@ -15,10 +16,13 @@ export default function HotkeyTooltip({
   hotkey,
   children,
   className = "",
+  showWithoutHotkey = false,
 }: HotkeyTooltipProps) {
+  const hasHotkey = Boolean(hotkey);
+  const displayedHotkey = hotkey ? formatForDisplay(hotkey) : null;
   // With no hotkey to surface, the tooltip would just duplicate the control's
   // own aria-label/title — so skip the hover chrome entirely.
-  if (!hotkey) {
+  if (!hasHotkey && !showWithoutHotkey) {
     return <>{children}</>;
   }
   return (
@@ -27,9 +31,11 @@ export default function HotkeyTooltip({
       <div className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 z-50 mb-1.5 flex flex-col items-center opacity-0 transition-opacity duration-150 group-hover/tooltip:opacity-100">
         <div className="flex items-center gap-1.5 whitespace-nowrap rounded-lg border border-[#fafafa]/10 bg-[#131316]/95 px-2.5 py-1.5 backdrop-blur-sm">
           <span className="text-[11px] text-[#fafafa]/75">{label}</span>
-          <kbd className="rounded border border-[#fafafa]/15 bg-[#fafafa]/[0.06] px-1.5 py-px text-[10px] text-[#fafafa]/75">
-            {formatForDisplay(hotkey)}
-          </kbd>
+          {hasHotkey ? (
+            <kbd className="rounded border border-[#fafafa]/15 bg-[#fafafa]/[0.06] px-1.5 py-px text-[10px] text-[#fafafa]/75">
+              {displayedHotkey}
+            </kbd>
+          ) : null}
         </div>
         {/* downward arrow */}
         <div className="relative h-[7px] w-[14px] overflow-hidden">

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -85,7 +85,7 @@ const DevMeetToolsPanel = dynamic(() => import("./DevMeetToolsPanel"), {
 
 interface MeetsMainContentProps {
   isJoined: boolean;
-  /** True under the phone-width breakpoint — gates compact control/panel layout. */
+  /** True under the phone-width breakpoint. Gates compact control/panel layout. */
   isMobile?: boolean;
   connectionState: ConnectionState;
   isLoading: boolean;
@@ -468,7 +468,7 @@ export default function MeetsMainContent({
     setLocked,
     refreshState,
   } = useApps();
-  const { isActive: isGameActive } = useGame();
+  const { isActive: isGameActive, refresh: refreshGameState } = useGame();
   const [isGamesOpen, setIsGamesOpen] = useState(false);
   const isDevToolsEnabled = process.env.NODE_ENV === "development";
   const isDevPlaygroundEnabled = isDevToolsEnabled;
@@ -491,8 +491,9 @@ export default function MeetsMainContent({
   useEffect(() => {
     if (connectionState === "joined") {
       refreshState();
+      refreshGameState();
     }
-  }, [connectionState, refreshState]);
+  }, [connectionState, refreshState, refreshGameState]);
   const participantsArray = useMemo(
     () => Array.from(participants.values()),
     [participants],
@@ -594,7 +595,7 @@ export default function MeetsMainContent({
       !hasLiveDevCamera &&
       (cameraPermissionState === "prompt" ||
         cameraPermissionState === "denied"));
-  // You're the one sharing your screen — the stage tile defaults to a
+  // You're the one sharing your screen, so the stage tile defaults to a
   // chooser instead of mirroring your own share back at you (see
   // GridLayout's `isLocalPresenter` handling).
   const isLocalPresenter = isScreenSharing && Boolean(presentationStream);

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -56,7 +56,9 @@ import {
   isBrowserVideoUserId,
   isSystemUserId,
 } from "../lib/utils";
-import { useApps } from "@conclave/apps-sdk";
+import { useApps, useGame } from "@conclave/apps-sdk";
+import { GamePanel } from "./games/GamePanel";
+import { GamesPanel } from "./games/GamesPanel";
 import { useCameraPermissionState } from "../hooks/useCameraPermissionState";
 import { useStableSpeakerId } from "../hooks/useStableSpeakerId";
 import {
@@ -466,6 +468,8 @@ export default function MeetsMainContent({
     setLocked,
     refreshState,
   } = useApps();
+  const { isActive: isGameActive } = useGame();
+  const [isGamesOpen, setIsGamesOpen] = useState(false);
   const isDevToolsEnabled = process.env.NODE_ENV === "development";
   const isDevPlaygroundEnabled = isDevToolsEnabled;
   const isWhiteboardActive = appsState.activeAppId === "whiteboard";
@@ -532,6 +536,7 @@ export default function MeetsMainContent({
   const [isVideoEffectsOpen, setIsVideoEffectsOpen] = useState(false);
   const [isViewPanelOpen, setIsViewPanelOpen] = useState(false);
   const [canReserveDockedPanel, setCanReserveDockedPanel] = useState(false);
+  const [viewportWidth, setViewportWidth] = useState(1280);
   const [showAndroidUpsell, setShowAndroidUpsell] = useState(false);
   const [viewSettings, setViewSettings] = useState<MeetViewSettings>(
     readStoredMeetViewSettings,
@@ -548,6 +553,14 @@ export default function MeetsMainContent({
     return () => {
       mediaQuery.removeEventListener("change", updateReserveBreakpoint);
     };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onResize = () => setViewportWidth(window.innerWidth);
+    onResize();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
   }, []);
   useEffect(() => {
     writeStoredMeetViewSettings(viewSettings);
@@ -900,6 +913,31 @@ export default function MeetsMainContent({
     [setIsParticipantsOpen],
   );
 
+  // The game dock (launcher / active game) is independent of the chat &
+  // participants panels: on wide screens it docks side-by-side with them, so
+  // you can chat while a game runs. Toggling it does NOT close the others.
+  const handleToggleGames = useCallback(() => {
+    setIsGamesOpen((open) => !open);
+  }, []);
+
+  // Once a game is actually running, the active GamePanel takes the dock slot,
+  // so collapse the (now-redundant) launcher.
+  useEffect(() => {
+    if (isGameActive) setIsGamesOpen(false);
+  }, [isGameActive]);
+
+  // Secondary right-dock panels (chat, participants, etc). The game dock sits to
+  // the left of these when both are open on a wide enough screen.
+  const isSecondaryPanelOpen =
+    isChatOpen ||
+    isParticipantsOpen ||
+    isHostControlsOpen ||
+    isVideoEffectsOpen ||
+    isViewPanelOpen;
+  const isGameDockPresent = isGameActive || isGamesOpen;
+  const gameDockOffset =
+    canReserveDockedPanel && isSecondaryPanelOpen ? DOCKED_PANEL_WIDTH : 0;
+
   const handleToggleHostControls = useCallback(() => {
     const opening = !isHostControlsOpen;
     // One right-dock panel at a time. Fire the side effects OUTSIDE the setState
@@ -1105,19 +1143,19 @@ export default function MeetsMainContent({
     return videoParticipant?.screenShareStream ?? null;
   }, [participantsArray]);
   const dockedPanelReserve =
-    canReserveDockedPanel &&
-    isJoined &&
-    !isWebinarAttendee &&
-    (isChatOpen ||
-      isParticipantsOpen ||
-      isHostControlsOpen ||
-      isVideoEffectsOpen ||
-      isViewPanelOpen)
-      ? DOCKED_PANEL_WIDTH
+    canReserveDockedPanel && isJoined && !isWebinarAttendee
+      ? (isSecondaryPanelOpen ? DOCKED_PANEL_WIDTH : 0) +
+        (isGameDockPresent ? DOCKED_PANEL_WIDTH : 0)
       : 0;
   const mainContentStyle = isJoined
     ? { paddingRight: `calc(1rem + ${dockedPanelReserve}px)` }
     : undefined;
+  // When docked panels eat into the stage, the full controls bar (clock +
+  // center + side cluster) gets cramped. Fold it to its compact layout once the
+  // remaining width is tight so it stays comfortable instead of squeezing.
+  const stageWidth = viewportWidth - dockedPanelReserve;
+  const isControlsBarTight = !isMobile && isJoined && stageWidth < 900;
+  const useCompactControls = isMobile || isControlsBarTight;
   const isRecoveringMeeting = isJoined && connectionState !== "joined";
   const isTerminalMeetingError =
     Boolean(meetError) && meetError?.recoverable === false;
@@ -1604,7 +1642,7 @@ export default function MeetsMainContent({
         ) : (
           <div className="safe-area-pb flex w-full flex-col items-center gap-2">
             <ControlsBar
-                compact={isMobile}
+                compact={useCompactControls}
                 roomId={roomId}
                 isMuted={isMuted}
                 isMuteTogglePending={isMuteTogglePending}
@@ -1640,6 +1678,9 @@ export default function MeetsMainContent({
                 isGhostMode={ghostEnabled}
                 isParticipantsOpen={isParticipantsOpen}
                 onToggleParticipants={handleToggleParticipants}
+                isGamesOpen={isGamesOpen}
+                onToggleGames={handleToggleGames}
+                hasActiveGame={isGameActive}
                 isHostControlsOpen={isHostControlsOpen}
                 onToggleHostControls={
                   isAdmin ? handleToggleHostControls : undefined
@@ -1705,6 +1746,14 @@ export default function MeetsMainContent({
             )}
           </div>
         ))}
+
+      {isJoined && !isWebinarAttendee && isGameActive && (
+        <GamePanel rightOffset={gameDockOffset} />
+      )}
+
+      {isJoined && !isWebinarAttendee && isGamesOpen && !isGameActive && (
+        <GamesPanel rightOffset={gameDockOffset} onClose={() => setIsGamesOpen(false)} />
+      )}
 
       {isJoined && !isWebinarAttendee && isChatOpen && (
         <ChatPanel

--- a/apps/web/src/app/components/controls-config.ts
+++ b/apps/web/src/app/components/controls-config.ts
@@ -1,4 +1,5 @@
 import {
+  Gamepad2,
   Globe,
   Hand,
   LayoutGrid,
@@ -69,6 +70,9 @@ export interface ControlsBarProps {
   isGhostMode?: boolean;
   isParticipantsOpen?: boolean;
   onToggleParticipants?: () => void;
+  isGamesOpen?: boolean;
+  onToggleGames?: () => void;
+  hasActiveGame?: boolean;
   isHostControlsOpen?: boolean;
   onToggleHostControls?: () => void;
   pendingUsersCount?: number;
@@ -193,6 +197,15 @@ export function buildControlsConfig(p: ControlsBarProps): ControlsConfig {
       variant: p.isParticipantsOpen ? "active" : "default",
       badge: p.pendingUsersCount,
       onPress: p.onToggleParticipants,
+    });
+  }
+  if (p.onToggleGames) {
+    sideControls.push({
+      id: "games",
+      icon: Gamepad2,
+      label: p.hasActiveGame ? "Game in progress" : "Games",
+      variant: p.isGamesOpen || p.hasActiveGame ? "active" : "default",
+      onPress: p.onToggleGames,
     });
   }
   sideControls.push({

--- a/apps/web/src/app/components/controls-config.ts
+++ b/apps/web/src/app/components/controls-config.ts
@@ -135,6 +135,7 @@ export interface ControlDescriptor {
   icon: LucideIcon;
   label: string;
   hotkey?: string;
+  showTooltipWithoutHotkey?: boolean;
   variant: ControlButtonVariant;
   badge?: number;
   disabled?: boolean;
@@ -204,6 +205,7 @@ export function buildControlsConfig(p: ControlsBarProps): ControlsConfig {
       id: "games",
       icon: Gamepad2,
       label: p.hasActiveGame ? "Game in progress" : "Games",
+      showTooltipWithoutHotkey: true,
       variant: p.isGamesOpen || p.hasActiveGame ? "active" : "default",
       onPress: p.onToggleGames,
     });

--- a/apps/web/src/app/components/games/BluffGame.tsx
+++ b/apps/web/src/app/components/games/BluffGame.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import React, { useState } from "react";
+import { color, radius } from "@conclave/ui-tokens";
+import {
+  CountdownRing,
+  GameLobby,
+  GhostButton,
+  HEAD_FONT,
+  PrimaryButton,
+  useRemaining,
+  type GameViewProps,
+} from "./gameUi";
+
+type ChooseOption = { id: string; text: string };
+type RevealOption = {
+  id: string;
+  text: string;
+  kind: "real" | "fake";
+  ownerName: string | null;
+  votes: number;
+};
+
+type BluffPublic = {
+  phase: "lobby" | "write" | "choose" | "reveal" | "results";
+  round: number;
+  totalRounds: number;
+  serverNow: number;
+  deadline: number | null;
+  question: string | null;
+  submittedCount: number;
+  chosenCount: number;
+  totalPlayers: number;
+  options: (ChooseOption | RevealOption)[];
+  roundPoints: { id: string; name: string; points: number }[];
+  scoreboard: { id: string; name: string; score: number }[];
+};
+
+type BluffMe = {
+  yourFake: string | null;
+  submitted: boolean;
+  yourPick: string | null;
+  ownOptionId: string | null;
+  score: number;
+};
+
+const Question = ({ text }: { text: string }) => (
+  <div
+    style={{
+      borderRadius: radius.md,
+      background: color.surfaceRaised,
+      border: `1px solid ${color.border}`,
+      padding: "12px 14px",
+    }}
+  >
+    <p style={{ fontFamily: HEAD_FONT, fontSize: 15, color: color.text, margin: 0, lineHeight: 1.4 }}>
+      {text}
+    </p>
+  </div>
+);
+
+export default function BluffGame({
+  pub,
+  me,
+  players,
+  userId,
+  isAdmin,
+  move,
+}: GameViewProps<BluffPublic, BluffMe>) {
+  const remaining = useRemaining(pub.deadline, pub.serverNow);
+  const [draft, setDraft] = useState("");
+
+  if (pub.phase === "lobby") {
+    return (
+      <GameLobby
+        gameId="bluff"
+        title="Write a convincing lie"
+        blurb="Everyone invents a fake answer to a real prompt, then tries to spot the truth among the bluffs. Fool people for points."
+        players={players}
+        userId={userId}
+        isAdmin={isAdmin}
+        canStart={pub.totalPlayers >= 2}
+        disabledLabel="Need at least 2 players"
+        onStart={() => move("start")}
+      />
+    );
+  }
+
+  if (pub.phase === "results") {
+    const top = pub.scoreboard[0];
+    return (
+      <div>
+        <p style={{ fontFamily: HEAD_FONT, fontSize: 18, color: color.text, margin: "0 0 4px", textAlign: "center" }}>
+          Best bluffer
+        </p>
+        {top ? (
+          <p style={{ fontSize: 13, color: color.accent, textAlign: "center", margin: "0 0 14px" }}>
+            {top.name} wins with {top.score}
+          </p>
+        ) : null}
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {pub.scoreboard.map((entry, index) => (
+            <div
+              key={entry.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "8px 12px",
+                borderRadius: radius.md,
+                background: index === 0 ? color.accentSoft : color.surfaceRaised,
+              }}
+            >
+              <span style={{ width: 18, color: color.textFaint, fontSize: 13, fontFamily: HEAD_FONT }}>{index + 1}</span>
+              <span style={{ flex: 1, color: color.text, fontSize: 14 }}>{entry.name}</span>
+              <span style={{ color: color.text, fontFamily: HEAD_FONT, fontWeight: 500 }}>{entry.score}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const header = (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      <p style={{ fontSize: 11, color: color.textFaint, margin: 0 }}>
+        Round {pub.round + 1} of {pub.totalRounds}
+      </p>
+      {pub.deadline ? (
+        <CountdownRing
+          remainingMs={remaining}
+          totalMs={pub.phase === "write" ? 40000 : 30000}
+          label={pub.phase === "write" ? `${pub.submittedCount}/${pub.totalPlayers}` : `${pub.chosenCount}/${pub.totalPlayers}`}
+        />
+      ) : null}
+    </div>
+  );
+
+  if (pub.phase === "write") {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        {header}
+        <Question text={pub.question ?? ""} />
+        {me.submitted ? (
+          <div style={{ textAlign: "center", padding: "12px 0" }}>
+            <p style={{ fontSize: 13, color: color.textMuted, margin: 0 }}>Your bluff</p>
+            <p style={{ fontFamily: HEAD_FONT, fontSize: 16, color: color.accent, margin: "6px 0 0" }}>
+              {me.yourFake}
+            </p>
+            <p style={{ fontSize: 12, color: color.textFaint, margin: "10px 0 0" }}>
+              Waiting for everyone. {pub.submittedCount}/{pub.totalPlayers} in.
+            </p>
+          </div>
+        ) : (
+          <>
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value.slice(0, 60))}
+              placeholder="Make up a believable answer"
+              rows={2}
+              style={{
+                width: "100%",
+                resize: "none",
+                borderRadius: radius.md,
+                border: `1.5px solid ${color.border}`,
+                background: color.surface,
+                color: color.text,
+                padding: "10px 12px",
+                fontSize: 14,
+                fontFamily: "inherit",
+                outline: "none",
+              }}
+            />
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <span style={{ fontSize: 11, color: color.textFaint }}>{draft.length}/60</span>
+              <PrimaryButton disabled={!draft.trim()} onClick={() => move("submit", { text: draft.trim() })}>
+                Submit bluff
+              </PrimaryButton>
+            </div>
+          </>
+        )}
+        {isAdmin ? (
+          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+            <GhostButton onClick={() => move("skip")}>Skip</GhostButton>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (pub.phase === "choose") {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        {header}
+        <Question text={pub.question ?? ""} />
+        <p style={{ fontSize: 12, color: color.textMuted, margin: 0, textAlign: "center" }}>
+          Which one is the truth?
+        </p>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {(pub.options as ChooseOption[]).map((option) => {
+            const isOwn = me.ownOptionId === option.id;
+            const isMyPick = me.yourPick === option.id;
+            const locked = isOwn || me.yourPick !== null;
+            return (
+              <button
+                key={option.id}
+                type="button"
+                disabled={locked}
+                onClick={() => move("choose", { optionId: option.id })}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "12px 14px",
+                  borderRadius: radius.md,
+                  border: `1.5px solid ${isMyPick ? color.accent : color.border}`,
+                  background: isMyPick ? color.accentSoft : color.surfaceRaised,
+                  color: color.text,
+                  fontSize: 14,
+                  textAlign: "left",
+                  cursor: locked ? "default" : "pointer",
+                  opacity: isOwn ? 0.5 : 1,
+                }}
+              >
+                <span style={{ flex: 1 }}>{option.text}</span>
+                {isOwn ? (
+                  <span style={{ fontSize: 11, color: color.textFaint }}>your bluff</span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+        {isAdmin ? (
+          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+            <GhostButton onClick={() => move("skip")}>Reveal</GhostButton>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  // reveal
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <p style={{ fontSize: 11, color: color.textFaint, margin: 0 }}>
+        Round {pub.round + 1} of {pub.totalRounds}
+      </p>
+      <Question text={pub.question ?? ""} />
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {(pub.options as RevealOption[]).map((option) => {
+          const real = option.kind === "real";
+          const isMyPick = me.yourPick === option.id;
+          return (
+            <div
+              key={option.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "10px 14px",
+                borderRadius: radius.md,
+                border: `1.5px solid ${real ? color.success : isMyPick ? color.accent : color.border}`,
+                background: real ? "rgba(34,197,94,0.14)" : color.surfaceRaised,
+              }}
+            >
+              <div style={{ flex: 1 }}>
+                <span style={{ fontSize: 14, color: color.text }}>{option.text}</span>
+                <div style={{ fontSize: 11, color: real ? color.success : color.textFaint, marginTop: 2 }}>
+                  {real ? "The truth" : `Bluff by ${option.ownerName ?? "someone"}`}
+                  {isMyPick ? " · you picked this" : ""}
+                </div>
+              </div>
+              <span style={{ fontSize: 12, color: color.textMuted, fontFamily: HEAD_FONT }}>
+                {option.votes}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {pub.roundPoints.length > 0 ? (
+        <p style={{ fontSize: 12, color: color.textMuted, margin: 0, lineHeight: 1.6 }}>
+          {pub.roundPoints.map((r) => `${r.name} +${r.points}`).join(" · ")}
+        </p>
+      ) : null}
+      {isAdmin ? (
+        <div style={{ display: "flex", justifyContent: "flex-end" }}>
+          <GhostButton onClick={() => move("next")}>Next</GhostButton>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/components/games/GamePanel.tsx
+++ b/apps/web/src/app/components/games/GamePanel.tsx
@@ -7,8 +7,20 @@ import {
   GAME_DOCK_PANEL_CLASS,
   GAME_DOCK_TITLE_CLASS,
   HEAD_FONT,
+  Leaderboard,
 } from "./gameUi";
 import { getGameRenderer } from "./registry";
+
+type ScoreRow = { id: string; name: string; score: number };
+
+const readScoreboard = (view: unknown): ScoreRow[] | null => {
+  const board = (view as { scoreboard?: unknown } | null)?.scoreboard;
+  if (!Array.isArray(board)) return null;
+  return board.filter(
+    (r): r is ScoreRow =>
+      Boolean(r) && typeof r.id === "string" && typeof r.name === "string" && typeof r.score === "number",
+  );
+};
 
 /**
  * The active game as a right-docked panel (same dock model as Chat/Participants).
@@ -32,15 +44,8 @@ export function GamePanel({ rightOffset = 0 }: { rightOffset?: number }) {
       aria-label={`${publicState.name} game`}
     >
       <div className={GAME_DOCK_HEADER_CLASS}>
-        <div className="flex min-w-0 items-center gap-2">
+        <div className="flex h-8 min-w-0 items-center gap-2">
           <h2 className={GAME_DOCK_TITLE_CLASS}>{publicState.name}</h2>
-          <span
-            className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.03] px-2.5 text-[12px] font-medium text-[#a1a1aa]"
-            aria-label="Game live"
-          >
-            <span className="h-1.5 w-1.5 rounded-full bg-[#ff6b57]" />
-            Live
-          </span>
         </div>
         {isAdmin ? (
           <button
@@ -77,16 +82,23 @@ export function GamePanel({ rightOffset = 0 }: { rightOffset?: number }) {
             </p>
           </div>
         ) : (
-          <Game
-            pub={publicState.view as never}
-            me={view as never}
-            players={publicState.players}
-            isAdmin={isAdmin}
-            userId={userId}
-            hostId={publicState.hostId}
-            phase={publicState.phase}
-            move={move}
-          />
+          <>
+            <Game
+              pub={publicState.view as never}
+              me={view as never}
+              players={publicState.players}
+              isAdmin={isAdmin}
+              userId={userId}
+              hostId={publicState.hostId}
+              phase={publicState.phase}
+              move={move}
+            />
+            {publicState.hasLeaderboard &&
+            publicState.phase !== "lobby" &&
+            publicState.phase !== "results" ? (
+              <Leaderboard rows={readScoreboard(publicState.view) ?? []} userId={userId} />
+            ) : null}
+          </>
         )}
       </div>
     </aside>

--- a/apps/web/src/app/components/games/GamePanel.tsx
+++ b/apps/web/src/app/components/games/GamePanel.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useGame } from "@conclave/apps-sdk";
+import { color } from "@conclave/ui-tokens";
+import {
+  GAME_DOCK_HEADER_CLASS,
+  GAME_DOCK_PANEL_CLASS,
+  GAME_DOCK_TITLE_CLASS,
+  HEAD_FONT,
+} from "./gameUi";
+import { getGameRenderer } from "./registry";
+
+/**
+ * The active game as a right-docked panel (same dock model as Chat/Participants).
+ * The video grid keeps the main stage and reserves width for this panel, so the
+ * game sits beside the group instead of taking over an empty stage. On mobile it
+ * becomes a full-width sheet that respects the safe-area insets.
+ */
+export function GamePanel({ rightOffset = 0 }: { rightOffset?: number }) {
+  const { publicState, view, isAdmin, userId, move, endGame } = useGame();
+  if (!publicState) return null;
+
+  const Game = getGameRenderer(publicState.gameId);
+  const isPlayer = Boolean(
+    userId && publicState.players.some((player) => player.id === userId),
+  );
+
+  return (
+    <aside
+      className={GAME_DOCK_PANEL_CLASS}
+      style={{ right: rightOffset, fontFamily: HEAD_FONT }}
+      aria-label={`${publicState.name} game`}
+    >
+      <div className={GAME_DOCK_HEADER_CLASS}>
+        <div className="flex min-w-0 items-center gap-2">
+          <h2 className={GAME_DOCK_TITLE_CLASS}>{publicState.name}</h2>
+          <span
+            className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.03] px-2.5 text-[12px] font-medium text-[#a1a1aa]"
+            aria-label="Game live"
+          >
+            <span className="h-1.5 w-1.5 rounded-full bg-[#ff6b57]" />
+            Live
+          </span>
+        </div>
+        {isAdmin ? (
+          <button
+            type="button"
+            onClick={() => endGame()}
+            className="ml-2 inline-flex h-8 shrink-0 items-center justify-center rounded-lg border border-white/10 px-3 text-[12px] font-medium text-[#a1a1aa] transition-colors hover:bg-white/[0.06] hover:text-[#fafafa]"
+          >
+            End game
+          </button>
+        ) : null}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        {!Game ? (
+          <p style={{ fontSize: 13, color: color.textFaint }}>
+            This game is not supported on web yet.
+          </p>
+        ) : !isPlayer ? (
+          <div style={{ padding: "18px 4px", textAlign: "center" }}>
+            <p style={{ fontFamily: HEAD_FONT, fontSize: 17, color: color.text, margin: 0 }}>
+              Game in progress
+            </p>
+            <p style={{ fontSize: 13, color: color.textMuted, lineHeight: 1.5, margin: "8px 0 0" }}>
+              This round started before you joined. You can watch the room and join the next game.
+            </p>
+          </div>
+        ) : view == null ? (
+          <div style={{ padding: "18px 4px", textAlign: "center" }}>
+            <p style={{ fontFamily: HEAD_FONT, fontSize: 17, color: color.text, margin: 0 }}>
+              Loading your game view
+            </p>
+            <p style={{ fontSize: 13, color: color.textMuted, lineHeight: 1.5, margin: "8px 0 0" }}>
+              Waiting for the server to send your private view.
+            </p>
+          </div>
+        ) : (
+          <Game
+            pub={publicState.view as never}
+            me={view as never}
+            players={publicState.players}
+            isAdmin={isAdmin}
+            userId={userId}
+            hostId={publicState.hostId}
+            phase={publicState.phase}
+            move={move}
+          />
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/app/components/games/GamesPanel.tsx
+++ b/apps/web/src/app/components/games/GamesPanel.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { useGame } from "@conclave/apps-sdk";
+import type { GameConfig, GameOptionSpec } from "@conclave/apps-sdk";
 import { color, radius } from "@conclave/ui-tokens";
 import {
   GAME_DOCK_HEADER_CLASS,
@@ -13,7 +14,15 @@ import {
   PrimaryButton,
 } from "./gameUi";
 
-type CatalogEntry = { id: string; name: string; description: string; minPlayers: number; maxPlayers: number };
+type CatalogEntry = {
+  id: string;
+  name: string;
+  description: string;
+  minPlayers: number;
+  maxPlayers: number;
+  options: GameOptionSpec[];
+  hasLeaderboard: boolean;
+};
 
 /** One clean list row, used for both the launcher and the vote. Neutral by
  * default; a single coral accent marks selection / progress. */
@@ -84,6 +93,7 @@ export function GamesPanel({ onClose, rightOffset = 0 }: { onClose: () => void; 
   const { catalog, vote, isAdmin, userId, startGame, openVote, castVote, cancelVote } = useGame();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [configuring, setConfiguring] = useState<CatalogEntry | null>(null);
 
   const run = async (fn: () => Promise<{ success: boolean; error?: string }>) => {
     setBusy(true);
@@ -94,6 +104,14 @@ export function GamesPanel({ onClose, rightOffset = 0 }: { onClose: () => void; 
     return result.success;
   };
 
+  const pick = (entry: CatalogEntry) => {
+    setError(null);
+    if (entry.options.length > 0) setConfiguring(entry);
+    else run(() => startGame(entry.id));
+  };
+
+  const title = vote ? "Vote for a game" : configuring ? configuring.name : "Play a game";
+
   return (
     <aside
       className={GAME_DOCK_PANEL_CLASS}
@@ -101,9 +119,19 @@ export function GamesPanel({ onClose, rightOffset = 0 }: { onClose: () => void; 
       aria-label="Games"
     >
       <div className={GAME_DOCK_HEADER_CLASS}>
-        <h2 className={GAME_DOCK_TITLE_CLASS}>
-          {vote ? "Vote for a game" : "Play a game"}
-        </h2>
+        {configuring && !vote ? (
+          <button
+            type="button"
+            onClick={() => setConfiguring(null)}
+            aria-label="Back"
+            className="-ml-1 mr-1 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[#a1a1aa] transition-colors hover:bg-white/[0.06] hover:text-[#fafafa]"
+          >
+            <svg width={18} height={18} viewBox="0 0 24 24" fill="none" aria-hidden>
+              <path d="M15 18l-6-6 6-6" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+        ) : null}
+        <h2 className={GAME_DOCK_TITLE_CLASS}>{title}</h2>
         <GameDockCloseButton onClose={onClose} label="Close games" />
       </div>
 
@@ -118,12 +146,21 @@ export function GamesPanel({ onClose, rightOffset = 0 }: { onClose: () => void; 
             onStart={(id) => run(() => startGame(id))}
             onCancel={() => run(() => cancelVote())}
           />
+        ) : configuring ? (
+          <GameConfigView
+            entry={configuring}
+            busy={busy}
+            onStart={async (cfg) => {
+              const ok = await run(() => startGame(configuring.id, cfg));
+              if (ok) setConfiguring(null);
+            }}
+          />
         ) : (
           <LauncherView
             catalog={catalog}
             isAdmin={isAdmin}
             busy={busy}
-            onStart={(id) => run(() => startGame(id))}
+            onPick={pick}
             onOpenVote={() => run(() => openVote())}
           />
         )}
@@ -137,13 +174,13 @@ function LauncherView({
   catalog,
   isAdmin,
   busy,
-  onStart,
+  onPick,
   onOpenVote,
 }: {
   catalog: CatalogEntry[];
   isAdmin: boolean;
   busy: boolean;
-  onStart: (id: string) => void;
+  onPick: (entry: CatalogEntry) => void;
   onOpenVote: () => void;
 }) {
   return (
@@ -157,10 +194,17 @@ function LauncherView({
           name={entry.name}
           sub={entry.description}
           disabled={!isAdmin || busy}
-          onClick={isAdmin ? () => onStart(entry.id) : undefined}
+          onClick={isAdmin ? () => onPick(entry) : undefined}
           trailing={
-            <span style={{ fontSize: 11, color: color.textFaint, whiteSpace: "nowrap" }}>
-              {entry.minPlayers} to {entry.maxPlayers}
+            <span style={{ display: "flex", alignItems: "center", gap: 8, color: color.textFaint }}>
+              <span style={{ fontSize: 11, whiteSpace: "nowrap" }}>
+                {entry.minPlayers} to {entry.maxPlayers}
+              </span>
+              {isAdmin ? (
+                <svg width={16} height={16} viewBox="0 0 24 24" fill="none" aria-hidden>
+                  <path d="M9 6l6 6-6 6" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              ) : null}
             </span>
           }
         />
@@ -172,6 +216,108 @@ function LauncherView({
           </PrimaryButton>
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function Segmented<T extends string | number>({
+  value,
+  options,
+  onChange,
+}: {
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 4,
+        padding: 4,
+        borderRadius: radius.md,
+        background: color.surface,
+        border: `1px solid ${color.border}`,
+      }}
+    >
+      {options.map((opt) => {
+        const active = opt.value === value;
+        return (
+          <button
+            key={String(opt.value)}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            style={{
+              flex: 1,
+              padding: "7px 6px",
+              borderRadius: radius.sm,
+              border: "none",
+              background: active ? color.accent : "transparent",
+              color: active ? color.text : color.textMuted,
+              fontFamily: HEAD_FONT,
+              fontSize: 13,
+              fontWeight: 500,
+              cursor: "pointer",
+              transition: "background 140ms ease, color 140ms ease",
+            }}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function GameConfigView({
+  entry,
+  busy,
+  onStart,
+}: {
+  entry: CatalogEntry;
+  busy: boolean;
+  onStart: (config: GameConfig) => void;
+}) {
+  const [config, setConfig] = useState<GameConfig>(() => {
+    const initial: GameConfig = {};
+    for (const opt of entry.options) initial[opt.id] = opt.default;
+    return initial;
+  });
+
+  const setValue = (id: string, value: number | string) =>
+    setConfig((prev) => ({ ...prev, [id]: value }));
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+      <p style={{ fontSize: 13, color: color.textMuted, margin: 0, lineHeight: 1.5 }}>
+        {entry.description}. Set it up, then start.
+      </p>
+
+      {entry.options.map((opt) => (
+        <div key={opt.id} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <span style={{ fontSize: 13, color: color.text, fontFamily: HEAD_FONT }}>{opt.label}</span>
+          {opt.type === "number" ? (
+            <Segmented
+              value={config[opt.id] as number}
+              options={(opt.presets ?? [opt.min, Math.round((opt.min + opt.max) / 2), opt.max]).map((n) => ({
+                value: n,
+                label: `${n}${opt.suffix ? ` ${opt.suffix}` : ""}`,
+              }))}
+              onChange={(v) => setValue(opt.id, v)}
+            />
+          ) : (
+            <Segmented
+              value={config[opt.id] as string}
+              options={opt.choices.map((c) => ({ value: c.value, label: c.label }))}
+              onChange={(v) => setValue(opt.id, v)}
+            />
+          )}
+        </div>
+      ))}
+
+      <PrimaryButton full disabled={busy} onClick={() => onStart(config)}>
+        Start {entry.name}
+      </PrimaryButton>
     </div>
   );
 }

--- a/apps/web/src/app/components/games/GamesPanel.tsx
+++ b/apps/web/src/app/components/games/GamesPanel.tsx
@@ -229,10 +229,14 @@ function Segmented<T extends string | number>({
   options: { value: T; label: string }[];
   onChange: (value: T) => void;
 }) {
+  // Few options: a single equal-width segmented row. Many: wrap into chips so
+  // long labels never clip in the narrow dock.
+  const wrap = options.length > 4;
   return (
     <div
       style={{
         display: "flex",
+        flexWrap: wrap ? "wrap" : "nowrap",
         gap: 4,
         padding: 4,
         borderRadius: radius.md,
@@ -248,8 +252,8 @@ function Segmented<T extends string | number>({
             type="button"
             onClick={() => onChange(opt.value)}
             style={{
-              flex: 1,
-              padding: "7px 6px",
+              flex: wrap ? "0 0 auto" : 1,
+              padding: wrap ? "7px 13px" : "7px 6px",
               borderRadius: radius.sm,
               border: "none",
               background: active ? color.accent : "transparent",
@@ -257,6 +261,7 @@ function Segmented<T extends string | number>({
               fontFamily: HEAD_FONT,
               fontSize: 13,
               fontWeight: 500,
+              whiteSpace: "nowrap",
               cursor: "pointer",
               transition: "background 140ms ease, color 140ms ease",
             }}

--- a/apps/web/src/app/components/games/GamesPanel.tsx
+++ b/apps/web/src/app/components/games/GamesPanel.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import React, { useState } from "react";
+import { useGame } from "@conclave/apps-sdk";
+import { color, radius } from "@conclave/ui-tokens";
+import {
+  GAME_DOCK_HEADER_CLASS,
+  GAME_DOCK_PANEL_CLASS,
+  GAME_DOCK_TITLE_CLASS,
+  GameDockCloseButton,
+  GhostButton,
+  HEAD_FONT,
+  PrimaryButton,
+} from "./gameUi";
+
+type CatalogEntry = { id: string; name: string; description: string; minPlayers: number; maxPlayers: number };
+
+/** One clean list row, used for both the launcher and the vote. Neutral by
+ * default; a single coral accent marks selection / progress. */
+function Row({
+  name,
+  sub,
+  trailing,
+  onClick,
+  disabled,
+  selected,
+  fillRatio,
+}: {
+  name: string;
+  sub: string;
+  trailing?: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  selected?: boolean;
+  fillRatio?: number;
+}) {
+  const interactive = Boolean(onClick) && !disabled;
+  return (
+    <button
+      type="button"
+      disabled={disabled || !onClick}
+      onClick={onClick}
+      style={{
+        position: "relative",
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        width: "100%",
+        padding: "12px 14px",
+        borderRadius: radius.md,
+        border: `1px solid ${selected ? color.accent : color.border}`,
+        background: color.surfaceRaised,
+        textAlign: "left",
+        cursor: interactive ? "pointer" : "default",
+        overflow: "hidden",
+      }}
+    >
+      {typeof fillRatio === "number" ? (
+        <span
+          style={{
+            position: "absolute",
+            insetBlock: 0,
+            left: 0,
+            width: `${Math.max(0, Math.min(1, fillRatio)) * 100}%`,
+            background: color.accentSoft,
+            transition: "width 220ms ease",
+          }}
+        />
+      ) : null}
+      <span style={{ flex: 1, minWidth: 0, zIndex: 1 }}>
+        <span style={{ display: "block", fontFamily: HEAD_FONT, fontSize: 15, color: color.text }}>{name}</span>
+        <span style={{ display: "block", fontSize: 12.5, color: color.textMuted, marginTop: 1 }}>{sub}</span>
+      </span>
+      {trailing ? <span style={{ zIndex: 1, flexShrink: 0 }}>{trailing}</span> : null}
+    </button>
+  );
+}
+
+/**
+ * The docked Games launcher. The host can start a game directly, or put the
+ * choice to a room vote; everyone else votes or waits.
+ */
+export function GamesPanel({ onClose, rightOffset = 0 }: { onClose: () => void; rightOffset?: number }) {
+  const { catalog, vote, isAdmin, userId, startGame, openVote, castVote, cancelVote } = useGame();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (fn: () => Promise<{ success: boolean; error?: string }>) => {
+    setBusy(true);
+    setError(null);
+    const result = await fn();
+    setBusy(false);
+    if (!result.success) setError(result.error ?? "Something went wrong");
+    return result.success;
+  };
+
+  return (
+    <aside
+      className={GAME_DOCK_PANEL_CLASS}
+      style={{ right: rightOffset, fontFamily: HEAD_FONT }}
+      aria-label="Games"
+    >
+      <div className={GAME_DOCK_HEADER_CLASS}>
+        <h2 className={GAME_DOCK_TITLE_CLASS}>
+          {vote ? "Vote for a game" : "Play a game"}
+        </h2>
+        <GameDockCloseButton onClose={onClose} label="Close games" />
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        {vote ? (
+          <VoteView
+            vote={vote}
+            isAdmin={isAdmin}
+            userId={userId}
+            busy={busy}
+            onCast={(id) => run(() => castVote(id))}
+            onStart={(id) => run(() => startGame(id))}
+            onCancel={() => run(() => cancelVote())}
+          />
+        ) : (
+          <LauncherView
+            catalog={catalog}
+            isAdmin={isAdmin}
+            busy={busy}
+            onStart={(id) => run(() => startGame(id))}
+            onOpenVote={() => run(() => openVote())}
+          />
+        )}
+        {error ? <p style={{ fontSize: 12, color: color.danger, margin: "12px 0 0" }}>{error}</p> : null}
+      </div>
+    </aside>
+  );
+}
+
+function LauncherView({
+  catalog,
+  isAdmin,
+  busy,
+  onStart,
+  onOpenVote,
+}: {
+  catalog: CatalogEntry[];
+  isAdmin: boolean;
+  busy: boolean;
+  onStart: (id: string) => void;
+  onOpenVote: () => void;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <p style={{ fontSize: 13, color: color.textMuted, margin: "0 0 4px", lineHeight: 1.5 }}>
+        {isAdmin ? "Pick a game, or let the room vote." : "The host is picking a game."}
+      </p>
+      {catalog.map((entry) => (
+        <Row
+          key={entry.id}
+          name={entry.name}
+          sub={entry.description}
+          disabled={!isAdmin || busy}
+          onClick={isAdmin ? () => onStart(entry.id) : undefined}
+          trailing={
+            <span style={{ fontSize: 11, color: color.textFaint, whiteSpace: "nowrap" }}>
+              {entry.minPlayers} to {entry.maxPlayers}
+            </span>
+          }
+        />
+      ))}
+      {isAdmin ? (
+        <div style={{ marginTop: 6 }}>
+          <PrimaryButton full tone="neutral" disabled={busy} onClick={onOpenVote}>
+            Put it to a vote
+          </PrimaryButton>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function VoteView({
+  vote,
+  isAdmin,
+  userId,
+  busy,
+  onCast,
+  onStart,
+  onCancel,
+}: {
+  vote: { candidates: CatalogEntry[]; tally: Record<string, number>; votes: Record<string, string>; totalPlayers: number };
+  isAdmin: boolean;
+  userId: string | null;
+  busy: boolean;
+  onCast: (id: string) => void;
+  onStart: (id: string) => void;
+  onCancel: () => void;
+}) {
+  const voters = Object.keys(vote.votes).length;
+  const maxVotes = Math.max(1, ...Object.values(vote.tally));
+  const yourVote = userId ? vote.votes[userId] : undefined;
+  let leaderId: string | null = null;
+  let leaderVotes = -1;
+  for (const entry of vote.candidates) {
+    const v = vote.tally[entry.id] ?? 0;
+    if (v > leaderVotes) {
+      leaderVotes = v;
+      leaderId = entry.id;
+    }
+  }
+  const leaderName = vote.candidates.find((c) => c.id === leaderId)?.name ?? null;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <p style={{ fontSize: 13, color: color.textMuted, margin: "0 0 4px" }}>
+        {isAdmin ? "Vote too, then start the winner." : "Tap the game you want."}{" "}
+        <span style={{ color: color.textFaint }}>
+          {voters} of {vote.totalPlayers} voted
+        </span>
+      </p>
+      {vote.candidates.map((entry) => {
+        const count = vote.tally[entry.id] ?? 0;
+        const mine = yourVote === entry.id;
+        return (
+          <Row
+            key={entry.id}
+            name={entry.name}
+            sub={entry.description}
+            disabled={busy}
+            selected={mine}
+            onClick={() => onCast(entry.id)}
+            fillRatio={count / maxVotes}
+            trailing={
+              <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                {mine ? <span style={{ fontSize: 11, color: color.accent }}>your pick</span> : null}
+                <span style={{ fontFamily: HEAD_FONT, fontSize: 15, color: color.text, minWidth: 14, textAlign: "right" }}>{count}</span>
+              </span>
+            }
+          />
+        );
+      })}
+      {isAdmin ? (
+        <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+          <GhostButton onClick={onCancel}>Cancel</GhostButton>
+          <div style={{ flex: 1 }}>
+            <PrimaryButton full disabled={busy || !leaderId} onClick={() => leaderId && onStart(leaderId)}>
+              {leaderVotes > 0 && leaderName ? `Start ${leaderName}` : "Start the leader"}
+            </PrimaryButton>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/components/games/GamesPanel.tsx
+++ b/apps/web/src/app/components/games/GamesPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import { ExternalLink } from "lucide-react";
 import { useGame } from "@conclave/apps-sdk";
 import type { GameConfig, GameOptionSpec } from "@conclave/apps-sdk";
 import { color, radius } from "@conclave/ui-tokens";
@@ -23,6 +24,9 @@ type CatalogEntry = {
   options: GameOptionSpec[];
   hasLeaderboard: boolean;
 };
+
+const ADD_GAME_DOCS_URL =
+  "https://github.com/ACM-VIT/conclave/blob/main/packages/apps-sdk/docs/guides/add-a-game.md";
 
 /** One clean list row, used for both the launcher and the vote. Neutral by
  * default; a single coral accent marks selection / progress. */
@@ -216,6 +220,27 @@ function LauncherView({
           </PrimaryButton>
         </div>
       ) : null}
+      <a
+        href={ADD_GAME_DOCS_URL}
+        target="_blank"
+        rel="noreferrer"
+        className="group mt-2 flex items-center gap-3 rounded-lg border border-white/10 bg-white/[0.025] px-3 py-2.5 text-left transition-colors hover:border-white/15 hover:bg-white/[0.045]"
+      >
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="text-[13px] font-medium text-[#fafafa]">
+            Add your own game
+          </span>
+          <span className="text-[12px] leading-snug text-[#a1a1aa]">
+            Build on the Apps SDK
+          </span>
+        </span>
+        <ExternalLink
+          size={15}
+          strokeWidth={1.75}
+          className="shrink-0 text-[#71717a] transition-colors group-hover:text-[#fafafa]"
+          aria-hidden="true"
+        />
+      </a>
     </div>
   );
 }

--- a/apps/web/src/app/components/games/ImposterGame.tsx
+++ b/apps/web/src/app/components/games/ImposterGame.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import React from "react";
+import { color, radius } from "@conclave/ui-tokens";
+import {
+  Avatar,
+  CountdownRing,
+  GameLobby,
+  GhostButton,
+  HEAD_FONT,
+  PrimaryButton,
+  useRemaining,
+  type GameViewProps,
+} from "./gameUi";
+
+type ImposterPlayer = { id: string; name: string };
+
+type ImposterResult = {
+  imposterId: string;
+  imposterName: string | null;
+  word: string;
+  votedOutId: string | null;
+  votedOutName: string | null;
+  crewWon: boolean;
+  tie: boolean;
+};
+
+type ImposterPublic = {
+  phase: "lobby" | "reveal" | "discuss" | "vote" | "result";
+  category: string;
+  serverNow: number;
+  deadline: number | null;
+  starterName: string | null;
+  players: ImposterPlayer[];
+  votedPlayerIds: string[];
+  voteCounts: Record<string, number>;
+  totalPlayers: number;
+  result: ImposterResult | null;
+};
+
+type ImposterMe = {
+  role: "imposter" | "crew";
+  category: string;
+  word: string | null;
+  hint: string | null;
+  yourVote: string | null;
+};
+
+function SecretCard({ me, compact }: { me: ImposterMe; compact?: boolean }) {
+  const isImposter = me.role === "imposter";
+  return (
+    <div
+      style={{
+        borderRadius: radius.lg,
+        padding: compact ? "12px 14px" : "22px 18px",
+        textAlign: "center",
+        background: isImposter ? color.dangerSoft : color.accentSoft,
+        border: `1.5px solid ${isImposter ? color.danger : color.accent}`,
+      }}
+    >
+      <p style={{ fontSize: 12, color: color.textMuted, margin: 0, fontFamily: HEAD_FONT }}>
+        {me.category}
+      </p>
+      {isImposter ? (
+        <>
+          <p style={{ fontFamily: HEAD_FONT, fontSize: compact ? 18 : 24, fontWeight: 500, color: color.danger, margin: "8px 0 0" }}>
+            You're the imposter
+          </p>
+          {!compact && me.hint ? (
+            <p style={{ fontSize: 13, color: color.textMuted, margin: "8px 0 0" }}>{me.hint}</p>
+          ) : null}
+        </>
+      ) : (
+        <p style={{ fontFamily: HEAD_FONT, fontSize: compact ? 18 : 28, fontWeight: 500, color: color.text, margin: "8px 0 0" }}>
+          {me.word}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function ImposterGame({
+  pub,
+  me,
+  players,
+  userId,
+  isAdmin,
+  move,
+}: GameViewProps<ImposterPublic, ImposterMe>) {
+  const remaining = useRemaining(pub.deadline, pub.serverNow);
+
+  if (pub.phase === "lobby") {
+    return (
+      <GameLobby
+        gameId="imposter"
+        title="One of you is faking it"
+        blurb="Everyone gets a secret word except the imposter. Describe it out loud on camera, then vote on who is bluffing."
+        players={players}
+        userId={userId}
+        isAdmin={isAdmin}
+        canStart={pub.totalPlayers >= 3}
+        startLabel="Deal secret words"
+        disabledLabel="Need at least 3 players"
+        onStart={() => move("start")}
+      />
+    );
+  }
+
+  if (pub.phase === "reveal") {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 16, padding: "8px 0" }}>
+        <SecretCard me={me} />
+        <CountdownRing remainingMs={remaining} totalMs={6000} label="discuss" />
+        <p style={{ fontSize: 12, color: color.textFaint, margin: 0 }}>Memorize your card</p>
+      </div>
+    );
+  }
+
+  if (pub.phase === "result" && pub.result) {
+    const r = pub.result;
+    const banner = r.tie
+      ? { text: "Tie, the imposter survives", c: color.warning }
+      : r.crewWon
+        ? { text: "Crew wins! Imposter caught", c: color.success }
+        : { text: "Imposter escapes!", c: color.danger };
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: 14, padding: "4px 2px" }}>
+        <div
+          style={{
+            borderRadius: radius.md,
+            padding: "12px 14px",
+            textAlign: "center",
+            background: color.surfaceRaised,
+            border: `1.5px solid ${banner.c}`,
+            color: banner.c,
+            fontFamily: HEAD_FONT,
+            fontSize: 15,
+            fontWeight: 500,
+          }}
+        >
+          {banner.text}
+        </div>
+        <div style={{ textAlign: "center" }}>
+          <p style={{ fontSize: 12, color: color.textMuted, margin: 0 }}>The imposter was</p>
+          <p style={{ fontFamily: HEAD_FONT, fontSize: 20, color: color.text, margin: "4px 0" }}>
+            {r.imposterName ?? "?"}
+          </p>
+          <p style={{ fontSize: 13, color: color.textMuted, margin: 0 }}>
+            The secret word was <span style={{ color: color.accent }}>{r.word}</span>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // discuss + vote
+  const voting = pub.phase === "vote";
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <SecretCard me={me} compact />
+
+      {pub.phase === "discuss" ? (
+        <p style={{ fontSize: 13, color: color.textMuted, margin: 0, textAlign: "center", lineHeight: 1.5 }}>
+          {pub.starterName ? <><b style={{ color: color.text }}>{pub.starterName}</b> starts. </> : null}
+          Take turns describing the word, but stay vague. Don&apos;t give it away.
+        </p>
+      ) : (
+        <p style={{ fontSize: 13, color: color.textMuted, margin: 0, textAlign: "center" }}>
+          Who&apos;s the imposter? {pub.votedPlayerIds.length}/{pub.totalPlayers} voted.
+        </p>
+      )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {pub.players.map((player) => {
+          const isMe = player.id === userId;
+          const isMyVote = me.yourVote === player.id;
+          const voteCount = pub.voteCounts[player.id] ?? 0;
+          return (
+            <button
+              key={player.id}
+              type="button"
+              disabled={!voting || isMe}
+              onClick={() => move("vote", { target: player.id })}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "8px 12px",
+                borderRadius: radius.md,
+                border: `1.5px solid ${isMyVote ? color.accent : color.border}`,
+                background: isMyVote ? color.accentSoft : color.surfaceRaised,
+                color: color.text,
+                cursor: voting && !isMe ? "pointer" : "default",
+                opacity: isMe && voting ? 0.55 : 1,
+              }}
+            >
+              <Avatar name={player.name} size={30} highlight={isMyVote} />
+              <span style={{ flex: 1, textAlign: "left", fontSize: 14 }}>
+                {player.name}
+                {isMe ? " (you)" : ""}
+              </span>
+              {voting && voteCount > 0 ? (
+                <span style={{ fontSize: 12, color: color.textFaint, fontFamily: HEAD_FONT }}>
+                  {voteCount}
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+
+      {isAdmin ? (
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          {pub.phase === "discuss" ? (
+            <PrimaryButton onClick={() => move("callVote")}>Call vote</PrimaryButton>
+          ) : (
+            <GhostButton onClick={() => move("tally")}>End vote</GhostButton>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/components/games/MostLikelyToGame.tsx
+++ b/apps/web/src/app/components/games/MostLikelyToGame.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import React from "react";
+import { color, radius } from "@conclave/ui-tokens";
+import {
+  Avatar,
+  CountdownRing,
+  GameLobby,
+  GhostButton,
+  HEAD_FONT,
+  useRemaining,
+  type GameViewProps,
+} from "./gameUi";
+
+type MltPlayer = { id: string; name: string };
+
+type MltPublic = {
+  phase: "lobby" | "vote" | "reveal" | "results";
+  index: number;
+  total: number;
+  serverNow: number;
+  deadline: number | null;
+  voteDurationMs: number;
+  prompt: string | null;
+  players: MltPlayer[];
+  counts: Record<string, number>;
+  answeredCount: number;
+  totalPlayers: number;
+  winnerId: string | null;
+  winnerName: string | null;
+};
+
+type MltMe = { yourVote: string | null };
+
+export default function MostLikelyToGame({
+  pub,
+  me,
+  players,
+  userId,
+  isAdmin,
+  move,
+}: GameViewProps<MltPublic, MltMe>) {
+  const remaining = useRemaining(pub.deadline, pub.serverNow);
+
+  if (pub.phase === "lobby") {
+    return (
+      <GameLobby
+        gameId="most-likely-to"
+        title="Point the finger"
+        blurb="Each round, vote on who fits the prompt. The room decides who gets crowned."
+        players={players}
+        userId={userId}
+        isAdmin={isAdmin}
+        canStart={pub.totalPlayers >= 3}
+        disabledLabel="Need at least 3 players"
+        onStart={() => move("start")}
+      />
+    );
+  }
+
+  if (pub.phase === "results") {
+    return (
+      <div style={{ textAlign: "center", padding: "20px 4px" }}>
+        <p style={{ fontFamily: HEAD_FONT, fontSize: 18, color: color.text, margin: 0 }}>
+          That is a wrap
+        </p>
+        <p style={{ fontSize: 13, color: color.textMuted, margin: "8px 0 0" }}>
+          No hard feelings, right?
+        </p>
+      </div>
+    );
+  }
+
+  const reveal = pub.phase === "reveal";
+  const maxCount = Math.max(1, ...Object.values(pub.counts));
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <p style={{ fontSize: 11, color: color.textFaint, margin: 0 }}>
+          Round {pub.index + 1} of {pub.total}
+        </p>
+        {!reveal && pub.deadline ? (
+          <CountdownRing
+            remainingMs={remaining}
+            totalMs={pub.voteDurationMs}
+            label={`${pub.answeredCount}/${pub.totalPlayers}`}
+          />
+        ) : null}
+      </div>
+
+      <div style={{ textAlign: "center" }}>
+        <span style={{ fontSize: 13, color: color.textMuted }}>Who is most likely</span>
+        <p style={{ fontFamily: HEAD_FONT, fontSize: 19, color: color.text, margin: "4px 0 0", lineHeight: 1.3 }}>
+          {pub.prompt}?
+        </p>
+      </div>
+
+      {reveal && pub.winnerName ? (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "10px 14px",
+            borderRadius: radius.md,
+            background: color.accentSoft,
+            border: `1.5px solid ${color.accent}`,
+          }}
+        >
+          <Avatar name={pub.winnerName} size={32} highlight />
+          <span style={{ fontFamily: HEAD_FONT, fontSize: 15, color: color.text }}>
+            {pub.winnerName}
+          </span>
+          <span style={{ marginLeft: "auto", fontSize: 12, color: color.accent }}>
+            the room has spoken
+          </span>
+        </div>
+      ) : null}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {pub.players.map((player) => {
+          const isMyVote = me.yourVote === player.id;
+          const voteCount = pub.counts[player.id] ?? 0;
+          const isWinner = reveal && player.id === pub.winnerId;
+          return (
+            <button
+              key={player.id}
+              type="button"
+              disabled={reveal || me.yourVote !== null}
+              onClick={() => move("vote", { target: player.id })}
+              style={{
+                position: "relative",
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "8px 12px",
+                borderRadius: radius.md,
+                border: `1.5px solid ${isMyVote || isWinner ? color.accent : color.border}`,
+                background: color.surfaceRaised,
+                color: color.text,
+                cursor: reveal || me.yourVote !== null ? "default" : "pointer",
+                overflow: "hidden",
+              }}
+            >
+              {reveal ? (
+                <span
+                  style={{
+                    position: "absolute",
+                    left: 0,
+                    top: 0,
+                    bottom: 0,
+                    width: `${(voteCount / maxCount) * 100}%`,
+                    background: color.accentSoft,
+                  }}
+                />
+              ) : null}
+              <Avatar name={player.name} size={30} highlight={isMyVote} />
+              <span style={{ flex: 1, textAlign: "left", fontSize: 14, zIndex: 1 }}>
+                {player.name}
+                {player.id === userId ? " (you)" : ""}
+              </span>
+              {reveal && voteCount > 0 ? (
+                <span style={{ fontSize: 12, color: color.textMuted, fontFamily: HEAD_FONT, zIndex: 1 }}>
+                  {voteCount}
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+
+      {isAdmin ? (
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          {reveal ? (
+            <GhostButton onClick={() => move("next")}>Next</GhostButton>
+          ) : (
+            <GhostButton onClick={() => move("skip")}>Reveal</GhostButton>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/components/games/ReactionGame.tsx
+++ b/apps/web/src/app/components/games/ReactionGame.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { color, radius } from "@conclave/ui-tokens";
+import { GameLobby, GhostButton, HEAD_FONT, type GameViewProps } from "./gameUi";
+
+type ReactionResult = { id: string; name: string; reactionMs: number | null; early: boolean };
+
+type ReactionPublic = {
+  phase: "lobby" | "arming" | "go" | "reveal" | "results";
+  round: number;
+  totalRounds: number;
+  serverNow: number;
+  goAt: number | null;
+  tappedCount: number;
+  totalPlayers: number;
+  results: ReactionResult[];
+  winnerName: string | null;
+  scoreboard: { id: string; name: string; score: number }[];
+};
+
+type ReactionMe = {
+  tapped: boolean;
+  early: boolean;
+  reactionMs: number | null;
+  score: number;
+};
+
+/** Counts UP from the server go moment, skew-free. */
+function useElapsed(goAt: number | null, serverNow: number | null): number {
+  const [ms, setMs] = useState(0);
+  const baseRef = useRef({ goAt, serverNow, at: Date.now() });
+  useEffect(() => {
+    baseRef.current = { goAt, serverNow, at: Date.now() };
+  }, [goAt, serverNow]);
+  useEffect(() => {
+    if (goAt == null || serverNow == null) {
+      setMs(0);
+      return;
+    }
+    const tick = () => {
+      const b = baseRef.current;
+      if (b.goAt == null || b.serverNow == null) return;
+      setMs(Math.max(0, b.serverNow - b.goAt + (Date.now() - b.at)));
+    };
+    tick();
+    const id = window.setInterval(tick, 40);
+    return () => window.clearInterval(id);
+  }, [goAt, serverNow]);
+  return ms;
+}
+
+export default function ReactionGame({
+  pub,
+  me,
+  players,
+  userId,
+  isAdmin,
+  move,
+}: GameViewProps<ReactionPublic, ReactionMe>) {
+  const elapsed = useElapsed(pub.goAt, pub.serverNow);
+
+  if (pub.phase === "lobby") {
+    return (
+      <GameLobby
+        gameId="reaction"
+        title="Reflex test"
+        blurb="Wait for the panel to turn green, then tap as fast as you can. Tap early and you are out for the round."
+        players={players}
+        userId={userId}
+        isAdmin={isAdmin}
+        startLabel="Start"
+        onStart={() => move("start")}
+      />
+    );
+  }
+
+  if (pub.phase === "arming" || pub.phase === "go") {
+    const isGo = pub.phase === "go";
+    const faulted = me.tapped && me.early;
+    const tappedValid = me.tapped && !me.early;
+    let bg = "#7a1f1a";
+    let title = "Wait for green";
+    let sub = `Round ${pub.round + 1} of ${pub.totalRounds}`;
+    if (faulted) {
+      bg = color.danger;
+      title = "Too soon!";
+      sub = "Sit tight until the next round";
+    } else if (isGo) {
+      bg = "#1d7a3f";
+      title = tappedValid ? `${me.reactionMs} ms` : "TAP!";
+      sub = tappedValid ? "Locked in" : `${pub.tappedCount}/${pub.totalPlayers} tapped`;
+    }
+    const canTap = !me.tapped;
+    return (
+      <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: 340 }}>
+        <button
+          type="button"
+          disabled={!canTap}
+          onClick={() => move("tap")}
+          style={{
+            flex: 1,
+            minHeight: 300,
+            border: "none",
+            borderRadius: radius.lg,
+            background: bg,
+            color: "#fff",
+            cursor: canTap ? "pointer" : "default",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 8,
+            transition: "background 120ms ease",
+          }}
+        >
+          <span style={{ fontFamily: HEAD_FONT, fontSize: isGo && !tappedValid ? 44 : 30, fontWeight: 500 }}>
+            {title}
+          </span>
+          <span style={{ fontSize: 13, opacity: 0.85 }}>{sub}</span>
+          {isGo && !me.tapped ? (
+            <span style={{ fontSize: 12, opacity: 0.7, marginTop: 4 }}>{elapsed} ms</span>
+          ) : null}
+        </button>
+      </div>
+    );
+  }
+
+  if (pub.phase === "results") {
+    const top = pub.scoreboard[0];
+    return (
+      <div>
+        <p style={{ fontFamily: HEAD_FONT, fontSize: 18, color: color.text, margin: "0 0 4px", textAlign: "center" }}>
+          Sharpest reflexes
+        </p>
+        {top ? (
+          <p style={{ fontSize: 13, color: color.accent, textAlign: "center", margin: "0 0 14px" }}>
+            {top.name} takes it with {top.score}
+          </p>
+        ) : null}
+        <Scoreboard rows={pub.scoreboard} />
+      </div>
+    );
+  }
+
+  // reveal
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <p style={{ fontSize: 11, color: color.textFaint, margin: 0 }}>
+        Round {pub.round + 1} of {pub.totalRounds}
+      </p>
+      {pub.winnerName ? (
+        <p style={{ fontFamily: HEAD_FONT, fontSize: 17, color: color.text, margin: 0 }}>
+          {pub.winnerName} was fastest
+        </p>
+      ) : (
+        <p style={{ fontFamily: HEAD_FONT, fontSize: 16, color: color.textMuted, margin: 0 }}>
+          Nobody made it in time
+        </p>
+      )}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {pub.results.map((r, i) => (
+          <div
+            key={r.id}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: "8px 12px",
+              borderRadius: radius.md,
+              background: i === 0 && !r.early ? color.accentSoft : color.surfaceRaised,
+            }}
+          >
+            <span style={{ width: 16, fontSize: 12, color: color.textFaint, fontFamily: HEAD_FONT }}>{i + 1}</span>
+            <span style={{ flex: 1, fontSize: 14, color: color.text }}>{r.name}</span>
+            <span style={{ fontSize: 13, fontFamily: HEAD_FONT, color: r.early ? color.danger : color.text }}>
+              {r.early ? "too soon" : `${r.reactionMs} ms`}
+            </span>
+          </div>
+        ))}
+      </div>
+      {isAdmin ? (
+        <div style={{ display: "flex", justifyContent: "flex-end" }}>
+          <GhostButton onClick={() => move("next")}>Next</GhostButton>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function Scoreboard({ rows }: { rows: { id: string; name: string; score: number }[] }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      {rows.map((entry, index) => (
+        <div
+          key={entry.id}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "8px 12px",
+            borderRadius: radius.md,
+            background: index === 0 ? color.accentSoft : color.surfaceRaised,
+          }}
+        >
+          <span style={{ width: 18, color: color.textFaint, fontSize: 13, fontFamily: HEAD_FONT }}>{index + 1}</span>
+          <span style={{ flex: 1, color: color.text, fontSize: 14 }}>{entry.name}</span>
+          <span style={{ color: color.text, fontFamily: HEAD_FONT, fontWeight: 500 }}>{entry.score}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/components/games/TriviaGame.tsx
+++ b/apps/web/src/app/components/games/TriviaGame.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import React from "react";
+import { color, radius } from "@conclave/ui-tokens";
+import {
+  CountdownRing,
+  GameLobby,
+  GhostButton,
+  HEAD_FONT,
+  useRemaining,
+  type GameViewProps,
+} from "./gameUi";
+
+type Scoreboard = { id: string; name: string; score: number }[];
+
+type TriviaPublic = {
+  phase: "lobby" | "question" | "reveal" | "results";
+  questionIndex: number;
+  totalQuestions: number;
+  serverNow: number;
+  deadline: number | null;
+  questionDurationMs: number;
+  category: string | null;
+  prompt: string | null;
+  options: string[];
+  correctIndex: number | null;
+  optionCounts: number[];
+  answeredCount: number;
+  totalPlayers: number;
+  scoreboard: Scoreboard;
+};
+
+type TriviaMe = {
+  answered: boolean;
+  choice: number | null;
+  score: number;
+  rank: number | null;
+  lastRoundPoints: number;
+  correct: boolean | null;
+};
+
+const OPTION_LETTERS = ["A", "B", "C", "D", "E", "F"];
+// Kahoot-style signature colors so each answer reads as its own shape at a glance.
+const OPTION_COLORS = ["#E24B4A", "#378ADD", "#EF9F27", "#639922", "#7F77DD", "#1D9E75"];
+
+export default function TriviaGame({
+  pub,
+  me,
+  players,
+  userId,
+  isAdmin,
+  move,
+}: GameViewProps<TriviaPublic, TriviaMe>) {
+  const remaining = useRemaining(pub.deadline, pub.serverNow);
+
+  if (pub.phase === "lobby") {
+    return (
+      <GameLobby
+        gameId="trivia"
+        title={`${pub.totalQuestions} questions`}
+        blurb="Answer fast. The quicker you lock in a correct answer, the more points you score."
+        players={players}
+        userId={userId}
+        isAdmin={isAdmin}
+        startLabel="Start quiz"
+        onStart={() => move("start")}
+      />
+    );
+  }
+
+  if (pub.phase === "results") {
+    const top = pub.scoreboard[0];
+    return (
+      <div style={{ padding: "4px 2px" }}>
+        <p style={{ fontFamily: HEAD_FONT, fontSize: 18, color: color.text, margin: "0 0 4px", textAlign: "center" }}>
+          Final scores
+        </p>
+        {top ? (
+          <p style={{ fontSize: 13, color: color.accent, textAlign: "center", margin: "0 0 14px" }}>
+            🏆 {top.name} wins with {top.score}
+          </p>
+        ) : null}
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {pub.scoreboard.map((entry, index) => (
+            <div
+              key={entry.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "8px 12px",
+                borderRadius: radius.md,
+                background: index === 0 ? color.accentSoft : color.surfaceRaised,
+              }}
+            >
+              <span style={{ width: 18, color: color.textFaint, fontSize: 13, fontFamily: HEAD_FONT }}>
+                {index + 1}
+              </span>
+              <span style={{ flex: 1, color: color.text, fontSize: 14 }}>{entry.name}</span>
+              <span style={{ color: color.text, fontFamily: HEAD_FONT, fontWeight: 500 }}>
+                {entry.score}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const reveal = pub.phase === "reveal";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <div>
+          <p style={{ fontSize: 12, color: color.accent, margin: 0, fontFamily: HEAD_FONT }}>
+            {pub.category}
+          </p>
+          <p style={{ fontSize: 11, color: color.textFaint, margin: "2px 0 0" }}>
+            Question {pub.questionIndex + 1} of {pub.totalQuestions}
+          </p>
+        </div>
+        <CountdownRing
+          remainingMs={reveal ? 0 : remaining}
+          totalMs={pub.questionDurationMs}
+          label={reveal ? "" : `${pub.answeredCount}/${pub.totalPlayers}`}
+        />
+      </div>
+
+      <p style={{ fontFamily: HEAD_FONT, fontSize: 17, color: color.text, margin: 0, lineHeight: 1.35 }}>
+        {pub.prompt}
+      </p>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {pub.options.map((option, index) => {
+          const isMyChoice = me.choice === index;
+          const isCorrect = reveal && pub.correctIndex === index;
+          const isMyWrong = reveal && isMyChoice && pub.correctIndex !== index;
+          let bg: string = color.surfaceRaised;
+          let bd: string = color.border;
+          if (isCorrect) {
+            bg = "rgba(34, 197, 94, 0.18)";
+            bd = color.success;
+          } else if (isMyWrong) {
+            bg = color.dangerSoft;
+            bd = color.danger;
+          } else if (isMyChoice) {
+            bg = color.accentSoft;
+            bd = color.accent;
+          }
+          const locked = reveal || me.answered;
+          return (
+            <button
+              key={index}
+              type="button"
+              disabled={locked}
+              onClick={() => move("answer", { choice: index })}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                padding: "12px 14px",
+                borderRadius: radius.md,
+                border: `1.5px solid ${bd}`,
+                background: bg,
+                color: color.text,
+                fontSize: 14,
+                textAlign: "left",
+                cursor: locked ? "default" : "pointer",
+                transition: "background 150ms ease, border-color 150ms ease",
+              }}
+            >
+              <span
+                style={{
+                  width: 24,
+                  height: 24,
+                  borderRadius: radius.sm,
+                  background: OPTION_COLORS[index % OPTION_COLORS.length],
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontFamily: HEAD_FONT,
+                  fontSize: 12,
+                  fontWeight: 500,
+                  color: "#fff",
+                  flexShrink: 0,
+                }}
+              >
+                {OPTION_LETTERS[index]}
+              </span>
+              <span style={{ flex: 1 }}>{option}</span>
+              {reveal ? (
+                <span style={{ fontSize: 12, color: color.textFaint, fontFamily: HEAD_FONT }}>
+                  {pub.optionCounts[index] ?? 0}
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", minHeight: 28 }}>
+        <span style={{ fontSize: 12, color: color.textMuted }}>
+          {reveal
+            ? me.correct
+              ? `Correct! +${me.lastRoundPoints}`
+              : me.answered
+                ? "Not quite"
+                : "Time's up"
+            : me.answered
+              ? "Locked in"
+              : "Pick an answer"}
+        </span>
+        <span style={{ fontSize: 13, color: color.text, fontFamily: HEAD_FONT, fontWeight: 500 }}>
+          {me.score} pts{me.rank ? ` · #${me.rank}` : ""}
+        </span>
+      </div>
+
+      {isAdmin ? (
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          {reveal ? (
+            <GhostButton onClick={() => move("next")}>Next →</GhostButton>
+          ) : (
+            <GhostButton onClick={() => move("skip")}>Skip</GhostButton>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/components/games/WouldYouRatherGame.tsx
+++ b/apps/web/src/app/components/games/WouldYouRatherGame.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import React from "react";
+import { color, radius } from "@conclave/ui-tokens";
+import {
+  CountdownRing,
+  GameLobby,
+  GhostButton,
+  HEAD_FONT,
+  useRemaining,
+  type GameViewProps,
+} from "./gameUi";
+
+type WyrPublic = {
+  phase: "lobby" | "choose" | "reveal" | "results";
+  index: number;
+  total: number;
+  serverNow: number;
+  deadline: number | null;
+  chooseDurationMs: number;
+  optionA: string | null;
+  optionB: string | null;
+  counts: [number, number];
+  answeredCount: number;
+  totalPlayers: number;
+  namesA: string[];
+  namesB: string[];
+};
+
+type WyrMe = { choice: 0 | 1 | null };
+
+function OptionCard({
+  text,
+  picked,
+  accent,
+  onClick,
+  disabled,
+}: {
+  text: string;
+  picked: boolean;
+  accent: string;
+  onClick: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      style={{
+        flex: 1,
+        minHeight: 96,
+        padding: "16px 14px",
+        borderRadius: radius.lg,
+        border: `2px solid ${picked ? accent : color.border}`,
+        background: picked ? `${accent}26` : color.surfaceRaised,
+        color: color.text,
+        fontFamily: HEAD_FONT,
+        fontSize: 16,
+        fontWeight: 500,
+        lineHeight: 1.3,
+        cursor: disabled ? "default" : "pointer",
+        transition: "border-color 150ms ease, background 150ms ease",
+      }}
+    >
+      {text}
+    </button>
+  );
+}
+
+export default function WouldYouRatherGame({
+  pub,
+  me,
+  players,
+  userId,
+  isAdmin,
+  move,
+}: GameViewProps<WyrPublic, WyrMe>) {
+  const remaining = useRemaining(pub.deadline, pub.serverNow);
+
+  if (pub.phase === "lobby") {
+    return (
+      <GameLobby
+        gameId="would-you-rather"
+        title={`${pub.total} rounds, no wrong answers`}
+        blurb="Pick a side each round, then watch the room split and argue about it."
+        players={players}
+        userId={userId}
+        isAdmin={isAdmin}
+        onStart={() => move("start")}
+      />
+    );
+  }
+
+  if (pub.phase === "results") {
+    return (
+      <div style={{ textAlign: "center", padding: "20px 4px" }}>
+        <p style={{ fontFamily: HEAD_FONT, fontSize: 18, color: color.text, margin: 0 }}>
+          That is a wrap
+        </p>
+        <p style={{ fontSize: 13, color: color.textMuted, margin: "8px 0 0" }}>
+          Nice picks. Run it back any time.
+        </p>
+      </div>
+    );
+  }
+
+  const reveal = pub.phase === "reveal";
+  const [a, b] = pub.counts;
+  const total = Math.max(1, a + b);
+  const accentA = color.accent;
+  const accentB = color.accentSecondary;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <p style={{ fontSize: 11, color: color.textFaint, margin: 0 }}>
+          Round {pub.index + 1} of {pub.total}
+        </p>
+        {!reveal && pub.deadline ? (
+          <CountdownRing
+            remainingMs={remaining}
+            totalMs={pub.chooseDurationMs}
+            label={`${pub.answeredCount}/${pub.totalPlayers}`}
+          />
+        ) : null}
+      </div>
+
+      <p style={{ fontFamily: HEAD_FONT, fontSize: 15, color: color.textMuted, margin: 0, textAlign: "center" }}>
+        Would you rather
+      </p>
+
+      <div style={{ display: "flex", gap: 10 }}>
+        <OptionCard
+          text={pub.optionA ?? ""}
+          picked={me.choice === 0}
+          accent={accentA}
+          disabled={reveal || me.choice !== null}
+          onClick={() => move("choose", { option: 0 })}
+        />
+        <OptionCard
+          text={pub.optionB ?? ""}
+          picked={me.choice === 1}
+          accent={accentB}
+          disabled={reveal || me.choice !== null}
+          onClick={() => move("choose", { option: 1 })}
+        />
+      </div>
+
+      {reveal ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <div style={{ display: "flex", height: 12, borderRadius: radius.pill, overflow: "hidden", background: color.surfaceRaised }}>
+            <div style={{ width: `${(a / total) * 100}%`, background: accentA }} />
+            <div style={{ width: `${(b / total) * 100}%`, background: accentB }} />
+          </div>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12 }}>
+            <div style={{ flex: 1 }}>
+              <p style={{ fontFamily: HEAD_FONT, color: accentA, fontSize: 14, margin: 0 }}>{a} picked</p>
+              <p style={{ fontSize: 12, color: color.textMuted, margin: "2px 0 0", lineHeight: 1.5 }}>
+                {pub.namesA.join(", ") || "nobody"}
+              </p>
+            </div>
+            <div style={{ flex: 1, textAlign: "right" }}>
+              <p style={{ fontFamily: HEAD_FONT, color: accentB, fontSize: 14, margin: 0 }}>{b} picked</p>
+              <p style={{ fontSize: 12, color: color.textMuted, margin: "2px 0 0", lineHeight: 1.5 }}>
+                {pub.namesB.join(", ") || "nobody"}
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <p style={{ fontSize: 12, color: color.textMuted, textAlign: "center", margin: 0 }}>
+          {me.choice !== null ? "Locked in" : "Pick a side"}
+        </p>
+      )}
+
+      {isAdmin ? (
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          {reveal ? (
+            <GhostButton onClick={() => move("next")}>Next</GhostButton>
+          ) : (
+            <GhostButton onClick={() => move("skip")}>Reveal</GhostButton>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/components/games/covers.tsx
+++ b/apps/web/src/app/components/games/covers.tsx
@@ -1,0 +1,26 @@
+// Per-game identity: a single accent colour + display name. Used for the lobby
+// spotlight tint and overline. Deliberately minimal - no artwork, no glyphs.
+
+export const GAME_ACCENTS: Record<string, string> = {
+  trivia: "#3B8EE0",
+  bluff: "#8B7BF0",
+  "would-you-rather": "#22A578",
+  "most-likely-to": "#E06392",
+  reaction: "#E85046",
+  imposter: "#E0863A",
+};
+
+export const GAME_NAMES: Record<string, string> = {
+  trivia: "Trivia",
+  bluff: "Bluff",
+  "would-you-rather": "Would You Rather",
+  "most-likely-to": "Most Likely To",
+  reaction: "Reaction",
+  imposter: "Imposter",
+};
+
+export const accentFor = (gameId?: string): string =>
+  (gameId && GAME_ACCENTS[gameId]) || "#F95F4A";
+
+export const nameFor = (gameId?: string): string | undefined =>
+  gameId ? GAME_NAMES[gameId] : undefined;

--- a/apps/web/src/app/components/games/gameUi.tsx
+++ b/apps/web/src/app/components/games/gameUi.tsx
@@ -362,3 +362,54 @@ export function GameLobby({
     </div>
   );
 }
+
+/**
+ * Live leaderboard shown in the game dock for scoring games. Static and clean,
+ * sorted by score, with the local player highlighted. No animation.
+ */
+export function Leaderboard({
+  rows,
+  userId,
+  max = 6,
+  title = "Leaderboard",
+}: {
+  rows: { id: string; name: string; score: number }[];
+  userId?: string | null;
+  max?: number;
+  title?: string;
+}) {
+  const sorted = [...rows].sort((a, b) => b.score - a.score).slice(0, max);
+  if (sorted.length === 0) return null;
+  return (
+    <div style={{ marginTop: 18, paddingTop: 14, borderTop: `1px solid ${color.border}` }}>
+      <p style={{ fontSize: 11, color: color.textFaint, fontFamily: HEAD_FONT, margin: "0 0 8px" }}>{title}</p>
+      <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        {sorted.map((r, i) => {
+          const you = r.id === userId;
+          return (
+            <div
+              key={r.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "7px 10px",
+                borderRadius: radius.sm,
+                background: you ? color.accentSoft : "transparent",
+              }}
+            >
+              <span style={{ width: 16, fontSize: 12, color: i === 0 ? color.accent : color.textFaint, fontFamily: HEAD_FONT, fontWeight: 500 }}>
+                {i + 1}
+              </span>
+              <span style={{ flex: 1, minWidth: 0, fontSize: 13.5, color: color.text, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {r.name}
+                {you ? " (you)" : ""}
+              </span>
+              <span style={{ fontSize: 13, fontFamily: HEAD_FONT, fontWeight: 500, color: color.text }}>{r.score}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/components/games/gameUi.tsx
+++ b/apps/web/src/app/components/games/gameUi.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+import { color, radius } from "@conclave/ui-tokens";
+import type { GameMoveResult, GamePlayer } from "@conclave/apps-sdk";
+import { accentFor, nameFor } from "./covers";
+
+export const HEAD_FONT = "'PolySans Trial', sans-serif";
+export const GAME_DOCK_PANEL_CLASS =
+  "safe-area-pt safe-area-pb fixed right-0 top-0 bottom-0 z-40 flex w-full sm:w-[360px] flex-col border-l border-white/10 bg-[#18181b] animate-[meet-panel-in_280ms_cubic-bezier(0.22,1,0.36,1)]";
+export const GAME_DOCK_HEADER_CLASS =
+  "flex shrink-0 items-center justify-between border-b border-white/10 px-4 py-3";
+export const GAME_DOCK_TITLE_CLASS =
+  "min-w-0 truncate text-[15px] font-semibold text-[#fafafa]";
+
+export function GameDockCloseButton({
+  onClose,
+  label = "Close games",
+}: {
+  onClose: () => void;
+  label?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClose}
+      aria-label={label}
+      title={label}
+      className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[#a1a1aa] transition-colors hover:bg-white/[0.06] hover:text-[#fafafa]"
+    >
+      <X size={18} strokeWidth={1.75} />
+    </button>
+  );
+}
+
+/** Shared props every game renderer receives from the dock. */
+export type GameViewProps<Pub = unknown, Me = unknown> = {
+  pub: Pub;
+  me: Me;
+  players: GamePlayer[];
+  isAdmin: boolean;
+  userId: string | null;
+  hostId: string | null;
+  phase: string;
+  move: (type: string, payload?: unknown) => Promise<GameMoveResult>;
+};
+
+/**
+ * Counts down to a server deadline. `deadline` and `serverNow` are server-clock
+ * timestamps; we anchor to local time at the moment they arrive so clock skew
+ * between client and server never matters.
+ */
+export const useRemaining = (
+  deadline: number | null | undefined,
+  serverNow: number | null | undefined,
+): number => {
+  const [remaining, setRemaining] = useState(0);
+  const baseRef = useRef({ deadline, serverNow, at: Date.now() });
+
+  useEffect(() => {
+    baseRef.current = { deadline, serverNow, at: Date.now() };
+  }, [deadline, serverNow]);
+
+  useEffect(() => {
+    if (deadline == null || serverNow == null) {
+      setRemaining(0);
+      return;
+    }
+    const tick = () => {
+      const base = baseRef.current;
+      if (base.deadline == null || base.serverNow == null) {
+        setRemaining(0);
+        return;
+      }
+      const elapsed = Date.now() - base.at;
+      setRemaining(Math.max(0, base.deadline - base.serverNow - elapsed));
+    };
+    tick();
+    const id = window.setInterval(tick, 200);
+    return () => window.clearInterval(id);
+  }, [deadline, serverNow]);
+
+  return remaining;
+};
+
+export const initialsOf = (name: string): string =>
+  name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("") || "?";
+
+export function PrimaryButton({
+  children,
+  onClick,
+  disabled,
+  tone = "accent",
+  full,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  tone?: "accent" | "neutral";
+  full?: boolean;
+}) {
+  const bg = tone === "accent" ? color.accent : color.surfaceRaised;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        width: full ? "100%" : undefined,
+        padding: "10px 18px",
+        borderRadius: radius.pill,
+        border: "none",
+        background: disabled ? color.surfaceRaised : bg,
+        color: color.text,
+        fontFamily: HEAD_FONT,
+        fontSize: 14,
+        fontWeight: 500,
+        cursor: disabled ? "default" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+        transition: "transform 120ms ease, opacity 120ms ease",
+      }}
+      onMouseDown={(e) => {
+        if (!disabled) e.currentTarget.style.transform = "scale(0.97)";
+      }}
+      onMouseUp={(e) => {
+        e.currentTarget.style.transform = "scale(1)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = "scale(1)";
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function GhostButton({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        padding: "8px 14px",
+        borderRadius: radius.pill,
+        border: `1px solid ${color.border}`,
+        background: "transparent",
+        color: color.textMuted,
+        fontFamily: HEAD_FONT,
+        fontSize: 13,
+        fontWeight: 500,
+        cursor: disabled ? "default" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function Avatar({
+  name,
+  size = 34,
+  highlight,
+  dim,
+}: {
+  name: string;
+  size?: number;
+  highlight?: boolean;
+  dim?: boolean;
+}) {
+  return (
+    <div
+      title={name}
+      style={{
+        width: size,
+        height: size,
+        borderRadius: radius.pill,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: highlight ? color.accentSoft : color.surfaceRaised,
+        border: `1.5px solid ${highlight ? color.accent : color.border}`,
+        color: color.text,
+        fontFamily: HEAD_FONT,
+        fontSize: size * 0.36,
+        fontWeight: 500,
+        opacity: dim ? 0.4 : 1,
+        flexShrink: 0,
+      }}
+    >
+      {initialsOf(name)}
+    </div>
+  );
+}
+
+/** Pure SVG ring countdown with a number in the middle. */
+export function CountdownRing({
+  remainingMs,
+  totalMs,
+  label,
+}: {
+  remainingMs: number;
+  totalMs: number;
+  label?: string;
+}) {
+  const seconds = Math.ceil(remainingMs / 1000);
+  const ratio = totalMs > 0 ? Math.max(0, Math.min(1, remainingMs / totalMs)) : 0;
+  const r = 34;
+  const circ = 2 * Math.PI * r;
+  const urgent = remainingMs <= 5000;
+  return (
+    <div style={{ position: "relative", width: 84, height: 84 }}>
+      <svg width={84} height={84} viewBox="0 0 84 84">
+        <circle cx={42} cy={42} r={r} fill="none" stroke={color.border} strokeWidth={6} />
+        <circle
+          cx={42}
+          cy={42}
+          r={r}
+          fill="none"
+          stroke={urgent ? color.danger : color.accent}
+          strokeWidth={6}
+          strokeLinecap="round"
+          strokeDasharray={circ}
+          strokeDashoffset={circ * (1 - ratio)}
+          transform="rotate(-90 42 42)"
+          style={{ transition: "stroke-dashoffset 200ms linear" }}
+        />
+      </svg>
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: HEAD_FONT,
+          color: color.text,
+        }}
+      >
+        <span style={{ fontSize: 26, fontWeight: 500, lineHeight: 1 }}>{seconds}</span>
+        {label ? (
+          <span style={{ fontSize: 10, color: color.textFaint, marginTop: 2 }}>{label}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Party-game lobby: a calm "stage" composition. A soft accent spotlight sits
+ * behind a centred game name + title + blurb, with the start (host) or a warm
+ * "you're in" state (everyone else) below, so the screen feels good no matter
+ * who is looking at it. No artwork, no pills, no pulsing dots, no all-caps.
+ */
+export function GameLobby({
+  gameId,
+  title,
+  blurb,
+  players,
+  isAdmin,
+  canStart = true,
+  startLabel = "Start",
+  disabledLabel,
+  onStart,
+  waitingText = "The host will start the round",
+}: {
+  gameId?: string;
+  title: string;
+  blurb: string;
+  players: GamePlayer[];
+  isAdmin: boolean;
+  userId?: string | null;
+  canStart?: boolean;
+  startLabel?: string;
+  disabledLabel?: string;
+  onStart: () => void;
+  waitingText?: string;
+}) {
+  const accent = accentFor(gameId);
+  const name = nameFor(gameId) ?? "Game";
+  const count = `${players.length} ${players.length === 1 ? "player" : "players"} in the lobby`;
+  return (
+    <div
+      style={{
+        position: "relative",
+        overflow: "hidden",
+        height: "100%",
+        minHeight: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        padding: "16px 6px",
+      }}
+    >
+      {/* soft accent spotlight */}
+      <div
+        style={{
+          position: "absolute",
+          top: "10%",
+          left: "50%",
+          width: 320,
+          height: 320,
+          transform: "translateX(-50%)",
+          borderRadius: "50%",
+          background: accent,
+          opacity: 0.18,
+          filter: "blur(72px)",
+          pointerEvents: "none",
+        }}
+      />
+      <div style={{ position: "relative", zIndex: 1, display: "flex", flexDirection: "column", alignItems: "center", textAlign: "center" }}>
+        <span style={{ fontFamily: HEAD_FONT, fontSize: 13, fontWeight: 500, color: accent, margin: 0 }}>{name}</span>
+        <p style={{ fontFamily: HEAD_FONT, fontSize: 30, fontWeight: 500, color: color.text, margin: "10px 0 0", lineHeight: 1.12, maxWidth: 300 }}>
+          {title}
+        </p>
+        <p style={{ fontSize: 13.5, color: color.textMuted, margin: "12px 0 0", maxWidth: 290, lineHeight: 1.55 }}>
+          {blurb}
+        </p>
+
+        <div style={{ width: "100%", maxWidth: 300, marginTop: 26 }}>
+          {isAdmin ? (
+            <PrimaryButton full disabled={!canStart} onClick={onStart}>
+              {canStart ? startLabel : disabledLabel ?? startLabel}
+            </PrimaryButton>
+          ) : (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 9,
+                padding: "13px 16px",
+                borderRadius: radius.pill,
+                background: color.surfaceRaised,
+                border: `1px solid ${color.border}`,
+              }}
+            >
+              <span style={{ width: 7, height: 7, borderRadius: radius.pill, background: accent }} />
+              <span style={{ fontSize: 13, color: color.text }}>You&apos;re in</span>
+              <span style={{ fontSize: 13, color: color.textMuted }}>· {waitingText}</span>
+            </div>
+          )}
+          <p style={{ fontSize: 12, color: color.textFaint, margin: "12px 0 0" }}>{count}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/components/games/registry.tsx
+++ b/apps/web/src/app/components/games/registry.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import type React from "react";
+import type { GameViewProps } from "./gameUi";
+import TriviaGame from "./TriviaGame";
+import BluffGame from "./BluffGame";
+import WouldYouRatherGame from "./WouldYouRatherGame";
+import MostLikelyToGame from "./MostLikelyToGame";
+import ReactionGame from "./ReactionGame";
+import ImposterGame from "./ImposterGame";
+
+// Add a web renderer here (one line). The key is the game id from the SFU
+// module. Everything else (launcher, stage routing) reads from this map.
+export const GAME_RENDERERS: Record<string, React.ComponentType<GameViewProps>> = {
+  trivia: TriviaGame as React.ComponentType<GameViewProps>,
+  bluff: BluffGame as React.ComponentType<GameViewProps>,
+  "would-you-rather": WouldYouRatherGame as React.ComponentType<GameViewProps>,
+  "most-likely-to": MostLikelyToGame as React.ComponentType<GameViewProps>,
+  reaction: ReactionGame as React.ComponentType<GameViewProps>,
+  imposter: ImposterGame as React.ComponentType<GameViewProps>,
+};
+
+export const getGameRenderer = (
+  gameId: string,
+): React.ComponentType<GameViewProps> | undefined => GAME_RENDERERS[gameId];

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -23,6 +23,7 @@ import type {
   ConnectionState,
   Consumer,
   ConsumeResponse,
+  DisplayNameSnapshotEntry,
   HandRaisedNotification,
   HandRaisedSnapshot,
   JoinMode,
@@ -3500,6 +3501,100 @@ export function useMeetSocket({
     announcedRemoteProducersRef,
   ]);
 
+  const applyDisplayNameSnapshot = useCallback(
+    (users: DisplayNameSnapshotEntry[] = []) => {
+      const snapshot = new Map<string, string>();
+      const nextParticipantIds = new Set<string>([userId]);
+      const previousParticipantIds = participantIdsRef.current;
+      let clearedDepartedParticipant = false;
+
+      for (const { userId: snapshotUserId, displayName } of users) {
+        if (displayName) {
+          snapshot.set(snapshotUserId, displayName);
+        }
+        if (snapshotUserId === userId) {
+          continue;
+        }
+
+        clearedDepartedParticipant =
+          markRemoteParticipantPresent(snapshotUserId) ||
+          clearedDepartedParticipant;
+        if (!isSystemUserId(snapshotUserId)) {
+          nextParticipantIds.add(snapshotUserId);
+        }
+        const leaveTimeout = leaveTimeoutsRef.current.get(snapshotUserId);
+        if (leaveTimeout) {
+          window.clearTimeout(leaveTimeout);
+          leaveTimeoutsRef.current.delete(snapshotUserId);
+        }
+        clearParticipantConnectionStatus(snapshotUserId);
+        dispatchParticipants({
+          type: "ADD_PARTICIPANT",
+          userId: snapshotUserId,
+        });
+      }
+
+      for (const previousUserId of previousParticipantIds) {
+        if (
+          previousUserId === userId ||
+          nextParticipantIds.has(previousUserId)
+        ) {
+          continue;
+        }
+
+        const leaveTimeout = leaveTimeoutsRef.current.get(previousUserId);
+        markRemoteParticipantDeparted(previousUserId);
+        if (leaveTimeout) {
+          window.clearTimeout(leaveTimeout);
+          leaveTimeoutsRef.current.delete(previousUserId);
+        }
+        clearParticipantConnectionStatus(previousUserId);
+
+        const producersToClose = Array.from(producerMapRef.current.entries())
+          .filter(([, info]) => info.userId === previousUserId)
+          .map(
+            ([producerId, info]): ProducerInfo => ({
+              producerId,
+              producerUserId: previousUserId,
+              kind: info.kind,
+              type: info.type,
+            }),
+          );
+        for (const info of Array.from(pendingProducersRef.current.values())) {
+          if (info.producerUserId === previousUserId) {
+            dropDepartedProducer(info);
+          }
+        }
+        for (const producerInfo of producersToClose) {
+          dropDepartedProducer(producerInfo);
+        }
+        dispatchParticipants({
+          type: "REMOVE_PARTICIPANT",
+          userId: previousUserId,
+        });
+      }
+
+      participantIdsRef.current = nextParticipantIds;
+      setDisplayNames(snapshot);
+      if (clearedDepartedParticipant) {
+        void syncProducers();
+      }
+    },
+    [
+      clearParticipantConnectionStatus,
+      dispatchParticipants,
+      dropDepartedProducer,
+      leaveTimeoutsRef,
+      markRemoteParticipantDeparted,
+      markRemoteParticipantPresent,
+      pendingProducersRef,
+      producerMapRef,
+      setDisplayNames,
+      syncProducers,
+      userId,
+    ],
+  );
+
   const applyWebinarFeedProducers = useCallback(
     async (producers: ProducerInfo[]) => {
       const departedProducerIds = new Set<string>();
@@ -3750,6 +3845,9 @@ export function useMeetSocket({
                 linkSlug: previous?.linkSlug ?? null,
                 feedMode: previous?.feedMode ?? "active-speaker",
               }));
+              if (Array.isArray(response.displayNameSnapshot)) {
+                applyDisplayNameSnapshot(response.displayNameSnapshot);
+              }
 
               // Use pre-warmed Device if available, otherwise dynamic import
               const DeviceClass = prewarm?.Device
@@ -3835,6 +3933,7 @@ export function useMeetSocket({
       setWebinarRole,
       setWebinarSpeakerUserId,
       currentRoomIdRef,
+      applyDisplayNameSnapshot,
       deviceRef,
       createProducerTransport,
       createConsumerTransport,
@@ -4455,86 +4554,11 @@ export function useMeetSocket({
                 users,
                 roomId: eventRoomId,
               }: {
-                users: { userId: string; displayName?: string }[];
+                users: DisplayNameSnapshotEntry[];
                 roomId?: string;
               }) => {
                 if (!isRoomEvent(eventRoomId)) return;
-                const snapshot = new Map<string, string>();
-                const nextParticipantIds = new Set<string>([userId]);
-                const previousParticipantIds = participantIdsRef.current;
-                let clearedDepartedParticipant = false;
-                (users || []).forEach(
-                  ({ userId: snapshotUserId, displayName }) => {
-                    if (displayName) {
-                      snapshot.set(snapshotUserId, displayName);
-                    }
-                    if (snapshotUserId !== userId) {
-                      clearedDepartedParticipant =
-                        markRemoteParticipantPresent(snapshotUserId) ||
-                        clearedDepartedParticipant;
-                      if (!isSystemUserId(snapshotUserId)) {
-                        nextParticipantIds.add(snapshotUserId);
-                      }
-                      const leaveTimeout =
-                        leaveTimeoutsRef.current.get(snapshotUserId);
-                      if (leaveTimeout) {
-                        window.clearTimeout(leaveTimeout);
-                        leaveTimeoutsRef.current.delete(snapshotUserId);
-                      }
-                      clearParticipantConnectionStatus(snapshotUserId);
-                      dispatchParticipants({
-                        type: "ADD_PARTICIPANT",
-                        userId: snapshotUserId,
-                      });
-                    }
-                  },
-                );
-                for (const previousUserId of previousParticipantIds) {
-                  if (
-                    previousUserId === userId ||
-                    nextParticipantIds.has(previousUserId)
-                  ) {
-                    continue;
-                  }
-                  const leaveTimeout = leaveTimeoutsRef.current.get(previousUserId);
-                  markRemoteParticipantDeparted(previousUserId);
-                  if (leaveTimeout) {
-                    window.clearTimeout(leaveTimeout);
-                    leaveTimeoutsRef.current.delete(previousUserId);
-                  }
-                  clearParticipantConnectionStatus(previousUserId);
-                  const producersToClose = Array.from(
-                    producerMapRef.current.entries(),
-                  )
-                    .filter(([, info]) => info.userId === previousUserId)
-                    .map(
-                      ([producerId, info]): ProducerInfo => ({
-                        producerId,
-                        producerUserId: previousUserId,
-                        kind: info.kind,
-                        type: info.type,
-                      }),
-                    );
-                  for (const info of Array.from(
-                    pendingProducersRef.current.values(),
-                  )) {
-                    if (info.producerUserId === previousUserId) {
-                      dropDepartedProducer(info);
-                    }
-                  }
-                  for (const producerInfo of producersToClose) {
-                    dropDepartedProducer(producerInfo);
-                  }
-                  dispatchParticipants({
-                    type: "REMOVE_PARTICIPANT",
-                    userId: previousUserId,
-                  });
-                }
-                participantIdsRef.current = nextParticipantIds;
-                setDisplayNames(snapshot);
-                if (clearedDepartedParticipant) {
-                  void syncProducers();
-                }
+                applyDisplayNameSnapshot(users || []);
               },
             );
 
@@ -5286,6 +5310,7 @@ export function useMeetSocket({
       handleProducerClosed,
       handleRedirectRef,
       handleReconnectRef,
+      applyDisplayNameSnapshot,
       applyParticipantConnectionStatus,
       ensureLiveLocalMediaForJoin,
       getVideoPublishTrack,

--- a/apps/web/src/app/meets-client-page.tsx
+++ b/apps/web/src/app/meets-client-page.tsx
@@ -126,7 +126,7 @@ export default function MeetsClientPage({
     initialRoomId ?? (isPublicClient ? "" : "default-room");
 
   return (
-    <div className="w-full h-full min-h-screen bg-[#0a0a0b] overflow-auto relative">
+    <div className="w-full h-full min-h-[100dvh] bg-[#0a0a0b] overflow-auto relative">
       <MeetsClient
         initialRoomId={resolvedInitialRoomId}
         enableRoomRouting={isPublicClient}

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -11,6 +11,7 @@ import { signOut, useSession } from "@/lib/auth-client";
 import type { AssetUploadHandler } from "@conclave/apps-sdk";
 import {
   AppsProvider,
+  GameProvider,
   createAssetUploadHandler,
   registerApps,
 } from "@conclave/apps-sdk";
@@ -2583,12 +2584,14 @@ export default function MeetsClient({
         isAdmin={isAdminFlag}
         uploadAsset={uploadAsset}
       >
-        <MeetVolumeProvider
-          meetVolume={meetVolume}
-          setMeetVolume={setMeetVolume}
-        >
-          {content}
-        </MeetVolumeProvider>
+        <GameProvider socket={appsSocket} user={appsUser} isAdmin={isAdminFlag}>
+          <MeetVolumeProvider
+            meetVolume={meetVolume}
+            setMeetVolume={setMeetVolume}
+          >
+            {content}
+          </MeetVolumeProvider>
+        </GameProvider>
       </AppsProvider>
     </>
   );

--- a/packages/apps-sdk/README.md
+++ b/packages/apps-sdk/README.md
@@ -2,12 +2,13 @@
 
 In-meeting app runtime SDK for Conclave (`web` + `native`).
 
-This package gives you a shared runtime for collaborative meeting apps:
+This package gives you a shared runtime for collaborative meeting apps and server-authoritative games:
 
 - app registry and discovery
 - room-level app state (`activeAppId`, `locked`)
 - Yjs doc sync and awareness sync over SFU socket events
 - React provider + hooks for app and host UI
+- game provider + hooks for server-owned rules, scoring, and private views
 - optional cross-platform asset uploads
 
 ## Documentation
@@ -18,6 +19,7 @@ This package gives you a shared runtime for collaborative meeting apps:
 - Permissions and locking: [docs/reference/permissions-and-locking.md](./docs/reference/permissions-and-locking.md)
 - Socket events and sync protocol: [docs/reference/socket-events-and-sync.md](./docs/reference/socket-events-and-sync.md)
 - Add an app: [docs/guides/add-a-new-app-integration.md](./docs/guides/add-a-new-app-integration.md)
+- Add a game: [docs/guides/add-a-game.md](./docs/guides/add-a-game.md)
 - App cookbook: [docs/guides/app-cookbook.md](./docs/guides/app-cookbook.md)
 - Troubleshooting: [docs/guides/troubleshooting.md](./docs/guides/troubleshooting.md)
 - Contributing guide: [docs/guides/contributing-to-apps-sdk.md](./docs/guides/contributing-to-apps-sdk.md)
@@ -26,6 +28,7 @@ This package gives you a shared runtime for collaborative meeting apps:
 ## Who Should Use This Package
 
 - App authors: building a collaborative meeting surface (polls, notes, timers, etc.)
+- Game authors: building a game where the SFU owns rules, scoring, timers, or hidden information
 - Host integrators: wiring app menu and layout into Conclave web/mobile meeting shells
 - Reviewers/maintainers: validating permissions, sync behavior, and cross-platform wiring
 
@@ -36,6 +39,7 @@ This package gives you a shared runtime for collaborative meeting apps:
 | Understand how the runtime fits together | [Core concepts](./docs/reference/core-concepts.md) |
 | Know what each hook/API does | [Runtime APIs](./docs/reference/runtime-apis.md) |
 | Add a brand-new app integration | [Add a new app integration](./docs/guides/add-a-new-app-integration.md) |
+| Add a server-authoritative game | [Add a game to Conclave](./docs/guides/add-a-game.md) |
 | Start from a proven app shape | [App cookbook](./docs/guides/app-cookbook.md) |
 | Debug sync or permission behavior | [Socket events and sync](./docs/reference/socket-events-and-sync.md) + [Troubleshooting](./docs/guides/troubleshooting.md) |
 | Contribute safely and pass review quickly | [Contributing guide](./docs/guides/contributing-to-apps-sdk.md) |
@@ -164,6 +168,12 @@ Full workflow: [docs/guides/contributing-to-apps-sdk.md](./docs/guides/contribut
 - Dev playground (web): `@conclave/apps-sdk/dev-playground/web`
 - Dev playground (core): `@conclave/apps-sdk/dev-playground/core`
 
+## Games
+
+Conclave games use the Apps SDK game hooks, but the rules run on the SFU so private information, timers, scoring, and validation stay server-authoritative.
+
+Start here: [docs/guides/add-a-game.md](./docs/guides/add-a-game.md)
+
 ## Development Playground
 
 This repo includes a dev-only sample app for learning SDK patterns.
@@ -192,5 +202,6 @@ It demonstrates:
 - [docs/reference/core-concepts.md](./docs/reference/core-concepts.md)
 - [docs/reference/runtime-apis.md](./docs/reference/runtime-apis.md)
 - [docs/reference/socket-events-and-sync.md](./docs/reference/socket-events-and-sync.md)
+- [docs/guides/add-a-game.md](./docs/guides/add-a-game.md)
 - [docs/guides/app-cookbook.md](./docs/guides/app-cookbook.md)
 - [docs/guides/troubleshooting.md](./docs/guides/troubleshooting.md)

--- a/packages/apps-sdk/docs/README.md
+++ b/packages/apps-sdk/docs/README.md
@@ -1,6 +1,6 @@
 # Apps SDK Docs
 
-This docs tree explains how Conclave in-meeting apps work, how to build and integrate them, and how to debug runtime behavior when something goes wrong.
+This docs tree explains how Conclave in-meeting apps and games work, how to build and integrate them, and how to debug runtime behavior when something goes wrong.
 
 ## Start Here
 
@@ -9,6 +9,7 @@ If you are new to the SDK, read in this order:
 1. [Core Concepts](./reference/core-concepts.md)
 2. [Runtime APIs and Hooks](./reference/runtime-apis.md)
 3. [Add a New App Integration](./guides/add-a-new-app-integration.md)
+4. [Add a Game to Conclave](./guides/add-a-game.md)
 
 ## I Need To...
 
@@ -18,6 +19,7 @@ If you are new to the SDK, read in this order:
 | See what each hook/helper returns | [Runtime APIs and Hooks](./reference/runtime-apis.md) |
 | Learn the socket protocol and sync flow | [Socket Events and Sync](./reference/socket-events-and-sync.md) |
 | Add a new app from scaffold to host wiring | [Add a New App Integration](./guides/add-a-new-app-integration.md) |
+| Add a server-authoritative game | [Add a Game to Conclave](./guides/add-a-game.md) |
 | Pick a schema/control pattern quickly | [App Cookbook](./guides/app-cookbook.md) |
 | Validate permissions/lock behavior | [Permissions and Locking](./reference/permissions-and-locking.md) |
 | Fix common integration bugs quickly | [Troubleshooting](./guides/troubleshooting.md) |
@@ -26,6 +28,7 @@ If you are new to the SDK, read in this order:
 ## Guides
 
 - [Add a New App Integration](./guides/add-a-new-app-integration.md): step-by-step wiring from scaffold to host integration.
+- [Add a Game to Conclave](./guides/add-a-game.md): build a game with server rules, private player views, and a web renderer.
 - [App Cookbook](./guides/app-cookbook.md): recipe-style app patterns (polls, timer, notes, media).
 - [Troubleshooting](./guides/troubleshooting.md): symptom-first fixes for common runtime/integration failures.
 - [Contributing To Apps SDK](./guides/contributing-to-apps-sdk.md): contributor workflow, review checklist, and guardrails.

--- a/packages/apps-sdk/docs/guides/add-a-game.md
+++ b/packages/apps-sdk/docs/guides/add-a-game.md
@@ -1,0 +1,331 @@
+# Add a Game to Conclave
+
+This guide explains how to add an in-meeting game to Conclave. Games are part of the Apps SDK surface, but they use a different runtime model from collaborative Yjs apps.
+
+Use the game runtime when the server must own the rules. Good examples are trivia, bluffing games, reaction games, voting games, and hidden-role games.
+
+Use a regular collaborative app when everyone can safely see and edit the same shared document, such as a whiteboard, notes, polls, or a checklist.
+
+## What You Build
+
+A Conclave game has two parts:
+
+1. A server game module that owns the rules, state transitions, timers, scoring, and private information.
+2. A web renderer that displays the public state plus the current player's private view.
+
+The SFU game engine already handles sockets, room membership, admin checks, state broadcasts, private player views, and game cleanup. A new game should plug into those extension points. It should not require edits to core SFU handlers.
+
+## Fast Start
+
+Run the scaffold command from the repo root:
+
+```bash
+node packages/sfu/scripts/new-game.mjs quick-draw "Quick Draw"
+```
+
+The command creates:
+
+```text
+packages/sfu/server/games/modules/quickDraw.ts
+apps/web/src/app/components/games/QuickDrawGame.tsx
+```
+
+It also updates:
+
+```text
+packages/sfu/server/games/registry.ts
+apps/web/src/app/components/games/registry.tsx
+```
+
+After scaffolding, fill in the reducer, projections, and renderer. Then run:
+
+```bash
+CI=true corepack pnpm -C packages/sfu run typecheck
+CI=true corepack pnpm -C apps/web run lint
+node_modules/.bin/tsc --noEmit -p apps/web/tsconfig.json
+CI=true corepack pnpm -C packages/apps-sdk run check:apps
+```
+
+## Files You Usually Touch
+
+| Area | File | Purpose |
+| --- | --- | --- |
+| Server rules | `packages/sfu/server/games/modules/<game>.ts` | Authoritative game logic |
+| Server catalog | `packages/sfu/server/games/registry.ts` | Adds the game to `game:list` |
+| Web renderer | `apps/web/src/app/components/games/<Game>Game.tsx` | Renders the dock UI |
+| Web renderer map | `apps/web/src/app/components/games/registry.tsx` | Maps `gameId` to renderer |
+| Optional visual identity | `apps/web/src/app/components/games/covers.tsx` | Accent color and display name |
+
+## Files You Should Not Need To Touch
+
+These files are core runtime code. A normal game should not modify them:
+
+- `packages/sfu/server/socket/handlers/gameHandlers.ts`
+- `packages/sfu/server/games/engine.ts`
+- `packages/sfu/server/games/types.ts`
+- `packages/sfu/config/classes/Room.ts`
+- `packages/apps-sdk/src/games/GameProvider.tsx`
+
+If your game needs changes in one of those files, pause and check whether the feature should become a reusable runtime capability instead of a one-off game patch.
+
+## Server Game Module
+
+A game module implements `GameModule<State>`.
+
+```ts
+import {
+  GameMoveError,
+  type GameContext,
+  type GameModule,
+  type GameMove,
+} from "../types.js";
+
+type Phase = "lobby" | "question" | "results";
+
+type QuickDrawState = {
+  phase: Phase;
+  prompt: string | null;
+  guesses: Record<string, string>;
+};
+
+export const quickDrawModule: GameModule<QuickDrawState> = {
+  id: "quick-draw",
+  name: "Quick Draw",
+  description: "Draw from a prompt and vote on the winner",
+  minPlayers: 2,
+  maxPlayers: 12,
+  tickMs: 500,
+
+  setup(ctx: GameContext): QuickDrawState {
+    return {
+      phase: "lobby",
+      prompt: null,
+      guesses: {},
+    };
+  },
+
+  onMove(state, move: GameMove, ctx): QuickDrawState {
+    switch (move.type) {
+      case "start": {
+        if (!ctx.isAdmin(move.playerId)) {
+          throw new GameMoveError("Only the host can start");
+        }
+        if (state.phase !== "lobby") {
+          throw new GameMoveError("Already running");
+        }
+        return {
+          ...state,
+          phase: "question",
+          prompt: ctx.rng.pick(["a rocket", "a sandwich", "a tiny castle"]),
+        };
+      }
+      default:
+        throw new GameMoveError(`Unknown move: ${move.type}`);
+    }
+  },
+
+  getPhase: (state) => state.phase,
+
+  publicView(state, ctx) {
+    return {
+      phase: state.phase,
+      prompt: state.prompt,
+      totalPlayers: ctx.players.length,
+      serverNow: ctx.now,
+    };
+  },
+
+  playerView(state, playerId) {
+    return {
+      myGuess: state.guesses[playerId] ?? null,
+    };
+  },
+
+  isFinished: (state) => state.phase === "results",
+};
+```
+
+### Server Rules
+
+- Keep all scoring and rule validation on the server.
+- Throw `GameMoveError` for a rejected player action.
+- Use `ctx.rng` for shuffles, prompts, roles, and random choices.
+- Use `ctx.now` for deadlines and countdowns.
+- Use `ctx.isAdmin(playerId)` for host-only moves.
+- Keep reducers pure. Return a new state object when state changes.
+
+## Public and Private Views
+
+Every game sends two projections:
+
+| Projection | Who receives it | Use it for |
+| --- | --- | --- |
+| `publicView` | The whole room | Shared phase, timers, public scores, revealed answers |
+| `playerView` | One player only | Secret roles, private words, selected answer, personal status |
+
+Do not put secrets in `publicView`. Hidden-role games should put the secret role or word in `playerView`, then reveal only safe information in `publicView` when the phase allows it.
+
+## Moves
+
+The web renderer calls:
+
+```ts
+move("answer", { choice: 2 });
+```
+
+The server receives:
+
+```ts
+{
+  playerId: "user@example.com#session",
+  type: "answer",
+  payload: { choice: 2 }
+}
+```
+
+Validate every payload. Do not trust the client to send a valid player id, choice, score, or phase.
+
+For common player-target validation, use helpers from:
+
+```text
+packages/sfu/server/games/validation.ts
+```
+
+## Host Options
+
+Games can expose host-configurable setup options. The launcher renders these automatically before starting the game.
+
+```ts
+options: [
+  {
+    id: "rounds",
+    type: "number",
+    label: "Rounds",
+    min: 3,
+    max: 10,
+    default: 5,
+    presets: [3, 5, 7],
+  },
+  {
+    id: "pace",
+    type: "select",
+    label: "Pace",
+    default: "normal",
+    choices: [
+      { value: "relaxed", label: "Relaxed" },
+      { value: "normal", label: "Normal" },
+      { value: "fast", label: "Fast" },
+    ],
+  },
+],
+```
+
+Read options in `setup`:
+
+```ts
+import { numberOption, selectOption } from "../config.js";
+
+const rounds = numberOption(ctx.config, "rounds", 5);
+const pace = selectOption(ctx.config, "pace", "normal");
+```
+
+The server normalizes client input before the game starts. Unknown keys are dropped. Invalid values fall back to defaults.
+
+## Leaderboards
+
+If your game has scores, set:
+
+```ts
+hasLeaderboard: true,
+```
+
+Then include a scoreboard in `publicView`:
+
+```ts
+scoreboard: ctx.players
+  .map((player) => ({
+    id: player.id,
+    name: player.name,
+    score: state.scores[player.id] ?? 0,
+  }))
+  .sort((a, b) => b.score - a.score),
+```
+
+The dock can render a compact leaderboard automatically during active phases.
+
+## Web Renderer
+
+Create a renderer in:
+
+```text
+apps/web/src/app/components/games/<Game>Game.tsx
+```
+
+The renderer receives:
+
+```ts
+import { type GameViewProps } from "./gameUi";
+
+type QuickDrawPublic = {
+  phase: "lobby" | "question" | "results";
+  prompt: string | null;
+};
+
+type QuickDrawMe = {
+  myGuess: string | null;
+};
+
+export default function QuickDrawGame({
+  pub,
+  me,
+  isAdmin,
+  move,
+}: GameViewProps<QuickDrawPublic, QuickDrawMe>) {
+  // Render the game UI here.
+}
+```
+
+Keep the renderer as presentation code. It should read `pub` and `me`, collect user input, and call `move(type, payload)`. It should not duplicate server rules or compute authoritative scores.
+
+## Register the Game
+
+Add the server module to:
+
+```text
+packages/sfu/server/games/registry.ts
+```
+
+Add the web renderer to:
+
+```text
+apps/web/src/app/components/games/registry.tsx
+```
+
+If you want the lobby accent and fallback name to match the game, add entries in:
+
+```text
+apps/web/src/app/components/games/covers.tsx
+```
+
+## Review Checklist
+
+Before opening a PR, check:
+
+1. The server rejects illegal moves with `GameMoveError`.
+2. Secrets only appear in `playerView` until they are meant to be public.
+3. Timers use `ctx.now` and return `serverNow` for client countdowns.
+4. Host-only moves use `ctx.isAdmin(move.playerId)`.
+5. Player ids in payloads are validated against `ctx.players`.
+6. The game can handle disconnects. Players are snapshotted at game start.
+7. The launcher entry has clear `minPlayers`, `maxPlayers`, and description text.
+8. `pnpm -C packages/sfu run typecheck` passes.
+9. `pnpm -C apps/web run lint` passes.
+10. `pnpm -C packages/apps-sdk run check:apps` passes.
+
+## Related Docs
+
+- [Apps SDK Docs Home](../README.md)
+- [Runtime APIs and Hooks](../reference/runtime-apis.md)
+- [Core Concepts](../reference/core-concepts.md)
+- [Add a New App Integration](./add-a-new-app-integration.md)
+- [Server Game Runtime README](../../../sfu/server/games/README.md)

--- a/packages/apps-sdk/docs/reference/core-concepts.md
+++ b/packages/apps-sdk/docs/reference/core-concepts.md
@@ -12,6 +12,15 @@ An app is a collaborative in-meeting surface with:
 
 Apps are defined with `defineApp(...)` and registered with `registerApps(...)`.
 
+## Collaborative Apps and Games
+
+Conclave supports two in-meeting extension shapes:
+
+- Collaborative apps use Yjs. Everyone converges on the same shared document. Use this for whiteboards, notes, polls, checklists, and tools where the shared state can be visible to all participants.
+- Games use the server-authoritative game runtime. The SFU owns rules, timers, scoring, and private player views. Use this for hidden roles, trivia answers, timed reactions, scoring, and any rule set that clients should not be able to forge.
+
+If you are adding a game, start with [Add a Game to Conclave](../guides/add-a-game.md).
+
 ## Runtime Layers
 
 Think of the system in four layers:

--- a/packages/apps-sdk/docs/reference/runtime-apis.md
+++ b/packages/apps-sdk/docs/reference/runtime-apis.md
@@ -131,6 +131,98 @@ Returns:
 
 If provider has no upload handler, calling `uploadAsset` throws with a clear runtime error.
 
+## Game Runtime APIs
+
+Games use a server-authoritative runtime. The SDK exposes the client hook, but the SFU owns game rules, scoring, timers, and private projections.
+
+### `GameProvider`
+
+Wraps meeting UI that needs game controls or active game rendering.
+
+Props:
+
+- `socket`: connected room socket, or `null`
+- `user`: current player identity
+- `isAdmin`: role flag used for host-only game controls
+
+Provider responsibilities:
+
+- request the game catalog with `game:list`
+- subscribe to `game:state`, `game:view`, `game:snapshot`, `game:vote`, and `game:ended`
+- keep the active public game state in React context
+- keep the current player's private view in React context
+- expose methods that send acked game socket events
+
+### `useGame()`
+
+Returns the game runtime context:
+
+- `catalog`: available games from the SFU
+- `publicState`: room-wide public game state, or `null`
+- `view`: private view for the current player, or `null`
+- `vote`: active game vote, or `null`
+- `isActive`: `true` when a game is running
+- `isAdmin`: current role flag
+- `userId`: current player id
+- `startGame(gameId, options?)`
+- `endGame()`
+- `move(type, payload?)`
+- `openVote(candidateIds?)`
+- `castVote(gameId)`
+- `cancelVote()`
+- `refresh()`
+
+Ack behavior:
+
+- methods resolve to `{ success: boolean, error?: string }`
+- methods use an 8 second timeout in the provider implementation
+- `move` returns an error when no game is active
+
+### `startGame(gameId, options?)`
+
+Starts a game by id. Only admins can start games.
+
+`options` is a `GameConfig` object keyed by option id:
+
+```ts
+await startGame("trivia", {
+  questions: 10,
+  pace: "normal",
+});
+```
+
+The SFU validates options against the selected game module. Unknown keys are ignored. Invalid values fall back to defaults or are clamped to the allowed range.
+
+### `move(type, payload?)`
+
+Sends a player action to the active game:
+
+```ts
+await move("answer", { choice: 2 });
+```
+
+Client code should keep payloads small and simple. The server validates every move and can reject it with a user-facing error.
+
+### `publicState` and `view`
+
+Use `publicState.view` for information everyone can see. Use `view` for the current player's private projection.
+
+Do not assume both arrive in the same tick. Render loading or waiting states when `publicState` exists but `view` is still `null`.
+
+### Game Catalog Types
+
+Each `catalog` entry includes:
+
+- `id`
+- `name`
+- `description`
+- `minPlayers`
+- `maxPlayers`
+- `options`
+- `hasLeaderboard`
+
+`options` drives the host setup UI in the games launcher.
+
 ## Doc Helpers
 
 Use these helpers for predictable schema setup:
@@ -178,6 +270,7 @@ For native/non-web hosts, set `baseUrl` so relative endpoint resolves correctly.
 - Keep app id consistent across app definition, controls, and hooks.
 - Always gate write mutations using lock/admin state.
 - Avoid calling control methods before socket connect.
+- Use `useGame` for server-authoritative games where the server must own rules or hidden information.
 
 ## Related Docs
 
@@ -186,3 +279,4 @@ For native/non-web hosts, set `baseUrl` so relative endpoint resolves correctly.
 - [Socket Events and Sync](./socket-events-and-sync.md)
 - [Troubleshooting](../guides/troubleshooting.md)
 - [Add a New App Integration](../guides/add-a-new-app-integration.md)
+- [Add a Game to Conclave](../guides/add-a-game.md)

--- a/packages/apps-sdk/src/games/GameProvider.tsx
+++ b/packages/apps-sdk/src/games/GameProvider.tsx
@@ -10,6 +10,7 @@ import React, {
 import type { Socket } from "socket.io-client";
 import type {
   GameCatalogEntry,
+  GameConfig,
   GameContextValue,
   GameMoveResult,
   GamePublicState,
@@ -149,12 +150,12 @@ export function GameProvider({
   }, [socket, refresh]);
 
   const startGame = useCallback(
-    async (gameId: string): Promise<GameMoveResult> => {
+    async (gameId: string, options?: GameConfig): Promise<GameMoveResult> => {
       if (!socket) return { success: false, error: "Not connected" };
       return emitWithAck<GameMoveResult>(
         socket,
         "game:start",
-        { gameId },
+        { gameId, options },
         { success: false, error: "Timed out" },
       );
     },

--- a/packages/apps-sdk/src/games/GameProvider.tsx
+++ b/packages/apps-sdk/src/games/GameProvider.tsx
@@ -1,0 +1,254 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { Socket } from "socket.io-client";
+import type {
+  GameCatalogEntry,
+  GameContextValue,
+  GameMoveResult,
+  GamePublicState,
+  GameUser,
+  GameVote,
+} from "./types";
+
+const ACK_TIMEOUT_MS = 8_000;
+
+const GameContext = createContext<GameContextValue | null>(null);
+
+const isPublicState = (value: unknown): value is GamePublicState => {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.gameId === "string" &&
+    typeof record.phase === "string" &&
+    Array.isArray(record.players)
+  );
+};
+
+const emitWithAck = <T,>(
+  socket: Socket,
+  event: string,
+  payload: unknown,
+  fallback: T,
+): Promise<T> =>
+  new Promise((resolve) => {
+    let settled = false;
+    const done = (value: T) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    const timer = setTimeout(() => done(fallback), ACK_TIMEOUT_MS);
+    const ack = (response: T) => {
+      clearTimeout(timer);
+      done(response);
+    };
+    if (payload === undefined) {
+      socket.emit(event, ack);
+    } else {
+      socket.emit(event, payload, ack);
+    }
+  });
+
+export type GameProviderProps = {
+  socket: Socket | null;
+  user?: GameUser;
+  isAdmin?: boolean;
+  children: React.ReactNode;
+};
+
+export function GameProvider({
+  socket,
+  user,
+  isAdmin = false,
+  children,
+}: GameProviderProps) {
+  const [catalog, setCatalog] = useState<GameCatalogEntry[]>([]);
+  const [publicState, setPublicState] = useState<GamePublicState | null>(null);
+  const [view, setView] = useState<unknown>(null);
+  const [vote, setVote] = useState<GameVote | null>(null);
+  const activeGameIdRef = useRef<string | null>(null);
+
+  const userId = user?.id ?? null;
+
+  const refresh = useCallback(() => {
+    if (!socket) return;
+    socket.emit("game:getState", (state: unknown) => {
+      if (!state || typeof state !== "object") return;
+      const record = state as { active?: boolean; public?: unknown; view?: unknown; vote?: unknown };
+      if (record.active && isPublicState(record.public)) {
+        activeGameIdRef.current = record.public.gameId;
+        setPublicState(record.public);
+        setView(record.view ?? null);
+      } else {
+        activeGameIdRef.current = null;
+        setPublicState(null);
+        setView(null);
+      }
+      setVote((record.vote as GameVote | null) ?? null);
+    });
+    socket.emit("game:list", (entries: unknown) => {
+      if (Array.isArray(entries)) {
+        setCatalog(entries as GameCatalogEntry[]);
+      }
+    });
+  }, [socket]);
+
+  useEffect(() => {
+    if (!socket) {
+      setPublicState(null);
+      setView(null);
+      activeGameIdRef.current = null;
+      return;
+    }
+
+    const onState = (state: unknown) => {
+      if (!isPublicState(state)) return;
+      activeGameIdRef.current = state.gameId;
+      setPublicState(state);
+    };
+    const onView = (payload: unknown) => {
+      if (!payload || typeof payload !== "object") return;
+      const record = payload as { gameId?: unknown; view?: unknown };
+      if (
+        typeof record.gameId === "string" &&
+        record.gameId === activeGameIdRef.current
+      ) {
+        setView(record.view ?? null);
+      }
+    };
+    const onEnded = () => {
+      activeGameIdRef.current = null;
+      setPublicState(null);
+      setView(null);
+    };
+    const onVote = (payload: unknown) => {
+      setVote((payload as GameVote | null) ?? null);
+    };
+
+    socket.on("game:state", onState);
+    socket.on("game:view", onView);
+    socket.on("game:ended", onEnded);
+    socket.on("game:vote", onVote);
+    socket.on("connect", refresh);
+    refresh();
+
+    return () => {
+      socket.off("game:state", onState);
+      socket.off("game:view", onView);
+      socket.off("game:ended", onEnded);
+      socket.off("game:vote", onVote);
+      socket.off("connect", refresh);
+    };
+  }, [socket, refresh]);
+
+  const startGame = useCallback(
+    async (gameId: string): Promise<GameMoveResult> => {
+      if (!socket) return { success: false, error: "Not connected" };
+      return emitWithAck<GameMoveResult>(
+        socket,
+        "game:start",
+        { gameId },
+        { success: false, error: "Timed out" },
+      );
+    },
+    [socket],
+  );
+
+  const endGame = useCallback(async (): Promise<GameMoveResult> => {
+    if (!socket) return { success: false, error: "Not connected" };
+    return emitWithAck<GameMoveResult>(
+      socket,
+      "game:end",
+      undefined,
+      { success: false, error: "Timed out" },
+    );
+  }, [socket]);
+
+  const move = useCallback(
+    async (type: string, payload?: unknown): Promise<GameMoveResult> => {
+      if (!socket) return { success: false, error: "Not connected" };
+      const gameId = activeGameIdRef.current;
+      if (!gameId) return { success: false, error: "No active game" };
+      return emitWithAck<GameMoveResult>(
+        socket,
+        "game:move",
+        { gameId, type, payload },
+        { success: false, error: "Timed out" },
+      );
+    },
+    [socket],
+  );
+
+  const openVote = useCallback(
+    async (candidateIds?: string[]): Promise<GameMoveResult> => {
+      if (!socket) return { success: false, error: "Not connected" };
+      return emitWithAck<GameMoveResult>(
+        socket,
+        "game:vote:open",
+        { candidates: candidateIds },
+        { success: false, error: "Timed out" },
+      );
+    },
+    [socket],
+  );
+
+  const castVote = useCallback(
+    async (gameId: string): Promise<GameMoveResult> => {
+      if (!socket) return { success: false, error: "Not connected" };
+      return emitWithAck<GameMoveResult>(
+        socket,
+        "game:vote:cast",
+        { gameId },
+        { success: false, error: "Timed out" },
+      );
+    },
+    [socket],
+  );
+
+  const cancelVote = useCallback(async (): Promise<GameMoveResult> => {
+    if (!socket) return { success: false, error: "Not connected" };
+    return emitWithAck<GameMoveResult>(
+      socket,
+      "game:vote:cancel",
+      undefined,
+      { success: false, error: "Timed out" },
+    );
+  }, [socket]);
+
+  const value = useMemo<GameContextValue>(
+    () => ({
+      catalog,
+      publicState,
+      view,
+      vote,
+      isActive: publicState !== null,
+      isAdmin,
+      userId,
+      startGame,
+      endGame,
+      move,
+      openVote,
+      castVote,
+      cancelVote,
+      refresh,
+    }),
+    [catalog, publicState, view, vote, isAdmin, userId, startGame, endGame, move, openVote, castVote, cancelVote, refresh],
+  );
+
+  return <GameContext.Provider value={value}>{children}</GameContext.Provider>;
+}
+
+export const useGame = (): GameContextValue => {
+  const context = useContext(GameContext);
+  if (!context) {
+    throw new Error("useGame must be used within a GameProvider");
+  }
+  return context;
+};

--- a/packages/apps-sdk/src/games/GameProvider.tsx
+++ b/packages/apps-sdk/src/games/GameProvider.tsx
@@ -78,36 +78,48 @@ export function GameProvider({
 
   const userId = user?.id ?? null;
 
+  const applySnapshot = useCallback((state: unknown) => {
+    if (!state || typeof state !== "object") return;
+    const record = state as {
+      active?: boolean;
+      public?: unknown;
+      view?: unknown;
+      vote?: unknown;
+    };
+    if (record.active && isPublicState(record.public)) {
+      activeGameIdRef.current = record.public.gameId;
+      setPublicState(record.public);
+      setView(record.view ?? null);
+    } else {
+      activeGameIdRef.current = null;
+      setPublicState(null);
+      setView(null);
+    }
+    setVote((record.vote as GameVote | null) ?? null);
+  }, []);
+
   const refresh = useCallback(() => {
     if (!socket) return;
     socket.emit("game:getState", (state: unknown) => {
-      if (!state || typeof state !== "object") return;
-      const record = state as { active?: boolean; public?: unknown; view?: unknown; vote?: unknown };
-      if (record.active && isPublicState(record.public)) {
-        activeGameIdRef.current = record.public.gameId;
-        setPublicState(record.public);
-        setView(record.view ?? null);
-      } else {
-        activeGameIdRef.current = null;
-        setPublicState(null);
-        setView(null);
-      }
-      setVote((record.vote as GameVote | null) ?? null);
+      applySnapshot(state);
     });
     socket.emit("game:list", (entries: unknown) => {
       if (Array.isArray(entries)) {
         setCatalog(entries as GameCatalogEntry[]);
       }
     });
-  }, [socket]);
+  }, [socket, applySnapshot]);
 
   useEffect(() => {
     if (!socket) {
       setPublicState(null);
       setView(null);
+      setVote(null);
       activeGameIdRef.current = null;
       return;
     }
+
+    const onSnapshot = (state: unknown) => applySnapshot(state);
 
     const onState = (state: unknown) => {
       if (!isPublicState(state)) return;
@@ -128,6 +140,7 @@ export function GameProvider({
       activeGameIdRef.current = null;
       setPublicState(null);
       setView(null);
+      setVote(null);
     };
     const onVote = (payload: unknown) => {
       setVote((payload as GameVote | null) ?? null);
@@ -135,6 +148,7 @@ export function GameProvider({
 
     socket.on("game:state", onState);
     socket.on("game:view", onView);
+    socket.on("game:snapshot", onSnapshot);
     socket.on("game:ended", onEnded);
     socket.on("game:vote", onVote);
     socket.on("connect", refresh);
@@ -143,11 +157,12 @@ export function GameProvider({
     return () => {
       socket.off("game:state", onState);
       socket.off("game:view", onView);
+      socket.off("game:snapshot", onSnapshot);
       socket.off("game:ended", onEnded);
       socket.off("game:vote", onVote);
       socket.off("connect", refresh);
     };
-  }, [socket, refresh]);
+  }, [socket, refresh, applySnapshot]);
 
   const startGame = useCallback(
     async (gameId: string, options?: GameConfig): Promise<GameMoveResult> => {

--- a/packages/apps-sdk/src/games/index.ts
+++ b/packages/apps-sdk/src/games/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./GameProvider";

--- a/packages/apps-sdk/src/games/types.ts
+++ b/packages/apps-sdk/src/games/types.ts
@@ -9,12 +9,36 @@ export type GamePlayer = {
   name: string;
 };
 
+/** Host-configurable option spec for a game (mirrors the SFU schema). */
+export type GameOptionSpec =
+  | {
+      id: string;
+      type: "number";
+      label: string;
+      min: number;
+      max: number;
+      default: number;
+      presets?: number[];
+      suffix?: string;
+    }
+  | {
+      id: string;
+      type: "select";
+      label: string;
+      default: string;
+      choices: { value: string; label: string }[];
+    };
+
+export type GameConfig = Record<string, number | string>;
+
 export type GameCatalogEntry = {
   id: string;
   name: string;
   description: string;
   minPlayers: number;
   maxPlayers: number;
+  options: GameOptionSpec[];
+  hasLeaderboard: boolean;
 };
 
 /** Broadcast to the whole room on every state change. */
@@ -26,6 +50,7 @@ export type GamePublicState = {
   hostId: string | null;
   view: unknown;
   finished: boolean;
+  hasLeaderboard: boolean;
 };
 
 export type GameMoveResult = {
@@ -58,7 +83,7 @@ export type GameContextValue = {
   isActive: boolean;
   isAdmin: boolean;
   userId: string | null;
-  startGame: (gameId: string) => Promise<GameMoveResult>;
+  startGame: (gameId: string, options?: GameConfig) => Promise<GameMoveResult>;
   endGame: () => Promise<GameMoveResult>;
   move: (type: string, payload?: unknown) => Promise<GameMoveResult>;
   openVote: (candidateIds?: string[]) => Promise<GameMoveResult>;

--- a/packages/apps-sdk/src/games/types.ts
+++ b/packages/apps-sdk/src/games/types.ts
@@ -1,0 +1,68 @@
+/**
+ * Client-side mirror of the SFU game wire contract. The server is authoritative;
+ * the client only ever holds projections it was sent. View payloads are typed
+ * per game in the renderer that consumes them — here they stay `unknown`.
+ */
+
+export type GamePlayer = {
+  id: string;
+  name: string;
+};
+
+export type GameCatalogEntry = {
+  id: string;
+  name: string;
+  description: string;
+  minPlayers: number;
+  maxPlayers: number;
+};
+
+/** Broadcast to the whole room on every state change. */
+export type GamePublicState = {
+  gameId: string;
+  name: string;
+  phase: string;
+  players: GamePlayer[];
+  hostId: string | null;
+  view: unknown;
+  finished: boolean;
+};
+
+export type GameMoveResult = {
+  success: boolean;
+  error?: string;
+};
+
+export type GameUser = {
+  id: string;
+  name?: string | null;
+};
+
+/** A host-initiated vote on which game to play next. */
+export type GameVote = {
+  candidates: GameCatalogEntry[];
+  tally: Record<string, number>;
+  votes: Record<string, string>;
+  totalPlayers: number;
+};
+
+export type GameContextValue = {
+  /** Available games to launch. */
+  catalog: GameCatalogEntry[];
+  /** Current room-wide public game state, or null when no game is active. */
+  publicState: GamePublicState | null;
+  /** This player's private projection of the active game, if any. */
+  view: unknown;
+  /** Active pre-game vote, or null. */
+  vote: GameVote | null;
+  isActive: boolean;
+  isAdmin: boolean;
+  userId: string | null;
+  startGame: (gameId: string) => Promise<GameMoveResult>;
+  endGame: () => Promise<GameMoveResult>;
+  move: (type: string, payload?: unknown) => Promise<GameMoveResult>;
+  openVote: (candidateIds?: string[]) => Promise<GameMoveResult>;
+  castVote: (gameId: string) => Promise<GameMoveResult>;
+  cancelVote: () => Promise<GameMoveResult>;
+  refresh: () => void;
+};

--- a/packages/apps-sdk/src/index.ts
+++ b/packages/apps-sdk/src/index.ts
@@ -8,5 +8,6 @@ export * from "./sdk/hooks/useAppPresence";
 export * from "./sdk/hooks/useAppAssets";
 export * from "./sdk/hooks/useRegisteredApps";
 export * from "./sdk/assets/createAssetUploadHandler";
+export * from "./games/index";
 
 export * as WhiteboardCore from "./apps/whiteboard/core/index";

--- a/packages/meeting-core/src/types.ts
+++ b/packages/meeting-core/src/types.ts
@@ -171,12 +171,18 @@ export interface ProducerInfo {
   roomId?: string;
 }
 
+export interface DisplayNameSnapshotEntry {
+  userId: string;
+  displayName: string;
+}
+
 export type VideoQuality = "low" | "standard";
 
 export interface JoinRoomResponse {
   roomId?: string;
   rtpCapabilities: RtpCapabilities;
   existingProducers: ProducerInfo[];
+  displayNameSnapshot?: DisplayNameSnapshotEntry[];
   status?: "waiting" | "joined";
   hostUserId?: string | null;
   hostUserIds?: string[];

--- a/packages/sfu/config/classes/Room.ts
+++ b/packages/sfu/config/classes/Room.ts
@@ -22,6 +22,7 @@ import { config } from "../config.js";
 import { Admin } from "./Admin.js";
 import type { Client } from "./Client.js";
 import type { ProducerType } from "./Client.js";
+import type { GameSession } from "../../server/games/engine.js";
 
 export interface RoomOptions {
   id: string;
@@ -145,6 +146,13 @@ export class Room {
   private appsAwareness: Map<string, Awareness> = new Map();
   private appAwarenessClientIdsByUser: Map<string, Map<string, Set<number>>> =
     new Map();
+  // Server-authoritative game runtime (parallel to the collaborative apps
+  // relay above). At most one game runs per room. The tick timer is owned here
+  // so it is torn down with the room; the handler layer drives broadcasts.
+  public gameSession: GameSession | null = null;
+  public gameTickTimer: NodeJS.Timeout | null = null;
+  // Pre-game vote: the host can let the room vote on which game to play.
+  public gameVote: { candidates: string[]; votes: Record<string, string> } | null = null;
   private systemProducers: Map<
     string,
     { producer: Producer; userId: string; type: ProducerType }
@@ -1255,6 +1263,15 @@ export class Room {
     this.appsState.locked = false;
   }
 
+  clearGame(): void {
+    if (this.gameTickTimer) {
+      clearInterval(this.gameTickTimer);
+      this.gameTickTimer = null;
+    }
+    this.gameSession = null;
+    this.gameVote = null;
+  }
+
   close(): void {
     this.stopCleanupTimer();
     for (const pending of this.pendingDisconnects.values()) {
@@ -1272,6 +1289,7 @@ export class Room {
     this.webinarAttendeeCount = 0;
     this.meetingParticipantCount = 0;
     this.clearApps();
+    this.clearGame();
     if (this.webinarAudioLevelObserver) {
       try {
         this.webinarAudioLevelObserver.close();

--- a/packages/sfu/package.json
+++ b/packages/sfu/package.json
@@ -11,6 +11,7 @@
     "dev": "npx tsx server.ts",
     "prestart": "node scripts/ensure-mediasoup-worker.mjs",
     "start": "npx tsx server.ts",
+    "new:game": "node ./scripts/new-game.mjs",
     "typecheck": "npx tsc --noEmit"
   },
   "keywords": [],

--- a/packages/sfu/scripts/new-game.mjs
+++ b/packages/sfu/scripts/new-game.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Scaffold a new Conclave game end to end.
+ *
+ *   node packages/sfu/scripts/new-game.mjs <kebab-id> "Display Name"
+ *
+ * Creates:
+ *   - packages/sfu/server/games/modules/<camel>.ts   (authoritative logic)
+ *   - apps/web/src/app/components/games/<Pascal>Game.tsx  (renderer)
+ * and registers both (server registry + web registry) automatically.
+ *
+ * After running: fill in the reducer in the module and the JSX in the renderer.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../..");
+
+const [, , rawId, ...nameParts] = process.argv;
+if (!rawId || !/^[a-z][a-z0-9-]*$/.test(rawId)) {
+  console.error('Usage: node packages/sfu/scripts/new-game.mjs <kebab-id> "Display Name"');
+  process.exit(1);
+}
+const id = rawId;
+const name = nameParts.join(" ") || id;
+const camel = id.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+const Pascal = camel.charAt(0).toUpperCase() + camel.slice(1);
+
+const modulePath = resolve(repoRoot, `packages/sfu/server/games/modules/${camel}.ts`);
+const rendererPath = resolve(repoRoot, `apps/web/src/app/components/games/${Pascal}Game.tsx`);
+const serverRegistry = resolve(repoRoot, "packages/sfu/server/games/registry.ts");
+const webRegistry = resolve(repoRoot, "apps/web/src/app/components/games/registry.tsx");
+
+if (existsSync(modulePath) || existsSync(rendererPath)) {
+  console.error(`Refusing to overwrite existing files for "${id}".`);
+  process.exit(1);
+}
+
+const moduleTemplate = `import {
+  GameMoveError,
+  type GameContext,
+  type GameModule,
+  type GameMove,
+} from "../types.js";
+
+type Phase = "lobby" | "active" | "results";
+
+type ${Pascal}State = {
+  phase: Phase;
+  // TODO: model your authoritative state here.
+};
+
+export const ${camel}Module: GameModule<${Pascal}State> = {
+  id: "${id}",
+  name: "${name}",
+  description: "TODO: one-line description shown in the launcher.",
+  minPlayers: 1,
+  maxPlayers: 24,
+  tickMs: 500,
+
+  setup(ctx: GameContext): ${Pascal}State {
+    return { phase: "lobby" };
+  },
+
+  onMove(state, move: GameMove, ctx): ${Pascal}State {
+    switch (move.type) {
+      case "start": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can start");
+        if (state.phase !== "lobby") throw new GameMoveError("Already running");
+        return { ...state, phase: "active" };
+      }
+      default:
+        throw new GameMoveError(\`Unknown move: \${move.type}\`);
+    }
+  },
+
+  onTick(state, ctx): ${Pascal}State {
+    // TODO: drive deadlines / countdowns here, or delete onTick + tickMs.
+    return state;
+  },
+
+  getPhase: (state) => state.phase,
+
+  // Never leak secrets here - this goes to everyone.
+  publicView(state, ctx) {
+    return { phase: state.phase, serverNow: ctx.now, totalPlayers: ctx.players.length };
+  },
+
+  // This player's private slice (hidden information lives here).
+  playerView(state, playerId, ctx) {
+    return {};
+  },
+
+  isFinished: (state) => state.phase === "results",
+};
+`;
+
+const rendererTemplate = `"use client";
+
+import React from "react";
+import { color } from "@conclave/ui-tokens";
+import { HEAD_FONT, PrimaryButton, type GameViewProps } from "./gameUi";
+
+type ${Pascal}Public = { phase: "lobby" | "active" | "results"; totalPlayers: number };
+type ${Pascal}Me = Record<string, never>;
+
+export default function ${Pascal}Game({
+  pub,
+  isAdmin,
+  move,
+}: GameViewProps<${Pascal}Public, ${Pascal}Me>) {
+  if (pub.phase === "lobby") {
+    return (
+      <div style={{ textAlign: "center", padding: "12px 4px" }}>
+        <p style={{ fontFamily: HEAD_FONT, fontSize: 17, color: color.text, margin: "0 0 16px" }}>
+          ${name}
+        </p>
+        {isAdmin ? (
+          <PrimaryButton full onClick={() => move("start")}>Start</PrimaryButton>
+        ) : (
+          <p style={{ fontSize: 13, color: color.textFaint }}>Waiting for the host</p>
+        )}
+      </div>
+    );
+  }
+
+  // TODO: render the active and results phases.
+  return <p style={{ fontSize: 13, color: color.textMuted }}>TODO: build ${name}.</p>;
+}
+`;
+
+writeFileSync(modulePath, moduleTemplate);
+writeFileSync(rendererPath, rendererTemplate);
+
+// Auto-register on the server: add import + array entry.
+let server = readFileSync(serverRegistry, "utf8");
+server = server.replace(
+  /(import type \{ GameCatalogEntry)/,
+  `import { ${camel}Module } from "./modules/${camel}.js";\n$1`,
+);
+server = server.replace(
+  /(\n\];\n\nconst REGISTRY)/,
+  `\n  ${camel}Module as GameModule,$1`,
+);
+writeFileSync(serverRegistry, server);
+
+// Auto-register on the web: add import + map entry.
+let web = readFileSync(webRegistry, "utf8");
+web = web.replace(
+  /(export const GAME_RENDERERS)/,
+  `import ${Pascal}Game from "./${Pascal}Game";\n\n$1`,
+);
+web = web.replace(
+  /(\n};\n\nexport const getGameRenderer)/,
+  `\n  "${id}": ${Pascal}Game as React.ComponentType<GameViewProps>,$1`,
+);
+writeFileSync(webRegistry, web);
+
+console.log(`Created game "${id}" (${name}).`);
+console.log(`  server: packages/sfu/server/games/modules/${camel}.ts`);
+console.log(`  web:    apps/web/src/app/components/games/${Pascal}Game.tsx`);
+console.log("Both registries updated. Fill in the reducer + renderer, then run a typecheck.");

--- a/packages/sfu/server/games/README.md
+++ b/packages/sfu/server/games/README.md
@@ -6,11 +6,11 @@ of a shared CRDT (every client converges on identical, fully-visible state), the
 game runtime keeps canonical state **only on the server** and sends each client a
 _projection_:
 
-- `publicView` → broadcast to the whole room (`game:state`)
-- `playerView` → emitted privately to a single player (`game:view`)
+- `publicView` -> broadcast to the whole room (`game:state`)
+- `playerView` -> emitted privately to a single player (`game:view`)
 
 That split is what makes **hidden information** (secret roles, private words,
-unrevealed answers) possible — a CRDT cannot hide anything from anyone.
+unrevealed answers) possible. A CRDT cannot hide anything from anyone.
 
 ## Pieces
 
@@ -19,8 +19,8 @@ unrevealed answers) possible — a CRDT cannot hide anything from anyone.
 | `types.ts` | `GameModule` contract, wire payloads, `GameMoveError` |
 | `validation.ts` | reusable move validators for common server-authoritative rules |
 | `rng.ts` | seeded PRNG (server-only randomness for shuffles/deals) |
-| `engine.ts` | `GameSession` — owns authoritative state, applies moves, projects views |
-| `registry.ts` | maps `gameId → module` |
+| `engine.ts` | `GameSession` owns authoritative state, applies moves, projects views |
+| `registry.ts` | maps `gameId` to module |
 | `modules/*.ts` | the games themselves (pure reducers) |
 | `../socket/handlers/gameHandlers.ts` | socket wiring: validation, broadcast loop, per-player emit |
 
@@ -31,38 +31,42 @@ and torn down in `Room.close()` via `clearGame()`.
 
 | Event | Dir | Ack | Purpose |
 | --- | --- | --- | --- |
-| `game:list` | c→s | yes | available games catalog |
-| `game:start` | c→s | yes | admin starts a game (snapshots current participants as players) |
-| `game:move` | c→s | yes | a player submits a validated move |
-| `game:end` | c→s | yes | admin ends the game |
-| `game:getState` | c→s | yes | public state + your private view (reconnect/late join) |
-| `game:state` | s→room | no | public projection on every change |
-| `game:view` | s→player | no | **private** projection (hidden-info boundary) |
-| `game:ended` | s→room | no | game cleared |
+| `game:list` | c->s | yes | available games catalog |
+| `game:start` | c->s | yes | admin starts a game (snapshots current participants as players) |
+| `game:move` | c->s | yes | a player submits a validated move |
+| `game:end` | c->s | yes | admin ends the game |
+| `game:getState` | c->s | yes | public state + your private view (reconnect/late join) |
+| `game:state` | s->room | no | public projection on every change |
+| `game:view` | s->player | no | **private** projection (hidden-info boundary) |
+| `game:snapshot` | s->client | no | targeted join/reconnect snapshot: active game, private view, and vote |
+| `game:ended` | s->room | no | game cleared |
 
 ## Adding a game
 
+Full contributor guide: `packages/apps-sdk/docs/guides/add-a-game.md`.
+
 1. Create `modules/<id>.ts` exporting a `GameModule<YourState>`:
-   - `setup(ctx)` — build initial state with `ctx.rng` (seeded) and `ctx.players`.
-   - `onMove(state, move, ctx)` — return next state; `throw new GameMoveError(...)`
+   - `setup(ctx)`: build initial state with `ctx.rng` (seeded) and `ctx.players`.
+   - `onMove(state, move, ctx)`: return next state; `throw new GameMoveError(...)`
      to reject. Gate admin-only moves with `ctx.isAdmin(move.playerId)`.
      Use helpers from `validation.ts` for common payload checks such as selecting
      another player.
-   - `onTick(state, ctx)` + `tickMs` — for deadlines/countdowns (return the same
+   - `onTick(state, ctx)` + `tickMs`: for deadlines/countdowns (return the same
      reference to signal "no change").
-   - `getPhase(state)` — coarse label for the host UI.
-   - `publicView(state, ctx)` — **must not leak secrets**. Include `ctx.now` as
+   - `getPhase(state)`: coarse label for the host UI.
+   - `publicView(state, ctx)`: **must not leak secrets**. Include `ctx.now` as
      `serverNow` if you use deadlines so clients can run a skew-free countdown.
-   - `playerView(state, playerId, ctx)` — this player's private slice.
+   - `playerView(state, playerId, ctx)`: this player's private slice.
 2. Register it in `registry.ts`.
 3. Add a web renderer in `apps/web/src/app/components/games/` and route it in
-   `GamesDock.tsx`. The renderer is pure presentation: it reads the two views and
-   calls `move(type, payload)` — it holds **no** game logic.
+   `apps/web/src/app/components/games/registry.tsx`. The renderer is pure
+   presentation: it reads the two views and calls `move(type, payload)`. It
+   holds **no** game logic.
 
 ## Current games
 
-- `trivia` — Kahoot/Deezer-style timed quiz; speed-weighted scoring.
-- `imposter` — Spyfall-style social deduction; exercises the hidden-info path
+- `trivia`: Kahoot/Deezer-style timed quiz; speed-weighted scoring.
+- `imposter`: Spyfall-style social deduction; exercises the hidden-info path
   (imposter and crew receive different `playerView`s).
 
 ## Known gaps / next

--- a/packages/sfu/server/games/README.md
+++ b/packages/sfu/server/games/README.md
@@ -1,0 +1,74 @@
+# Game runtime (server-authoritative)
+
+This is the **second app archetype** for Conclave, parallel to the collaborative
+apps relay (`appsHandlers.ts` + Yjs). Where the apps relay is a dumb broadcaster
+of a shared CRDT (every client converges on identical, fully-visible state), the
+game runtime keeps canonical state **only on the server** and sends each client a
+_projection_:
+
+- `publicView` → broadcast to the whole room (`game:state`)
+- `playerView` → emitted privately to a single player (`game:view`)
+
+That split is what makes **hidden information** (secret roles, private words,
+unrevealed answers) possible — a CRDT cannot hide anything from anyone.
+
+## Pieces
+
+| File | Role |
+| --- | --- |
+| `types.ts` | `GameModule` contract, wire payloads, `GameMoveError` |
+| `validation.ts` | reusable move validators for common server-authoritative rules |
+| `rng.ts` | seeded PRNG (server-only randomness for shuffles/deals) |
+| `engine.ts` | `GameSession` — owns authoritative state, applies moves, projects views |
+| `registry.ts` | maps `gameId → module` |
+| `modules/*.ts` | the games themselves (pure reducers) |
+| `../socket/handlers/gameHandlers.ts` | socket wiring: validation, broadcast loop, per-player emit |
+
+The session/tick timer is owned by `Room` (`room.gameSession`, `room.gameTickTimer`)
+and torn down in `Room.close()` via `clearGame()`.
+
+## Socket contract
+
+| Event | Dir | Ack | Purpose |
+| --- | --- | --- | --- |
+| `game:list` | c→s | yes | available games catalog |
+| `game:start` | c→s | yes | admin starts a game (snapshots current participants as players) |
+| `game:move` | c→s | yes | a player submits a validated move |
+| `game:end` | c→s | yes | admin ends the game |
+| `game:getState` | c→s | yes | public state + your private view (reconnect/late join) |
+| `game:state` | s→room | no | public projection on every change |
+| `game:view` | s→player | no | **private** projection (hidden-info boundary) |
+| `game:ended` | s→room | no | game cleared |
+
+## Adding a game
+
+1. Create `modules/<id>.ts` exporting a `GameModule<YourState>`:
+   - `setup(ctx)` — build initial state with `ctx.rng` (seeded) and `ctx.players`.
+   - `onMove(state, move, ctx)` — return next state; `throw new GameMoveError(...)`
+     to reject. Gate admin-only moves with `ctx.isAdmin(move.playerId)`.
+     Use helpers from `validation.ts` for common payload checks such as selecting
+     another player.
+   - `onTick(state, ctx)` + `tickMs` — for deadlines/countdowns (return the same
+     reference to signal "no change").
+   - `getPhase(state)` — coarse label for the host UI.
+   - `publicView(state, ctx)` — **must not leak secrets**. Include `ctx.now` as
+     `serverNow` if you use deadlines so clients can run a skew-free countdown.
+   - `playerView(state, playerId, ctx)` — this player's private slice.
+2. Register it in `registry.ts`.
+3. Add a web renderer in `apps/web/src/app/components/games/` and route it in
+   `GamesDock.tsx`. The renderer is pure presentation: it reads the two views and
+   calls `move(type, payload)` — it holds **no** game logic.
+
+## Current games
+
+- `trivia` — Kahoot/Deezer-style timed quiz; speed-weighted scoring.
+- `imposter` — Spyfall-style social deduction; exercises the hidden-info path
+  (imposter and crew receive different `playerView`s).
+
+## Known gaps / next
+
+- Players are snapshotted at start; mid-game disconnects leave a stale seat
+  (public view still lists them; their private view simply stops being sent).
+- One game per room at a time (mirrors the single-`activeAppId` apps model).
+- Next archetype work: bind game seats to participant **video tiles** (badges,
+  turn rings, eliminated-tile dimming) and drive phase-based mute/spotlight.

--- a/packages/sfu/server/games/config.ts
+++ b/packages/sfu/server/games/config.ts
@@ -1,0 +1,46 @@
+import type { GameConfig, GameOptionSpec } from "./types.js";
+
+/** Build the all-defaults config for a set of option specs. */
+export const defaultConfig = (options: GameOptionSpec[] = []): GameConfig => {
+  const config: GameConfig = {};
+  for (const opt of options) config[opt.id] = opt.default;
+  return config;
+};
+
+/**
+ * Validate a raw (untrusted) config from the client against the module's option
+ * specs. Unknown keys are dropped; numbers are clamped to range and rounded;
+ * selects must be a known choice. Anything invalid falls back to the default.
+ */
+export const normalizeConfig = (
+  options: GameOptionSpec[] = [],
+  raw: unknown,
+): GameConfig => {
+  const input =
+    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  const config: GameConfig = {};
+  for (const opt of options) {
+    const value = input[opt.id];
+    if (opt.type === "number") {
+      const num = typeof value === "number" && Number.isFinite(value) ? value : opt.default;
+      config[opt.id] = Math.min(opt.max, Math.max(opt.min, Math.round(num)));
+    } else {
+      config[opt.id] =
+        typeof value === "string" && opt.choices.some((c) => c.value === value)
+          ? value
+          : opt.default;
+    }
+  }
+  return config;
+};
+
+/** Typed accessors for module setup code. */
+export const numberOption = (config: GameConfig, id: string, fallback: number): number => {
+  const value = config[id];
+  return typeof value === "number" ? value : fallback;
+};
+
+export const selectOption = (config: GameConfig, id: string, fallback: string): string => {
+  const value = config[id];
+  return typeof value === "string" ? value : fallback;
+};

--- a/packages/sfu/server/games/engine.ts
+++ b/packages/sfu/server/games/engine.ts
@@ -1,6 +1,7 @@
 import { createRng, createSeed } from "./rng.js";
 import {
   GameMoveError,
+  type GameConfig,
   type GameContext,
   type GameModule,
   type GamePlayer,
@@ -22,6 +23,7 @@ export class GameSession {
   private players: GamePlayer[];
   private readonly rng: GameRng;
   private readonly adminIds: Set<string>;
+  private readonly config: GameConfig;
   private state: unknown;
   private finished = false;
 
@@ -30,12 +32,14 @@ export class GameSession {
     players: GamePlayer[];
     adminIds: Iterable<string>;
     hostId: string;
+    config?: GameConfig;
     seed?: number;
   }) {
     this.module = options.module;
     this.players = dedupePlayers(options.players);
     this.adminIds = new Set(options.adminIds);
     this.hostId = options.hostId;
+    this.config = options.config ?? {};
     this.rng = createRng(options.seed ?? createSeed());
     this.state = this.module.setup(this.context());
     this.finished = this.module.isFinished?.(this.state) ?? false;
@@ -65,6 +69,7 @@ export class GameSession {
     return {
       players: this.players.slice(),
       rng: this.rng,
+      config: this.config,
       now,
       isAdmin: (playerId: string) => this.adminIds.has(playerId),
     };
@@ -123,6 +128,7 @@ export class GameSession {
       hostId: this.hostId,
       view: this.module.publicView(this.state, ctx),
       finished: this.finished,
+      hasLeaderboard: Boolean(this.module.hasLeaderboard),
     };
   }
 

--- a/packages/sfu/server/games/engine.ts
+++ b/packages/sfu/server/games/engine.ts
@@ -1,0 +1,143 @@
+import { createRng, createSeed } from "./rng.js";
+import {
+  GameMoveError,
+  type GameContext,
+  type GameModule,
+  type GamePlayer,
+  type GamePublicState,
+  type GameRng,
+} from "./types.js";
+
+/**
+ * Owns the authoritative state for one running game in one room.
+ *
+ * The session is transport-agnostic: it never touches socket.io. It exposes
+ * pure operations (`applyMove`, `tick`) and projection getters
+ * (`getPublicState`, `getPlayerView`). The handler layer is responsible for
+ * mapping projections onto sockets (room broadcast vs. per-player emit).
+ */
+export class GameSession {
+  readonly module: GameModule;
+  readonly hostId: string;
+  private players: GamePlayer[];
+  private readonly rng: GameRng;
+  private readonly adminIds: Set<string>;
+  private state: unknown;
+  private finished = false;
+
+  constructor(options: {
+    module: GameModule;
+    players: GamePlayer[];
+    adminIds: Iterable<string>;
+    hostId: string;
+    seed?: number;
+  }) {
+    this.module = options.module;
+    this.players = dedupePlayers(options.players);
+    this.adminIds = new Set(options.adminIds);
+    this.hostId = options.hostId;
+    this.rng = createRng(options.seed ?? createSeed());
+    this.state = this.module.setup(this.context());
+    this.finished = this.module.isFinished?.(this.state) ?? false;
+  }
+
+  get gameId(): string {
+    return this.module.id;
+  }
+
+  get tickMs(): number | null {
+    return this.module.tickMs ?? null;
+  }
+
+  isFinished(): boolean {
+    return this.finished;
+  }
+
+  hasPlayer(playerId: string): boolean {
+    return this.players.some((player) => player.id === playerId);
+  }
+
+  getPlayers(): GamePlayer[] {
+    return this.players.slice();
+  }
+
+  private context(now: number = Date.now()): GameContext {
+    return {
+      players: this.players.slice(),
+      rng: this.rng,
+      now,
+      isAdmin: (playerId: string) => this.adminIds.has(playerId),
+    };
+  }
+
+  /**
+   * Apply a player move. Returns `{ ok: true }` if the state advanced, or
+   * `{ ok: false, error }` if the module rejected it (illegal move) — in which
+   * case state is unchanged. Unexpected errors are surfaced generically.
+   */
+  applyMove(
+    playerId: string,
+    type: string,
+    payload: unknown,
+  ): { ok: true } | { ok: false; error: string } {
+    if (this.finished) {
+      return { ok: false, error: "Game has ended" };
+    }
+    if (!this.hasPlayer(playerId)) {
+      return { ok: false, error: "You are not a player in this game" };
+    }
+    try {
+      const next = this.module.onMove(
+        this.state,
+        { playerId, type, payload },
+        this.context(),
+      );
+      this.state = next;
+      this.finished = this.module.isFinished?.(next) ?? false;
+      return { ok: true };
+    } catch (error) {
+      if (error instanceof GameMoveError) {
+        return { ok: false, error: error.message };
+      }
+      throw error;
+    }
+  }
+
+  /** Advance time-driven state. Returns true if the projection changed. */
+  tick(now: number = Date.now()): boolean {
+    if (this.finished || !this.module.onTick) return false;
+    const next = this.module.onTick(this.state, this.context(now));
+    if (next === this.state) return false;
+    this.state = next;
+    this.finished = this.module.isFinished?.(next) ?? false;
+    return true;
+  }
+
+  getPublicState(now: number = Date.now()): GamePublicState {
+    const ctx = this.context(now);
+    return {
+      gameId: this.module.id,
+      name: this.module.name,
+      phase: this.module.getPhase(this.state),
+      players: this.players.slice(),
+      hostId: this.hostId,
+      view: this.module.publicView(this.state, ctx),
+      finished: this.finished,
+    };
+  }
+
+  getPlayerView(playerId: string, now: number = Date.now()): unknown {
+    return this.module.playerView(this.state, playerId, this.context(now));
+  }
+}
+
+const dedupePlayers = (players: GamePlayer[]): GamePlayer[] => {
+  const seen = new Set<string>();
+  const out: GamePlayer[] = [];
+  for (const player of players) {
+    if (!player?.id || seen.has(player.id)) continue;
+    seen.add(player.id);
+    out.push({ id: player.id, name: player.name });
+  }
+  return out;
+};

--- a/packages/sfu/server/games/engine.ts
+++ b/packages/sfu/server/games/engine.ts
@@ -21,6 +21,7 @@ export class GameSession {
   readonly module: GameModule;
   readonly hostId: string;
   private players: GamePlayer[];
+  private readonly playerIds: Set<string>;
   private readonly rng: GameRng;
   private readonly adminIds: Set<string>;
   private readonly config: GameConfig;
@@ -37,6 +38,7 @@ export class GameSession {
   }) {
     this.module = options.module;
     this.players = dedupePlayers(options.players);
+    this.playerIds = new Set(this.players.map((player) => player.id));
     this.adminIds = new Set(options.adminIds);
     this.hostId = options.hostId;
     this.config = options.config ?? {};
@@ -58,7 +60,7 @@ export class GameSession {
   }
 
   hasPlayer(playerId: string): boolean {
-    return this.players.some((player) => player.id === playerId);
+    return this.playerIds.has(playerId);
   }
 
   getPlayers(): GamePlayer[] {
@@ -77,7 +79,7 @@ export class GameSession {
 
   /**
    * Apply a player move. Returns `{ ok: true }` if the state advanced, or
-   * `{ ok: false, error }` if the module rejected it (illegal move) — in which
+   * `{ ok: false, error }` if the module rejected it (illegal move), in which
    * case state is unchanged. Unexpected errors are surfaced generically.
    */
   applyMove(

--- a/packages/sfu/server/games/modules/bluff.ts
+++ b/packages/sfu/server/games/modules/bluff.ts
@@ -4,6 +4,7 @@ import {
   type GameModule,
   type GameMove,
 } from "../types.js";
+import { numberOption } from "../config.js";
 
 /**
  * Bluff: a Fibbage-style game. Players see a prompt with a blank, secretly
@@ -107,15 +108,20 @@ export const bluffModule: GameModule<BluffState> = {
   minPlayers: 2,
   maxPlayers: 16,
   tickMs: 500,
+  hasLeaderboard: true,
+  options: [
+    { id: "rounds", type: "number", label: "Rounds", min: 2, max: 6, default: 4, presets: [3, 4, 5] },
+  ],
 
   setup(ctx: GameContext): BluffState {
     const scores: Record<string, number> = {};
     for (const p of ctx.players) scores[p.id] = 0;
+    const roundCount = Math.min(numberOption(ctx.config, "rounds", TOTAL_ROUNDS), PROMPT_BANK.length);
     return {
       phase: "lobby",
       round: 0,
-      totalRounds: Math.min(TOTAL_ROUNDS, PROMPT_BANK.length),
-      prompts: ctx.rng.shuffle(PROMPT_BANK).slice(0, TOTAL_ROUNDS),
+      totalRounds: roundCount,
+      prompts: ctx.rng.shuffle(PROMPT_BANK).slice(0, roundCount),
       deadline: 0,
       fakes: {},
       options: [],

--- a/packages/sfu/server/games/modules/bluff.ts
+++ b/packages/sfu/server/games/modules/bluff.ts
@@ -1,0 +1,263 @@
+import {
+  GameMoveError,
+  type GameContext,
+  type GameModule,
+  type GameMove,
+} from "../types.js";
+
+/**
+ * Bluff: a Fibbage-style game. Players see a prompt with a blank, secretly
+ * write a fake answer, then everyone (looking at all the fakes plus the one real
+ * answer) tries to pick the truth. You score for finding the truth and for
+ * fooling others into picking your lie. This showcases a different VIEW again:
+ * a free-text input phase followed by a dynamic pick-one list.
+ */
+
+const WRITE_MS = 40_000;
+const CHOOSE_MS = 30_000;
+const REVEAL_MS = 9_000;
+const TOTAL_ROUNDS = 4;
+const MAX_ANSWER_LEN = 60;
+const FOUND_TRUTH_POINTS = 1_000;
+const FOOLED_POINTS = 500;
+
+type Phase = "lobby" | "write" | "choose" | "reveal" | "results";
+
+type Prompt = { question: string; answer: string };
+
+type Option = { id: string; text: string; kind: "real" | "fake"; ownerId: string | null };
+
+type BluffState = {
+  phase: Phase;
+  round: number;
+  totalRounds: number;
+  prompts: Prompt[];
+  deadline: number;
+  fakes: Record<string, string>;
+  options: Option[];
+  picks: Record<string, string>;
+  scores: Record<string, number>;
+  roundPoints: Record<string, number>;
+};
+
+const PROMPT_BANK: Prompt[] = [
+  { question: "The unusual collective noun for a group of owls is a ___.", answer: "parliament" },
+  { question: "Nintendo was originally founded in 1889 to make ___.", answer: "playing cards" },
+  { question: "The dot over a lowercase i or j is called a ___.", answer: "tittle" },
+  { question: "A group of flamingos is called a ___.", answer: "flamboyance" },
+  { question: "The fear of long words is ironically called ___.", answer: "hippopotomonstrosesquippedaliophobia" },
+  { question: "Honey found in ancient Egyptian tombs was still ___.", answer: "edible" },
+  { question: "The world's largest desert by area is actually ___.", answer: "Antarctica" },
+  { question: "A jiffy is an actual unit of time equal to ___.", answer: "one hundredth of a second" },
+  { question: "The longest place name in the world is in ___.", answer: "New Zealand" },
+  { question: "Bananas are botanically classified as ___.", answer: "berries" },
+];
+
+const normalize = (text: string): string => text.trim().toLowerCase().replace(/\s+/g, " ");
+
+const buildOptions = (state: BluffState, ctx: GameContext): Option[] => {
+  const prompt = state.prompts[state.round];
+  const realKey = normalize(prompt.answer);
+  const seen = new Set<string>([realKey]);
+  const options: Option[] = [];
+  for (const player of ctx.players) {
+    const raw = state.fakes[player.id];
+    if (!raw) continue;
+    const text = raw.trim().slice(0, MAX_ANSWER_LEN);
+    const key = normalize(text);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    options.push({ id: `opt-${options.length}`, text, kind: "fake", ownerId: player.id });
+  }
+  options.push({ id: `opt-${options.length}`, text: prompt.answer, kind: "real", ownerId: null });
+  return ctx.rng.shuffle(options).map((opt, index) => ({ ...opt, id: `opt-${index}` }));
+};
+
+const scoreRound = (state: BluffState): void => {
+  const roundPoints: Record<string, number> = {};
+  const realOption = state.options.find((o) => o.kind === "real");
+  for (const [playerId, optionId] of Object.entries(state.picks)) {
+    if (realOption && optionId === realOption.id) {
+      roundPoints[playerId] = (roundPoints[playerId] ?? 0) + FOUND_TRUTH_POINTS;
+    }
+  }
+  for (const option of state.options) {
+    if (option.kind !== "fake" || !option.ownerId) continue;
+    const fooled = Object.values(state.picks).filter((id) => id === option.id).length;
+    if (fooled > 0) {
+      roundPoints[option.ownerId] =
+        (roundPoints[option.ownerId] ?? 0) + fooled * FOOLED_POINTS;
+    }
+  }
+  for (const [playerId, points] of Object.entries(roundPoints)) {
+    state.scores[playerId] = (state.scores[playerId] ?? 0) + points;
+  }
+  state.roundPoints = roundPoints;
+};
+
+const scoreboard = (state: BluffState, ctx: GameContext) =>
+  ctx.players
+    .map((p) => ({ id: p.id, name: p.name, score: state.scores[p.id] ?? 0 }))
+    .sort((a, b) => b.score - a.score);
+
+export const bluffModule: GameModule<BluffState> = {
+  id: "bluff",
+  name: "Bluff",
+  description: "Fool the room, find the truth",
+  minPlayers: 2,
+  maxPlayers: 16,
+  tickMs: 500,
+
+  setup(ctx: GameContext): BluffState {
+    const scores: Record<string, number> = {};
+    for (const p of ctx.players) scores[p.id] = 0;
+    return {
+      phase: "lobby",
+      round: 0,
+      totalRounds: Math.min(TOTAL_ROUNDS, PROMPT_BANK.length),
+      prompts: ctx.rng.shuffle(PROMPT_BANK).slice(0, TOTAL_ROUNDS),
+      deadline: 0,
+      fakes: {},
+      options: [],
+      picks: {},
+      scores,
+      roundPoints: {},
+    };
+  },
+
+  onMove(state, move: GameMove, ctx): BluffState {
+    switch (move.type) {
+      case "start": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can start");
+        if (state.phase !== "lobby") throw new GameMoveError("Already running");
+        if (ctx.players.length < 2) throw new GameMoveError("Need at least 2 players");
+        return { ...state, phase: "write", round: 0, deadline: ctx.now + WRITE_MS, fakes: {} };
+      }
+      case "submit": {
+        if (state.phase !== "write") throw new GameMoveError("Not accepting answers");
+        const text = (move.payload as { text?: unknown })?.text;
+        if (typeof text !== "string" || !text.trim()) throw new GameMoveError("Write something");
+        const trimmed = text.trim().slice(0, MAX_ANSWER_LEN);
+        const real = state.prompts[state.round]?.answer ?? "";
+        if (normalize(trimmed) === normalize(real)) {
+          throw new GameMoveError("That is the real answer. Write a bluff.");
+        }
+        const fakes = { ...state.fakes, [move.playerId]: trimmed };
+        const everyone =
+          ctx.players.length > 0 && ctx.players.every((p) => fakes[p.id]);
+        return { ...state, fakes, deadline: everyone ? ctx.now : state.deadline };
+      }
+      case "choose": {
+        if (state.phase !== "choose") throw new GameMoveError("Voting is closed");
+        const optionId = (move.payload as { optionId?: unknown })?.optionId;
+        const option = state.options.find((o) => o.id === optionId);
+        if (!option) throw new GameMoveError("Invalid choice");
+        if (option.ownerId === move.playerId) throw new GameMoveError("You cannot pick your own bluff");
+        const picks = { ...state.picks, [move.playerId]: option.id };
+        const everyone =
+          ctx.players.length > 0 && ctx.players.every((p) => picks[p.id]);
+        return { ...state, picks, deadline: everyone ? ctx.now : state.deadline };
+      }
+      case "next": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can advance");
+        if (state.phase !== "reveal") throw new GameMoveError("Wait for the reveal");
+        return { ...state, deadline: ctx.now };
+      }
+      case "skip": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can skip");
+        if (state.phase !== "write" && state.phase !== "choose") throw new GameMoveError("Nothing to skip");
+        return { ...state, deadline: ctx.now };
+      }
+      default:
+        throw new GameMoveError(`Unknown move: ${move.type}`);
+    }
+  },
+
+  onTick(state, ctx): BluffState {
+    if (state.phase === "write" && ctx.now >= state.deadline) {
+      const options = buildOptions(state, ctx);
+      return { ...state, phase: "choose", options, picks: {}, deadline: ctx.now + CHOOSE_MS };
+    }
+    if (state.phase === "choose" && ctx.now >= state.deadline) {
+      const next: BluffState = {
+        ...state,
+        options: state.options.map((o) => ({ ...o })),
+        picks: { ...state.picks },
+        scores: { ...state.scores },
+      };
+      scoreRound(next);
+      next.phase = "reveal";
+      next.deadline = ctx.now + REVEAL_MS;
+      return next;
+    }
+    if (state.phase === "reveal" && ctx.now >= state.deadline) {
+      const isLast = state.round + 1 >= state.totalRounds;
+      if (isLast) return { ...state, phase: "results" };
+      return {
+        ...state,
+        phase: "write",
+        round: state.round + 1,
+        deadline: ctx.now + WRITE_MS,
+        fakes: {},
+        options: [],
+        picks: {},
+        roundPoints: {},
+      };
+    }
+    return state;
+  },
+
+  getPhase: (state) => state.phase,
+
+  publicView(state, ctx) {
+    const prompt = state.prompts[state.round];
+    const reveal = state.phase === "reveal";
+    const nameOf = (id: string | null) =>
+      id ? ctx.players.find((p) => p.id === id)?.name ?? null : null;
+    return {
+      phase: state.phase,
+      round: state.round,
+      totalRounds: state.totalRounds,
+      serverNow: ctx.now,
+      deadline:
+        state.phase === "write" || state.phase === "choose" ? state.deadline : null,
+      question: state.phase === "lobby" ? null : prompt?.question ?? null,
+      submittedCount: Object.keys(state.fakes).length,
+      chosenCount: Object.keys(state.picks).length,
+      totalPlayers: ctx.players.length,
+      // During choose, hand out text only - never the kind or author.
+      options:
+        state.phase === "choose"
+          ? state.options.map((o) => ({ id: o.id, text: o.text }))
+          : reveal
+            ? state.options.map((o) => ({
+                id: o.id,
+                text: o.text,
+                kind: o.kind,
+                ownerName: nameOf(o.ownerId),
+                votes: Object.values(state.picks).filter((p) => p === o.id).length,
+              }))
+            : [],
+      roundPoints: reveal
+        ? ctx.players
+            .map((p) => ({ id: p.id, name: p.name, points: state.roundPoints[p.id] ?? 0 }))
+            .filter((entry) => entry.points > 0)
+            .sort((a, b) => b.points - a.points)
+        : [],
+      scoreboard: scoreboard(state, ctx),
+    };
+  },
+
+  playerView(state, playerId) {
+    const ownOption = state.options.find((o) => o.ownerId === playerId);
+    return {
+      yourFake: state.fakes[playerId] ?? null,
+      submitted: Boolean(state.fakes[playerId]),
+      yourPick: state.picks[playerId] ?? null,
+      ownOptionId: ownOption?.id ?? null,
+      score: state.scores[playerId] ?? 0,
+    };
+  },
+
+  isFinished: (state) => state.phase === "results",
+};

--- a/packages/sfu/server/games/modules/imposter.ts
+++ b/packages/sfu/server/games/modules/imposter.ts
@@ -5,6 +5,7 @@ import {
   type GameMove,
 } from "../types.js";
 import { requirePlayerTarget } from "../validation.js";
+import { selectOption } from "../config.js";
 
 /**
  * Imposter: a Spyfall-style social deduction game, built for a video call.
@@ -94,9 +95,25 @@ export const imposterModule: GameModule<ImposterState> = {
   minPlayers: 3,
   maxPlayers: 12,
   tickMs: 500,
+  options: [
+    {
+      id: "category",
+      type: "select",
+      label: "Category",
+      default: "surprise",
+      choices: [
+        { value: "surprise", label: "Surprise me" },
+        ...WORD_SETS.map((s) => ({ value: s.category, label: s.category })),
+      ],
+    },
+  ],
 
   setup(ctx: GameContext): ImposterState {
-    const set = ctx.rng.pick(WORD_SETS);
+    const chosen = selectOption(ctx.config, "category", "surprise");
+    const set =
+      chosen === "surprise"
+        ? ctx.rng.pick(WORD_SETS)
+        : WORD_SETS.find((s) => s.category === chosen) ?? ctx.rng.pick(WORD_SETS);
     const word = ctx.rng.pick(set.words);
     const imposter = ctx.players.length > 0 ? ctx.rng.pick(ctx.players) : null;
     const starter = ctx.players.length > 0 ? ctx.rng.pick(ctx.players) : null;

--- a/packages/sfu/server/games/modules/imposter.ts
+++ b/packages/sfu/server/games/modules/imposter.ts
@@ -1,0 +1,232 @@
+import {
+  GameMoveError,
+  type GameContext,
+  type GameModule,
+  type GameMove,
+} from "../types.js";
+import { requirePlayerTarget } from "../validation.js";
+
+/**
+ * Imposter: a Spyfall-style social deduction game, built for a video call.
+ *
+ * Everyone shares a secret word EXCEPT one imposter, who only sees the
+ * category. Players take turns describing the word vaguely out loud (on camera),
+ * trying to expose the imposter without naming the word outright. Then everyone
+ * votes. This game exists to exercise the runtime's hidden-information path:
+ * `playerView` returns a DIFFERENT projection for the imposter than for crew,
+ * and the secret never appears in `publicView` until the result.
+ */
+
+const REVEAL_MS = 6_000;
+
+type Phase = "lobby" | "reveal" | "discuss" | "vote" | "result";
+
+type WordSet = { category: string; words: string[] };
+
+type ImposterResult = {
+  imposterId: string;
+  word: string;
+  votedOutId: string | null;
+  crewWon: boolean;
+  tie: boolean;
+};
+
+type ImposterState = {
+  phase: Phase;
+  category: string;
+  word: string;
+  imposterId: string;
+  starterId: string;
+  deadline: number;
+  votes: Record<string, string>;
+  result: ImposterResult | null;
+};
+
+const WORD_SETS: WordSet[] = [
+  { category: "Places", words: ["Airport", "Beach", "Casino", "Hospital", "Library", "Submarine", "Space station", "Theme park"] },
+  { category: "Food", words: ["Pizza", "Sushi", "Tacos", "Ramen", "Pancakes", "Dumplings", "Ice cream", "Curry"] },
+  { category: "Animals", words: ["Penguin", "Octopus", "Elephant", "Kangaroo", "Dolphin", "Chameleon", "Sloth", "Falcon"] },
+  { category: "Movies", words: ["Titanic", "Inception", "Jaws", "Frozen", "Gladiator", "Avatar", "The Matrix", "Up"] },
+  { category: "Jobs", words: ["Astronaut", "Chef", "Firefighter", "Detective", "Pilot", "Surgeon", "Magician", "Architect"] },
+  { category: "Sports", words: ["Tennis", "Surfing", "Boxing", "Curling", "Archery", "Skiing", "Cricket", "Fencing"] },
+];
+
+const nameOf = (ctx: GameContext, playerId: string | null): string | null => {
+  if (!playerId) return null;
+  return ctx.players.find((player) => player.id === playerId)?.name ?? null;
+};
+
+const tallyVotes = (state: ImposterState): ImposterResult => {
+  const counts = new Map<string, number>();
+  for (const target of Object.values(state.votes)) {
+    counts.set(target, (counts.get(target) ?? 0) + 1);
+  }
+  let topId: string | null = null;
+  let topCount = 0;
+  let tie = false;
+  for (const [id, count] of counts) {
+    if (count > topCount) {
+      topId = id;
+      topCount = count;
+      tie = false;
+    } else if (count === topCount) {
+      tie = true;
+    }
+  }
+  const votedOutId = tie ? null : topId;
+  return {
+    imposterId: state.imposterId,
+    word: state.word,
+    votedOutId,
+    crewWon: votedOutId !== null && votedOutId === state.imposterId,
+    tie,
+  };
+};
+
+const everyoneVoted = (state: ImposterState, ctx: GameContext): boolean =>
+  ctx.players.length > 0 &&
+  ctx.players.every((player) => Boolean(state.votes[player.id]));
+
+export const imposterModule: GameModule<ImposterState> = {
+  id: "imposter",
+  name: "Imposter",
+  description: "Spot the faker in the room",
+  minPlayers: 3,
+  maxPlayers: 12,
+  tickMs: 500,
+
+  setup(ctx: GameContext): ImposterState {
+    const set = ctx.rng.pick(WORD_SETS);
+    const word = ctx.rng.pick(set.words);
+    const imposter = ctx.players.length > 0 ? ctx.rng.pick(ctx.players) : null;
+    const starter = ctx.players.length > 0 ? ctx.rng.pick(ctx.players) : null;
+    return {
+      phase: "lobby",
+      category: set.category,
+      word,
+      imposterId: imposter?.id ?? "",
+      starterId: starter?.id ?? "",
+      deadline: 0,
+      votes: {},
+      result: null,
+    };
+  },
+
+  onMove(state, move: GameMove, ctx): ImposterState {
+    switch (move.type) {
+      case "start": {
+        if (!ctx.isAdmin(move.playerId)) {
+          throw new GameMoveError("Only the host can start the round");
+        }
+        if (state.phase !== "lobby") {
+          throw new GameMoveError("The round already started");
+        }
+        if (ctx.players.length < 3) {
+          throw new GameMoveError("Need at least 3 players");
+        }
+        return { ...state, phase: "reveal", deadline: ctx.now + REVEAL_MS };
+      }
+      case "callVote": {
+        if (!ctx.isAdmin(move.playerId)) {
+          throw new GameMoveError("Only the host can call a vote");
+        }
+        if (state.phase !== "discuss") {
+          throw new GameMoveError("Can only call a vote during discussion");
+        }
+        return { ...state, phase: "vote", votes: {} };
+      }
+      case "vote": {
+        if (state.phase !== "vote") {
+          throw new GameMoveError("Voting is not open");
+        }
+        const target = requirePlayerTarget(
+          ctx,
+          move.playerId,
+          (move.payload as { target?: unknown })?.target,
+          {
+            allowSelf: false,
+            invalidMessage: "Invalid vote target",
+            selfMessage: "You cannot vote for yourself",
+          },
+        );
+        const votes = { ...state.votes, [move.playerId]: target };
+        const next = { ...state, votes };
+        if (everyoneVoted(next, ctx)) {
+          return { ...next, phase: "result", result: tallyVotes(next) };
+        }
+        return next;
+      }
+      case "tally": {
+        if (!ctx.isAdmin(move.playerId)) {
+          throw new GameMoveError("Only the host can end the vote");
+        }
+        if (state.phase !== "vote") {
+          throw new GameMoveError("No vote in progress");
+        }
+        return { ...state, phase: "result", result: tallyVotes(state) };
+      }
+      default:
+        throw new GameMoveError(`Unknown move: ${move.type}`);
+    }
+  },
+
+  onTick(state, ctx): ImposterState {
+    if (state.phase === "reveal" && ctx.now >= state.deadline) {
+      return { ...state, phase: "discuss" };
+    }
+    return state;
+  },
+
+  getPhase: (state) => state.phase,
+
+  publicView(state, ctx) {
+    const voteCounts: Record<string, number> = {};
+    if (state.phase === "vote" || state.phase === "result") {
+      for (const target of Object.values(state.votes)) {
+        voteCounts[target] = (voteCounts[target] ?? 0) + 1;
+      }
+    }
+    return {
+      phase: state.phase,
+      category: state.category,
+      serverNow: ctx.now,
+      deadline: state.phase === "reveal" ? state.deadline : null,
+      starterName: nameOf(ctx, state.starterId),
+      players: ctx.players.map((player) => ({ id: player.id, name: player.name })),
+      votedPlayerIds:
+        state.phase === "vote" || state.phase === "result"
+          ? Object.keys(state.votes)
+          : [],
+      voteCounts,
+      totalPlayers: ctx.players.length,
+      result:
+        state.phase === "result" && state.result
+          ? {
+              imposterId: state.result.imposterId,
+              imposterName: nameOf(ctx, state.result.imposterId),
+              word: state.result.word,
+              votedOutId: state.result.votedOutId,
+              votedOutName: nameOf(ctx, state.result.votedOutId),
+              crewWon: state.result.crewWon,
+              tie: state.result.tie,
+            }
+          : null,
+    };
+  },
+
+  playerView(state, playerId, ctx) {
+    const isImposter = playerId === state.imposterId;
+    const revealed = state.phase !== "lobby";
+    return {
+      role: isImposter ? "imposter" : "crew",
+      category: state.category,
+      word: isImposter || !revealed ? null : state.word,
+      hint: isImposter
+        ? "You don't know the word. Blend in and avoid getting caught."
+        : null,
+      yourVote: state.votes[playerId] ?? null,
+    };
+  },
+
+  isFinished: (state) => state.phase === "result",
+};

--- a/packages/sfu/server/games/modules/mostLikelyTo.ts
+++ b/packages/sfu/server/games/modules/mostLikelyTo.ts
@@ -4,6 +4,7 @@ import {
   type GameModule,
   type GameMove,
 } from "../types.js";
+import { numberOption } from "../config.js";
 import { requirePlayerTarget } from "../validation.js";
 
 /**
@@ -56,12 +57,15 @@ export const mostLikelyToModule: GameModule<MltState> = {
   minPlayers: 3,
   maxPlayers: 50,
   tickMs: 500,
+  options: [
+    { id: "rounds", type: "number", label: "Rounds", min: 3, max: 10, default: 6, presets: [4, 6, 8] },
+  ],
 
   setup(ctx: GameContext): MltState {
     return {
       phase: "lobby",
       index: 0,
-      prompts: ctx.rng.shuffle(PROMPT_BANK).slice(0, ROUNDS_PER_GAME),
+      prompts: ctx.rng.shuffle(PROMPT_BANK).slice(0, numberOption(ctx.config, "rounds", ROUNDS_PER_GAME)),
       deadline: 0,
       votes: {},
     };

--- a/packages/sfu/server/games/modules/mostLikelyTo.ts
+++ b/packages/sfu/server/games/modules/mostLikelyTo.ts
@@ -1,0 +1,152 @@
+import {
+  GameMoveError,
+  type GameContext,
+  type GameModule,
+  type GameMove,
+} from "../types.js";
+import { requirePlayerTarget } from "../validation.js";
+
+/**
+ * Most Likely To: point the finger. Each round poses "who is most likely
+ * to..." and everyone secretly votes a player. The reveal shows the tally and
+ * crowns whoever the room picked. Built for groups, and it plays off real faces
+ * on camera, so it scales to large rooms.
+ */
+
+const VOTE_MS = 15_000;
+const ROUNDS_PER_GAME = 6;
+
+type Phase = "lobby" | "vote" | "reveal" | "results";
+
+type MltState = {
+  phase: Phase;
+  index: number;
+  prompts: string[];
+  deadline: number;
+  votes: Record<string, string>;
+};
+
+const PROMPT_BANK: string[] = [
+  "to become famous",
+  "to survive a zombie apocalypse",
+  "to forget their own birthday",
+  "to start a successful company",
+  "to laugh at the wrong moment",
+  "to move to another country on a whim",
+  "to win a reality TV show",
+  "to text back three days later",
+  "to adopt ten pets",
+  "to become a world leader",
+  "to get lost in their own neighborhood",
+  "to break into spontaneous dance",
+];
+
+const tally = (state: MltState): Record<string, number> => {
+  const counts: Record<string, number> = {};
+  for (const target of Object.values(state.votes)) {
+    counts[target] = (counts[target] ?? 0) + 1;
+  }
+  return counts;
+};
+
+export const mostLikelyToModule: GameModule<MltState> = {
+  id: "most-likely-to",
+  name: "Most Likely To",
+  description: "Vote who the room picks",
+  minPlayers: 3,
+  maxPlayers: 50,
+  tickMs: 500,
+
+  setup(ctx: GameContext): MltState {
+    return {
+      phase: "lobby",
+      index: 0,
+      prompts: ctx.rng.shuffle(PROMPT_BANK).slice(0, ROUNDS_PER_GAME),
+      deadline: 0,
+      votes: {},
+    };
+  },
+
+  onMove(state, move: GameMove, ctx): MltState {
+    switch (move.type) {
+      case "start": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can start");
+        if (state.phase !== "lobby") throw new GameMoveError("Already running");
+        if (ctx.players.length < 3) throw new GameMoveError("Need at least 3 players");
+        return { ...state, phase: "vote", index: 0, deadline: ctx.now + VOTE_MS, votes: {} };
+      }
+      case "vote": {
+        if (state.phase !== "vote") throw new GameMoveError("Voting is closed");
+        const target = requirePlayerTarget(
+          ctx,
+          move.playerId,
+          (move.payload as { target?: unknown })?.target,
+          { invalidMessage: "Invalid vote" },
+        );
+        const votes = { ...state.votes, [move.playerId]: target };
+        const everyone = ctx.players.length > 0 && Object.keys(votes).length >= ctx.players.length;
+        return { ...state, votes, deadline: everyone ? ctx.now : state.deadline };
+      }
+      case "next": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can advance");
+        if (state.phase !== "reveal") throw new GameMoveError("Wait for the reveal");
+        return { ...state, deadline: ctx.now };
+      }
+      case "skip": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can skip");
+        if (state.phase !== "vote") throw new GameMoveError("Nothing to skip");
+        return { ...state, deadline: ctx.now };
+      }
+      default:
+        throw new GameMoveError(`Unknown move: ${move.type}`);
+    }
+  },
+
+  onTick(state, ctx): MltState {
+    if (state.phase === "vote" && ctx.now >= state.deadline) {
+      return { ...state, phase: "reveal", deadline: 0 };
+    }
+    if (state.phase === "reveal" && ctx.now >= state.deadline && state.deadline > 0) {
+      const isLast = state.index + 1 >= state.prompts.length;
+      if (isLast) return { ...state, phase: "results" };
+      return { ...state, phase: "vote", index: state.index + 1, deadline: ctx.now + VOTE_MS, votes: {} };
+    }
+    return state;
+  },
+
+  getPhase: (state) => state.phase,
+
+  publicView(state, ctx) {
+    const reveal = state.phase === "reveal";
+    const counts = reveal ? tally(state) : {};
+    let winnerId: string | null = null;
+    let winnerCount = 0;
+    for (const [id, count] of Object.entries(counts)) {
+      if (count > winnerCount) {
+        winnerId = id;
+        winnerCount = count;
+      }
+    }
+    return {
+      phase: state.phase,
+      index: state.index,
+      total: state.prompts.length,
+      serverNow: ctx.now,
+      deadline: state.phase === "vote" ? state.deadline : null,
+      voteDurationMs: VOTE_MS,
+      prompt: state.phase === "lobby" ? null : (state.prompts[state.index] ?? null),
+      players: ctx.players.map((player) => ({ id: player.id, name: player.name })),
+      counts,
+      answeredCount: Object.keys(state.votes).length,
+      totalPlayers: ctx.players.length,
+      winnerId: reveal ? winnerId : null,
+      winnerName: reveal && winnerId ? ctx.players.find((p) => p.id === winnerId)?.name ?? null : null,
+    };
+  },
+
+  playerView(state, playerId) {
+    return { yourVote: state.votes[playerId] ?? null };
+  },
+
+  isFinished: (state) => state.phase === "results",
+};

--- a/packages/sfu/server/games/modules/reaction.ts
+++ b/packages/sfu/server/games/modules/reaction.ts
@@ -4,6 +4,7 @@ import {
   type GameModule,
   type GameMove,
 } from "../types.js";
+import { numberOption } from "../config.js";
 
 /**
  * Reaction: a reflex arena. Each round the panel waits ("do not tap"), then
@@ -66,11 +67,16 @@ export const reactionModule: GameModule<ReactionState> = {
   minPlayers: 1,
   maxPlayers: 50,
   tickMs: 120,
+  hasLeaderboard: true,
+  options: [
+    { id: "rounds", type: "number", label: "Rounds", min: 3, max: 10, default: 5, presets: [3, 5, 7] },
+  ],
 
   setup(ctx: GameContext): ReactionState {
     const scores: Record<string, number> = {};
     for (const p of ctx.players) scores[p.id] = 0;
-    return { phase: "lobby", round: 0, totalRounds: TOTAL_ROUNDS, goAt: 0, deadline: 0, taps: {}, scores };
+    const totalRounds = numberOption(ctx.config, "rounds", TOTAL_ROUNDS);
+    return { phase: "lobby", round: 0, totalRounds, goAt: 0, deadline: 0, taps: {}, scores };
   },
 
   onMove(state, move: GameMove, ctx): ReactionState {

--- a/packages/sfu/server/games/modules/reaction.ts
+++ b/packages/sfu/server/games/modules/reaction.ts
@@ -1,0 +1,170 @@
+import {
+  GameMoveError,
+  type GameContext,
+  type GameModule,
+  type GameMove,
+} from "../types.js";
+
+/**
+ * Reaction: a reflex arena. Each round the panel waits ("do not tap"), then
+ * flips to "TAP" at a random moment. Fastest valid tap wins; tapping early is a
+ * fault. Reaction time is measured server-side from the authoritative go moment,
+ * so no client can cheat the clock. This is a deliberately different VIEW: a
+ * full-panel tappable zone instead of a list.
+ */
+
+const TOTAL_ROUNDS = 5;
+const MIN_ARM_MS = 1_500;
+const MAX_ARM_MS = 5_000;
+const GO_WINDOW_MS = 4_000;
+const REVEAL_MS = 4_500;
+const RANK_POINTS = [100, 80, 65, 55, 45];
+const MIN_VALID_POINTS = 30;
+
+type Phase = "lobby" | "arming" | "go" | "reveal" | "results";
+
+type Tap = { reactionMs: number | null; early: boolean };
+
+type ReactionState = {
+  phase: Phase;
+  round: number;
+  totalRounds: number;
+  goAt: number;
+  deadline: number;
+  taps: Record<string, Tap>;
+  scores: Record<string, number>;
+};
+
+const startRound = (state: ReactionState, ctx: GameContext, round: number): ReactionState => ({
+  ...state,
+  phase: "arming",
+  round,
+  goAt: ctx.now + MIN_ARM_MS + ctx.rng.int(MAX_ARM_MS - MIN_ARM_MS),
+  deadline: 0,
+  taps: {},
+});
+
+const scoreRound = (state: ReactionState): void => {
+  const valid = Object.entries(state.taps)
+    .filter(([, tap]) => !tap.early && tap.reactionMs != null)
+    .sort((a, b) => (a[1].reactionMs ?? 0) - (b[1].reactionMs ?? 0));
+  valid.forEach(([playerId], rank) => {
+    const points = RANK_POINTS[rank] ?? MIN_VALID_POINTS;
+    state.scores[playerId] = (state.scores[playerId] ?? 0) + points;
+  });
+};
+
+const scoreboard = (state: ReactionState, ctx: GameContext) =>
+  ctx.players
+    .map((p) => ({ id: p.id, name: p.name, score: state.scores[p.id] ?? 0 }))
+    .sort((a, b) => b.score - a.score);
+
+export const reactionModule: GameModule<ReactionState> = {
+  id: "reaction",
+  name: "Reaction",
+  description: "Tap the instant it turns green",
+  minPlayers: 1,
+  maxPlayers: 50,
+  tickMs: 120,
+
+  setup(ctx: GameContext): ReactionState {
+    const scores: Record<string, number> = {};
+    for (const p of ctx.players) scores[p.id] = 0;
+    return { phase: "lobby", round: 0, totalRounds: TOTAL_ROUNDS, goAt: 0, deadline: 0, taps: {}, scores };
+  },
+
+  onMove(state, move: GameMove, ctx): ReactionState {
+    switch (move.type) {
+      case "start": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can start");
+        if (state.phase !== "lobby") throw new GameMoveError("Already running");
+        return startRound(state, ctx, 0);
+      }
+      case "tap": {
+        if (state.phase !== "arming" && state.phase !== "go") {
+          throw new GameMoveError("Not now");
+        }
+        if (state.taps[move.playerId]) throw new GameMoveError("Already tapped");
+        const tap: Tap =
+          state.phase === "arming"
+            ? { reactionMs: null, early: true }
+            : { reactionMs: Math.max(0, ctx.now - state.goAt), early: false };
+        return { ...state, taps: { ...state.taps, [move.playerId]: tap } };
+      }
+      case "next": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can advance");
+        if (state.phase !== "reveal") throw new GameMoveError("Wait for the reveal");
+        return { ...state, deadline: ctx.now };
+      }
+      default:
+        throw new GameMoveError(`Unknown move: ${move.type}`);
+    }
+  },
+
+  onTick(state, ctx): ReactionState {
+    if (state.phase === "arming" && ctx.now >= state.goAt) {
+      return { ...state, phase: "go", deadline: ctx.now + GO_WINDOW_MS };
+    }
+    if (state.phase === "go") {
+      const everyone =
+        ctx.players.length > 0 && ctx.players.every((p) => state.taps[p.id]);
+      if (ctx.now >= state.deadline || everyone) {
+        const next: ReactionState = { ...state, taps: { ...state.taps }, scores: { ...state.scores } };
+        scoreRound(next);
+        next.phase = "reveal";
+        next.deadline = ctx.now + REVEAL_MS;
+        return next;
+      }
+    }
+    if (state.phase === "reveal" && ctx.now >= state.deadline) {
+      const isLast = state.round + 1 >= state.totalRounds;
+      if (isLast) return { ...state, phase: "results" };
+      return startRound(state, ctx, state.round + 1);
+    }
+    return state;
+  },
+
+  getPhase: (state) => state.phase,
+
+  publicView(state, ctx) {
+    const reveal = state.phase === "reveal";
+    const results = reveal
+      ? Object.entries(state.taps)
+          .map(([id, tap]) => ({
+            id,
+            name: ctx.players.find((p) => p.id === id)?.name ?? "?",
+            reactionMs: tap.reactionMs,
+            early: tap.early,
+          }))
+          .sort((a, b) => {
+            if (a.early !== b.early) return a.early ? 1 : -1;
+            return (a.reactionMs ?? 9_999) - (b.reactionMs ?? 9_999);
+          })
+      : [];
+    const winner = results.find((r) => !r.early && r.reactionMs != null) ?? null;
+    return {
+      phase: state.phase,
+      round: state.round,
+      totalRounds: state.totalRounds,
+      serverNow: ctx.now,
+      goAt: state.phase === "go" ? state.goAt : null,
+      tappedCount: Object.keys(state.taps).length,
+      totalPlayers: ctx.players.length,
+      results,
+      winnerName: winner?.name ?? null,
+      scoreboard: scoreboard(state, ctx),
+    };
+  },
+
+  playerView(state, playerId) {
+    const tap = state.taps[playerId];
+    return {
+      tapped: Boolean(tap),
+      early: tap?.early ?? false,
+      reactionMs: tap?.reactionMs ?? null,
+      score: state.scores[playerId] ?? 0,
+    };
+  },
+
+  isFinished: (state) => state.phase === "results",
+};

--- a/packages/sfu/server/games/modules/trivia.ts
+++ b/packages/sfu/server/games/modules/trivia.ts
@@ -4,6 +4,7 @@ import {
   type GameModule,
   type GameMove,
 } from "../types.js";
+import { numberOption, selectOption } from "../config.js";
 
 /**
  * Trivia: a Kahoot/Deezer-style scored quiz.
@@ -35,11 +36,14 @@ type TriviaState = {
   questionIndex: number;
   questions: LoadedQuestion[];
   questionStart: number;
+  questionMs: number;
   deadline: number;
   answers: Record<string, Answer>;
   scores: Record<string, number>;
   lastRound: Record<string, number>;
 };
+
+const PACE_MS: Record<string, number> = { relaxed: 30_000, normal: 20_000, fast: 12_000 };
 
 type RawQuestion = {
   category: string;
@@ -76,7 +80,7 @@ const scoreRound = (state: TriviaState): void => {
     let gained = 0;
     if (answer.choice === question.correctIndex) {
       const used = Math.max(0, answer.at - state.questionStart);
-      const ratio = Math.max(0, Math.min(1, 1 - used / QUESTION_MS));
+      const ratio = Math.max(0, Math.min(1, 1 - used / state.questionMs));
       gained = BASE_POINTS + Math.round(SPEED_POINTS * ratio);
     }
     lastRound[playerId] = gained;
@@ -101,11 +105,28 @@ export const triviaModule: GameModule<TriviaState> = {
   minPlayers: 1,
   maxPlayers: 24,
   tickMs: 500,
+  hasLeaderboard: true,
+  options: [
+    { id: "questions", type: "number", label: "Questions", min: 3, max: 15, default: 7, presets: [5, 7, 10] },
+    {
+      id: "pace",
+      type: "select",
+      label: "Pace",
+      default: "normal",
+      choices: [
+        { value: "relaxed", label: "Relaxed" },
+        { value: "normal", label: "Normal" },
+        { value: "fast", label: "Fast" },
+      ],
+    },
+  ],
 
   setup(ctx: GameContext): TriviaState {
+    const questionCount = numberOption(ctx.config, "questions", QUESTIONS_PER_GAME);
+    const questionMs = PACE_MS[selectOption(ctx.config, "pace", "normal")] ?? QUESTION_MS;
     const picked = ctx.rng
       .shuffle(QUESTION_BANK)
-      .slice(0, QUESTIONS_PER_GAME)
+      .slice(0, questionCount)
       .map((raw): LoadedQuestion => {
         const options = ctx.rng.shuffle(raw.options);
         return {
@@ -122,6 +143,7 @@ export const triviaModule: GameModule<TriviaState> = {
       questionIndex: 0,
       questions: picked,
       questionStart: 0,
+      questionMs,
       deadline: 0,
       answers: {},
       scores,
@@ -143,7 +165,7 @@ export const triviaModule: GameModule<TriviaState> = {
           phase: "question",
           questionIndex: 0,
           questionStart: ctx.now,
-          deadline: ctx.now + QUESTION_MS,
+          deadline: ctx.now + state.questionMs,
           answers: {},
           lastRound: {},
         };
@@ -222,7 +244,7 @@ export const triviaModule: GameModule<TriviaState> = {
         phase: "question",
         questionIndex: state.questionIndex + 1,
         questionStart: ctx.now,
-        deadline: ctx.now + QUESTION_MS,
+        deadline: ctx.now + state.questionMs,
         answers: {},
         lastRound: {},
       };
@@ -249,7 +271,7 @@ export const triviaModule: GameModule<TriviaState> = {
       totalQuestions: state.questions.length,
       serverNow: ctx.now,
       deadline: state.phase === "question" || reveal ? state.deadline : null,
-      questionDurationMs: QUESTION_MS,
+      questionDurationMs: state.questionMs,
       category: showQuestion ? question?.category ?? null : null,
       prompt: showQuestion ? question?.prompt ?? null : null,
       options: showQuestion ? question?.options ?? [] : [],

--- a/packages/sfu/server/games/modules/trivia.ts
+++ b/packages/sfu/server/games/modules/trivia.ts
@@ -1,0 +1,283 @@
+import {
+  GameMoveError,
+  type GameContext,
+  type GameModule,
+  type GameMove,
+} from "../types.js";
+
+/**
+ * Trivia: a Kahoot/Deezer-style scored quiz.
+ *
+ * Flow: lobby -> (question -> reveal) x N -> results. The server holds the
+ * correct answer and only discloses it during the reveal phase. Points reward
+ * both correctness and speed. Timers are driven by `onTick` against a deadline.
+ */
+
+const QUESTION_MS = 20_000;
+const REVEAL_MS = 6_000;
+const QUESTIONS_PER_GAME = 7;
+const BASE_POINTS = 500;
+const SPEED_POINTS = 500;
+
+type Phase = "lobby" | "question" | "reveal" | "results";
+
+type LoadedQuestion = {
+  category: string;
+  prompt: string;
+  options: string[];
+  correctIndex: number;
+};
+
+type Answer = { choice: number; at: number };
+
+type TriviaState = {
+  phase: Phase;
+  questionIndex: number;
+  questions: LoadedQuestion[];
+  questionStart: number;
+  deadline: number;
+  answers: Record<string, Answer>;
+  scores: Record<string, number>;
+  lastRound: Record<string, number>;
+};
+
+type RawQuestion = {
+  category: string;
+  prompt: string;
+  options: string[];
+  answer: string;
+};
+
+const QUESTION_BANK: RawQuestion[] = [
+  { category: "Geography", prompt: "Which country has the most natural lakes?", options: ["Canada", "Russia", "Finland", "Brazil"], answer: "Canada" },
+  { category: "Science", prompt: "What planet has the most moons?", options: ["Jupiter", "Saturn", "Neptune", "Uranus"], answer: "Saturn" },
+  { category: "Film", prompt: "Which film won the first ever Best Picture Oscar?", options: ["Wings", "Sunrise", "Metropolis", "The Jazz Singer"], answer: "Wings" },
+  { category: "Music", prompt: "Which instrument has 88 keys?", options: ["Piano", "Organ", "Harpsichord", "Accordion"], answer: "Piano" },
+  { category: "History", prompt: "In which year did the Berlin Wall fall?", options: ["1989", "1991", "1987", "1985"], answer: "1989" },
+  { category: "Food", prompt: "Which spice is derived from a crocus flower?", options: ["Saffron", "Turmeric", "Paprika", "Cumin"], answer: "Saffron" },
+  { category: "Tech", prompt: "What does 'HTTP' stand for?", options: ["HyperText Transfer Protocol", "High Transfer Text Protocol", "HyperText Transport Process", "Hyperlink Text Transfer Path"], answer: "HyperText Transfer Protocol" },
+  { category: "Sport", prompt: "How many players are on a standard soccer team on the pitch?", options: ["11", "10", "9", "12"], answer: "11" },
+  { category: "Nature", prompt: "What is the largest living structure on Earth?", options: ["Great Barrier Reef", "Amazon Rainforest", "Sahara Desert", "Mount Everest"], answer: "Great Barrier Reef" },
+  { category: "Space", prompt: "What is the closest star to Earth?", options: ["The Sun", "Proxima Centauri", "Sirius", "Alpha Centauri"], answer: "The Sun" },
+  { category: "Art", prompt: "Who painted 'The Starry Night'?", options: ["Vincent van Gogh", "Claude Monet", "Pablo Picasso", "Edvard Munch"], answer: "Vincent van Gogh" },
+  { category: "Language", prompt: "Which language has the most native speakers?", options: ["Mandarin Chinese", "English", "Spanish", "Hindi"], answer: "Mandarin Chinese" },
+  { category: "Biology", prompt: "How many chambers does a human heart have?", options: ["4", "2", "3", "5"], answer: "4" },
+  { category: "Geography", prompt: "What is the smallest country in the world?", options: ["Vatican City", "Monaco", "Nauru", "San Marino"], answer: "Vatican City" },
+  { category: "Chemistry", prompt: "What is the chemical symbol for gold?", options: ["Au", "Ag", "Gd", "Go"], answer: "Au" },
+];
+
+const otherPlayersAllAnswered = (state: TriviaState, total: number): boolean =>
+  total > 0 && Object.keys(state.answers).length >= total;
+
+const scoreRound = (state: TriviaState): void => {
+  const question = state.questions[state.questionIndex];
+  const lastRound: Record<string, number> = {};
+  for (const [playerId, answer] of Object.entries(state.answers)) {
+    let gained = 0;
+    if (answer.choice === question.correctIndex) {
+      const used = Math.max(0, answer.at - state.questionStart);
+      const ratio = Math.max(0, Math.min(1, 1 - used / QUESTION_MS));
+      gained = BASE_POINTS + Math.round(SPEED_POINTS * ratio);
+    }
+    lastRound[playerId] = gained;
+    state.scores[playerId] = (state.scores[playerId] ?? 0) + gained;
+  }
+  state.lastRound = lastRound;
+};
+
+const scoreboard = (state: TriviaState, ctx: GameContext) =>
+  ctx.players
+    .map((player) => ({
+      id: player.id,
+      name: player.name,
+      score: state.scores[player.id] ?? 0,
+    }))
+    .sort((a, b) => b.score - a.score);
+
+export const triviaModule: GameModule<TriviaState> = {
+  id: "trivia",
+  name: "Trivia",
+  description: "Quick-fire quiz",
+  minPlayers: 1,
+  maxPlayers: 24,
+  tickMs: 500,
+
+  setup(ctx: GameContext): TriviaState {
+    const picked = ctx.rng
+      .shuffle(QUESTION_BANK)
+      .slice(0, QUESTIONS_PER_GAME)
+      .map((raw): LoadedQuestion => {
+        const options = ctx.rng.shuffle(raw.options);
+        return {
+          category: raw.category,
+          prompt: raw.prompt,
+          options,
+          correctIndex: options.indexOf(raw.answer),
+        };
+      });
+    const scores: Record<string, number> = {};
+    for (const player of ctx.players) scores[player.id] = 0;
+    return {
+      phase: "lobby",
+      questionIndex: 0,
+      questions: picked,
+      questionStart: 0,
+      deadline: 0,
+      answers: {},
+      scores,
+      lastRound: {},
+    };
+  },
+
+  onMove(state, move: GameMove, ctx): TriviaState {
+    switch (move.type) {
+      case "start": {
+        if (!ctx.isAdmin(move.playerId)) {
+          throw new GameMoveError("Only the host can start the quiz");
+        }
+        if (state.phase !== "lobby") {
+          throw new GameMoveError("The quiz is already running");
+        }
+        return {
+          ...state,
+          phase: "question",
+          questionIndex: 0,
+          questionStart: ctx.now,
+          deadline: ctx.now + QUESTION_MS,
+          answers: {},
+          lastRound: {},
+        };
+      }
+      case "answer": {
+        if (state.phase !== "question") {
+          throw new GameMoveError("Not accepting answers right now");
+        }
+        const choice = (move.payload as { choice?: unknown })?.choice;
+        const question = state.questions[state.questionIndex];
+        if (
+          typeof choice !== "number" ||
+          !Number.isInteger(choice) ||
+          choice < 0 ||
+          choice >= question.options.length
+        ) {
+          throw new GameMoveError("Invalid answer");
+        }
+        if (state.answers[move.playerId]) {
+          throw new GameMoveError("You already answered");
+        }
+        const answers = {
+          ...state.answers,
+          [move.playerId]: { choice, at: ctx.now },
+        };
+        const deadline = otherPlayersAllAnswered(
+          { ...state, answers },
+          ctx.players.length,
+        )
+          ? ctx.now
+          : state.deadline;
+        return { ...state, answers, deadline };
+      }
+      case "skip": {
+        if (!ctx.isAdmin(move.playerId)) {
+          throw new GameMoveError("Only the host can skip");
+        }
+        if (state.phase !== "question") {
+          throw new GameMoveError("Nothing to skip");
+        }
+        return { ...state, deadline: ctx.now };
+      }
+      case "next": {
+        if (!ctx.isAdmin(move.playerId)) {
+          throw new GameMoveError("Only the host can advance");
+        }
+        if (state.phase !== "reveal") {
+          throw new GameMoveError("Wait for the reveal");
+        }
+        return { ...state, deadline: ctx.now };
+      }
+      default:
+        throw new GameMoveError(`Unknown move: ${move.type}`);
+    }
+  },
+
+  onTick(state, ctx): TriviaState {
+    if (state.phase === "question" && ctx.now >= state.deadline) {
+      const next: TriviaState = {
+        ...state,
+        answers: { ...state.answers },
+        scores: { ...state.scores },
+      };
+      scoreRound(next);
+      next.phase = "reveal";
+      next.deadline = ctx.now + REVEAL_MS;
+      return next;
+    }
+    if (state.phase === "reveal" && ctx.now >= state.deadline) {
+      const isLast = state.questionIndex + 1 >= state.questions.length;
+      if (isLast) {
+        return { ...state, phase: "results" };
+      }
+      return {
+        ...state,
+        phase: "question",
+        questionIndex: state.questionIndex + 1,
+        questionStart: ctx.now,
+        deadline: ctx.now + QUESTION_MS,
+        answers: {},
+        lastRound: {},
+      };
+    }
+    return state;
+  },
+
+  getPhase: (state) => state.phase,
+
+  publicView(state, ctx) {
+    const question = state.questions[state.questionIndex];
+    const showQuestion = state.phase === "question" || state.phase === "reveal";
+    const reveal = state.phase === "reveal";
+    const optionCounts = question
+      ? question.options.map(
+          (_, index) =>
+            Object.values(state.answers).filter((a) => a.choice === index)
+              .length,
+        )
+      : [];
+    return {
+      phase: state.phase,
+      questionIndex: state.questionIndex,
+      totalQuestions: state.questions.length,
+      serverNow: ctx.now,
+      deadline: state.phase === "question" || reveal ? state.deadline : null,
+      questionDurationMs: QUESTION_MS,
+      category: showQuestion ? question?.category ?? null : null,
+      prompt: showQuestion ? question?.prompt ?? null : null,
+      options: showQuestion ? question?.options ?? [] : [],
+      correctIndex: reveal ? question?.correctIndex ?? null : null,
+      optionCounts: reveal ? optionCounts : [],
+      answeredCount: Object.keys(state.answers).length,
+      totalPlayers: ctx.players.length,
+      scoreboard: scoreboard(state, ctx),
+    };
+  },
+
+  playerView(state, playerId, ctx) {
+    const question = state.questions[state.questionIndex];
+    const mine = state.answers[playerId];
+    const ordered = scoreboard(state, ctx);
+    const rank = ordered.findIndex((entry) => entry.id === playerId);
+    return {
+      answered: Boolean(mine),
+      choice: mine?.choice ?? null,
+      score: state.scores[playerId] ?? 0,
+      rank: rank >= 0 ? rank + 1 : null,
+      lastRoundPoints: state.lastRound[playerId] ?? 0,
+      correct:
+        state.phase === "reveal" && question
+          ? mine?.choice === question.correctIndex
+          : null,
+    };
+  },
+
+  isFinished: (state) => state.phase === "results",
+};

--- a/packages/sfu/server/games/modules/wouldYouRather.ts
+++ b/packages/sfu/server/games/modules/wouldYouRather.ts
@@ -4,6 +4,7 @@ import {
   type GameModule,
   type GameMove,
 } from "../types.js";
+import { numberOption } from "../config.js";
 
 /**
  * Would You Rather: a "split the room" party game for groups of any size.
@@ -65,12 +66,15 @@ export const wouldYouRatherModule: GameModule<WyrState> = {
   minPlayers: 1,
   maxPlayers: 50,
   tickMs: 500,
+  options: [
+    { id: "rounds", type: "number", label: "Rounds", min: 3, max: 10, default: 6, presets: [4, 6, 8] },
+  ],
 
   setup(ctx: GameContext): WyrState {
     return {
       phase: "lobby",
       index: 0,
-      prompts: ctx.rng.shuffle(PROMPT_BANK).slice(0, ROUNDS_PER_GAME),
+      prompts: ctx.rng.shuffle(PROMPT_BANK).slice(0, numberOption(ctx.config, "rounds", ROUNDS_PER_GAME)),
       deadline: 0,
       choices: {},
     };

--- a/packages/sfu/server/games/modules/wouldYouRather.ts
+++ b/packages/sfu/server/games/modules/wouldYouRather.ts
@@ -1,0 +1,151 @@
+import {
+  GameMoveError,
+  type GameContext,
+  type GameModule,
+  type GameMove,
+} from "../types.js";
+
+/**
+ * Would You Rather: a "split the room" party game for groups of any size.
+ *
+ * Each round shows two options. Everyone picks one, then the room split is
+ * revealed (counts plus who landed where). No right answer, no losing - it is
+ * about seeing where your friends land and arguing about it on camera.
+ */
+
+const CHOOSE_MS = 15_000;
+const ROUNDS_PER_GAME = 6;
+
+type Phase = "lobby" | "choose" | "reveal" | "results";
+
+type Prompt = { a: string; b: string };
+
+type WyrState = {
+  phase: Phase;
+  index: number;
+  prompts: Prompt[];
+  deadline: number;
+  choices: Record<string, 0 | 1>;
+};
+
+const PROMPT_BANK: Prompt[] = [
+  { a: "Be able to fly", b: "Be invisible" },
+  { a: "Never have to sleep", b: "Never have to eat" },
+  { a: "Always be 10 minutes late", b: "Always be 20 minutes early" },
+  { a: "Live without music", b: "Live without movies" },
+  { a: "Have a rewind button", b: "Have a pause button" },
+  { a: "Fight one horse-sized duck", b: "Fight 100 duck-sized horses" },
+  { a: "Only whisper", b: "Only shout" },
+  { a: "Know when you will die", b: "Know how you will die" },
+  { a: "Be a famous actor", b: "Be a famous musician" },
+  { a: "Have unlimited tacos", b: "Have unlimited pizza" },
+  { a: "Read minds", b: "See the future" },
+  { a: "Never use a touchscreen again", b: "Never use a keyboard again" },
+];
+
+const splitCounts = (state: WyrState): [number, number] => {
+  let a = 0;
+  let b = 0;
+  for (const choice of Object.values(state.choices)) {
+    if (choice === 0) a += 1;
+    else b += 1;
+  }
+  return [a, b];
+};
+
+const namesFor = (state: WyrState, ctx: GameContext, option: 0 | 1): string[] =>
+  ctx.players
+    .filter((player) => state.choices[player.id] === option)
+    .map((player) => player.name);
+
+export const wouldYouRatherModule: GameModule<WyrState> = {
+  id: "would-you-rather",
+  name: "Would You Rather",
+  description: "Pick a side, no wrong answers",
+  minPlayers: 1,
+  maxPlayers: 50,
+  tickMs: 500,
+
+  setup(ctx: GameContext): WyrState {
+    return {
+      phase: "lobby",
+      index: 0,
+      prompts: ctx.rng.shuffle(PROMPT_BANK).slice(0, ROUNDS_PER_GAME),
+      deadline: 0,
+      choices: {},
+    };
+  },
+
+  onMove(state, move: GameMove, ctx): WyrState {
+    switch (move.type) {
+      case "start": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can start");
+        if (state.phase !== "lobby") throw new GameMoveError("Already running");
+        return { ...state, phase: "choose", index: 0, deadline: ctx.now + CHOOSE_MS, choices: {} };
+      }
+      case "choose": {
+        if (state.phase !== "choose") throw new GameMoveError("Not accepting picks");
+        const option = (move.payload as { option?: unknown })?.option;
+        if (option !== 0 && option !== 1) throw new GameMoveError("Invalid pick");
+        const pick: 0 | 1 = option;
+        const choices: Record<string, 0 | 1> = { ...state.choices, [move.playerId]: pick };
+        const everyone = ctx.players.length > 0 && Object.keys(choices).length >= ctx.players.length;
+        return { ...state, choices, deadline: everyone ? ctx.now : state.deadline };
+      }
+      case "next": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can advance");
+        if (state.phase !== "reveal") throw new GameMoveError("Wait for the reveal");
+        return { ...state, deadline: ctx.now };
+      }
+      case "skip": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can skip");
+        if (state.phase !== "choose") throw new GameMoveError("Nothing to skip");
+        return { ...state, deadline: ctx.now };
+      }
+      default:
+        throw new GameMoveError(`Unknown move: ${move.type}`);
+    }
+  },
+
+  onTick(state, ctx): WyrState {
+    if (state.phase === "choose" && ctx.now >= state.deadline) {
+      return { ...state, phase: "reveal", deadline: 0 };
+    }
+    if (state.phase === "reveal" && ctx.now >= state.deadline && state.deadline > 0) {
+      const isLast = state.index + 1 >= state.prompts.length;
+      if (isLast) return { ...state, phase: "results" };
+      return { ...state, phase: "choose", index: state.index + 1, deadline: ctx.now + CHOOSE_MS, choices: {} };
+    }
+    return state;
+  },
+
+  getPhase: (state) => state.phase,
+
+  publicView(state, ctx) {
+    const prompt = state.prompts[state.index];
+    const reveal = state.phase === "reveal";
+    const [a, b] = splitCounts(state);
+    return {
+      phase: state.phase,
+      index: state.index,
+      total: state.prompts.length,
+      serverNow: ctx.now,
+      deadline: state.phase === "choose" ? state.deadline : null,
+      chooseDurationMs: CHOOSE_MS,
+      optionA: prompt?.a ?? null,
+      optionB: prompt?.b ?? null,
+      counts: state.phase === "lobby" ? [0, 0] : [a, b],
+      answeredCount: Object.keys(state.choices).length,
+      totalPlayers: ctx.players.length,
+      namesA: reveal ? namesFor(state, ctx, 0) : [],
+      namesB: reveal ? namesFor(state, ctx, 1) : [],
+    };
+  },
+
+  playerView(state, playerId) {
+    const choice = state.choices[playerId];
+    return { choice: choice === undefined ? null : choice };
+  },
+
+  isFinished: (state) => state.phase === "results",
+};

--- a/packages/sfu/server/games/registry.ts
+++ b/packages/sfu/server/games/registry.ts
@@ -30,4 +30,6 @@ export const getGameCatalog = (): GameCatalogEntry[] =>
     description: module.description,
     minPlayers: module.minPlayers,
     maxPlayers: module.maxPlayers,
+    options: module.options ?? [],
+    hasLeaderboard: Boolean(module.hasLeaderboard),
   }));

--- a/packages/sfu/server/games/registry.ts
+++ b/packages/sfu/server/games/registry.ts
@@ -1,0 +1,33 @@
+import { bluffModule } from "./modules/bluff.js";
+import { imposterModule } from "./modules/imposter.js";
+import { mostLikelyToModule } from "./modules/mostLikelyTo.js";
+import { reactionModule } from "./modules/reaction.js";
+import { triviaModule } from "./modules/trivia.js";
+import { wouldYouRatherModule } from "./modules/wouldYouRather.js";
+import type { GameCatalogEntry, GameModule } from "./types.js";
+
+// Register a game here (one line). The order is the order shown in the launcher.
+const MODULES: GameModule[] = [
+  triviaModule as GameModule,
+  bluffModule as GameModule,
+  wouldYouRatherModule as GameModule,
+  mostLikelyToModule as GameModule,
+  reactionModule as GameModule,
+  imposterModule as GameModule,
+];
+
+const REGISTRY = new Map<string, GameModule>(
+  MODULES.map((module) => [module.id, module]),
+);
+
+export const getGameModule = (gameId: string): GameModule | undefined =>
+  REGISTRY.get(gameId);
+
+export const getGameCatalog = (): GameCatalogEntry[] =>
+  MODULES.map((module) => ({
+    id: module.id,
+    name: module.name,
+    description: module.description,
+    minPlayers: module.minPlayers,
+    maxPlayers: module.maxPlayers,
+  }));

--- a/packages/sfu/server/games/rng.ts
+++ b/packages/sfu/server/games/rng.ts
@@ -1,0 +1,48 @@
+import { randomBytes } from "node:crypto";
+import type { GameRng } from "./types.js";
+
+/**
+ * Small, fast, seedable PRNG (mulberry32). We seed it from crypto so deals and
+ * shuffles are unpredictable to clients, but keep it deterministic given a seed
+ * so a session could be replayed for debugging.
+ */
+const mulberry32 = (seed: number): (() => number) => {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+export const createSeed = (): number => randomBytes(4).readUInt32LE(0);
+
+export const createRng = (seed: number = createSeed()): GameRng => {
+  const next = mulberry32(seed);
+  const int = (maxExclusive: number): number => {
+    if (!Number.isFinite(maxExclusive) || maxExclusive <= 0) return 0;
+    return Math.floor(next() * maxExclusive);
+  };
+  return {
+    next,
+    int,
+    shuffle<T>(items: readonly T[]): T[] {
+      const copy = items.slice();
+      for (let i = copy.length - 1; i > 0; i -= 1) {
+        const j = int(i + 1);
+        const tmp = copy[i];
+        copy[i] = copy[j];
+        copy[j] = tmp;
+      }
+      return copy;
+    },
+    pick<T>(items: readonly T[]): T {
+      if (items.length === 0) {
+        throw new Error("Cannot pick from an empty list");
+      }
+      return items[int(items.length)];
+    },
+  };
+};

--- a/packages/sfu/server/games/types.ts
+++ b/packages/sfu/server/games/types.ts
@@ -116,6 +116,8 @@ export type GameCatalogEntry = {
   description: string;
   minPlayers: number;
   maxPlayers: number;
+  options: GameOptionSpec[];
+  hasLeaderboard: boolean;
 };
 
 /* ---- Wire payloads (socket contract) ---- */
@@ -156,6 +158,7 @@ export type GamePublicState = {
   hostId: string | null;
   view: unknown;
   finished: boolean;
+  hasLeaderboard: boolean;
 };
 
 /** Emitted privately to a single player. */

--- a/packages/sfu/server/games/types.ts
+++ b/packages/sfu/server/games/types.ts
@@ -30,9 +30,35 @@ export type GameRng = {
   pick<T>(items: readonly T[]): T;
 };
 
+/** Host-configurable option specs, declared by a module and rendered by the UI. */
+export type GameOptionSpec =
+  | {
+      id: string;
+      type: "number";
+      label: string;
+      min: number;
+      max: number;
+      default: number;
+      /** Quick presets surfaced as a segmented control. */
+      presets?: number[];
+      suffix?: string;
+    }
+  | {
+      id: string;
+      type: "select";
+      label: string;
+      default: string;
+      choices: { value: string; label: string }[];
+    };
+
+/** Resolved, validated config values keyed by option id. */
+export type GameConfig = Record<string, number | string>;
+
 export type GameContext = {
   players: GamePlayer[];
   rng: GameRng;
+  /** Host-chosen configuration (validated, with defaults filled in). */
+  config: GameConfig;
   /** Server clock (ms epoch) captured at the start of the operation. */
   now: number;
   isAdmin(playerId: string): boolean;
@@ -57,6 +83,11 @@ export type GameModule<S = unknown> = {
   maxPlayers: number;
   /** When set, the engine calls `onTick` on this cadence for timers/deadlines. */
   tickMs?: number;
+  /** Host-configurable options shown before the game starts. */
+  options?: GameOptionSpec[];
+  /** When true, the dock shows a live leaderboard (the publicView must expose a
+   *  `scoreboard` array of `{ id, name, score }`). */
+  hasLeaderboard?: boolean;
 
   setup(ctx: GameContext): S;
   /** Apply a validated move. Throw `GameMoveError` to reject it. */

--- a/packages/sfu/server/games/types.ts
+++ b/packages/sfu/server/games/types.ts
@@ -1,0 +1,154 @@
+/**
+ * Server-authoritative game runtime types.
+ *
+ * Unlike the collaborative apps runtime (where the SFU is a dumb Yjs relay and
+ * every client converges on identical, fully-visible state), the game runtime
+ * keeps canonical state ONLY on the server. Each client receives a projection:
+ *
+ *   - `publicView`  -> broadcast to the whole room (what everyone may see)
+ *   - `playerView`  -> emitted privately to a single player (hidden information)
+ *
+ * Moves are validated server-side. A module rejects an illegal move by throwing
+ * `GameMoveError`. Randomness comes from a seeded server RNG so shuffles/deals
+ * cannot be predicted or replayed by clients.
+ */
+
+export type GamePlayer = {
+  id: string;
+  name: string;
+};
+
+/** Deterministic, server-seeded RNG handed to game modules. */
+export type GameRng = {
+  /** Float in [0, 1). */
+  next(): number;
+  /** Integer in [0, maxExclusive). */
+  int(maxExclusive: number): number;
+  /** Returns a new shuffled copy (Fisher-Yates). */
+  shuffle<T>(items: readonly T[]): T[];
+  /** Picks one element. Throws on empty input. */
+  pick<T>(items: readonly T[]): T;
+};
+
+export type GameContext = {
+  players: GamePlayer[];
+  rng: GameRng;
+  /** Server clock (ms epoch) captured at the start of the operation. */
+  now: number;
+  isAdmin(playerId: string): boolean;
+};
+
+export type GameMove = {
+  playerId: string;
+  type: string;
+  payload: unknown;
+};
+
+/**
+ * A game module is the authoritative definition of one game. It is pure with
+ * respect to its own state: every method takes the current state and returns
+ * the next one (or a projection). No socket or IO concerns leak in here.
+ */
+export type GameModule<S = unknown> = {
+  id: string;
+  name: string;
+  description: string;
+  minPlayers: number;
+  maxPlayers: number;
+  /** When set, the engine calls `onTick` on this cadence for timers/deadlines. */
+  tickMs?: number;
+
+  setup(ctx: GameContext): S;
+  /** Apply a validated move. Throw `GameMoveError` to reject it. */
+  onMove(state: S, move: GameMove, ctx: GameContext): S;
+  /** Optional time-driven progression (phase deadlines, countdowns). */
+  onTick?(state: S, ctx: GameContext): S;
+
+  /** Coarse lifecycle label surfaced to the host UI (e.g. "lobby", "question"). */
+  getPhase(state: S): string;
+  publicView(state: S, ctx: GameContext): unknown;
+  playerView(state: S, playerId: string, ctx: GameContext): unknown;
+  isFinished?(state: S): boolean;
+};
+
+/** Thrown by a module's `onMove` to reject an illegal move with a reason. */
+export class GameMoveError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GameMoveError";
+  }
+}
+
+export type GameCatalogEntry = {
+  id: string;
+  name: string;
+  description: string;
+  minPlayers: number;
+  maxPlayers: number;
+};
+
+/* ---- Wire payloads (socket contract) ---- */
+
+export type GameStartData = {
+  gameId?: unknown;
+  options?: unknown;
+};
+
+export type GameStartResponse = {
+  success: boolean;
+  gameId?: string;
+  error?: string;
+};
+
+export type GameMoveData = {
+  gameId?: unknown;
+  type?: unknown;
+  payload?: unknown;
+};
+
+export type GameMoveResponse = {
+  success: boolean;
+  error?: string;
+};
+
+export type GameEndResponse = {
+  success: boolean;
+  error?: string;
+};
+
+/** Broadcast to the whole room on every state change. */
+export type GamePublicState = {
+  gameId: string;
+  name: string;
+  phase: string;
+  players: GamePlayer[];
+  hostId: string | null;
+  view: unknown;
+  finished: boolean;
+};
+
+/** Emitted privately to a single player. */
+export type GamePlayerView = {
+  gameId: string;
+  view: unknown;
+};
+
+export type GameStateResponse = {
+  active: boolean;
+  public?: GamePublicState;
+  view?: unknown;
+  vote?: GameVoteState | null;
+};
+
+/* ---- Game vote (host puts game choice to the room) ---- */
+
+export type GameVoteState = {
+  candidates: GameCatalogEntry[];
+  tally: Record<string, number>;
+  votes: Record<string, string>;
+  totalPlayers: number;
+};
+
+export type GameVoteOpenData = { candidates?: unknown };
+export type GameVoteCastData = { gameId?: unknown };
+export type GameVoteResponse = { success: boolean; error?: string };

--- a/packages/sfu/server/games/validation.ts
+++ b/packages/sfu/server/games/validation.ts
@@ -1,0 +1,33 @@
+import { GameMoveError, type GameContext } from "./types.js";
+
+export type PlayerTargetOptions = {
+  allowSelf?: boolean;
+  invalidMessage?: string;
+  selfMessage?: string;
+};
+
+/**
+ * Shared server-side validator for moves that target another player.
+ * Game modules own their rules, but they should not have to reimplement the
+ * same payload/type/self-target checks for every vote, challenge, or pick.
+ */
+export const requirePlayerTarget = (
+  ctx: GameContext,
+  actorId: string,
+  target: unknown,
+  options: PlayerTargetOptions = {},
+): string => {
+  const invalidMessage = options.invalidMessage ?? "Invalid player target";
+  if (
+    typeof target !== "string" ||
+    !ctx.players.some((player) => player.id === target)
+  ) {
+    throw new GameMoveError(invalidMessage);
+  }
+  if (options.allowSelf === false && target === actorId) {
+    throw new GameMoveError(
+      options.selfMessage ?? "You cannot target yourself",
+    );
+  }
+  return target;
+};

--- a/packages/sfu/server/http/schedulingRoutes.ts
+++ b/packages/sfu/server/http/schedulingRoutes.ts
@@ -46,6 +46,8 @@ const MAX_ID_LENGTH = 256;
 const MAX_EMAIL_LENGTH = 320;
 const MAX_NAME_LENGTH = 120;
 const MAX_TEXT_LENGTH = 2000;
+const MINUTE_MS = 60 * 1000;
+const DAY_MS = 24 * 60 * MINUTE_MS;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_FREEBUSY_URL = "https://www.googleapis.com/calendar/v3/freeBusy";
@@ -486,8 +488,6 @@ const createGoogleCalendarEvent = async (
   }
 };
 
-const MINUTE_MS = 60 * 1000;
-
 const meetingMatchesProfile = (
   meeting: ScheduledMeeting,
   profile: SchedulingProfile,
@@ -795,27 +795,53 @@ export const registerSchedulingRoutes = (
       sendCalendarUnavailable(res);
       return;
     }
-    const from = Number(req.query.from ?? Date.now());
-    const to = Number(req.query.to ?? Date.now() + 14 * 24 * 60 * 60 * 1000);
-    if (!Number.isFinite(from) || !Number.isFinite(to) || to <= from) {
+    const now = Date.now();
+    const requestedFrom = Number(req.query.from ?? now);
+    const requestedTo = Number(req.query.to ?? now + 14 * DAY_MS);
+    if (
+      !Number.isFinite(requestedFrom) ||
+      !Number.isFinite(requestedTo) ||
+      requestedTo <= requestedFrom
+    ) {
       res.status(400).json({ error: "Invalid slot range." });
       return;
     }
+    const slotFrom = Math.max(
+      requestedFrom,
+      now + target.eventType.minimumNoticeMinutes * MINUTE_MS,
+    );
+    const slotTo = Math.min(
+      requestedTo,
+      now + target.eventType.bookingWindowDays * DAY_MS,
+    );
+    if (slotTo <= slotFrom) {
+      res.json({ slots: [] });
+      return;
+    }
+    const busyFrom =
+      slotFrom - target.eventType.bufferBeforeMinutes * MINUTE_MS;
+    const busyTo = slotTo + target.eventType.bufferAfterMinutes * MINUTE_MS;
     try {
-      const internalBusy = collectInternalBusy(state, target.profile, from, to);
+      const internalBusy = collectInternalBusy(
+        state,
+        target.profile,
+        busyFrom,
+        busyTo,
+      );
       const googleBusy = await fetchOptionalGoogleBusy(
         state,
         target.calendar,
         target.eventType,
-        from,
-        to,
+        busyFrom,
+        busyTo,
       );
       const slots = generateAvailableSlots({
         eventType: target.eventType,
         availability: getProfileAvailability(state.scheduling, target.profile),
         busyIntervals: [...internalBusy, ...googleBusy],
-        from,
-        to,
+        from: slotFrom,
+        to: slotTo,
+        now,
         timeZone: target.profile.timeZone,
       });
       res.json({ slots });

--- a/packages/sfu/server/socket/handlers/gameHandlers.ts
+++ b/packages/sfu/server/socket/handlers/gameHandlers.ts
@@ -1,6 +1,7 @@
 import { Admin } from "../../../config/classes/Admin.js";
 import type { Room } from "../../../config/classes/Room.js";
 import { GameSession } from "../../games/engine.js";
+import { normalizeConfig } from "../../games/config.js";
 import { getGameCatalog, getGameModule } from "../../games/registry.js";
 import type {
   GameCatalogEntry,
@@ -88,6 +89,8 @@ const buildVoteState = (room: Room): GameVoteState | null => {
         description: module.description,
         minPlayers: module.minPlayers,
         maxPlayers: module.maxPlayers,
+        options: module.options ?? [],
+        hasLeaderboard: Boolean(module.hasLeaderboard),
       });
     }
   }
@@ -197,6 +200,7 @@ export const registerGameHandlers = (context: ConnectionContext): void => {
           players,
           adminIds: collectAdminIds(room),
           hostId: context.currentClient.id,
+          config: normalizeConfig(module.options, data?.options),
         });
       } catch (error) {
         Logger.error("[Games] failed to start", error);

--- a/packages/sfu/server/socket/handlers/gameHandlers.ts
+++ b/packages/sfu/server/socket/handlers/gameHandlers.ts
@@ -18,7 +18,7 @@ import type {
   GameVoteState,
 } from "../../games/types.js";
 import { Logger } from "../../../utilities/loggers.js";
-import type { Server as SocketIOServer } from "socket.io";
+import type { Server as SocketIOServer, Socket } from "socket.io";
 import type { ConnectionContext } from "../context.js";
 import { RATE_LIMITS, takeToken } from "../rateLimit.js";
 import { respond } from "./ack.js";
@@ -48,6 +48,14 @@ const snapshotPlayers = (room: Room): GamePlayer[] => {
   return players;
 };
 
+const countPlayers = (room: Room): number => {
+  let count = 0;
+  for (const client of room.clients.values()) {
+    if (!client.isObserver) count += 1;
+  }
+  return count;
+};
+
 const collectAdminIds = (room: Room): string[] => {
   const ids: string[] = [];
   for (const client of room.clients.values()) {
@@ -59,7 +67,7 @@ const collectAdminIds = (room: Room): string[] => {
 /**
  * Push the latest projections to the room: one public broadcast, plus a private
  * per-player view to each player's own socket. The private emit is the
- * hidden-information boundary — a player only ever receives their own view.
+ * hidden-information boundary. A player only ever receives their own view.
  */
 const broadcastGame = (io: SocketIOServer, room: Room): void => {
   const session = room.gameSession;
@@ -99,11 +107,50 @@ const buildVoteState = (room: Room): GameVoteState | null => {
   for (const choice of Object.values(vote.votes)) {
     tally[choice] = (tally[choice] ?? 0) + 1;
   }
-  return { candidates, tally, votes: vote.votes, totalPlayers: snapshotPlayers(room).length };
+  return {
+    candidates,
+    tally,
+    votes: vote.votes,
+    totalPlayers: countPlayers(room),
+  };
 };
 
 const broadcastVote = (io: SocketIOServer, room: Room): void => {
   io.to(room.channelId).emit("game:vote", buildVoteState(room));
+};
+
+export const buildGameStateResponse = (
+  room: Room | null | undefined,
+  playerId: string | null | undefined,
+): GameStateResponse => {
+  if (!room) {
+    return { active: false, vote: null };
+  }
+
+  const session = room.gameSession;
+  const vote = buildVoteState(room);
+  if (!session) {
+    return { active: false, vote };
+  }
+
+  const now = Date.now();
+  const response: GameStateResponse = {
+    active: true,
+    public: session.getPublicState(now),
+    vote,
+  };
+  if (playerId && session.hasPlayer(playerId)) {
+    response.view = session.getPlayerView(playerId, now);
+  }
+  return response;
+};
+
+export const emitGameSnapshot = (
+  socket: Socket,
+  room: Room,
+  playerId: string | null | undefined,
+): void => {
+  socket.emit("game:snapshot", buildGameStateResponse(room, playerId));
 };
 
 const stopGameLoop = (room: Room): void => {
@@ -364,20 +411,12 @@ export const registerGameHandlers = (context: ConnectionContext): void => {
   });
 
   socket.on("game:getState", (callback: (state: GameStateResponse) => void) => {
-    const room = context.currentRoom;
-    const session = room?.gameSession;
-    if (!session || !context.currentClient || !room) {
-      respond(callback, { active: false, vote: room ? buildVoteState(room) : null });
-      return;
-    }
-    const now = Date.now();
-    respond(callback, {
-      active: true,
-      public: session.getPublicState(now),
-      view: session.hasPlayer(context.currentClient.id)
-        ? session.getPlayerView(context.currentClient.id, now)
-        : undefined,
-      vote: buildVoteState(room),
-    });
+    respond(
+      callback,
+      buildGameStateResponse(
+        context.currentRoom,
+        context.currentClient?.id ?? null,
+      ),
+    );
   });
 };

--- a/packages/sfu/server/socket/handlers/gameHandlers.ts
+++ b/packages/sfu/server/socket/handlers/gameHandlers.ts
@@ -1,0 +1,379 @@
+import { Admin } from "../../../config/classes/Admin.js";
+import type { Room } from "../../../config/classes/Room.js";
+import { GameSession } from "../../games/engine.js";
+import { getGameCatalog, getGameModule } from "../../games/registry.js";
+import type {
+  GameCatalogEntry,
+  GameEndResponse,
+  GameMoveData,
+  GameMoveResponse,
+  GamePlayer,
+  GameStartData,
+  GameStartResponse,
+  GameStateResponse,
+  GameVoteCastData,
+  GameVoteOpenData,
+  GameVoteResponse,
+  GameVoteState,
+} from "../../games/types.js";
+import { Logger } from "../../../utilities/loggers.js";
+import type { Server as SocketIOServer } from "socket.io";
+import type { ConnectionContext } from "../context.js";
+import { RATE_LIMITS, takeToken } from "../rateLimit.js";
+import { respond } from "./ack.js";
+
+const MAX_GAME_ID_LENGTH = 64;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
+
+const normalizeGameId = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const id = value.trim();
+  if (!id || id.length > MAX_GAME_ID_LENGTH || CONTROL_CHARACTER_PATTERN.test(id)) {
+    return null;
+  }
+  return id;
+};
+
+/** Snapshot the current in-meeting participants as game players. */
+const snapshotPlayers = (room: Room): GamePlayer[] => {
+  const players: GamePlayer[] = [];
+  for (const client of room.clients.values()) {
+    if (client.isObserver) continue;
+    players.push({
+      id: client.id,
+      name: room.getDisplayNameForUser(client.id) ?? "Guest",
+    });
+  }
+  return players;
+};
+
+const collectAdminIds = (room: Room): string[] => {
+  const ids: string[] = [];
+  for (const client of room.clients.values()) {
+    if (client instanceof Admin) ids.push(client.id);
+  }
+  return ids;
+};
+
+/**
+ * Push the latest projections to the room: one public broadcast, plus a private
+ * per-player view to each player's own socket. The private emit is the
+ * hidden-information boundary — a player only ever receives their own view.
+ */
+const broadcastGame = (io: SocketIOServer, room: Room): void => {
+  const session = room.gameSession;
+  if (!session) return;
+  const now = Date.now();
+  io.to(room.channelId).emit("game:state", session.getPublicState(now));
+  for (const player of session.getPlayers()) {
+    const client = room.clients.get(player.id);
+    if (!client) continue;
+    client.socket.emit("game:view", {
+      gameId: session.gameId,
+      view: session.getPlayerView(player.id, now),
+    });
+  }
+};
+
+const buildVoteState = (room: Room): GameVoteState | null => {
+  const vote = room.gameVote;
+  if (!vote) return null;
+  const candidates: GameCatalogEntry[] = [];
+  for (const id of vote.candidates) {
+    const module = getGameModule(id);
+    if (module) {
+      candidates.push({
+        id: module.id,
+        name: module.name,
+        description: module.description,
+        minPlayers: module.minPlayers,
+        maxPlayers: module.maxPlayers,
+      });
+    }
+  }
+  const tally: Record<string, number> = {};
+  for (const id of vote.candidates) tally[id] = 0;
+  for (const choice of Object.values(vote.votes)) {
+    tally[choice] = (tally[choice] ?? 0) + 1;
+  }
+  return { candidates, tally, votes: vote.votes, totalPlayers: snapshotPlayers(room).length };
+};
+
+const broadcastVote = (io: SocketIOServer, room: Room): void => {
+  io.to(room.channelId).emit("game:vote", buildVoteState(room));
+};
+
+const stopGameLoop = (room: Room): void => {
+  if (room.gameTickTimer) {
+    clearInterval(room.gameTickTimer);
+    room.gameTickTimer = null;
+  }
+};
+
+const startGameLoop = (io: SocketIOServer, room: Room): void => {
+  stopGameLoop(room);
+  const session = room.gameSession;
+  if (!session || session.tickMs == null) return;
+  room.gameTickTimer = setInterval(() => {
+    const active = room.gameSession;
+    if (!active) {
+      stopGameLoop(room);
+      return;
+    }
+    try {
+      if (active.tick()) {
+        broadcastGame(io, room);
+      }
+      if (active.isFinished()) {
+        stopGameLoop(room);
+      }
+    } catch (error) {
+      Logger.warn("[Games] tick failed", error);
+      stopGameLoop(room);
+    }
+  }, session.tickMs);
+};
+
+export const registerGameHandlers = (context: ConnectionContext): void => {
+  const { socket, io } = context;
+
+  socket.on(
+    "game:list",
+    (callback: (catalog: GameCatalogEntry[]) => void) => {
+      respond(callback, getGameCatalog());
+    },
+  );
+
+  socket.on(
+    "game:start",
+    (data: GameStartData, callback: (response: GameStartResponse) => void) => {
+      if (!context.currentRoom || !context.currentClient) {
+        respond(callback, { success: false, error: "Not in a room" });
+        return;
+      }
+      if (!(context.currentClient instanceof Admin)) {
+        respond(callback, { success: false, error: "Only the host can start a game" });
+        return;
+      }
+      if (!takeToken(socket, "game:start", RATE_LIMITS.gameControl)) {
+        respond(callback, { success: false, error: "Slow down" });
+        return;
+      }
+      const room = context.currentRoom;
+      if (room.gameSession) {
+        respond(callback, { success: false, error: "A game is already running" });
+        return;
+      }
+      const gameId = normalizeGameId(data?.gameId);
+      if (!gameId) {
+        respond(callback, { success: false, error: "Invalid game id" });
+        return;
+      }
+      const module = getGameModule(gameId);
+      if (!module) {
+        respond(callback, { success: false, error: "Unknown game" });
+        return;
+      }
+      const players = snapshotPlayers(room);
+      if (players.length < module.minPlayers) {
+        respond(callback, {
+          success: false,
+          error: `Need at least ${module.minPlayers} players`,
+        });
+        return;
+      }
+      if (players.length > module.maxPlayers) {
+        respond(callback, {
+          success: false,
+          error: `Supports up to ${module.maxPlayers} players`,
+        });
+        return;
+      }
+
+      try {
+        stopGameLoop(room);
+        room.gameSession = new GameSession({
+          module,
+          players,
+          adminIds: collectAdminIds(room),
+          hostId: context.currentClient.id,
+        });
+      } catch (error) {
+        Logger.error("[Games] failed to start", error);
+        room.gameSession = null;
+        respond(callback, { success: false, error: "Failed to start game" });
+        return;
+      }
+
+      room.gameVote = null;
+      broadcastVote(io, room);
+      startGameLoop(io, room);
+      broadcastGame(io, room);
+      respond(callback, { success: true, gameId });
+    },
+  );
+
+  socket.on(
+    "game:vote:open",
+    (data: GameVoteOpenData, callback: (response: GameVoteResponse) => void) => {
+      if (!context.currentRoom || !context.currentClient) {
+        respond(callback, { success: false, error: "Not in a room" });
+        return;
+      }
+      if (!(context.currentClient instanceof Admin)) {
+        respond(callback, { success: false, error: "Only the host can open a vote" });
+        return;
+      }
+      if (context.currentRoom.gameSession) {
+        respond(callback, { success: false, error: "A game is already running" });
+        return;
+      }
+      if (!takeToken(socket, "game:vote:open", RATE_LIMITS.gameControl)) {
+        respond(callback, { success: false, error: "Slow down" });
+        return;
+      }
+      const allIds = getGameCatalog().map((entry) => entry.id);
+      let candidates = allIds;
+      if (Array.isArray(data?.candidates)) {
+        const picked = data.candidates
+          .map((value) => normalizeGameId(value))
+          .filter((id): id is string => Boolean(id && getGameModule(id)));
+        if (picked.length >= 2) candidates = Array.from(new Set(picked));
+      }
+      context.currentRoom.gameVote = { candidates, votes: {} };
+      broadcastVote(io, context.currentRoom);
+      respond(callback, { success: true });
+    },
+  );
+
+  socket.on(
+    "game:vote:cast",
+    (data: GameVoteCastData, callback: (response: GameVoteResponse) => void) => {
+      if (!context.currentRoom || !context.currentClient) {
+        respond(callback, { success: false, error: "Not in a room" });
+        return;
+      }
+      if (context.currentClient.isObserver) {
+        respond(callback, { success: false, error: "Watch-only attendees cannot vote" });
+        return;
+      }
+      if (!takeToken(socket, "game:vote:cast", RATE_LIMITS.gameMove)) {
+        respond(callback, { success: false, error: "Slow down" });
+        return;
+      }
+      const vote = context.currentRoom.gameVote;
+      if (!vote) {
+        respond(callback, { success: false, error: "No vote in progress" });
+        return;
+      }
+      const gameId = normalizeGameId(data?.gameId);
+      if (!gameId || !vote.candidates.includes(gameId)) {
+        respond(callback, { success: false, error: "Invalid choice" });
+        return;
+      }
+      vote.votes[context.currentClient.id] = gameId;
+      broadcastVote(io, context.currentRoom);
+      respond(callback, { success: true });
+    },
+  );
+
+  socket.on("game:vote:cancel", (callback: (response: GameVoteResponse) => void) => {
+    if (!context.currentRoom || !context.currentClient) {
+      respond(callback, { success: false, error: "Not in a room" });
+      return;
+    }
+    if (!(context.currentClient instanceof Admin)) {
+      respond(callback, { success: false, error: "Only the host can cancel the vote" });
+      return;
+    }
+    context.currentRoom.gameVote = null;
+    broadcastVote(io, context.currentRoom);
+    respond(callback, { success: true });
+  });
+
+  socket.on(
+    "game:move",
+    (data: GameMoveData, callback: (response: GameMoveResponse) => void) => {
+      if (!context.currentRoom || !context.currentClient) {
+        respond(callback, { success: false, error: "Not in a room" });
+        return;
+      }
+      if (context.currentClient.isObserver) {
+        respond(callback, { success: false, error: "Watch-only attendees cannot play" });
+        return;
+      }
+      if (!takeToken(socket, "game:move", RATE_LIMITS.gameMove)) {
+        respond(callback, { success: false, error: "Too many moves" });
+        return;
+      }
+      const room = context.currentRoom;
+      const session = room.gameSession;
+      const gameId = normalizeGameId(data?.gameId);
+      if (!session || !gameId || session.gameId !== gameId) {
+        respond(callback, { success: false, error: "No active game" });
+        return;
+      }
+      if (typeof data?.type !== "string" || data.type.length > MAX_GAME_ID_LENGTH) {
+        respond(callback, { success: false, error: "Invalid move" });
+        return;
+      }
+
+      let result: { ok: true } | { ok: false; error: string };
+      try {
+        result = session.applyMove(context.currentClient.id, data.type, data.payload);
+      } catch (error) {
+        Logger.warn("[Games] move failed", error);
+        respond(callback, { success: false, error: "Move failed" });
+        return;
+      }
+      if (!result.ok) {
+        respond(callback, { success: false, error: result.error });
+        return;
+      }
+
+      broadcastGame(io, room);
+      if (session.isFinished()) {
+        stopGameLoop(room);
+      } else if (!room.gameTickTimer) {
+        startGameLoop(io, room);
+      }
+      respond(callback, { success: true });
+    },
+  );
+
+  socket.on("game:end", (callback: (response: GameEndResponse) => void) => {
+    if (!context.currentRoom || !context.currentClient) {
+      respond(callback, { success: false, error: "Not in a room" });
+      return;
+    }
+    if (!(context.currentClient instanceof Admin)) {
+      respond(callback, { success: false, error: "Only the host can end the game" });
+      return;
+    }
+    const room = context.currentRoom;
+    const gameId = room.gameSession?.gameId ?? null;
+    room.clearGame();
+    if (gameId) {
+      io.to(room.channelId).emit("game:ended", { gameId });
+    }
+    respond(callback, { success: true });
+  });
+
+  socket.on("game:getState", (callback: (state: GameStateResponse) => void) => {
+    const room = context.currentRoom;
+    const session = room?.gameSession;
+    if (!session || !context.currentClient || !room) {
+      respond(callback, { active: false, vote: room ? buildVoteState(room) : null });
+      return;
+    }
+    const now = Date.now();
+    respond(callback, {
+      active: true,
+      public: session.getPublicState(now),
+      view: session.hasPlayer(context.currentClient.id)
+        ? session.getPlayerView(context.currentClient.id, now)
+        : undefined,
+      vote: buildVoteState(room),
+    });
+  });
+};

--- a/packages/sfu/server/socket/handlers/joinRoom.ts
+++ b/packages/sfu/server/socket/handlers/joinRoom.ts
@@ -408,11 +408,10 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
         const wasReconnecting = room.clearPendingDisconnect(userId);
         const isReplacingExistingSeat =
           Boolean(existingClient) || staleSameIdentitySeats.length > 0;
-        const isReclaimingMeetingParticipantSeat =
+        const isSameSessionMeetingParticipantRejoin =
           !isWebinarAttendeeJoin &&
           Boolean(
-            (existingClient && !existingClient.isObserver) ||
-              staleSameIdentitySeats.some((seat) => seat.isMeetingParticipant),
+            wasReconnecting || (existingClient && !existingClient.isObserver),
           );
         const reclaimingWebinarSeat =
           isWebinarAttendeeJoin &&
@@ -502,7 +501,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           !isWebinarAttendeeJoin &&
           !isAdminJoin &&
           requiresMeetingInviteCode &&
-          !isReclaimingMeetingParticipantSeat;
+          !isSameSessionMeetingParticipantRejoin;
 
         if (shouldValidateMeetingInviteCode && !meetingInviteCode) {
           respond(callback, { error: "Meeting invite code required." });

--- a/packages/sfu/server/socket/handlers/joinRoom.ts
+++ b/packages/sfu/server/socket/handlers/joinRoom.ts
@@ -51,6 +51,7 @@ import type { ConnectionContext } from "../context.js";
 import { registerAdminHandlers } from "./adminHandlers.js";
 import { respond } from "./ack.js";
 import { emitChatHistorySnapshot } from "./chatHistory.js";
+import { emitGameSnapshot } from "./gameHandlers.js";
 import {
   clearBrowserState,
   getBrowserState,
@@ -889,6 +890,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           locked: context.currentRoom.appsState.locked,
           roomId: context.currentRoom.id,
         });
+        emitGameSnapshot(socket, context.currentRoom, context.currentClient.id);
 
         const newQuality = context.currentRoom.updateVideoQuality();
         if (newQuality) {

--- a/packages/sfu/server/socket/handlers/joinRoom.ts
+++ b/packages/sfu/server/socket/handlers/joinRoom.ts
@@ -374,26 +374,75 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           }
         }
 
+        const existingClient = room.getClient(userId);
+        const staleSameIdentityUserIds = Array.from(
+          room.userKeysById.entries(),
+        )
+          .filter(([candidateUserId, candidateUserKey]) => {
+            if (candidateUserId === userId || candidateUserKey !== userKey) {
+              return false;
+            }
+            const candidateClient = room.getClient(candidateUserId);
+            return (
+              room.hasPendingDisconnect(candidateUserId) ||
+              candidateClient?.socket.connected === false
+            );
+          })
+          .map(([candidateUserId]) => candidateUserId);
         const pendingDisconnectStartedAt =
           room.getPendingDisconnectStartedAt(userId);
         const wasReconnectNoticeEmitted =
           room.wasPendingDisconnectNotified(userId);
         const wasReconnecting = room.clearPendingDisconnect(userId);
-        const existingClient = room.getClient(userId);
+        const isReclaimingExistingSeat =
+          wasReconnecting || staleSameIdentityUserIds.length > 0;
         const reclaimingWebinarSeat = existingClient
           ? Boolean(existingClient.isWebinarAttendee)
-          : false;
+          : staleSameIdentityUserIds.some((candidateUserId) =>
+              Boolean(room.getClient(candidateUserId)?.isWebinarAttendee),
+            );
 
-        if (existingClient) {
-          Logger.warn(`User ${userId} re-joining room ${roomId}`);
-          const awarenessRemovals = room.clearUserAwareness(userId);
+        const removeClientForRejoin = (
+          targetUserId: string,
+          options?: { notifyPeers?: boolean },
+        ) => {
+          const client = room.getClient(targetUserId);
+          if (!client) return;
+
+          const awarenessRemovals = room.clearUserAwareness(targetUserId);
           for (const removal of awarenessRemovals) {
             io.to(roomChannelId).emit("apps:awareness", {
               appId: removal.appId,
               awarenessUpdate: removal.awarenessUpdate,
             } satisfies AppsAwarenessData);
           }
-          room.removeClient(userId);
+
+          room.removeClient(targetUserId);
+
+          if (!options?.notifyPeers) return;
+          if (client.isGhost) {
+            emitUserLeft(room, targetUserId, {
+              ghostOnly: true,
+              excludeUserId: targetUserId,
+            });
+          } else if (!client.isWebinarAttendee) {
+            io.to(roomChannelId).emit("userLeft", {
+              userId: targetUserId,
+              roomId: room.id,
+            });
+          }
+        };
+
+        for (const staleUserId of staleSameIdentityUserIds) {
+          Logger.warn(
+            `Reclaiming stale session ${staleUserId} for identity ${userKey} in room ${roomId}`,
+          );
+          removeClientForRejoin(staleUserId, { notifyPeers: true });
+        }
+
+        if (existingClient) {
+          Logger.warn(`User ${userId} re-joining room ${roomId}`);
+          removeClientForRejoin(userId);
         }
 
         if (
@@ -454,7 +503,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           !isWebinarAttendeeJoin &&
           !isAdminJoin &&
           requiresMeetingInviteCode &&
-          !wasReconnecting &&
+          !isReclaimingExistingSeat &&
           !existingClient;
 
         if (shouldValidateMeetingInviteCode && !meetingInviteCode) {
@@ -843,7 +892,11 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
         emitWebinarAttendeeCountChanged(io, state, context.currentRoom);
         emitWebinarFeedChanged(io, state, context.currentRoom);
 
-        if (webinarConfig.scheduledWebinarId && !wasReconnecting && !existingClient) {
+        if (
+          webinarConfig.scheduledWebinarId &&
+          !isReclaimingExistingSeat &&
+          !existingClient
+        ) {
           const attendeeCount = context.currentRoom.getWebinarAttendeeCount();
           const webinarWithJoinMetric = recordWebinarJoin(
             state.scheduledWebinars,
@@ -886,6 +939,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           roomId,
           rtpCapabilities: context.currentRoom.rtpCapabilities,
           existingProducers,
+          displayNameSnapshot,
           status: "joined",
           hostUserId: context.currentRoom.getHostUserId(),
           hostUserIds: context.currentRoom.getAdminUserIds(),

--- a/packages/sfu/server/socket/handlers/joinRoom.ts
+++ b/packages/sfu/server/socket/handlers/joinRoom.ts
@@ -375,32 +375,51 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
         }
 
         const existingClient = room.getClient(userId);
-        const staleSameIdentityUserIds = Array.from(
+        const staleSameIdentitySeats = Array.from(
           room.userKeysById.entries(),
         )
-          .filter(([candidateUserId, candidateUserKey]) => {
+          .flatMap(([candidateUserId, candidateUserKey]) => {
             if (candidateUserId === userId || candidateUserKey !== userKey) {
-              return false;
+              return [];
             }
             const candidateClient = room.getClient(candidateUserId);
-            return (
-              room.hasPendingDisconnect(candidateUserId) ||
-              candidateClient?.socket.connected === false
-            );
-          })
-          .map(([candidateUserId]) => candidateUserId);
+            if (
+              !(
+                room.hasPendingDisconnect(candidateUserId) ||
+                candidateClient?.socket.connected === false
+              )
+            ) {
+              return [];
+            }
+            return [
+              {
+                userId: candidateUserId,
+                isMeetingParticipant: Boolean(
+                  candidateClient && !candidateClient.isObserver,
+                ),
+                isWebinarAttendee: Boolean(candidateClient?.isWebinarAttendee),
+              },
+            ];
+          });
         const pendingDisconnectStartedAt =
           room.getPendingDisconnectStartedAt(userId);
         const wasReconnectNoticeEmitted =
           room.wasPendingDisconnectNotified(userId);
         const wasReconnecting = room.clearPendingDisconnect(userId);
-        const isReclaimingExistingSeat =
-          wasReconnecting || staleSameIdentityUserIds.length > 0;
-        const reclaimingWebinarSeat = existingClient
-          ? Boolean(existingClient.isWebinarAttendee)
-          : staleSameIdentityUserIds.some((candidateUserId) =>
-              Boolean(room.getClient(candidateUserId)?.isWebinarAttendee),
-            );
+        const isReplacingExistingSeat =
+          Boolean(existingClient) || staleSameIdentitySeats.length > 0;
+        const isReclaimingMeetingParticipantSeat =
+          !isWebinarAttendeeJoin &&
+          Boolean(
+            (existingClient && !existingClient.isObserver) ||
+              staleSameIdentitySeats.some((seat) => seat.isMeetingParticipant),
+          );
+        const reclaimingWebinarSeat =
+          isWebinarAttendeeJoin &&
+          Boolean(
+            existingClient?.isWebinarAttendee ||
+              staleSameIdentitySeats.some((seat) => seat.isWebinarAttendee),
+          );
 
         const removeClientForRejoin = (
           targetUserId: string,
@@ -433,18 +452,6 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           }
         };
 
-        for (const staleUserId of staleSameIdentityUserIds) {
-          Logger.warn(
-            `Reclaiming stale session ${staleUserId} for identity ${userKey} in room ${roomId}`,
-          );
-          removeClientForRejoin(staleUserId, { notifyPeers: true });
-        }
-
-        if (existingClient) {
-          Logger.warn(`User ${userId} re-joining room ${roomId}`);
-          removeClientForRejoin(userId);
-        }
-
         if (
           isWebinarAttendeeJoin &&
           !reclaimingWebinarSeat &&
@@ -452,14 +459,6 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
         ) {
           respond(callback, { error: "Webinar is full." });
           return;
-        }
-
-        const browserState = getBrowserState(roomChannelId);
-        if (browserState.active && room.clients.size === 0) {
-          Logger.info(
-            `[SharedBrowser] Clearing stale browser session for empty room ${roomId}`,
-          );
-          clearBrowserState(roomChannelId);
         }
 
         const isReturningPrimaryHost =
@@ -503,8 +502,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           !isWebinarAttendeeJoin &&
           !isAdminJoin &&
           requiresMeetingInviteCode &&
-          !isReclaimingExistingSeat &&
-          !existingClient;
+          !isReclaimingMeetingParticipantSeat;
 
         if (shouldValidateMeetingInviteCode && !meetingInviteCode) {
           respond(callback, { error: "Meeting invite code required." });
@@ -655,6 +653,30 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
             meetingRequiresInviteCode: room.requiresMeetingInviteCode,
           });
           return;
+        }
+
+        for (const { userId: staleUserId } of staleSameIdentitySeats) {
+          Logger.warn(
+            `Reclaiming stale session ${staleUserId} for identity ${userKey} in room ${roomId}`,
+          );
+          removeClientForRejoin(staleUserId, { notifyPeers: true });
+        }
+
+        if (existingClient) {
+          Logger.warn(`User ${userId} re-joining room ${roomId}`);
+          removeClientForRejoin(userId);
+        }
+
+        const browserState = getBrowserState(roomChannelId);
+        if (
+          browserState.active &&
+          room.clients.size === 0 &&
+          !isReplacingExistingSeat
+        ) {
+          Logger.info(
+            `[SharedBrowser] Clearing stale browser session for empty room ${roomId}`,
+          );
+          clearBrowserState(roomChannelId);
         }
 
         if (
@@ -894,7 +916,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
 
         if (
           webinarConfig.scheduledWebinarId &&
-          !isReclaimingExistingSeat &&
+          !wasReconnecting &&
           !existingClient
         ) {
           const attendeeCount = context.currentRoom.getWebinarAttendeeCount();

--- a/packages/sfu/server/socket/rateLimit.ts
+++ b/packages/sfu/server/socket/rateLimit.ts
@@ -122,4 +122,8 @@ export const RATE_LIMITS = {
   consumerControl: { capacity: 30, refillPerSec: 10 },
   // Shared browser controls proxy to a separate service; keep them coalesced.
   sharedBrowserControl: { capacity: 10, refillPerSec: 2 },
+  // Game moves (answers, votes): tapping should feel instant, abuse should not.
+  gameMove: { capacity: 20, refillPerSec: 8 },
+  // Game lifecycle (start/end/state): low frequency, admin-driven.
+  gameControl: { capacity: 10, refillPerSec: 2 },
 } as const satisfies Record<string, TokenBucketOptions>;

--- a/packages/sfu/server/socket/registerConnectionHandlers.ts
+++ b/packages/sfu/server/socket/registerConnectionHandlers.ts
@@ -14,6 +14,7 @@ import { registerRouterHandlers } from "./handlers/routerHandlers.js";
 import { registerSharedBrowserHandlers } from "./handlers/sharedBrowserHandlers.js";
 import { registerTransportHandlers } from "./handlers/transportHandlers.js";
 import { registerAppsHandlers } from "./handlers/appsHandlers.js";
+import { registerGameHandlers } from "./handlers/gameHandlers.js";
 import { registerWebinarHandlers } from "./handlers/webinarHandlers.js";
 
 export const registerConnectionHandlers = (
@@ -35,6 +36,7 @@ export const registerConnectionHandlers = (
     registerReactionHandlers(context);
     registerHandHandlers(context);
     registerAppsHandlers(context);
+    registerGameHandlers(context);
     registerMeetingHandlers(context);
     registerWebinarHandlers(context);
     registerSharedBrowserHandlers(context);

--- a/packages/sfu/types.ts
+++ b/packages/sfu/types.ts
@@ -59,6 +59,7 @@ export interface JoinRoomResponse {
   roomId?: string;
   rtpCapabilities: RtpCapabilities;
   existingProducers: ProducerInfo[];
+  displayNameSnapshot?: DisplayNameSnapshotEntry[];
   status?: "waiting" | "joined";
   hostUserId?: string | null;
   hostUserIds?: string[];
@@ -167,6 +168,11 @@ export interface ProducerInfo {
   type: "webcam" | "screen";
   paused?: boolean;
   roomId?: string;
+}
+
+export interface DisplayNameSnapshotEntry {
+  userId: string;
+  displayName: string;
 }
 
 export type WebinarFeedMode = "active-speaker";


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds room games and improves participant snapshots during meeting joins. The main changes are:

- New game launcher, docked game panel, and web game views.
- Server-side game registry, game engine, socket handlers, and rate limits.
- Join responses now include display-name snapshots.
- Stale same-identity seat handling was updated for invite-code checks and webinar metrics.

<h3>Confidence Score: 5/5</h3>

The reviewed changes appear safe to merge.

No actionable correctness or security issues were identified in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Base and head clients connected over Socket.IO, where the base join ACK lacked a displayNameSnapshot while the head join ACK now includes displayNameSnapshot and client two receives a displayNameSnapshot event listing both users.
- The head now exposes a playable game API, with game:list returning six catalog entries, game:start returning success with gameId 'would-you-rather', game:getState returning an active state, admin moves and p1 actions returning success, and game:end reporting success while clients receive game:state, private game:view, and game:ended events.
- The head ControlsBar UI changed from the base to include a Games launcher, and the tooltip behavior on hover is now label-only as shown in the updated UI assets.
- The apps-sdk-games harness on head now exports the game APIs and the test completes with exit code 0, emitting socket events and reporting final state including gameId 'tic-tac-toe' and a snapshot board.

<a href="https://app.greptile.com/trex/runs/12546592/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/sfu/server/socket/handlers/joinRoom.ts`, line 501-505 ([link](https://github.com/acm-vit/conclave/blob/6c7bd2233b7b6a19758eb78bea075486285b2033/packages/sfu/server/socket/handlers/joinRoom.ts#L501-L505)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Stale Seat Bypass**

   When an invite-protected meeting has a pending or socket-disconnected participant with the same `userKey`, a new session can still skip invite-code validation. `isReclaimingMeetingParticipantSeat` is set from that stale seat before the stale client is removed, so `shouldValidateMeetingInviteCode` becomes false even when the new join did not provide `meetingInviteCode`. This admits the new session without the required room invite code.

   

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FjoinRoom.ts%0ALine%3A%20501-505%0A%0AComment%3A%0A**Stale%20Seat%20Bypass**%0A%0AWhen%20an%20invite-protected%20meeting%20has%20a%20pending%20or%20socket-disconnected%20participant%20with%20the%20same%20%60userKey%60%2C%20a%20new%20session%20can%20still%20skip%20invite-code%20validation.%20%60isReclaimingMeetingParticipantSeat%60%20is%20set%20from%20that%20stale%20seat%20before%20the%20stale%20client%20is%20removed%2C%20so%20%60shouldValidateMeetingInviteCode%60%20becomes%20false%20even%20when%20the%20new%20join%20did%20not%20provide%20%60meetingInviteCode%60.%20This%20admits%20the%20new%20session%20without%20the%20required%20room%20invite%20code.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20const%20shouldValidateMeetingInviteCode%20%3D%0A%20%20%20%20%20%20%20%20%20%20!isWebinarAttendeeJoin%20%26%26%0A%20%20%20%20%20%20%20%20%20%20!isAdminJoin%20%26%26%0A%20%20%20%20%20%20%20%20%20%20requiresMeetingInviteCode%20%26%26%0A%20%20%20%20%20%20%20%20%20%20!wasReconnecting%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FjoinRoom.ts%0ALine%3A%20501-505%0A%0AComment%3A%0A**Stale%20Seat%20Bypass**%0A%0AWhen%20an%20invite-protected%20meeting%20has%20a%20pending%20or%20socket-disconnected%20participant%20with%20the%20same%20%60userKey%60%2C%20a%20new%20session%20can%20still%20skip%20invite-code%20validation.%20%60isReclaimingMeetingParticipantSeat%60%20is%20set%20from%20that%20stale%20seat%20before%20the%20stale%20client%20is%20removed%2C%20so%20%60shouldValidateMeetingInviteCode%60%20becomes%20false%20even%20when%20the%20new%20join%20did%20not%20provide%20%60meetingInviteCode%60.%20This%20admits%20the%20new%20session%20without%20the%20required%20room%20invite%20code.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20const%20shouldValidateMeetingInviteCode%20%3D%0A%20%20%20%20%20%20%20%20%20%20!isWebinarAttendeeJoin%20%26%26%0A%20%20%20%20%20%20%20%20%20%20!isAdminJoin%20%26%26%0A%20%20%20%20%20%20%20%20%20%20requiresMeetingInviteCode%20%26%26%0A%20%20%20%20%20%20%20%20%20%20!wasReconnecting%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FjoinRoom.ts%0ALine%3A%20501-505%0A%0AComment%3A%0A**Stale%20Seat%20Bypass**%0A%0AWhen%20an%20invite-protected%20meeting%20has%20a%20pending%20or%20socket-disconnected%20participant%20with%20the%20same%20%60userKey%60%2C%20a%20new%20session%20can%20still%20skip%20invite-code%20validation.%20%60isReclaimingMeetingParticipantSeat%60%20is%20set%20from%20that%20stale%20seat%20before%20the%20stale%20client%20is%20removed%2C%20so%20%60shouldValidateMeetingInviteCode%60%20becomes%20false%20even%20when%20the%20new%20join%20did%20not%20provide%20%60meetingInviteCode%60.%20This%20admits%20the%20new%20session%20without%20the%20required%20room%20invite%20code.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20const%20shouldValidateMeetingInviteCode%20%3D%0A%20%20%20%20%20%20%20%20%20%20!isWebinarAttendeeJoin%20%26%26%0A%20%20%20%20%20%20%20%20%20%20!isAdminJoin%20%26%26%0A%20%20%20%20%20%20%20%20%20%20requiresMeetingInviteCode%20%26%26%0A%20%20%20%20%20%20%20%20%20%20!wasReconnecting%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Game socket control events crash because RATE_LIMITS lacks game profiles**

   - **Bug**
     - Emitting `game:start` on head reaches `packages/sfu/server/socket/handlers/gameHandlers.ts`, but the handler calls `takeToken(socket, "game:start", RATE_LIMITS.gameControl)`. `RATE_LIMITS.gameControl` is undefined, so `takeToken` dereferences `options.capacity` and the Socket.IO server process throws instead of acking either the invalid-game validation response or a successful would-you-rather start. The same missing profile also affects `game:vote:open`, and `RATE_LIMITS.gameMove` is missing for `game:vote:cast` and `game:move`.
   - **Cause**
     - `packages/sfu/server/socket/rateLimit.ts` defines many named profiles through `sharedBrowserControl`, but does not define `gameControl` or `gameMove` while the new `gameHandlers.ts` references both.
   - **Fix**
     - Add `gameControl` and `gameMove` entries to `RATE_LIMITS` in `packages/sfu/server/socket/rateLimit.ts` with appropriate capacity/refill settings, or update `gameHandlers.ts` to use existing profiles. Add a socket-level regression test that asserts `game:start` invalid game returns `{ success:false, error:"Unknown game" }` and valid would-you-rather start broadcasts `game:state`/`game:view`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["add"](https://github.com/acm-vit/conclave/commit/aeebf1e0394b09c03dff4c368742e7fc711f841b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40334916)</sub>

<!-- /greptile_comment -->