### PR TITLE
Staging

### DIFF
--- a/apps/web/src/app/components/TranscriptPanel.tsx
+++ b/apps/web/src/app/components/TranscriptPanel.tsx
@@ -765,8 +765,11 @@ export default function TranscriptPanel({
       <div className="shrink-0 border-b border-white/10 px-4 py-3">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <h2 className="text-[15px] font-semibold text-[#fafafa]">
+            <h2 className="flex items-center gap-2 text-[15px] font-semibold text-[#fafafa]">
               Transcript
+              <span className="inline-flex shrink-0 items-center rounded-md border border-[#F95F4A]/30 bg-[#F95F4A]/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#F95F4A]">
+                Beta
+              </span>
             </h2>
             {isRunning && session.controller ? (
               <p className="mt-0.5 truncate text-[11.5px] text-[#a1a1aa]">

--- a/apps/web/src/app/components/games/GamesPanel.tsx
+++ b/apps/web/src/app/components/games/GamesPanel.tsx
@@ -173,6 +173,7 @@ export function GamesPanel({
           />
         ) : configuring ? (
           <GameConfigView
+            key={configuring.id}
             entry={configuring}
             busy={busy}
             onStart={async (cfg) => {

--- a/apps/web/src/app/hooks/useMeetingTranscript.ts
+++ b/apps/web/src/app/hooks/useMeetingTranscript.ts
@@ -24,6 +24,7 @@ import {
   TranscriptAudioRelay,
   type TranscriptRelaySource,
 } from "../lib/transcript-audio";
+import { resolveSnapshotViewerConnectionId } from "../lib/transcript-connection";
 
 export type TranscriptConnectionStatus =
   | "idle"
@@ -368,7 +369,9 @@ export function useMeetingTranscript({
 
       switch (message.type) {
         case "snapshot": {
-          setViewerConnectionId(message.viewerConnectionId ?? null);
+          setViewerConnectionId((current) =>
+            resolveSnapshotViewerConnectionId(current, message),
+          );
           setHasGlobalOpenAiKey(message.globalOpenAiKeyAvailable === true);
           applyServiceVersion(message.serviceVersion);
           setSession(message.session);

--- a/apps/web/src/app/lib/transcript-connection.ts
+++ b/apps/web/src/app/lib/transcript-connection.ts
@@ -1,0 +1,9 @@
+export const resolveSnapshotViewerConnectionId = (
+  currentViewerConnectionId: string | null,
+  snapshot: { viewerConnectionId?: string | null },
+): string | null => {
+  if (Object.prototype.hasOwnProperty.call(snapshot, "viewerConnectionId")) {
+    return snapshot.viewerConnectionId ?? null;
+  }
+  return currentViewerConnectionId;
+};

--- a/apps/web/test/transcript-connection.test.ts
+++ b/apps/web/test/transcript-connection.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolveSnapshotViewerConnectionId } from "../src/app/lib/transcript-connection";
+
+describe("resolveSnapshotViewerConnectionId", () => {
+  it("preserves the current viewer connection when a room-wide snapshot omits it", () => {
+    expect(resolveSnapshotViewerConnectionId("viewer-a", {})).toBe("viewer-a");
+  });
+
+  it("updates the viewer connection when the snapshot includes it", () => {
+    expect(
+      resolveSnapshotViewerConnectionId("viewer-a", {
+        viewerConnectionId: "viewer-b",
+      }),
+    ).toBe("viewer-b");
+  });
+
+  it("clears the viewer connection when the snapshot explicitly nulls it", () => {
+    expect(
+      resolveSnapshotViewerConnectionId("viewer-a", {
+        viewerConnectionId: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/sfu/server/games/modules/wouldYouRather.ts
+++ b/packages/sfu/server/games/modules/wouldYouRather.ts
@@ -54,31 +54,107 @@ const PROMPT_BANK: Prompt[] = [
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === "object" && !Array.isArray(value));
 
-const parseGeneratedPrompts = (payload: unknown): Prompt[] | null => {
-  if (!isRecord(payload) || !Array.isArray(payload.prompts)) return null;
-  const prompts: Prompt[] = [];
+const generatedTextFromKeys = (
+  item: Record<string, unknown>,
+  keys: string[],
+): string | null => {
+  for (const key of keys) {
+    const text = cleanGeneratedText(item[key], 90);
+    if (text) return text;
+  }
+  return null;
+};
+
+const uniquePrompts = (prompts: Prompt[], maxItems: number): Prompt[] => {
+  const unique: Prompt[] = [];
   const seen = new Set<string>();
-  for (const item of payload.prompts) {
-    if (!isRecord(item)) continue;
-    const a = cleanGeneratedText(item.a, 90);
-    const b = cleanGeneratedText(item.b, 90);
-    if (!a || !b) continue;
-    const aKey = normalizeGeneratedKey(a);
-    const bKey = normalizeGeneratedKey(b);
+  for (const prompt of prompts) {
+    const aKey = normalizeGeneratedKey(prompt.a);
+    const bKey = normalizeGeneratedKey(prompt.b);
     if (!aKey || !bKey || aKey === bKey) continue;
     const pairKey = [aKey, bKey]
       .sort()
       .join("|");
     if (seen.has(pairKey)) continue;
     seen.add(pairKey);
+    unique.push(prompt);
+    if (unique.length >= maxItems) break;
+  }
+  return unique;
+};
+
+const parseGeneratedPrompts = (payload: unknown): Prompt[] | null => {
+  if (!isRecord(payload) || !Array.isArray(payload.prompts)) return null;
+  const prompts: Prompt[] = [];
+  for (const item of payload.prompts) {
+    if (!isRecord(item)) continue;
+    const a = generatedTextFromKeys(item, ["a", "optionA", "choiceA", "left"]);
+    const b = generatedTextFromKeys(item, ["b", "optionB", "choiceB", "right"]);
+    if (!a || !b) continue;
     prompts.push({ a, b });
     if (prompts.length >= 10) break;
   }
-  return prompts.length > 0 ? prompts : null;
+  const unique = uniquePrompts(prompts, 10);
+  return unique.length > 0 ? unique : null;
 };
 
 const generatedPromptsFromContent = (content: unknown): Prompt[] =>
   Array.isArray(content) ? (content as Prompt[]) : [];
+
+const topicFallbackPrompts = (topic: string): Prompt[] => {
+  const label = cleanGeneratedText(topic, 45);
+  if (!label) return [];
+  return uniquePrompts(
+    [
+      {
+        a: `Know every insider detail about ${label}`,
+        b: `Be surprised by every ${label} twist`,
+      },
+      {
+        a: `Make one bold ${label} prediction that comes true`,
+        b: `Explain one confusing ${label} story perfectly`,
+      },
+      {
+        a: `Have unlimited budget for a ${label} project`,
+        b: `Have perfect timing for every ${label} decision`,
+      },
+      {
+        a: `Spend a week only talking about ${label}`,
+        b: `Avoid all ${label} updates for a year`,
+      },
+      {
+        a: `Be first to discover the next big ${label} story`,
+        b: `Be best at making ${label} fun for everyone`,
+      },
+      {
+        a: `Get front-row access to a major ${label} moment`,
+        b: `Get a private briefing on what happens next in ${label}`,
+      },
+      {
+        a: `Only use tools related to ${label}`,
+        b: `Never use tools related to ${label}`,
+      },
+      {
+        a: `Host a room debate about ${label}`,
+        b: `Judge everyone else's ${label} takes silently`,
+      },
+      {
+        a: `Have your favorite ${label} idea become real`,
+        b: `Have your funniest ${label} idea go viral`,
+      },
+      {
+        a: `Be known for one brilliant ${label} take`,
+        b: `Be forgiven for one terrible ${label} take`,
+      },
+    ]
+      .map((prompt) => ({
+        a: cleanGeneratedText(prompt.a, 90) ?? "",
+        b: cleanGeneratedText(prompt.b, 90) ?? "",
+      }))
+      .filter((prompt) => prompt.a && prompt.b),
+    10,
+  );
+};
 
 const splitCounts = (state: WyrState): [number, number] => {
   let a = 0;
@@ -115,6 +191,8 @@ export const wouldYouRatherModule: GameModule<WyrState> = {
       topic,
       instructions: [
         `Create ${rounds} balanced would-you-rather prompts.`,
+        "Every choice must clearly depend on the topic. Do not return generic superpower, food, travel, or lifestyle choices unless the topic itself asks for them.",
+        "Use concrete topic-specific nouns, people, events, products, places, or scenarios when they fit.",
         "Each prompt needs two distinct choices that are quick to read aloud.",
         "Avoid choices that are offensive, sexual, or personally invasive.",
       ].join(" "),
@@ -147,8 +225,13 @@ export const wouldYouRatherModule: GameModule<WyrState> = {
 
   setup(ctx: GameContext): WyrState {
     const generatedPrompts = generatedPromptsFromContent(ctx.content);
+    const fallbackPrompts = topicFallbackPrompts(gameContentTopic(ctx.config));
     const promptBank = ctx.rng.shuffle(
-      generatedPrompts.length > 0 ? generatedPrompts : PROMPT_BANK,
+      generatedPrompts.length > 0
+        ? generatedPrompts
+        : fallbackPrompts.length > 0
+          ? fallbackPrompts
+          : PROMPT_BANK,
     );
     return {
       phase: "lobby",


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR updates transcript UI/state handling and Would You Rather prompt generation. The main changes are:

- Added a Beta badge to the transcript panel.
- Preserved transcript viewer connection ids when snapshots omit the field.
- Added tests for transcript connection id resolution.
- Keyed the game config view by game id.
- Broadened Would You Rather generated prompt parsing.
- Added topic-based fallback prompts for Would You Rather.

<h3>Confidence Score: 4/5</h3>

The Would You Rather generated-content path can end games earlier than the configured round count.

- Duplicate generated prompts can be removed before setup.
- Setup still treats any non-empty generated list as complete.
- Transcript state handling has cleanup guards for the reachable stale-id cases.

packages/sfu/server/games/modules/wouldYouRather.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/components/TranscriptPanel.tsx | Adds a visual Beta badge to the transcript heading. |
| apps/web/src/app/components/games/GamesPanel.tsx | Keys the config form by game id, which resets state across different game ids but can preserve stale state across same-id entry changes. |
| apps/web/src/app/hooks/useMeetingTranscript.ts | Uses the new resolver when applying snapshot viewer connection ids. |
| apps/web/src/app/lib/transcript-connection.ts | Adds a helper that distinguishes omitted viewer ids from explicit null values. |
| apps/web/test/transcript-connection.test.ts | Covers preserving, updating, and clearing transcript viewer connection ids. |
| packages/sfu/server/games/modules/wouldYouRather.ts | Broadens generated prompt parsing and adds topic fallbacks, but can accept too few unique generated prompts for the requested rounds. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fsfu%2Fserver%2Fgames%2Fmodules%2FwouldYouRather.ts%3A230-232%0A**Deduped%20Prompts%20End%20Early**%0A%0AWhen%20generated%20content%20has%20duplicates%2C%20%60parseGeneratedPrompts%60%20can%20now%20return%20a%20non-empty%20list%20that%20is%20shorter%20than%20the%20configured%20round%20count.%20This%20branch%20still%20prefers%20that%20shortened%20list%20over%20the%20fallback%20banks%2C%20so%20a%206-round%20game%20with%20only%202%20unique%20generated%20pairs%20silently%20plays%202%20rounds%20and%20ends%20early.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2Fgames%2FGamesPanel.tsx%3A176%0A**Same-Id%20Config%20Stays%20Stale**%0A%0AIf%20the%20catalog%20ever%20contains%20or%20refreshes%20to%20a%20different%20entry%20with%20the%20same%20game%20id%20but%20different%20option%20specs%2C%20this%20key%20keeps%20%60GameConfigView%60%20mounted%20while%20its%20local%20%60config%60%20state%20was%20initialized%20from%20the%20previous%20entry.%20The%20user%20can%20then%20submit%20stale%20option%20values%20for%20the%20newly%20selected%20entry%20because%20the%20form%20does%20not%20re-read%20%60entry.options%60%20unless%20the%20key%20changes.%0A%0A&repo=acm-vit%2Fconclave&pr=112&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fsfu%2Fserver%2Fgames%2Fmodules%2FwouldYouRather.ts%3A230-232%0A**Deduped%20Prompts%20End%20Early**%0A%0AWhen%20generated%20content%20has%20duplicates%2C%20%60parseGeneratedPrompts%60%20can%20now%20return%20a%20non-empty%20list%20that%20is%20shorter%20than%20the%20configured%20round%20count.%20This%20branch%20still%20prefers%20that%20shortened%20list%20over%20the%20fallback%20banks%2C%20so%20a%206-round%20game%20with%20only%202%20unique%20generated%20pairs%20silently%20plays%202%20rounds%20and%20ends%20early.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2Fgames%2FGamesPanel.tsx%3A176%0A**Same-Id%20Config%20Stays%20Stale**%0A%0AIf%20the%20catalog%20ever%20contains%20or%20refreshes%20to%20a%20different%20entry%20with%20the%20same%20game%20id%20but%20different%20option%20specs%2C%20this%20key%20keeps%20%60GameConfigView%60%20mounted%20while%20its%20local%20%60config%60%20state%20was%20initialized%20from%20the%20previous%20entry.%20The%20user%20can%20then%20submit%20stale%20option%20values%20for%20the%20newly%20selected%20entry%20because%20the%20form%20does%20not%20re-read%20%60entry.options%60%20unless%20the%20key%20changes.%0A%0A&repo=acm-vit%2Fconclave&pr=112&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fsfu%2Fserver%2Fgames%2Fmodules%2FwouldYouRather.ts%3A230-232%0A**Deduped%20Prompts%20End%20Early**%0A%0AWhen%20generated%20content%20has%20duplicates%2C%20%60parseGeneratedPrompts%60%20can%20now%20return%20a%20non-empty%20list%20that%20is%20shorter%20than%20the%20configured%20round%20count.%20This%20branch%20still%20prefers%20that%20shortened%20list%20over%20the%20fallback%20banks%2C%20so%20a%206-round%20game%20with%20only%202%20unique%20generated%20pairs%20silently%20plays%202%20rounds%20and%20ends%20early.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2Fgames%2FGamesPanel.tsx%3A176%0A**Same-Id%20Config%20Stays%20Stale**%0A%0AIf%20the%20catalog%20ever%20contains%20or%20refreshes%20to%20a%20different%20entry%20with%20the%20same%20game%20id%20but%20different%20option%20specs%2C%20this%20key%20keeps%20%60GameConfigView%60%20mounted%20while%20its%20local%20%60config%60%20state%20was%20initialized%20from%20the%20previous%20entry.%20The%20user%20can%20then%20submit%20stale%20option%20values%20for%20the%20newly%20selected%20entry%20because%20the%20form%20does%20not%20re-read%20%60entry.options%60%20unless%20the%20key%20changes.%0A%0A&pr=112&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: add resolveSnapshotViewerConnectio..."](https://github.com/acm-vit/conclave/commit/ed174aaba920c639fd4b0e6d781479889162b469) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40487025)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->