### PR TITLE
Staging

### DIFF
--- a/apps/web/src/app/hooks/useMeetingTranscript.ts
+++ b/apps/web/src/app/hooks/useMeetingTranscript.ts
@@ -169,6 +169,7 @@ export function useMeetingTranscript({
   isMuted,
   localStream,
   participants,
+  activeSpeakerId,
   isViewOnly = false,
   resolveDisplayName,
   getTranscriptToken,
@@ -205,11 +206,22 @@ export function useMeetingTranscript({
   const subscribedRef = useRef(false);
   const connectRef = useRef<(() => Promise<boolean>) | null>(null);
   const serviceVersionRef = useRef<TranscriptServiceVersion | null>(null);
+  const autoTakeoverAttemptRef = useRef<string | null>(null);
 
   const transcriptSources = useMemo<TranscriptRelaySource[]>(() => {
     const sources: TranscriptRelaySource[] = [];
     if (isViewOnly) return sources;
-    if (!isMuted && isLiveAudioStream(localStream)) {
+    const activeRemoteParticipant =
+      activeSpeakerId && activeSpeakerId !== currentUserId
+        ? participants.get(activeSpeakerId)
+        : null;
+    const activeRemoteHasAudio = Boolean(
+      activeRemoteParticipant &&
+        ((!activeRemoteParticipant.isMuted &&
+          isLiveAudioStream(activeRemoteParticipant.audioStream)) ||
+          isLiveAudioStream(activeRemoteParticipant.screenShareAudioStream)),
+    );
+    if (!activeRemoteHasAudio && !isMuted && isLiveAudioStream(localStream)) {
       sources.push({
         id: `local:${localStream!.id}`,
         stream: localStream!,
@@ -246,6 +258,7 @@ export function useMeetingTranscript({
     }
     return sources;
   }, [
+    activeSpeakerId,
     currentDisplayName,
     currentUserId,
     isMuted,
@@ -616,6 +629,38 @@ export function useMeetingTranscript({
       setPermissionError,
     ],
   );
+
+  useEffect(() => {
+    if (
+      isViewOnly ||
+      !hasGlobalOpenAiKey ||
+      session.status !== "takeover_needed" ||
+      session.controller?.userId !== currentUserId ||
+      tokenInfo?.capabilities.takeover === false
+    ) {
+      return;
+    }
+
+    const attemptKey = [
+      session.controller.connectionId,
+      session.updatedAt,
+      serviceVersion?.id ?? "unknown",
+    ].join(":");
+    if (autoTakeoverAttemptRef.current === attemptKey) return;
+    autoTakeoverAttemptRef.current = attemptKey;
+    void takeover({});
+  }, [
+    currentUserId,
+    hasGlobalOpenAiKey,
+    isViewOnly,
+    serviceVersion?.id,
+    session.controller?.connectionId,
+    session.controller?.userId,
+    session.status,
+    session.updatedAt,
+    takeover,
+    tokenInfo?.capabilities.takeover,
+  ]);
 
   const stop = useCallback(() => {
     if (!canStop) {

--- a/apps/web/test/transcript-session-recovery.test.ts
+++ b/apps/web/test/transcript-session-recovery.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type {
+  TranscriptServiceVersion,
+  TranscriptSessionState,
+} from "@conclave/meeting-core/transcript-types";
+import {
+  recoverPersistedTranscriptSession,
+  TRANSCRIPT_RELAY_RECOVERED_MESSAGE,
+  TRANSCRIPT_WORKER_UPDATED_MESSAGE,
+} from "../transcript-worker/src/session-recovery";
+
+const version = (id: string): TranscriptServiceVersion => ({
+  id,
+  tag: null,
+  timestamp: null,
+});
+
+const session = (
+  overrides: Partial<TranscriptSessionState> = {},
+): TranscriptSessionState => ({
+  roomId: "room-a",
+  status: "live",
+  controller: {
+    userId: "u1",
+    displayName: "Ada",
+    connectionId: "conn-a",
+    startedAt: 1,
+    lastSeenAt: 2,
+  },
+  transcriptModel: "gpt-realtime-whisper",
+  qaModel: "gpt-5.5",
+  keySource: "global",
+  startedAt: 1,
+  updatedAt: 2,
+  error: null,
+  ...overrides,
+});
+
+describe("recoverPersistedTranscriptSession", () => {
+  it("turns active sessions from older worker versions into service-update takeover", () => {
+    const recovered = recoverPersistedTranscriptSession(
+      session(),
+      version("old"),
+      version("new"),
+    );
+
+    expect(recovered.status).toBe("takeover_needed");
+    expect(recovered.error).toBe(TRANSCRIPT_WORKER_UPDATED_MESSAGE);
+  });
+
+  it("preserves a same-version recovered relay message for active sessions", () => {
+    const recovered = recoverPersistedTranscriptSession(
+      session(),
+      version("same"),
+      version("same"),
+    );
+
+    expect(recovered.status).toBe("takeover_needed");
+    expect(recovered.error).toBe(TRANSCRIPT_RELAY_RECOVERED_MESSAGE);
+  });
+
+  it("rewrites legacy controller-disconnected snapshots when version metadata is missing", () => {
+    const recovered = recoverPersistedTranscriptSession(
+      session({
+        status: "takeover_needed",
+        error: "Transcript controller disconnected.",
+      }),
+      undefined,
+      version("new"),
+    );
+
+    expect(recovered.status).toBe("takeover_needed");
+    expect(recovered.error).toBe(TRANSCRIPT_WORKER_UPDATED_MESSAGE);
+  });
+});

--- a/apps/web/test/transcript-speaker-attribution.test.ts
+++ b/apps/web/test/transcript-speaker-attribution.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { TranscriptSpeaker } from "@conclave/meeting-core/transcript-types";
+import { TranscriptSpeakerAttribution } from "../transcript-worker/src/speaker-attribution";
+
+const speaker = (
+  userId: string,
+  displayName: string,
+): TranscriptSpeaker => ({
+  userId,
+  displayName,
+  source: "remote",
+});
+
+describe("TranscriptSpeakerAttribution", () => {
+  it("binds committed OpenAI item IDs to the committed speaker", () => {
+    const attribution = new TranscriptSpeakerAttribution();
+    const ada = speaker("u1", "Ada");
+    const grace = speaker("u2", "Grace");
+
+    attribution.enqueueCommit(ada);
+    attribution.enqueueCommit(grace);
+
+    expect(attribution.bindCommittedItem("item-a")).toEqual(ada);
+    expect(attribution.bindCommittedItem("item-b")).toEqual(grace);
+    expect(attribution.getItemSpeaker("item-a")).toEqual(ada);
+    expect(attribution.getItemSpeaker("item-b")).toEqual(grace);
+  });
+
+  it("keeps item lookup stable when transcription finals arrive out of order", () => {
+    const attribution = new TranscriptSpeakerAttribution();
+    const ada = speaker("u1", "Ada");
+    const grace = speaker("u2", "Grace");
+
+    attribution.enqueueCommit(ada);
+    attribution.enqueueCommit(grace);
+    attribution.bindCommittedItem("item-a");
+    attribution.bindCommittedItem("item-b");
+
+    expect(attribution.getItemSpeaker("item-b")).toEqual(grace);
+    expect(attribution.getItemSpeaker("item-a")).toEqual(ada);
+  });
+
+  it("clears pending and committed speaker state between sessions", () => {
+    const attribution = new TranscriptSpeakerAttribution();
+
+    attribution.enqueueCommit(speaker("u1", "Ada"));
+    attribution.bindCommittedItem("item-a");
+    attribution.reset();
+
+    expect(attribution.peekPendingSpeaker()).toBeNull();
+    expect(attribution.getItemSpeaker("item-a")).toBeNull();
+    expect(attribution.bindCommittedItem("item-b")).toBeNull();
+  });
+});

--- a/apps/web/transcript-worker/src/room.ts
+++ b/apps/web/transcript-worker/src/room.ts
@@ -36,6 +36,8 @@ import {
   type TranscriptRateBucketName,
 } from "./rate-limit";
 import { getTranscriptServiceVersion } from "./service-version";
+import { recoverPersistedTranscriptSession } from "./session-recovery";
+import { TranscriptSpeakerAttribution } from "./speaker-attribution";
 import {
   canRefreshTranscriptMinutes,
   canStopTranscriptSession,
@@ -85,7 +87,7 @@ export class TranscriptRoom {
   private readonly loaded: Promise<void>;
   private readonly viewers = new Map<WebSocket, Viewer>();
   private readonly partialSegments = new Map<string, TranscriptSegment>();
-  private pendingSpeakers: TranscriptSpeaker[] = [];
+  private readonly speakerAttribution = new TranscriptSpeakerAttribution();
   private latestSpeaker: TranscriptSpeaker | null = null;
   private hasPendingAudio = false;
   private pendingAudioSamples = 0;
@@ -192,22 +194,14 @@ export class TranscriptRoom {
   private async load(): Promise<void> {
     const snapshot = await this.state.storage.get<PersistedSnapshot>("snapshot");
     if (!snapshot) return;
-    this.session = snapshot.session;
+    this.session = recoverPersistedTranscriptSession(
+      snapshot.session,
+      snapshot.serviceVersion,
+      this.serviceVersion(),
+    );
     this.segments = snapshot.segments ?? [];
     this.minutes = snapshot.minutes ?? createEmptyMinutes(this.session.qaModel);
     this.sequence = snapshot.sequence ?? this.segments.length;
-    if (
-      this.session.status === "live" ||
-      this.session.status === "starting" ||
-      this.session.status === "stopping"
-    ) {
-      this.session = {
-        ...this.session,
-        status: "takeover_needed",
-        updatedAt: Date.now(),
-        error: "Transcript relay recovered without the in-memory OpenAI key.",
-      };
-    }
   }
 
   private ensureSession(roomId: string): TranscriptSessionState {
@@ -344,10 +338,10 @@ export class TranscriptRoom {
       this.markTakeoverNeeded("Transcript controller disconnected.");
       this.broadcast({
         type: "handoff.requested",
-      session: this.session,
-      globalOpenAiKeyAvailable: this.hasGlobalOpenAiKey(),
-      serviceVersion: this.serviceVersion(),
-    });
+        session: this.session,
+        globalOpenAiKeyAvailable: this.hasGlobalOpenAiKey(),
+        serviceVersion: this.serviceVersion(),
+      });
       await this.persist();
     }
     await this.armCleanupAlarm();
@@ -559,7 +553,7 @@ export class TranscriptRoom {
       this.openAiSocket.send(
         JSON.stringify({ type: "input_audio_buffer.commit" }),
       );
-      this.pendingSpeakers.push(speaker);
+      this.speakerAttribution.enqueueCommit(speaker);
       this.hasPendingAudio = false;
       this.pendingAudioSamples = 0;
       return true;
@@ -696,7 +690,7 @@ export class TranscriptRoom {
   private resetOpenAiAudioState(): void {
     const hadPartials = this.partialSegments.size > 0;
     this.partialSegments.clear();
-    this.pendingSpeakers = [];
+    this.speakerAttribution.reset();
     this.latestSpeaker = null;
     this.hasPendingAudio = false;
     this.pendingAudioSamples = 0;
@@ -713,6 +707,13 @@ export class TranscriptRoom {
       await this.handleOpenAiFailure(
         event.error?.message || "Realtime transcription error.",
       );
+      return;
+    }
+    if (event.type === "input_audio_buffer.committed" && event.item_id) {
+      const speaker = this.speakerAttribution.bindCommittedItem(event.item_id);
+      if (speaker) {
+        this.reassignSegmentSpeaker(event.item_id, speaker);
+      }
       return;
     }
     if (
@@ -754,7 +755,8 @@ export class TranscriptRoom {
     const existing = this.partialSegments.get(itemId);
     if (existing) return existing;
     const speaker =
-      this.pendingSpeakers.shift() ??
+      this.speakerAttribution.getItemSpeaker(itemId) ??
+      this.speakerAttribution.peekPendingSpeaker() ??
       this.latestSpeaker ??
       normalizeSpeaker(undefined, {
         userId: this.session?.controller?.userId || "unknown",
@@ -779,6 +781,77 @@ export class TranscriptRoom {
     return segment;
   }
 
+  private reassignSegmentSpeaker(
+    itemId: string,
+    speaker: TranscriptSpeaker,
+  ): void {
+    const partial = this.partialSegments.get(itemId);
+    if (partial && !this.hasSegmentSpeaker(partial, speaker)) {
+      const now = Date.now();
+      const next: TranscriptSegment = {
+        ...partial,
+        speakerUserId: speaker.userId,
+        speakerDisplayName: speaker.displayName,
+        source: speaker.source,
+        updatedAt: now,
+      };
+      this.partialSegments.set(itemId, next);
+      this.broadcast({
+        type: "segment.delta",
+        delta: this.toSegmentDelta(next, "", now),
+      });
+    }
+
+    const finalIndex = this.segments.findIndex(
+      (candidate) => candidate.itemId === itemId,
+    );
+    if (finalIndex < 0) return;
+
+    const finalSegment = this.segments[finalIndex];
+    if (!finalSegment || this.hasSegmentSpeaker(finalSegment, speaker)) return;
+    const nextFinal: TranscriptSegment = {
+      ...finalSegment,
+      speakerUserId: speaker.userId,
+      speakerDisplayName: speaker.displayName,
+      source: speaker.source,
+      updatedAt: Date.now(),
+    };
+    this.segments[finalIndex] = nextFinal;
+    this.broadcast({ type: "segment.final", segment: nextFinal });
+  }
+
+  private hasSegmentSpeaker(
+    segment: TranscriptSegment,
+    speaker: TranscriptSpeaker,
+  ): boolean {
+    return (
+      segment.speakerUserId === speaker.userId &&
+      segment.speakerDisplayName === speaker.displayName &&
+      segment.source === speaker.source
+    );
+  }
+
+  private toSegmentDelta(
+    segment: TranscriptSegment,
+    delta: string,
+    updatedAt: number,
+  ): TranscriptSegmentDelta {
+    return {
+      id: segment.id,
+      itemId: segment.itemId,
+      sequence: segment.sequence,
+      speaker: {
+        userId: segment.speakerUserId,
+        displayName: segment.speakerDisplayName,
+        source: segment.source,
+      },
+      text: segment.text,
+      delta,
+      startMs: segment.startMs,
+      updatedAt,
+    };
+  }
+
   private applyTranscriptDelta(itemId: string, delta: string): void {
     const segment = this.allocateSegment(itemId);
     const now = Date.now();
@@ -788,21 +861,10 @@ export class TranscriptRoom {
       updatedAt: now,
     };
     this.partialSegments.set(itemId, next);
-    const envelope: TranscriptSegmentDelta = {
-      id: next.id,
-      itemId: next.itemId,
-      sequence: next.sequence,
-      speaker: {
-        userId: next.speakerUserId,
-        displayName: next.speakerDisplayName,
-        source: next.source,
-      },
-      text: next.text,
-      delta,
-      startMs: next.startMs,
-      updatedAt: now,
-    };
-    this.broadcast({ type: "segment.delta", delta: envelope });
+    this.broadcast({
+      type: "segment.delta",
+      delta: this.toSegmentDelta(next, delta, now),
+    });
   }
 
   private async applyTranscriptFinal(
@@ -1005,6 +1067,7 @@ export class TranscriptRoom {
       segments: this.segments,
       minutes: this.minutes,
       sequence: this.sequence,
+      serviceVersion: this.serviceVersion(),
     } satisfies PersistedSnapshot);
     await this.armCleanupAlarm();
   }

--- a/apps/web/transcript-worker/src/session-recovery.ts
+++ b/apps/web/transcript-worker/src/session-recovery.ts
@@ -1,0 +1,60 @@
+import type {
+  TranscriptServiceVersion,
+  TranscriptSessionState,
+} from "@conclave/meeting-core/transcript-types";
+
+export const TRANSCRIPT_WORKER_UPDATED_MESSAGE =
+  "Transcript worker updated. Resume or take over to keep transcription running.";
+
+export const TRANSCRIPT_RELAY_RECOVERED_MESSAGE =
+  "Transcript relay recovered. Resume or take over to keep transcription running.";
+
+const ACTIVE_RECOVERY_STATUSES = new Set<TranscriptSessionState["status"]>([
+  "live",
+  "starting",
+  "stopping",
+]);
+
+const shouldTreatAsServiceUpdate = (
+  snapshotVersion: TranscriptServiceVersion | undefined,
+  currentVersion: TranscriptServiceVersion,
+): boolean => !snapshotVersion?.id || snapshotVersion.id !== currentVersion.id;
+
+const isLegacyControllerDisconnect = (message: string | null | undefined) =>
+  !message || /controller disconnected|recovered without/i.test(message);
+
+export const recoverPersistedTranscriptSession = (
+  session: TranscriptSessionState,
+  snapshotVersion: TranscriptServiceVersion | undefined,
+  currentVersion: TranscriptServiceVersion,
+): TranscriptSessionState => {
+  const serviceUpdated = shouldTreatAsServiceUpdate(
+    snapshotVersion,
+    currentVersion,
+  );
+
+  if (ACTIVE_RECOVERY_STATUSES.has(session.status)) {
+    return {
+      ...session,
+      status: "takeover_needed",
+      updatedAt: Date.now(),
+      error: serviceUpdated
+        ? TRANSCRIPT_WORKER_UPDATED_MESSAGE
+        : TRANSCRIPT_RELAY_RECOVERED_MESSAGE,
+    };
+  }
+
+  if (
+    session.status === "takeover_needed" &&
+    serviceUpdated &&
+    isLegacyControllerDisconnect(session.error)
+  ) {
+    return {
+      ...session,
+      updatedAt: Date.now(),
+      error: TRANSCRIPT_WORKER_UPDATED_MESSAGE,
+    };
+  }
+
+  return session;
+};

--- a/apps/web/transcript-worker/src/speaker-attribution.ts
+++ b/apps/web/transcript-worker/src/speaker-attribution.ts
@@ -1,0 +1,30 @@
+import type { TranscriptSpeaker } from "@conclave/meeting-core/transcript-types";
+
+export class TranscriptSpeakerAttribution {
+  private readonly pendingCommitSpeakers: TranscriptSpeaker[] = [];
+  private readonly itemSpeakers = new Map<string, TranscriptSpeaker>();
+
+  enqueueCommit(speaker: TranscriptSpeaker): void {
+    this.pendingCommitSpeakers.push(speaker);
+  }
+
+  bindCommittedItem(itemId: string): TranscriptSpeaker | null {
+    const speaker = this.pendingCommitSpeakers.shift() ?? null;
+    if (!speaker) return null;
+    this.itemSpeakers.set(itemId, speaker);
+    return speaker;
+  }
+
+  getItemSpeaker(itemId: string): TranscriptSpeaker | null {
+    return this.itemSpeakers.get(itemId) ?? null;
+  }
+
+  peekPendingSpeaker(): TranscriptSpeaker | null {
+    return this.pendingCommitSpeakers[0] ?? null;
+  }
+
+  reset(): void {
+    this.pendingCommitSpeakers.length = 0;
+    this.itemSpeakers.clear();
+  }
+}

--- a/apps/web/transcript-worker/src/types.ts
+++ b/apps/web/transcript-worker/src/types.ts
@@ -55,6 +55,7 @@ export type PersistedSnapshot = {
   segments: TranscriptSegment[];
   minutes: TranscriptMinutesSnapshot;
   sequence: number;
+  serviceVersion?: TranscriptServiceVersion;
 };
 
 export type ClientEnvelope =
@@ -88,6 +89,7 @@ export type QaAskEnvelope = Extract<ClientEnvelope, { type: "qa.ask" }>;
 export type OpenAiRealtimeEvent = {
   type?: string;
   item_id?: string;
+  previous_item_id?: string;
   delta?: string;
   transcript?: string;
   error?: {

--- a/packages/sfu/config/config.ts
+++ b/packages/sfu/config/config.ts
@@ -322,7 +322,7 @@ export const config = {
     timeoutMs: toNumber(process.env.SFU_GAME_AI_TIMEOUT_MS, 25000, {
       integer: true,
       min: 500,
-      max: 30000,
+      max: 120000,
     }),
     maxOutputTokens: toNumber(process.env.SFU_GAME_AI_MAX_OUTPUT_TOKENS, 2200, {
       integer: true,

--- a/packages/sfu/server/games/aiContent.ts
+++ b/packages/sfu/server/games/aiContent.ts
@@ -23,7 +23,7 @@ type GeneratedContentRequest<T> = {
 
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/g;
 const MAX_GENERATED_TEXT_LENGTH = 240;
-const CURRENT_TOPIC_TIMEOUT_MS = 25_000;
+const CURRENT_TOPIC_TIMEOUT_MS = 60_000;
 const CURRENT_TOPIC_PATTERN =
   /\b(latest|recent|current|news|today|this week|this month|this year|breaking|new)\b/i;
 


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR updates transcript recovery, speaker attribution, and game AI timeout behavior. The main changes are:

- Persisted transcript sessions now store worker service version data.
- Recovered live transcript sessions can move into takeover flow.
- The client can auto-take over eligible recovered sessions.
- Transcript speaker attribution now binds committed OpenAI item IDs to speakers.
- Local transcript capture now reacts to the active remote speaker.
- Game AI timeout limits were increased.

<h3>Confidence Score: 4/5</h3>

The changes are mostly contained, but transcript capture has a confirmed source-selection failure that can drop local speech during speaker transitions.

Focused execution reproduced the local-audio omission path, and the remaining issues are localized to transcript recovery and speaker attribution behavior.

apps/web/src/app/hooks/useMeetingTranscript.ts and apps/web/transcript-worker/src/room.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Proof 0: Reproduced the stale remote speaker suppression scenario using a focused Node runtime harness and observed that when the local user begins talking while the remote is still active, the relay sources include only the remote stream during the stale active-speaker window.
- Proof 1: Validated session recovery behavior across before/after commits using the validation harness, showing updated transcripts and that snapshot persistence now includes serviceVersion.
- Proof 2: Tried the repository Vitest test for speaker attribution but environment restrictions blocked the run; a focused harness execution was captured as the successful artifact.
- Proof 3: Compared SFU configuration before and after, noting updated timeouts and that the harness inspector is attached and used to verify the new defaults.

<a href="https://app.greptile.com/trex/runs/12616890/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetingTranscript.ts%3A225%0A**Stale%20Remote%20Speaker%20Suppresses%20Local%20Audio**%0A%0AWhen%20a%20remote%20participant%20was%20the%20active%20speaker%20and%20then%20goes%20quiet%2C%20the%20active-speaker%20state%20can%20linger%20while%20their%20stream%20is%20still%20live.%20During%20that%20window%20this%20branch%20drops%20the%20local%20mic%20from%20%60transcriptSources%60%2C%20so%20if%20the%20local%20user%20starts%20talking%20immediately%20after%20the%20remote%20speaker%2C%20the%20relay%20can%20receive%20only%20the%20silent%20remote%20stream%20and%20miss%20the%20start%20of%20the%20local%20utterance.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetingTranscript.ts%3A637%0A**Recovered%20Error%20Sessions%20Do%20Not%20Resume**%0A%0AThe%20automatic%20takeover%20only%20runs%20for%20%60takeover_needed%60%2C%20but%20the%20server%20takeover%20policy%20also%20accepts%20%60error%60.%20If%20a%20persisted%20transcript%20session%20is%20already%20in%20%60error%60%20when%20the%20worker%20recovers%20or%20updates%2C%20recovery%20leaves%20that%20status%20unchanged%2C%20so%20the%20original%20controller%20with%20a%20global%20key%20will%20not%20auto-resume%20and%20the%20session%20stays%20stuck%20until%20a%20manual%20action%20happens.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Ftranscript-worker%2Fsrc%2Froom.ts%3A758%0A**Unbound%20Items%20Reuse%20Pending%20Speakers**%0A%0AIf%20OpenAI%20sends%20a%20transcription%20delta%20or%20final%20for%20an%20item%20before%2C%20or%20without%2C%20the%20matching%20%60input_audio_buffer.committed%60%20event%2C%20this%20fallback%20assigns%20the%20segment%20from%20the%20head%20of%20the%20pending%20commit%20queue%20without%20consuming%20it.%20The%20next%20committed%20item%20can%20then%20bind%20that%20stale%20speaker%20to%20a%20different%20%60item_id%60%2C%20causing%20later%20transcript%20segments%20to%20show%20the%20wrong%20speaker%20and%20never%20be%20corrected.%0A%0A&repo=acm-vit%2Fconclave&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetingTranscript.ts%3A225%0A**Stale%20Remote%20Speaker%20Suppresses%20Local%20Audio**%0A%0AWhen%20a%20remote%20participant%20was%20the%20active%20speaker%20and%20then%20goes%20quiet%2C%20the%20active-speaker%20state%20can%20linger%20while%20their%20stream%20is%20still%20live.%20During%20that%20window%20this%20branch%20drops%20the%20local%20mic%20from%20%60transcriptSources%60%2C%20so%20if%20the%20local%20user%20starts%20talking%20immediately%20after%20the%20remote%20speaker%2C%20the%20relay%20can%20receive%20only%20the%20silent%20remote%20stream%20and%20miss%20the%20start%20of%20the%20local%20utterance.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetingTranscript.ts%3A637%0A**Recovered%20Error%20Sessions%20Do%20Not%20Resume**%0A%0AThe%20automatic%20takeover%20only%20runs%20for%20%60takeover_needed%60%2C%20but%20the%20server%20takeover%20policy%20also%20accepts%20%60error%60.%20If%20a%20persisted%20transcript%20session%20is%20already%20in%20%60error%60%20when%20the%20worker%20recovers%20or%20updates%2C%20recovery%20leaves%20that%20status%20unchanged%2C%20so%20the%20original%20controller%20with%20a%20global%20key%20will%20not%20auto-resume%20and%20the%20session%20stays%20stuck%20until%20a%20manual%20action%20happens.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Ftranscript-worker%2Fsrc%2Froom.ts%3A758%0A**Unbound%20Items%20Reuse%20Pending%20Speakers**%0A%0AIf%20OpenAI%20sends%20a%20transcription%20delta%20or%20final%20for%20an%20item%20before%2C%20or%20without%2C%20the%20matching%20%60input_audio_buffer.committed%60%20event%2C%20this%20fallback%20assigns%20the%20segment%20from%20the%20head%20of%20the%20pending%20commit%20queue%20without%20consuming%20it.%20The%20next%20committed%20item%20can%20then%20bind%20that%20stale%20speaker%20to%20a%20different%20%60item_id%60%2C%20causing%20later%20transcript%20segments%20to%20show%20the%20wrong%20speaker%20and%20never%20be%20corrected.%0A%0A&repo=acm-vit%2Fconclave&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetingTranscript.ts%3A225%0A**Stale%20Remote%20Speaker%20Suppresses%20Local%20Audio**%0A%0AWhen%20a%20remote%20participant%20was%20the%20active%20speaker%20and%20then%20goes%20quiet%2C%20the%20active-speaker%20state%20can%20linger%20while%20their%20stream%20is%20still%20live.%20During%20that%20window%20this%20branch%20drops%20the%20local%20mic%20from%20%60transcriptSources%60%2C%20so%20if%20the%20local%20user%20starts%20talking%20immediately%20after%20the%20remote%20speaker%2C%20the%20relay%20can%20receive%20only%20the%20silent%20remote%20stream%20and%20miss%20the%20start%20of%20the%20local%20utterance.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetingTranscript.ts%3A637%0A**Recovered%20Error%20Sessions%20Do%20Not%20Resume**%0A%0AThe%20automatic%20takeover%20only%20runs%20for%20%60takeover_needed%60%2C%20but%20the%20server%20takeover%20policy%20also%20accepts%20%60error%60.%20If%20a%20persisted%20transcript%20session%20is%20already%20in%20%60error%60%20when%20the%20worker%20recovers%20or%20updates%2C%20recovery%20leaves%20that%20status%20unchanged%2C%20so%20the%20original%20controller%20with%20a%20global%20key%20will%20not%20auto-resume%20and%20the%20session%20stays%20stuck%20until%20a%20manual%20action%20happens.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Ftranscript-worker%2Fsrc%2Froom.ts%3A758%0A**Unbound%20Items%20Reuse%20Pending%20Speakers**%0A%0AIf%20OpenAI%20sends%20a%20transcription%20delta%20or%20final%20for%20an%20item%20before%2C%20or%20without%2C%20the%20matching%20%60input_audio_buffer.committed%60%20event%2C%20this%20fallback%20assigns%20the%20segment%20from%20the%20head%20of%20the%20pending%20commit%20queue%20without%20consuming%20it.%20The%20next%20committed%20item%20can%20then%20bind%20that%20stale%20speaker%20to%20a%20different%20%60item_id%60%2C%20causing%20later%20transcript%20segments%20to%20show%20the%20wrong%20speaker%20and%20never%20be%20corrected.%0A%0A&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: implement session recovery and spe..."](https://github.com/acm-vit/conclave/commit/6837ae2207cd38b05301e0c51fa3e2af6221a2d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40484424)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->