### PR TITLE
fix: load sfu env file in deploy compose

### DIFF
--- a/scripts/deploy-sfu.sh
+++ b/scripts/deploy-sfu.sh
@@ -63,7 +63,11 @@ if [[ "$HAS_UPSTASH" != "true" && -z "${REDIS_PASSWORD:-}" && -z "${REDIS_URL:-}
   exit 1
 fi
 
-COMPOSE=(docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE")
+COMPOSE_ENV_FILES=(--env-file "$ENV_FILE")
+if [[ -f "$SFU_ENV_FILE" ]]; then
+  COMPOSE_ENV_FILES+=(--env-file "$SFU_ENV_FILE")
+fi
+COMPOSE=(docker compose "${COMPOSE_ENV_FILES[@]}" -f "$COMPOSE_FILE")
 HAS_REDIS_SERVICE="false"
 if "${COMPOSE[@]}" config --services | rg -x "redis" >/dev/null 2>&1; then
   HAS_REDIS_SERVICE="true"


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR makes the SFU deploy script pass the package env file to Docker Compose. The main changes are:

- Builds a Compose env-file argument list.
- Adds `packages/sfu/.env` when it exists.
- Keeps the existing Compose file and command flow.

<h3>Confidence Score: 3/5</h3>

The change is small and localized, but deployment behavior can differ when both root and package env files define the same Compose interpolation keys.

The modified script is straightforward, with the main risk concentrated in env-file ordering and precedence during deploy.

scripts/deploy-sfu.sh

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before running the environment load, T-Rex inspected the initial Compose setup and noted that only the root .env file was used, with docker shim reporting env\_file\_count=1 and SFU\_REQUIRE\_REDIS\_ADAPTER unset.
- After applying the environment changes, T-Rex re-inspected the Compose setup and confirmed that head COMPOSE now loads both root/.env and packages/sfu/.env, with docker shim reporting env\_file\_count=2 and SFU\_REQUIRE\_REDIS\_ADAPTER set to fixture-sfu-only-value.

<a href="https://app.greptile.com/trex/runs/12616176/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fdeploy-sfu.sh%3A67-68%0A**SFU%20Env%20Shadows%20Root%20Settings**%0A%0AWhen%20%60packages%2Fsfu%2F.env%60%20exists%20and%20defines%20a%20shared%20key%20such%20as%20%60REDIS_URL%60%2C%20%60ANNOUNCED_IP%60%2C%20or%20%60BROWSER_SERVICE_URL%60%2C%20this%20second%20%60--env-file%60%20wins%20during%20Compose%20interpolation.%20A%20stale%20package%20env%20file%20can%20silently%20override%20the%20root%20deployment%20settings%20and%20start%20the%20SFU%20with%20the%20wrong%20Redis%20endpoint%2C%20announced%20IP%2C%20or%20service%20URL.%0A%0A&repo=acm-vit%2Fconclave&pr=110&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fdeploy-sfu.sh%3A67-68%0A**SFU%20Env%20Shadows%20Root%20Settings**%0A%0AWhen%20%60packages%2Fsfu%2F.env%60%20exists%20and%20defines%20a%20shared%20key%20such%20as%20%60REDIS_URL%60%2C%20%60ANNOUNCED_IP%60%2C%20or%20%60BROWSER_SERVICE_URL%60%2C%20this%20second%20%60--env-file%60%20wins%20during%20Compose%20interpolation.%20A%20stale%20package%20env%20file%20can%20silently%20override%20the%20root%20deployment%20settings%20and%20start%20the%20SFU%20with%20the%20wrong%20Redis%20endpoint%2C%20announced%20IP%2C%20or%20service%20URL.%0A%0A&repo=acm-vit%2Fconclave&pr=110&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fdeploy-sfu.sh%3A67-68%0A**SFU%20Env%20Shadows%20Root%20Settings**%0A%0AWhen%20%60packages%2Fsfu%2F.env%60%20exists%20and%20defines%20a%20shared%20key%20such%20as%20%60REDIS_URL%60%2C%20%60ANNOUNCED_IP%60%2C%20or%20%60BROWSER_SERVICE_URL%60%2C%20this%20second%20%60--env-file%60%20wins%20during%20Compose%20interpolation.%20A%20stale%20package%20env%20file%20can%20silently%20override%20the%20root%20deployment%20settings%20and%20start%20the%20SFU%20with%20the%20wrong%20Redis%20endpoint%2C%20announced%20IP%2C%20or%20service%20URL.%0A%0A&pr=110&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: load sfu env file in deploy compose"](https://github.com/acm-vit/conclave/commit/af68deeae2263b3220bd7ab360c197ada3b1cce0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40482976)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->