### PR TITLE
resolve issues

### DIFF
--- a/apps/web/public/transcript-pcm-processor.js
+++ b/apps/web/public/transcript-pcm-processor.js
@@ -11,6 +11,7 @@ class TranscriptPcmProcessor extends AudioWorkletProcessor {
     this.port.onmessage = (event) => {
       if (event.data && event.data.type === "flush") {
         this.flush();
+        this.port.postMessage({ type: "flushed" });
       }
     };
   }

--- a/apps/web/src/app/hooks/useMeetingTranscript.ts
+++ b/apps/web/src/app/hooks/useMeetingTranscript.ts
@@ -83,6 +83,7 @@ type ServerEnvelope =
       delta: Parameters<typeof mergeTranscriptDelta>[1];
     }
   | { type: "segment.final"; segment: TranscriptSegment }
+  | { type: "partials.reset" }
   | { type: "minutes.updated"; minutes: TranscriptMinutesSnapshot }
   | {
       type: "qa.delta";
@@ -385,6 +386,9 @@ export function useMeetingTranscript({
           });
           setSegments((prev) => mergeTranscriptFinal(prev, message.segment));
           return;
+        case "partials.reset":
+          setPartials(new Map());
+          return;
         case "minutes.updated":
           setMinutes(message.minutes);
           return;
@@ -505,7 +509,7 @@ export function useMeetingTranscript({
   }, [connect]);
 
   const reconnect = useCallback(async (): Promise<boolean> => {
-    relayRef.current?.stop();
+    const relay = relayRef.current;
     relayRef.current = null;
     const socket = socketRef.current;
     socketRef.current = null;
@@ -513,6 +517,7 @@ export function useMeetingTranscript({
     setViewerConnectionId(null);
     setIsStreamingAudio(false);
     setAvailableServiceVersion(null);
+    if (relay) await relay.stop();
     try {
       socket?.close();
     } catch {}
@@ -683,10 +688,21 @@ export function useMeetingTranscript({
   useEffect(() => {
     if (!isJoined) {
       subscribedRef.current = false;
-      relayRef.current?.stop();
+      const relay = relayRef.current;
       relayRef.current = null;
-      socketRef.current?.close();
+      const socket = socketRef.current;
       socketRef.current = null;
+      if (relay) {
+        void relay.stop().finally(() => {
+          try {
+            socket?.close();
+          } catch {}
+        });
+      } else {
+        try {
+          socket?.close();
+        } catch {}
+      }
       setConnectionStatus("idle");
       setSession(buildIdleSession(roomId));
       setSegments([]);
@@ -708,8 +724,21 @@ export function useMeetingTranscript({
 
   useEffect(() => {
     return () => {
-      relayRef.current?.stop();
-      socketRef.current?.close();
+      const relay = relayRef.current;
+      const socket = socketRef.current;
+      relayRef.current = null;
+      socketRef.current = null;
+      if (relay) {
+        void relay.stop().finally(() => {
+          try {
+            socket?.close();
+          } catch {}
+        });
+      } else {
+        try {
+          socket?.close();
+        } catch {}
+      }
     };
   }, []);
 
@@ -721,7 +750,7 @@ export function useMeetingTranscript({
       session.controller.connectionId === viewerConnectionId &&
       hasUsableOpenSocket(socketRef.current);
     if (!shouldStream) {
-      relayRef.current?.stop();
+      void relayRef.current?.stop();
       relayRef.current = null;
       setIsStreamingAudio(false);
       return;
@@ -734,9 +763,6 @@ export function useMeetingTranscript({
         },
         onCommit: (speaker) => {
           send({ type: "audio.commit", speaker });
-        },
-        onClear: (speaker) => {
-          send({ type: "audio.clear", speaker });
         },
       });
     }

--- a/apps/web/src/app/lib/transcript-audio.ts
+++ b/apps/web/src/app/lib/transcript-audio.ts
@@ -13,7 +13,6 @@ export interface TranscriptRelaySource {
 export interface TranscriptAudioRelayOptions {
   onAudioChunk: (audioBase64: string, speaker: TranscriptSpeaker) => void;
   onCommit: (speaker: TranscriptSpeaker) => void;
-  onClear: (speaker: TranscriptSpeaker) => void;
 }
 
 type ConnectedSource = {
@@ -27,6 +26,7 @@ type ConnectedSource = {
   lastCommitAt: number;
   pendingChunks: Int16Array[];
   pendingSampleCount: number;
+  flushResolvers: Array<() => void>;
 };
 
 const TARGET_SAMPLE_RATE = 24000;
@@ -111,6 +111,14 @@ const isAudioWorkletProcessor = (
   typeof AudioWorkletNode !== "undefined" &&
   processor instanceof AudioWorkletNode;
 
+const isSameRelaySpeaker = (
+  left: TranscriptSpeaker,
+  right: TranscriptSpeaker,
+): boolean =>
+  left.userId === right.userId &&
+  left.displayName === right.displayName &&
+  left.source === right.source;
+
 export class TranscriptAudioRelay {
   private readonly options: TranscriptAudioRelayOptions;
   private context: AudioContext | null = null;
@@ -152,12 +160,7 @@ export class TranscriptAudioRelay {
 
     for (const [id, connected] of this.connectedSources) {
       if (liveIds.has(id)) continue;
-      if (connected.speaker.source === "local") {
-        this.clearQueuedAudio(connected);
-        this.options.onClear(connected.speaker);
-      } else {
-        this.commitIfNeeded(connected);
-      }
+      await this.flushAndCommit(connected);
       this.disconnectSource(connected);
       this.connectedSources.delete(id);
     }
@@ -165,8 +168,11 @@ export class TranscriptAudioRelay {
     for (const source of liveSources) {
       const existing = this.connectedSources.get(source.id);
       if (existing) {
+        if (!isSameRelaySpeaker(existing.speaker, source.speaker)) {
+          await this.flushAndCommit(existing);
+        }
         existing.speaker = source.speaker;
-        existing.speechGateEnabled = source.speaker.source !== "local";
+        existing.speechGateEnabled = true;
         continue;
       }
       const connected = await this.connectSource(source);
@@ -174,14 +180,13 @@ export class TranscriptAudioRelay {
     }
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     if (this.commitTimer !== null) {
       window.clearInterval(this.commitTimer);
       this.commitTimer = null;
     }
     for (const connected of this.connectedSources.values()) {
-      this.clearQueuedAudio(connected);
-      this.options.onClear(connected.speaker);
+      await this.flushAndCommit(connected);
       this.disconnectSource(connected);
     }
     this.connectedSources.clear();
@@ -207,12 +212,13 @@ export class TranscriptAudioRelay {
       gain,
       processor: await this.createProcessor(),
       speaker: relaySource.speaker,
-      speechGateEnabled: relaySource.speaker.source !== "local",
+      speechGateEnabled: true,
       speechUntil: 0,
       lastChunkAt: 0,
       lastCommitAt: 0,
       pendingChunks: [],
       pendingSampleCount: 0,
+      flushResolvers: [],
     };
 
     this.attachProcessorHandler(connected);
@@ -262,6 +268,10 @@ export class TranscriptAudioRelay {
           buffer?: ArrayBuffer;
           level?: number;
         };
+        if (data.type === "flushed") {
+          this.resolveProcessorFlushes(connected);
+          return;
+        }
         if (data.type !== "pcm" || !data.buffer) return;
         if (!isSpeechFrame(connected, data.level ?? 0)) return;
         this.queueAudioSamples(connected, new Int16Array(data.buffer));
@@ -309,6 +319,35 @@ export class TranscriptAudioRelay {
     this.options.onCommit(connected.speaker);
   }
 
+  private async flushAndCommit(connected: ConnectedSource): Promise<void> {
+    await this.flushProcessor(connected);
+    this.commitIfNeeded(connected);
+  }
+
+  private flushProcessor(connected: ConnectedSource): Promise<void> {
+    if (!isAudioWorkletProcessor(connected.processor)) {
+      return Promise.resolve();
+    }
+    const processor = connected.processor;
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timeout);
+        resolve();
+      };
+      const timeout = window.setTimeout(finish, 80);
+      connected.flushResolvers.push(finish);
+      processor.port.postMessage({ type: "flush" });
+    });
+  }
+
+  private resolveProcessorFlushes(connected: ConnectedSource): void {
+    const resolvers = connected.flushResolvers.splice(0);
+    for (const resolve of resolvers) resolve();
+  }
+
   private queueAudioSamples(
     connected: ConnectedSource,
     samples: Int16Array,
@@ -338,10 +377,4 @@ export class TranscriptAudioRelay {
     );
   }
 
-  private clearQueuedAudio(connected: ConnectedSource): void {
-    connected.pendingChunks = [];
-    connected.pendingSampleCount = 0;
-    connected.lastChunkAt = 0;
-    connected.lastCommitAt = 0;
-  }
 }

--- a/apps/web/transcript-worker/src/room.ts
+++ b/apps/web/transcript-worker/src/room.ts
@@ -571,6 +571,13 @@ export class TranscriptRoom {
 
   private clearAudio(viewer: Viewer): void {
     if (!this.isController(viewer) || !this.openAiSocket) return;
+    if (this.hasPendingAudio && this.latestSpeaker) {
+      this.commitOpenAiBuffer(
+        this.latestSpeaker,
+        "Transcript audio commit failed.",
+      );
+      return;
+    }
     try {
       this.openAiSocket.send(
         JSON.stringify({ type: "input_audio_buffer.clear" }),
@@ -579,8 +586,6 @@ export class TranscriptRoom {
       void this.handleOpenAiFailure("Transcript audio clear failed.");
       return;
     }
-    this.pendingSpeakers = [];
-    this.latestSpeaker = null;
     this.hasPendingAudio = false;
     this.pendingAudioSamples = 0;
   }
@@ -689,11 +694,15 @@ export class TranscriptRoom {
   }
 
   private resetOpenAiAudioState(): void {
+    const hadPartials = this.partialSegments.size > 0;
     this.partialSegments.clear();
     this.pendingSpeakers = [];
     this.latestSpeaker = null;
     this.hasPendingAudio = false;
     this.pendingAudioSamples = 0;
+    if (hadPartials) {
+      this.broadcast({ type: "partials.reset" });
+    }
   }
 
   private async handleOpenAiEvent(raw: string): Promise<void> {


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR changes how transcript audio is flushed and reset.

- Adds a worklet `flushed` acknowledgement.
- Replaces relay clear-on-stop with async flush-and-commit.
- Adds client handling for `partials.reset`.
- Broadcasts partial resets from the transcript worker.

<h3>Confidence Score: 3/5</h3>

Merge safety is reduced because transcript clear and stop paths can finalize audio that callers intended to discard.

The changed audio lifecycle touches cancellation, speaker attribution, and final buffer handling; one clear-path issue was reproduced with runtime evidence, while related paths remain risky from code behavior.

apps/web/transcript-worker/src/room.ts and apps/web/src/app/lib/transcript-audio.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused audio.clear pending-audio harness with a mocked OpenAI socket.
- Observed that the harness emitted input\_audio\_buffer.commit and did not emit input\_audio\_buffer.clear, with the pending speaker queued for finalization.
- Tried to run a focused Vitest harness for a stale speaker after clear, but the run was blocked by a Node.js version mismatch.
- Tried to run a focused Vitest harness for local source removal, injecting queued PCM through the TranscriptAudioRelay, but the run was blocked by a Node.js version mismatch.
- Compared the before and after partial-reset logs to verify how the head transitions from delta updates to a reset of partial words.
- Before: speaker-handoff-01-before.log shows the base state with the checkout and initial speaker information.
- After: speaker-handoff-02-after.log shows that callbacks onAudioChunk and onCommit for Speaker A occur before the update, followed by currentSpeaker=Speaker B and pendingSampleCount=0.
- Before: speech-gate-01-before.log shows queueing and framing details before enabling speech gate.
- After: speech-gate-02-after.log shows speechGateEnabled=true, with below-threshold deliveries producing zero chunks/commits and the speech frame producing chunksAdded=1 and commitsAdded=1.

<a href="https://app.greptile.com/trex/runs/12615915/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fweb%2Ftranscript-worker%2Fsrc%2Froom.ts%3A574-579%0A**Clear%20Commits%20Pending%20Audio**%0A%0AWhen%20a%20controller%20sends%20%60audio.clear%60%20while%20OpenAI%20has%20pending%20audio%2C%20this%20branch%20sends%20%60input_audio_buffer.commit%60%20instead%20of%20%60input_audio_buffer.clear%60.%20A%20caller%20trying%20to%20discard%20buffered%20audio%20now%20finalizes%20it%2C%20so%20cancelled%20or%20teardown%20audio%20can%20appear%20as%20a%20transcript%20segment.%0A%0A%23%23%23%20Issue%202%20of%204%0Aapps%2Fweb%2Ftranscript-worker%2Fsrc%2Froom.ts%3A589-590%0A**Speaker%20State%20Survives%20Clear**%0A%0AAfter%20a%20successful%20OpenAI%20clear%2C%20this%20path%20no%20longer%20resets%20%60pendingSpeakers%60%20or%20%60latestSpeaker%60.%20If%20a%20previous%20commit%20queued%20a%20speaker%20and%20the%20clear%20happens%20before%20the%20transcription%20event%20is%20allocated%2C%20the%20stale%20speaker%20can%20still%20be%20popped%20for%20a%20later%20segment%2C%20which%20can%20attribute%20post-clear%20transcript%20text%20to%20the%20wrong%20person.%0A%0A%23%23%23%20Issue%203%20of%204%0Aapps%2Fweb%2Fsrc%2Fapp%2Flib%2Ftranscript-audio.ts%3A340%0A**Timed%20Flush%20Drops%20Tail%20Audio**%0A%0AIf%20the%20audio%20worklet%20does%20not%20reply%20with%20%60flushed%60%20within%2080ms%2C%20%60flushAndCommit%28%29%60%20continues%20and%20disconnects%20the%20source%20even%20though%20the%20worklet%20may%20still%20hold%20the%20final%20PCM%20frame.%20A%20busy%20audio%20thread%20or%20throttled%20tab%20can%20then%20lose%20the%20end%20of%20a%20source%20during%20stop%2C%20reconnect%2C%20or%20source%20removal.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fweb%2Fsrc%2Fapp%2Flib%2Ftranscript-audio.ts%3A163%0A**Local%20Stop%20Now%20Finalizes%20Audio**%0A%0ARemoved%20local%20sources%20used%20to%20discard%20queued%20audio%20and%20send%20%60audio.clear%60%3B%20this%20path%20now%20flushes%20and%20commits%20every%20source%20type.%20When%20a%20local%20user%20leaves%2C%20reconnects%2C%20or%20loses%20their%20local%20source%2C%20buffered%20local%20audio%20that%20was%20previously%20cancelled%20can%20be%20sent%20to%20OpenAI%20and%20finalized%20in%20the%20transcript.%0A%0A&repo=acm-vit%2Fconclave&pr=109&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fweb%2Ftranscript-worker%2Fsrc%2Froom.ts%3A574-579%0A**Clear%20Commits%20Pending%20Audio**%0A%0AWhen%20a%20controller%20sends%20%60audio.clear%60%20while%20OpenAI%20has%20pending%20audio%2C%20this%20branch%20sends%20%60input_audio_buffer.commit%60%20instead%20of%20%60input_audio_buffer.clear%60.%20A%20caller%20trying%20to%20discard%20buffered%20audio%20now%20finalizes%20it%2C%20so%20cancelled%20or%20teardown%20audio%20can%20appear%20as%20a%20transcript%20segment.%0A%0A%23%23%23%20Issue%202%20of%204%0Aapps%2Fweb%2Ftranscript-worker%2Fsrc%2Froom.ts%3A589-590%0A**Speaker%20State%20Survives%20Clear**%0A%0AAfter%20a%20successful%20OpenAI%20clear%2C%20this%20path%20no%20longer%20resets%20%60pendingSpeakers%60%20or%20%60latestSpeaker%60.%20If%20a%20previous%20commit%20queued%20a%20speaker%20and%20the%20clear%20happens%20before%20the%20transcription%20event%20is%20allocated%2C%20the%20stale%20speaker%20can%20still%20be%20popped%20for%20a%20later%20segment%2C%20which%20can%20attribute%20post-clear%20transcript%20text%20to%20the%20wrong%20person.%0A%0A%23%23%23%20Issue%203%20of%204%0Aapps%2Fweb%2Fsrc%2Fapp%2Flib%2Ftranscript-audio.ts%3A340%0A**Timed%20Flush%20Drops%20Tail%20Audio**%0A%0AIf%20the%20audio%20worklet%20does%20not%20reply%20with%20%60flushed%60%20within%2080ms%2C%20%60flushAndCommit%28%29%60%20continues%20and%20disconnects%20the%20source%20even%20though%20the%20worklet%20may%20still%20hold%20the%20final%20PCM%20frame.%20A%20busy%20audio%20thread%20or%20throttled%20tab%20can%20then%20lose%20the%20end%20of%20a%20source%20during%20stop%2C%20reconnect%2C%20or%20source%20removal.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fweb%2Fsrc%2Fapp%2Flib%2Ftranscript-audio.ts%3A163%0A**Local%20Stop%20Now%20Finalizes%20Audio**%0A%0ARemoved%20local%20sources%20used%20to%20discard%20queued%20audio%20and%20send%20%60audio.clear%60%3B%20this%20path%20now%20flushes%20and%20commits%20every%20source%20type.%20When%20a%20local%20user%20leaves%2C%20reconnects%2C%20or%20loses%20their%20local%20source%2C%20buffered%20local%20audio%20that%20was%20previously%20cancelled%20can%20be%20sent%20to%20OpenAI%20and%20finalized%20in%20the%20transcript.%0A%0A&repo=acm-vit%2Fconclave&pr=109&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fweb%2Ftranscript-worker%2Fsrc%2Froom.ts%3A574-579%0A**Clear%20Commits%20Pending%20Audio**%0A%0AWhen%20a%20controller%20sends%20%60audio.clear%60%20while%20OpenAI%20has%20pending%20audio%2C%20this%20branch%20sends%20%60input_audio_buffer.commit%60%20instead%20of%20%60input_audio_buffer.clear%60.%20A%20caller%20trying%20to%20discard%20buffered%20audio%20now%20finalizes%20it%2C%20so%20cancelled%20or%20teardown%20audio%20can%20appear%20as%20a%20transcript%20segment.%0A%0A%23%23%23%20Issue%202%20of%204%0Aapps%2Fweb%2Ftranscript-worker%2Fsrc%2Froom.ts%3A589-590%0A**Speaker%20State%20Survives%20Clear**%0A%0AAfter%20a%20successful%20OpenAI%20clear%2C%20this%20path%20no%20longer%20resets%20%60pendingSpeakers%60%20or%20%60latestSpeaker%60.%20If%20a%20previous%20commit%20queued%20a%20speaker%20and%20the%20clear%20happens%20before%20the%20transcription%20event%20is%20allocated%2C%20the%20stale%20speaker%20can%20still%20be%20popped%20for%20a%20later%20segment%2C%20which%20can%20attribute%20post-clear%20transcript%20text%20to%20the%20wrong%20person.%0A%0A%23%23%23%20Issue%203%20of%204%0Aapps%2Fweb%2Fsrc%2Fapp%2Flib%2Ftranscript-audio.ts%3A340%0A**Timed%20Flush%20Drops%20Tail%20Audio**%0A%0AIf%20the%20audio%20worklet%20does%20not%20reply%20with%20%60flushed%60%20within%2080ms%2C%20%60flushAndCommit%28%29%60%20continues%20and%20disconnects%20the%20source%20even%20though%20the%20worklet%20may%20still%20hold%20the%20final%20PCM%20frame.%20A%20busy%20audio%20thread%20or%20throttled%20tab%20can%20then%20lose%20the%20end%20of%20a%20source%20during%20stop%2C%20reconnect%2C%20or%20source%20removal.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fweb%2Fsrc%2Fapp%2Flib%2Ftranscript-audio.ts%3A163%0A**Local%20Stop%20Now%20Finalizes%20Audio**%0A%0ARemoved%20local%20sources%20used%20to%20discard%20queued%20audio%20and%20send%20%60audio.clear%60%3B%20this%20path%20now%20flushes%20and%20commits%20every%20source%20type.%20When%20a%20local%20user%20leaves%2C%20reconnects%2C%20or%20loses%20their%20local%20source%2C%20buffered%20local%20audio%20that%20was%20previously%20cancelled%20can%20be%20sent%20to%20OpenAI%20and%20finalized%20in%20the%20transcript.%0A%0A&pr=109&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["resolve issues"](https://github.com/acm-vit/conclave/commit/3b25597c81c32a22d7507d23f3b9a54b286fbaff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40482527)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->