### PR TITLE
small patch

### DIFF
--- a/apps/web/src/app/components/TranscriptPanel.tsx
+++ b/apps/web/src/app/components/TranscriptPanel.tsx
@@ -227,10 +227,10 @@ function StartStage({
             className="mt-7 w-full max-w-[300px] space-y-2.5"
           >
             <input
-              value={isOnTheHouse ? "On the house" : apiKey}
+              value={isOnTheHouse ? "API Key on the house" : apiKey}
               onChange={(event) => setApiKey(event.target.value)}
               type={isOnTheHouse ? "text" : "password"}
-              placeholder={isOnTheHouse ? "On the house" : "OpenAI API key"}
+              placeholder={isOnTheHouse ? "API Key on the house" : "OpenAI API key"}
               autoComplete="off"
               autoFocus={!isOnTheHouse}
               readOnly={isOnTheHouse}
@@ -771,7 +771,7 @@ export default function TranscriptPanel({
             {isRunning && session.controller ? (
               <p className="mt-0.5 truncate text-[11.5px] text-[#a1a1aa]">
                 Hosted by {session.controller.displayName}
-                {session.keySource === "global" ? " · On the house" : ""}
+                {session.keySource === "global" ? "" : ""}
               </p>
             ) : transcript.isViewOnly ? (
               <p className="mt-0.5 truncate text-[11.5px] text-[#a1a1aa]">


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adjusts the transcript panel copy for hosted API key sessions. The main changes are:

- Renames the start input text to `API Key on the house`.
- Removes the running-session `On the house` suffix from the hosted-by line.

<h3>Confidence Score: 3/5</h3>

The change is small and localized to transcript panel copy, but one live-session state loses important key-source context.

The edited component has a clear regression in user-facing state labeling while the rest of the patch is narrow.

apps/web/src/app/components/TranscriptPanel.tsx

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FTranscriptPanel.tsx%3A774%0A**Global%20Key%20State%20Disappears**%0A%0AWhen%20a%20session%20is%20already%20running%20with%20%60session.keySource%20%3D%3D%3D%20%22global%22%60%2C%20this%20branch%20now%20renders%20the%20same%20text%20as%20a%20controller-key%20session.%20Users%20joining%20a%20live%20room%20no%20longer%20see%20the%20old%20hosted-key%20indicator%2C%20so%20the%20header%20cannot%20tell%20them%20whether%20the%20room%20is%20using%20Conclave's%20shared%20key%20or%20someone's%20provided%20key.%0A%0A&repo=acm-vit%2Fconclave&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FTranscriptPanel.tsx%3A774%0A**Global%20Key%20State%20Disappears**%0A%0AWhen%20a%20session%20is%20already%20running%20with%20%60session.keySource%20%3D%3D%3D%20%22global%22%60%2C%20this%20branch%20now%20renders%20the%20same%20text%20as%20a%20controller-key%20session.%20Users%20joining%20a%20live%20room%20no%20longer%20see%20the%20old%20hosted-key%20indicator%2C%20so%20the%20header%20cannot%20tell%20them%20whether%20the%20room%20is%20using%20Conclave's%20shared%20key%20or%20someone's%20provided%20key.%0A%0A&repo=acm-vit%2Fconclave&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FTranscriptPanel.tsx%3A774%0A**Global%20Key%20State%20Disappears**%0A%0AWhen%20a%20session%20is%20already%20running%20with%20%60session.keySource%20%3D%3D%3D%20%22global%22%60%2C%20this%20branch%20now%20renders%20the%20same%20text%20as%20a%20controller-key%20session.%20Users%20joining%20a%20live%20room%20no%20longer%20see%20the%20old%20hosted-key%20indicator%2C%20so%20the%20header%20cannot%20tell%20them%20whether%20the%20room%20is%20using%20Conclave's%20shared%20key%20or%20someone's%20provided%20key.%0A%0A&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["small patch"](https://github.com/acm-vit/conclave/commit/d6c94f910152b38d88a2c7f1451e1db9a5ee105f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40470868)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->