### PR TITLE
Staging

### DIFF
--- a/apps/web/src/app/api/sfu/join/route.ts
+++ b/apps/web/src/app/api/sfu/join/route.ts
@@ -62,7 +62,7 @@ const CLOUDFLARE_TURN_CREDENTIALS_URL =
   "https://rtc.live.cloudflare.com/v1/turn/keys";
 const CLOUDFLARE_TURN_DEFAULT_TTL_SECONDS = 86400;
 const CLOUDFLARE_TURN_MAX_TTL_SECONDS = 86400;
-const CLOUDFLARE_TURN_REQUEST_TIMEOUT_MS = 5000;
+const CLOUDFLARE_TURN_REQUEST_TIMEOUT_MS = 1500;
 
 type RoomRoutingResponse = {
   owner?: {
@@ -337,6 +337,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Missing session ID" }, { status: 400 });
   }
 
+  const iceServersPromise = resolveIceServers();
   const clientId = resolveClientId(request, body);
   const joinMode =
     body?.joinMode === "webinar_attendee" ? "webinar_attendee" : "meeting";
@@ -440,7 +441,7 @@ export async function POST(request: Request) {
     { expiresIn: "12h" },
   );
 
-  const iceServers = await resolveIceServers();
+  const iceServers = await iceServersPromise;
 
   return NextResponse.json({
     token,

--- a/apps/web/src/app/components/JoinScreen.tsx
+++ b/apps/web/src/app/components/JoinScreen.tsx
@@ -1073,7 +1073,7 @@ function JoinScreen({
                 </div>
               </div>
 
-          <div className="safe-area-pb flex min-h-0 shrink-0 flex-col justify-start gap-3 p-5 sm:gap-4 sm:p-8 md:min-h-[520px] md:justify-center">
+          <div className="safe-area-pb flex min-h-0 shrink-0 flex-col justify-start gap-3 p-5 pb-8 sm:gap-4 sm:p-8 sm:pb-12 md:min-h-[520px] md:justify-center">
             <div className="space-y-1.5">
               <h1
                 className="text-[22px] leading-tight text-[#fafafa]"


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR changes the SFU join path and adjusts spacing on the join screen.

- Starts ICE server resolution earlier in the join API.
- Lowers the Cloudflare TURN request timeout.
- Adds extra bottom padding to the join form panel.

<h3>Confidence Score: 4/5</h3>

The SFU join API can spend TURN credential generation before rejecting unauthorized requests, and slow TURN responses can degrade valid joins to STUN-only connectivity.

- The external TURN request now starts before the auth and room checks complete.
- The shorter timeout can remove TURN servers from otherwise valid join responses.
- The join screen spacing change may hide bottom controls on short mobile screens.

apps/web/src/app/api/sfu/join/route.ts; apps/web/src/app/components/JoinScreen.tsx

<details open><summary><h3>Security Review</h3></summary>

The join API now starts Cloudflare TURN credential generation before session and room authorization complete. Anonymous rejected requests can still trigger that external credential-generation side effect when TURN credentials are configured.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/sfu/join/route.ts | Starts TURN server resolution before authorization finishes and shortens the Cloudflare TURN timeout. |
| apps/web/src/app/components/JoinScreen.tsx | Adds bottom padding to the join form panel inside a constrained layout. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fapi%2Fsfu%2Fjoin%2Froute.ts%3A340%0A**Pre-Auth%20TURN%20Generation**%0A%0AAn%20anonymous%20caller%20can%20send%20parseable%20JSON%20with%20any%20non-empty%20%60roomId%60%20and%20%60sessionId%60%2C%20and%20this%20line%20starts%20the%20Cloudflare%20TURN%20credential%20request%20before%20the%20session%20and%20room%20authorization%20checks%20run.%20Rejected%20joins%20can%20still%20consume%20TURN%20generation%20quota%20or%20rate%20limit%20the%20shared%20Cloudflare%20token%2C%20which%20can%20block%20legitimate%20users%20from%20receiving%20TURN%20servers.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fapi%2Fsfu%2Fjoin%2Froute.ts%3A65%0A**Slow%20TURN%20Falls%20Back**%0A%0AWhen%20Cloudflare%20takes%20longer%20than%201500ms%20to%20generate%20TURN%20credentials%2C%20the%20abort%20path%20is%20caught%20and%20%60resolveIceServers%28%29%60%20returns%20only%20public%20STUN%20servers.%20Valid%20joins%20can%20then%20succeed%20at%20the%20API%20layer%20but%20fail%20media%20connectivity%20for%20users%20behind%20NATs%20that%20require%20TURN.%0A%0A%60%60%60suggestion%0Aconst%20CLOUDFLARE_TURN_REQUEST_TIMEOUT_MS%20%3D%205000%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FJoinScreen.tsx%3A1076%0A**Bottom%20Controls%20Can%20Clip**%0A%0AThis%20panel%20already%20has%20%60safe-area-pb%60%20and%20sits%20inside%20an%20%60overflow-hidden%60%20wrapper%20while%20%60shrink-0%60%20prevents%20it%20from%20compressing.%20On%20short%20mobile%20viewports%2C%20the%20extra%20%60pb-8%60%20or%20%60sm%3Apb-12%60%20can%20push%20the%20join%20and%20invite%20controls%20below%20the%20clipped%20parent%20instead%20of%20making%20them%20scrollable.%0A%0A&repo=acm-vit%2Fconclave&pr=103&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fapi%2Fsfu%2Fjoin%2Froute.ts%3A340%0A**Pre-Auth%20TURN%20Generation**%0A%0AAn%20anonymous%20caller%20can%20send%20parseable%20JSON%20with%20any%20non-empty%20%60roomId%60%20and%20%60sessionId%60%2C%20and%20this%20line%20starts%20the%20Cloudflare%20TURN%20credential%20request%20before%20the%20session%20and%20room%20authorization%20checks%20run.%20Rejected%20joins%20can%20still%20consume%20TURN%20generation%20quota%20or%20rate%20limit%20the%20shared%20Cloudflare%20token%2C%20which%20can%20block%20legitimate%20users%20from%20receiving%20TURN%20servers.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fapi%2Fsfu%2Fjoin%2Froute.ts%3A65%0A**Slow%20TURN%20Falls%20Back**%0A%0AWhen%20Cloudflare%20takes%20longer%20than%201500ms%20to%20generate%20TURN%20credentials%2C%20the%20abort%20path%20is%20caught%20and%20%60resolveIceServers%28%29%60%20returns%20only%20public%20STUN%20servers.%20Valid%20joins%20can%20then%20succeed%20at%20the%20API%20layer%20but%20fail%20media%20connectivity%20for%20users%20behind%20NATs%20that%20require%20TURN.%0A%0A%60%60%60suggestion%0Aconst%20CLOUDFLARE_TURN_REQUEST_TIMEOUT_MS%20%3D%205000%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FJoinScreen.tsx%3A1076%0A**Bottom%20Controls%20Can%20Clip**%0A%0AThis%20panel%20already%20has%20%60safe-area-pb%60%20and%20sits%20inside%20an%20%60overflow-hidden%60%20wrapper%20while%20%60shrink-0%60%20prevents%20it%20from%20compressing.%20On%20short%20mobile%20viewports%2C%20the%20extra%20%60pb-8%60%20or%20%60sm%3Apb-12%60%20can%20push%20the%20join%20and%20invite%20controls%20below%20the%20clipped%20parent%20instead%20of%20making%20them%20scrollable.%0A%0A&repo=acm-vit%2Fconclave&pr=103&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fapi%2Fsfu%2Fjoin%2Froute.ts%3A340%0A**Pre-Auth%20TURN%20Generation**%0A%0AAn%20anonymous%20caller%20can%20send%20parseable%20JSON%20with%20any%20non-empty%20%60roomId%60%20and%20%60sessionId%60%2C%20and%20this%20line%20starts%20the%20Cloudflare%20TURN%20credential%20request%20before%20the%20session%20and%20room%20authorization%20checks%20run.%20Rejected%20joins%20can%20still%20consume%20TURN%20generation%20quota%20or%20rate%20limit%20the%20shared%20Cloudflare%20token%2C%20which%20can%20block%20legitimate%20users%20from%20receiving%20TURN%20servers.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fapi%2Fsfu%2Fjoin%2Froute.ts%3A65%0A**Slow%20TURN%20Falls%20Back**%0A%0AWhen%20Cloudflare%20takes%20longer%20than%201500ms%20to%20generate%20TURN%20credentials%2C%20the%20abort%20path%20is%20caught%20and%20%60resolveIceServers%28%29%60%20returns%20only%20public%20STUN%20servers.%20Valid%20joins%20can%20then%20succeed%20at%20the%20API%20layer%20but%20fail%20media%20connectivity%20for%20users%20behind%20NATs%20that%20require%20TURN.%0A%0A%60%60%60suggestion%0Aconst%20CLOUDFLARE_TURN_REQUEST_TIMEOUT_MS%20%3D%205000%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FJoinScreen.tsx%3A1076%0A**Bottom%20Controls%20Can%20Clip**%0A%0AThis%20panel%20already%20has%20%60safe-area-pb%60%20and%20sits%20inside%20an%20%60overflow-hidden%60%20wrapper%20while%20%60shrink-0%60%20prevents%20it%20from%20compressing.%20On%20short%20mobile%20viewports%2C%20the%20extra%20%60pb-8%60%20or%20%60sm%3Apb-12%60%20can%20push%20the%20join%20and%20invite%20controls%20below%20the%20clipped%20parent%20instead%20of%20making%20them%20scrollable.%0A%0A&pr=103&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["lil ui fix"](https://github.com/acm-vit/conclave/commit/44a083237a5569428326bf1491af68399351b8c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40460623)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->