### PR TITLE
fixes

### DIFF
--- a/apps/web/src/app/api/sfu/join/route.ts
+++ b/apps/web/src/app/api/sfu/join/route.ts
@@ -515,12 +515,18 @@ export async function POST(request: Request) {
       id: sessionUser!.id,
       email: sessionUser!.email,
     });
+  const canGhostJoin = !isWebinarAttendeeJoin && requestedGhost && isSuperAdmin;
+  if (requestedGhost && !canGhostJoin) {
+    return NextResponse.json(
+      { error: "Ghost mode is not available for this session" },
+      { status: 403 },
+    );
+  }
   const isForcedHost =
     !isWebinarAttendeeJoin &&
-    (Boolean(
+    Boolean(
       normalizedSessionEmail && alwaysHostEmails.has(normalizedSessionEmail),
-    ) ||
-      (isSuperAdmin && requestedGhost));
+    );
   const requestedHost = Boolean(body?.isHost ?? body?.isAdmin);
 
   // For scheduled webinar rooms, only the actual host or a registered co-host
@@ -572,6 +578,7 @@ export async function POST(request: Request) {
       isHost,
       isAdmin: isHost,
       allowRoomCreation,
+      canGhostJoin,
       clientId,
       sessionId,
       joinMode,

--- a/apps/web/src/app/components/BrowserLayout.tsx
+++ b/apps/web/src/app/components/BrowserLayout.tsx
@@ -11,7 +11,6 @@ import {
 } from "../lib/utils";
 import { isRemoteParticipantVisible } from "../lib/participant-visibility";
 import ParticipantVideo from "./ParticipantVideo";
-import { GhostParticipantOverlay } from "./GhostParticipantChrome";
 import { Avatar, NamePlate } from "@conclave/ui-tokens/web";
 import { color } from "@conclave/ui-tokens";
 
@@ -252,8 +251,12 @@ function BrowserLayout({
                                 src={`${resolvedNoVncUrl}${resolvedNoVncUrl.includes("?") ? "&" : "?"}autoconnect=true&resize=scale&quality=0&compression=9`}
                                 onLoad={() => setIsReady(true)}
                                 className="absolute inset-0 w-full h-full border-0"
-                                style={{ opacity: 0, pointerEvents: "auto" }}
+                                style={{
+                                    opacity: 0,
+                                    pointerEvents: isGhost ? "none" : "auto",
+                                }}
                                 allow="clipboard-read; clipboard-write"
+                                tabIndex={isGhost ? -1 : undefined}
                                 title="Shared Browser Input"
                             />
                         </div>
@@ -263,8 +266,12 @@ function BrowserLayout({
                                 src={resolvedNoVncUrl}
                                 onLoad={() => setIsReady(true)}
                                 className="h-full w-full border-0 transition-opacity duration-200"
-                                style={{ opacity: isReady ? 1 : 0 }}
+                                style={{
+                                    opacity: isReady ? 1 : 0,
+                                    pointerEvents: isGhost ? "none" : "auto",
+                                }}
                                 allow="clipboard-read; clipboard-write"
+                                tabIndex={isGhost ? -1 : undefined}
                                 title="Shared Browser"
                             />
                             {!isReady && (
@@ -327,66 +334,67 @@ function BrowserLayout({
             </div>
 
             <div className="flex h-36 w-full shrink-0 flex-row gap-3 overflow-x-auto overflow-y-visible pb-1 sm:h-auto sm:w-64 sm:flex-col sm:overflow-y-auto sm:overflow-x-visible sm:px-1 sm:pb-0">
-                <div className={`acm-video-tile h-36 w-48 shrink-0 sm:w-auto ${isLocalActiveSpeaker ? "speaking" : ""}`}>
-                    <video
-                        ref={localVideoRef}
-                        autoPlay
-                        muted
-                        playsInline
-                        className={`w-full h-full object-cover ${isCameraOff ? "hidden" : ""
-                            } ${isMirrorCamera ? "scale-x-[-1]" : ""}`}
-                    />
-                    {isCameraOff && (
-                        <div
-                            className="absolute inset-0 flex items-center justify-center"
-                            style={{ backgroundColor: color.surface }}
-                        >
-                            <Avatar name={localName} id={currentUserId} size={48} />
-                        </div>
-                    )}
-                    {isGhost && <GhostParticipantOverlay compact />}
-                    {isHandRaised && (
-                        <div
-                            className="absolute top-3 left-3 rounded-full p-1.5 text-amber-300"
-                            style={{
-                                backgroundColor: "rgba(251, 191, 36, 0.2)",
-                                border: "1px solid rgba(251, 191, 36, 0.4)",
-                            }}
-                            title="Hand raised"
-                        >
-                            <Hand size={18} strokeWidth={1.75} className="h-3.5 w-3.5" />
-                        </div>
-                    )}
-                    <div className="absolute bottom-3 left-3 flex max-w-[80%] items-center gap-1.5">
-                        <NamePlate name="You" isLocal />
-                        {isLocalActiveSpeaker && !isMuted ? (
-                            <span
-                                className="rounded-full px-2 py-1"
-                                style={{
-                                    backgroundColor: color.scrim,
-                                    border: `1px solid ${color.border}`,
-                                }}
+                {!isGhost && (
+                    <div className={`acm-video-tile h-36 w-48 shrink-0 sm:w-auto ${isLocalActiveSpeaker ? "speaking" : ""}`}>
+                        <video
+                            ref={localVideoRef}
+                            autoPlay
+                            muted
+                            playsInline
+                            className={`w-full h-full object-cover ${isCameraOff ? "hidden" : ""
+                                } ${isMirrorCamera ? "scale-x-[-1]" : ""}`}
+                        />
+                        {isCameraOff && (
+                            <div
+                                className="absolute inset-0 flex items-center justify-center"
+                                style={{ backgroundColor: color.surface }}
                             >
-                                <span className="acm-voice-activity" aria-label="Speaking">
-                                    <span />
-                                    <span />
-                                    <span />
-                                </span>
-                            </span>
-                        ) : null}
-                    </div>
-                    <div
-                        className="absolute bottom-3 right-3 inline-flex items-center justify-center rounded-full p-1.5"
-                        style={{ backgroundColor: color.scrim, border: `1px solid ${color.border}` }}
-                        title={isMuted ? "Microphone off" : "Microphone on"}
-                    >
-                        {isMuted ? (
-                            <MicOff size={18} strokeWidth={1.75} className="h-3.5 w-3.5" style={{ color: color.accent }} />
-                        ) : (
-                            <Mic size={18} strokeWidth={1.75} className="h-3.5 w-3.5" style={{ color: color.success }} />
+                                <Avatar name={localName} id={currentUserId} size={48} />
+                            </div>
                         )}
+                        {isHandRaised && (
+                            <div
+                                className="absolute top-3 left-3 rounded-full p-1.5 text-amber-300"
+                                style={{
+                                    backgroundColor: "rgba(251, 191, 36, 0.2)",
+                                    border: "1px solid rgba(251, 191, 36, 0.4)",
+                                }}
+                                title="Hand raised"
+                            >
+                                <Hand size={18} strokeWidth={1.75} className="h-3.5 w-3.5" />
+                            </div>
+                        )}
+                        <div className="absolute bottom-3 left-3 flex max-w-[80%] items-center gap-1.5">
+                            <NamePlate name="You" isLocal />
+                            {isLocalActiveSpeaker && !isMuted ? (
+                                <span
+                                    className="rounded-full px-2 py-1"
+                                    style={{
+                                        backgroundColor: color.scrim,
+                                        border: `1px solid ${color.border}`,
+                                    }}
+                                >
+                                    <span className="acm-voice-activity" aria-label="Speaking">
+                                        <span />
+                                        <span />
+                                        <span />
+                                    </span>
+                                </span>
+                            ) : null}
+                        </div>
+                        <div
+                            className="absolute bottom-3 right-3 inline-flex items-center justify-center rounded-full p-1.5"
+                            style={{ backgroundColor: color.scrim, border: `1px solid ${color.border}` }}
+                            title={isMuted ? "Microphone off" : "Microphone on"}
+                        >
+                            {isMuted ? (
+                                <MicOff size={18} strokeWidth={1.75} className="h-3.5 w-3.5" style={{ color: color.accent }} />
+                            ) : (
+                                <Mic size={18} strokeWidth={1.75} className="h-3.5 w-3.5" style={{ color: color.success }} />
+                            )}
+                        </div>
                     </div>
-                </div>
+                )}
 
                 {remoteParticipants.map((participant) => (
                         <ParticipantVideo

--- a/apps/web/src/app/components/ChatPanel.tsx
+++ b/apps/web/src/app/components/ChatPanel.tsx
@@ -534,12 +534,12 @@ function ChatPanel({
         >
           {messages.length === 0 ? (
             (() => {
-              const restricted = isGhostMode
-                ? {
-                    icon: <Ghost size={20} strokeWidth={1.75} />,
-                    title: "You're in ghost mode",
-                    body: "Chat is hidden while you're invisible. Turn off ghost mode to join in.",
-                  }
+                  const restricted = isGhostMode
+                    ? {
+                        icon: <Ghost size={20} strokeWidth={1.75} />,
+                        title: "You're in ghost mode",
+                        body: "Messages stay visible here, but sending and replying are disabled while you're invisible.",
+                      }
                 : isChatLocked && !isAdmin
                   ? {
                       icon: <Lock size={20} strokeWidth={1.75} />,
@@ -710,7 +710,7 @@ function ChatPanel({
                 </button>
               ) : null;
 
-              const replyButton = onReply ? (
+              const replyButton = onReply && !isChatDisabled ? (
                 <button
                   type="button"
                   onClick={() => onReply(msg)}
@@ -900,7 +900,7 @@ function ChatPanel({
               })}
             </div>
           )}
-          {replyTarget && (
+          {replyTarget && !isChatDisabled && (
             <div className="mb-2 flex items-stretch gap-2.5 overflow-hidden rounded-xl bg-white/[0.04] pr-1.5">
               <span
                 className="w-[3px] shrink-0 bg-[#F95F4A]"
@@ -944,7 +944,7 @@ function ChatPanel({
               onKeyDown={handleKeyDown}
               placeholder={
                 isGhostMode
-                  ? "Ghost mode: chat disabled"
+                  ? "Ghost mode: watching chat"
                   : isChatLocked && !isAdmin
                     ? "Chat locked by host"
                     : "Send a message"

--- a/apps/web/src/app/components/DevPlaygroundLayout.tsx
+++ b/apps/web/src/app/components/DevPlaygroundLayout.tsx
@@ -8,7 +8,6 @@ import { useSmartParticipantOrder } from "../hooks/useSmartParticipantOrder";
 import type { Participant } from "../lib/types";
 import { getSpeakerHighlightClasses, isSystemUserId } from "../lib/utils";
 import { isRemoteParticipantVisible } from "../lib/participant-visibility";
-import { GhostParticipantOverlay } from "./GhostParticipantChrome";
 import ParticipantVideo from "./ParticipantVideo";
 
 interface DevPlaygroundLayoutProps {
@@ -84,44 +83,45 @@ function DevPlaygroundLayout({
         <DevPlaygroundWebApp />
       </div>
       <aside className="hidden lg:flex w-64 shrink-0 flex-col gap-3 overflow-y-auto overflow-x-visible px-1">
-        <div
-          className={`relative bg-[#232327] border border-white/5 rounded-lg overflow-hidden h-36 shrink-0 transition-all duration-200 ${getSpeakerHighlightClasses(
-            isLocalActiveSpeaker
-          )}`}
-        >
-          <video
-            ref={localVideoRef}
-            autoPlay
-            muted
-            playsInline
-            className={`w-full h-full object-cover ${
-              isCameraOff ? "hidden" : ""
-            } ${isMirrorCamera ? "scale-x-[-1]" : ""}`}
-          />
-          {isCameraOff && (
-            <div className="absolute inset-0 flex items-center justify-center bg-[#18181b]">
-              <Avatar id={userEmail} name={userEmail} size={48} />
-            </div>
-          )}
-          {isGhost && <GhostParticipantOverlay compact />}
-          {isHandRaised && (
-            <div
-              className="absolute top-3 left-3 p-1.5 rounded-full bg-amber-500/20 border border-amber-400/40 text-amber-300"
-              title="Hand raised"
-            >
-              <Hand className="w-3 h-3" />
-            </div>
-          )}
+        {!isGhost && (
           <div
-            className="absolute bottom-3 left-3 bg-black/70 backdrop-blur-sm border border-[#fafafa]/10 rounded-full px-3 py-1.5 flex items-center gap-2 text-[10px]"
-            style={{ fontFamily: "'PolySans Trial', sans-serif" }}
+            className={`relative bg-[#232327] border border-white/5 rounded-lg overflow-hidden h-36 shrink-0 transition-all duration-200 ${getSpeakerHighlightClasses(
+              isLocalActiveSpeaker
+            )}`}
           >
-            <span className="font-medium text-[#fafafa] uppercase tracking-wide">
-              You
-            </span>
-            {isMuted ? <span className="text-[#F95F4A]">Muted</span> : null}
+            <video
+              ref={localVideoRef}
+              autoPlay
+              muted
+              playsInline
+              className={`w-full h-full object-cover ${
+                isCameraOff ? "hidden" : ""
+              } ${isMirrorCamera ? "scale-x-[-1]" : ""}`}
+            />
+            {isCameraOff && (
+              <div className="absolute inset-0 flex items-center justify-center bg-[#18181b]">
+                <Avatar id={userEmail} name={userEmail} size={48} />
+              </div>
+            )}
+            {isHandRaised && (
+              <div
+                className="absolute top-3 left-3 p-1.5 rounded-full bg-amber-500/20 border border-amber-400/40 text-amber-300"
+                title="Hand raised"
+              >
+                <Hand className="w-3 h-3" />
+              </div>
+            )}
+            <div
+              className="absolute bottom-3 left-3 bg-black/70 backdrop-blur-sm border border-[#fafafa]/10 rounded-full px-3 py-1.5 flex items-center gap-2 text-[10px]"
+              style={{ fontFamily: "'PolySans Trial', sans-serif" }}
+            >
+              <span className="font-medium text-[#fafafa] uppercase tracking-wide">
+                You
+              </span>
+              {isMuted ? <span className="text-[#F95F4A]">Muted</span> : null}
+            </div>
           </div>
-        </div>
+        )}
 
         {participantsList.map((participant) => (
           <ParticipantVideo

--- a/apps/web/src/app/components/GridLayout.tsx
+++ b/apps/web/src/app/components/GridLayout.tsx
@@ -1003,9 +1003,21 @@ function GridLayout({
       return next;
     });
   }, []);
-  const isLocalActiveSpeaker = activeSpeakerId === currentUserId;
-  const isLocalPinned = pinnedId === LOCAL_STAGE_ID;
+  const canRenderSelfView = !isGhost;
+  const isLocalActiveSpeaker =
+    canRenderSelfView && activeSpeakerId === currentUserId;
+  const isLocalPinned = canRenderSelfView && pinnedId === LOCAL_STAGE_ID;
   const hasPresentation = hasLiveVideo(presentationStream);
+  useEffect(() => {
+    if (!isGhost) return;
+    setPinnedId((current) => (current === LOCAL_STAGE_ID ? null : current));
+    setFullVideoTileIds((current) => {
+      if (!current.has("local")) return current;
+      const next = new Set(current);
+      next.delete("local");
+      return next;
+    });
+  }, [isGhost]);
   // Default to the placeholder (not your own mirrored screen) each time a
   // new share session starts; reset happens the moment sharing stops so the
   // NEXT share starts fresh rather than carrying over the last choice.
@@ -1143,10 +1155,10 @@ function GridLayout({
   );
   const roomSpeakerParticipantIds = useMemo(
     () => [
-      currentUserId,
+      ...(canRenderSelfView ? [currentUserId] : []),
       ...remoteInput.map((participant) => participant.userId),
     ],
-    [currentUserId, remoteInput],
+    [canRenderSelfView, currentUserId, remoteInput],
   );
   const featuredSpeakerId = useStableSpeakerId({
     primarySpeakerId: activeSpeakerId,
@@ -1162,12 +1174,13 @@ function GridLayout({
     requestedSelfViewMode === "auto"
       ? autoSelfViewMode
       : requestedSelfViewMode;
-  const canDetachSelfView = remoteInput.length > 0 || hasPresentation;
+  const canDetachSelfView =
+    canRenderSelfView && (remoteInput.length > 0 || hasPresentation);
   const effectiveSelfViewMode: ResolvedSelfViewMode = canDetachSelfView
     ? detachedSelfViewMode
     : "tile";
   const shouldShowSelfAsTile =
-    effectiveSelfViewMode === "tile" || isLocalPinned;
+    canRenderSelfView && (effectiveSelfViewMode === "tile" || isLocalPinned);
   const isLocalFeaturedSpeaker = featuredSpeakerId === currentUserId;
   const featuredRemoteParticipant =
     featuredSpeakerId && featuredSpeakerId !== currentUserId
@@ -1182,7 +1195,7 @@ function GridLayout({
             participantHasLiveVideo(featuredRemoteParticipant),
         );
   const autoStageMode = chooseStageMode({
-    count: remoteInput.length + 1,
+    count: remoteInput.length + (canRenderSelfView ? 1 : 0),
     presenting: hasPresentation,
     pinned: Boolean(pinnedId),
     hasActiveVideoSpeaker: hasFeaturedVideoSpeaker,

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -1875,9 +1875,9 @@ export default function MeetsMainContent({
           isDmEnabled={isDmEnabled}
           isAdmin={isAdmin}
           mentionableParticipants={mentionableParticipants}
-          replyTarget={replyTarget}
-          onReply={onReplyToMessage}
-          onCancelReply={onCancelReply}
+          replyTarget={ghostEnabled ? null : replyTarget}
+          onReply={ghostEnabled ? undefined : onReplyToMessage}
+          onCancelReply={ghostEnabled ? undefined : onCancelReply}
         />
       )}
 
@@ -1965,7 +1965,7 @@ export default function MeetsMainContent({
         <MeetViewPanel
           settings={viewSettings}
           onSettingsChange={setViewSettings}
-          participantCount={visibleParticipantCount + 1}
+          participantCount={visibleParticipantCount + (ghostEnabled ? 0 : 1)}
           onClose={handleCloseViewPanel}
         />
       )}

--- a/apps/web/src/app/components/WhiteboardLayout.tsx
+++ b/apps/web/src/app/components/WhiteboardLayout.tsx
@@ -8,7 +8,6 @@ import { useSmartParticipantOrder } from "../hooks/useSmartParticipantOrder";
 import type { Participant } from "../lib/types";
 import { getSpeakerHighlightClasses, isSystemUserId } from "../lib/utils";
 import { isRemoteParticipantVisible } from "../lib/participant-visibility";
-import { GhostParticipantOverlay } from "./GhostParticipantChrome";
 import ParticipantVideo from "./ParticipantVideo";
 
 interface WhiteboardLayoutProps {
@@ -84,44 +83,45 @@ function WhiteboardLayout({
         <WhiteboardWebApp />
       </div>
       <aside className="hidden lg:flex w-64 shrink-0 flex-col gap-3 overflow-y-auto overflow-x-visible px-1">
-        <div
-          className={`relative bg-[#232327] border border-white/5 rounded-lg overflow-hidden h-36 shrink-0 transition-all duration-200 ${getSpeakerHighlightClasses(
-            isLocalActiveSpeaker
-          )}`}
-        >
-          <video
-            ref={localVideoRef}
-            autoPlay
-            muted
-            playsInline
-            className={`w-full h-full object-cover ${
-              isCameraOff ? "hidden" : ""
-            } ${isMirrorCamera ? "scale-x-[-1]" : ""}`}
-          />
-          {isCameraOff && (
-            <div className="absolute inset-0 flex items-center justify-center bg-[#18181b]">
-              <Avatar id={userEmail} name={userEmail} size={48} />
-            </div>
-          )}
-          {isGhost && <GhostParticipantOverlay compact />}
-          {isHandRaised && (
-            <div
-              className="absolute top-3 left-3 p-1.5 rounded-full bg-amber-500/20 border border-amber-400/40 text-amber-300"
-              title="Hand raised"
-            >
-              <Hand className="w-3 h-3" />
-            </div>
-          )}
+        {!isGhost && (
           <div
-            className="absolute bottom-3 left-3 bg-black/70 backdrop-blur-sm border border-[#fafafa]/10 rounded-full px-3 py-1.5 flex items-center gap-2 text-[10px]"
-            style={{ fontFamily: "'PolySans Trial', sans-serif" }}
+            className={`relative bg-[#232327] border border-white/5 rounded-lg overflow-hidden h-36 shrink-0 transition-all duration-200 ${getSpeakerHighlightClasses(
+              isLocalActiveSpeaker
+            )}`}
           >
-            <span className="font-medium text-[#fafafa] uppercase tracking-wide">
-              You
-            </span>
-            {isMuted ? <span className="text-[#F95F4A]">Muted</span> : null}
+            <video
+              ref={localVideoRef}
+              autoPlay
+              muted
+              playsInline
+              className={`w-full h-full object-cover ${
+                isCameraOff ? "hidden" : ""
+              } ${isMirrorCamera ? "scale-x-[-1]" : ""}`}
+            />
+            {isCameraOff && (
+              <div className="absolute inset-0 flex items-center justify-center bg-[#18181b]">
+                <Avatar id={userEmail} name={userEmail} size={48} />
+              </div>
+            )}
+            {isHandRaised && (
+              <div
+                className="absolute top-3 left-3 p-1.5 rounded-full bg-amber-500/20 border border-amber-400/40 text-amber-300"
+                title="Hand raised"
+              >
+                <Hand className="w-3 h-3" />
+              </div>
+            )}
+            <div
+              className="absolute bottom-3 left-3 bg-black/70 backdrop-blur-sm border border-[#fafafa]/10 rounded-full px-3 py-1.5 flex items-center gap-2 text-[10px]"
+              style={{ fontFamily: "'PolySans Trial', sans-serif" }}
+            >
+              <span className="font-medium text-[#fafafa] uppercase tracking-wide">
+                You
+              </span>
+              {isMuted ? <span className="text-[#F95F4A]">Muted</span> : null}
+            </div>
           </div>
-        </div>
+        )}
 
         {participantsList.map((participant) => (
           <ParticipantVideo

--- a/apps/web/src/app/components/games/BluffGame.tsx
+++ b/apps/web/src/app/components/games/BluffGame.tsx
@@ -65,6 +65,7 @@ export default function BluffGame({
   players,
   userId,
   isAdmin,
+  readOnly = false,
   move,
 }: GameViewProps<BluffPublic, BluffMe>) {
   const remaining = useRemaining(pub.deadline, pub.serverNow);
@@ -79,6 +80,7 @@ export default function BluffGame({
         players={players}
         userId={userId}
         isAdmin={isAdmin}
+        readOnly={readOnly}
         canStart={pub.totalPlayers >= 2}
         disabledLabel="Need at least 2 players"
         onStart={() => move("start")}
@@ -156,6 +158,7 @@ export default function BluffGame({
             <textarea
               value={draft}
               onChange={(e) => setDraft(e.target.value.slice(0, 60))}
+              disabled={readOnly}
               placeholder="Make up a believable answer"
               rows={2}
               style={{
@@ -173,13 +176,16 @@ export default function BluffGame({
             />
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
               <span style={{ fontSize: 11, color: color.textFaint }}>{draft.length}/60</span>
-              <PrimaryButton disabled={!draft.trim()} onClick={() => move("submit", { text: draft.trim() })}>
+              <PrimaryButton
+                disabled={readOnly || !draft.trim()}
+                onClick={() => move("submit", { text: draft.trim() })}
+              >
                 Submit bluff
               </PrimaryButton>
             </div>
           </>
         )}
-        {isAdmin ? (
+        {isAdmin && !readOnly ? (
           <div style={{ display: "flex", justifyContent: "flex-end" }}>
             <GhostButton onClick={() => move("skip")}>Skip</GhostButton>
           </div>
@@ -200,7 +206,7 @@ export default function BluffGame({
           {(pub.options as ChooseOption[]).map((option) => {
             const isOwn = me.ownOptionId === option.id;
             const isMyPick = me.yourPick === option.id;
-            const locked = isOwn || me.yourPick !== null;
+            const locked = readOnly || isOwn || me.yourPick !== null;
             return (
               <button
                 key={option.id}
@@ -230,7 +236,7 @@ export default function BluffGame({
             );
           })}
         </div>
-        {isAdmin ? (
+        {isAdmin && !readOnly ? (
           <div style={{ display: "flex", justifyContent: "flex-end" }}>
             <GhostButton onClick={() => move("skip")}>Reveal</GhostButton>
           </div>
@@ -282,7 +288,7 @@ export default function BluffGame({
           {pub.roundPoints.map((r) => `${r.name} +${r.points}`).join(" · ")}
         </p>
       ) : null}
-      {isAdmin ? (
+      {isAdmin && !readOnly ? (
         <div style={{ display: "flex", justifyContent: "flex-end" }}>
           <GhostButton onClick={() => move("next")}>Next</GhostButton>
         </div>

--- a/apps/web/src/app/components/games/GamePanel.tsx
+++ b/apps/web/src/app/components/games/GamePanel.tsx
@@ -40,7 +40,8 @@ export function GamePanel({
   maxDockWidth?: number;
   onDockWidthChange?: (width: number) => void;
 }) {
-  const { publicState, view, isAdmin, userId, move, endGame } = useGame();
+  const { publicState, view, isAdmin, isReadOnly, userId, move, endGame } =
+    useGame();
   if (!publicState) return null;
 
   const Game = getGameRenderer(publicState.gameId);
@@ -63,7 +64,7 @@ export function GamePanel({
         <div className="flex h-8 min-w-0 items-center gap-2">
           <h2 className={GAME_DOCK_TITLE_CLASS}>{publicState.name}</h2>
         </div>
-        {isAdmin ? (
+        {isAdmin && !isReadOnly ? (
           <button
             type="button"
             onClick={() => endGame()}
@@ -104,6 +105,7 @@ export function GamePanel({
               me={view as never}
               players={publicState.players}
               isAdmin={isAdmin}
+              readOnly={isReadOnly}
               userId={userId}
               hostId={publicState.hostId}
               phase={publicState.phase}

--- a/apps/web/src/app/components/games/GamesPanel.tsx
+++ b/apps/web/src/app/components/games/GamesPanel.tsx
@@ -110,7 +110,17 @@ export function GamesPanel({
   maxDockWidth?: number;
   onDockWidthChange?: (width: number) => void;
 }) {
-  const { catalog, vote, isAdmin, userId, startGame, openVote, castVote, cancelVote } = useGame();
+  const {
+    catalog,
+    vote,
+    isAdmin,
+    isReadOnly,
+    userId,
+    startGame,
+    openVote,
+    castVote,
+    cancelVote,
+  } = useGame();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [configuring, setConfiguring] = useState<CatalogEntry | null>(null);
@@ -165,6 +175,7 @@ export function GamesPanel({
           <VoteView
             vote={vote}
             isAdmin={isAdmin}
+            readOnly={isReadOnly}
             userId={userId}
             busy={busy}
             onCast={(id) => run(() => castVote(id))}
@@ -176,6 +187,7 @@ export function GamesPanel({
             key={configuring.id}
             entry={configuring}
             busy={busy}
+            readOnly={isReadOnly}
             onStart={async (cfg) => {
               const ok = await run(() => startGame(configuring.id, cfg));
               if (ok) setConfiguring(null);
@@ -185,6 +197,7 @@ export function GamesPanel({
           <LauncherView
             catalog={catalog}
             isAdmin={isAdmin}
+            readOnly={isReadOnly}
             busy={busy}
             onPick={pick}
             onOpenVote={() => run(() => openVote())}
@@ -199,12 +212,14 @@ export function GamesPanel({
 function LauncherView({
   catalog,
   isAdmin,
+  readOnly,
   busy,
   onPick,
   onOpenVote,
 }: {
   catalog: CatalogEntry[];
   isAdmin: boolean;
+  readOnly: boolean;
   busy: boolean;
   onPick: (entry: CatalogEntry) => void;
   onOpenVote: () => void;
@@ -212,21 +227,25 @@ function LauncherView({
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
       <p style={{ fontSize: 13, color: color.textMuted, margin: "0 0 4px", lineHeight: 1.5 }}>
-        {isAdmin ? "Pick a game, or let the room vote." : "The host is picking a game."}
+        {readOnly
+          ? "Observer mode can watch games but cannot start one."
+          : isAdmin
+            ? "Pick a game, or let the room vote."
+            : "The host is picking a game."}
       </p>
       {catalog.map((entry) => (
         <Row
           key={entry.id}
           name={entry.name}
           sub={entry.description}
-          disabled={!isAdmin || busy}
-          onClick={isAdmin ? () => onPick(entry) : undefined}
+          disabled={readOnly || !isAdmin || busy}
+          onClick={!readOnly && isAdmin ? () => onPick(entry) : undefined}
           trailing={
             <span style={{ display: "flex", alignItems: "center", gap: 8, color: color.textFaint }}>
               <span style={{ fontSize: 11, whiteSpace: "nowrap" }}>
                 {entry.minPlayers} to {entry.maxPlayers}
               </span>
-              {isAdmin ? (
+              {isAdmin && !readOnly ? (
                 <svg width={16} height={16} viewBox="0 0 24 24" fill="none" aria-hidden>
                   <path d="M9 6l6 6-6 6" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
@@ -235,7 +254,7 @@ function LauncherView({
           }
         />
       ))}
-      {isAdmin ? (
+      {isAdmin && !readOnly ? (
         <div style={{ marginTop: 6 }}>
           <PrimaryButton full tone="neutral" disabled={busy} onClick={onOpenVote}>
             Put it to a vote
@@ -324,10 +343,12 @@ function Segmented<T extends string | number>({
 function GameConfigView({
   entry,
   busy,
+  readOnly,
   onStart,
 }: {
   entry: CatalogEntry;
   busy: boolean;
+  readOnly: boolean;
   onStart: (config: GameConfig) => void;
 }) {
   const [config, setConfig] = useState<GameConfig>(() => {
@@ -414,7 +435,7 @@ function GameConfigView({
         </div>
       ))}
 
-      <PrimaryButton full disabled={busy} onClick={() => onStart(config)}>
+      <PrimaryButton full disabled={readOnly || busy} onClick={() => onStart(config)}>
         {busy ? (
           <span className="inline-flex min-w-0 items-center justify-center gap-2">
             <LoaderCircle
@@ -463,6 +484,7 @@ function buildGenerationProgressLabels(
 function VoteView({
   vote,
   isAdmin,
+  readOnly,
   userId,
   busy,
   onCast,
@@ -471,6 +493,7 @@ function VoteView({
 }: {
   vote: { candidates: CatalogEntry[]; tally: Record<string, number>; votes: Record<string, string>; totalPlayers: number };
   isAdmin: boolean;
+  readOnly: boolean;
   userId: string | null;
   busy: boolean;
   onCast: (id: string) => void;
@@ -494,7 +517,11 @@ function VoteView({
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
       <p style={{ fontSize: 13, color: color.textMuted, margin: "0 0 4px" }}>
-        {isAdmin ? "Vote too, then start the winner." : "Tap the game you want."}{" "}
+        {readOnly
+          ? "Observer mode can watch this vote."
+          : isAdmin
+            ? "Vote too, then start the winner."
+            : "Tap the game you want."}{" "}
         <span style={{ color: color.textFaint }}>
           {voters} of {vote.totalPlayers} voted
         </span>
@@ -507,9 +534,9 @@ function VoteView({
             key={entry.id}
             name={entry.name}
             sub={entry.description}
-            disabled={busy}
+            disabled={readOnly || busy}
             selected={mine}
-            onClick={() => onCast(entry.id)}
+            onClick={readOnly ? undefined : () => onCast(entry.id)}
             fillRatio={count / maxVotes}
             trailing={
               <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -520,7 +547,7 @@ function VoteView({
           />
         );
       })}
-      {isAdmin ? (
+      {isAdmin && !readOnly ? (
         <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
           <GhostButton onClick={onCancel}>Cancel</GhostButton>
           <div style={{ flex: 1 }}>

--- a/apps/web/src/app/components/games/ImposterGame.tsx
+++ b/apps/web/src/app/components/games/ImposterGame.tsx
@@ -85,6 +85,7 @@ export default function ImposterGame({
   players,
   userId,
   isAdmin,
+  readOnly = false,
   move,
 }: GameViewProps<ImposterPublic, ImposterMe>) {
   const remaining = useRemaining(pub.deadline, pub.serverNow);
@@ -98,6 +99,7 @@ export default function ImposterGame({
         players={players}
         userId={userId}
         isAdmin={isAdmin}
+        readOnly={readOnly}
         canStart={pub.totalPlayers >= 3}
         startLabel="Deal secret words"
         disabledLabel="Need at least 3 players"
@@ -179,7 +181,7 @@ export default function ImposterGame({
             <button
               key={player.id}
               type="button"
-              disabled={!voting || isMe}
+              disabled={readOnly || !voting || isMe}
               onClick={() => move("vote", { target: player.id })}
               style={{
                 display: "flex",
@@ -190,7 +192,7 @@ export default function ImposterGame({
                 border: `1.5px solid ${isMyVote ? color.accent : color.border}`,
                 background: isMyVote ? color.accentSoft : color.surfaceRaised,
                 color: color.text,
-                cursor: voting && !isMe ? "pointer" : "default",
+                cursor: !readOnly && voting && !isMe ? "pointer" : "default",
                 opacity: isMe && voting ? 0.55 : 1,
               }}
             >
@@ -209,7 +211,7 @@ export default function ImposterGame({
         })}
       </div>
 
-      {isAdmin ? (
+      {isAdmin && !readOnly ? (
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
           {pub.phase === "discuss" ? (
             <PrimaryButton onClick={() => move("callVote")}>Call vote</PrimaryButton>

--- a/apps/web/src/app/components/games/MostLikelyToGame.tsx
+++ b/apps/web/src/app/components/games/MostLikelyToGame.tsx
@@ -38,6 +38,7 @@ export default function MostLikelyToGame({
   players,
   userId,
   isAdmin,
+  readOnly = false,
   move,
 }: GameViewProps<MltPublic, MltMe>) {
   const remaining = useRemaining(pub.deadline, pub.serverNow);
@@ -51,6 +52,7 @@ export default function MostLikelyToGame({
         players={players}
         userId={userId}
         isAdmin={isAdmin}
+        readOnly={readOnly}
         canStart={pub.totalPlayers >= 3}
         disabledLabel="Need at least 3 players"
         onStart={() => move("start")}
@@ -127,7 +129,7 @@ export default function MostLikelyToGame({
             <button
               key={player.id}
               type="button"
-              disabled={reveal || me.yourVote !== null}
+              disabled={readOnly || reveal || me.yourVote !== null}
               onClick={() => move("vote", { target: player.id })}
               style={{
                 position: "relative",
@@ -139,7 +141,10 @@ export default function MostLikelyToGame({
                 border: `1.5px solid ${isMyVote || isWinner ? color.accent : color.border}`,
                 background: color.surfaceRaised,
                 color: color.text,
-                cursor: reveal || me.yourVote !== null ? "default" : "pointer",
+                cursor:
+                  readOnly || reveal || me.yourVote !== null
+                    ? "default"
+                    : "pointer",
                 overflow: "hidden",
               }}
             >
@@ -170,7 +175,7 @@ export default function MostLikelyToGame({
         })}
       </div>
 
-      {isAdmin ? (
+      {isAdmin && !readOnly ? (
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
           {reveal ? (
             <GhostButton onClick={() => move("next")}>Next</GhostButton>

--- a/apps/web/src/app/components/games/ReactionGame.tsx
+++ b/apps/web/src/app/components/games/ReactionGame.tsx
@@ -56,6 +56,7 @@ export default function ReactionGame({
   players,
   userId,
   isAdmin,
+  readOnly = false,
   move,
 }: GameViewProps<ReactionPublic, ReactionMe>) {
   const elapsed = useElapsed(pub.goAt, pub.serverNow);
@@ -69,6 +70,7 @@ export default function ReactionGame({
         players={players}
         userId={userId}
         isAdmin={isAdmin}
+        readOnly={readOnly}
         startLabel="Start"
         onStart={() => move("start")}
       />
@@ -91,7 +93,7 @@ export default function ReactionGame({
       title = tappedValid ? `${me.reactionMs} ms` : "TAP!";
       sub = tappedValid ? "Locked in" : `${pub.tappedCount}/${pub.totalPlayers} tapped`;
     }
-    const canTap = !me.tapped;
+    const canTap = !readOnly && !me.tapped;
     const handleTap = () => {
       void move("tap");
     };
@@ -133,7 +135,7 @@ export default function ReactionGame({
             {title}
           </span>
           <span style={{ fontSize: 13, opacity: 0.85 }}>{sub}</span>
-          {isGo && !me.tapped ? (
+          {isGo && !readOnly && !me.tapped ? (
             <span style={{ fontSize: 12, opacity: 0.7, marginTop: 4 }}>{elapsed} ms</span>
           ) : null}
         </button>
@@ -194,7 +196,7 @@ export default function ReactionGame({
           </div>
         ))}
       </div>
-      {isAdmin ? (
+      {isAdmin && !readOnly ? (
         <div style={{ display: "flex", justifyContent: "flex-end" }}>
           <GhostButton onClick={() => move("next")}>Next</GhostButton>
         </div>

--- a/apps/web/src/app/components/games/TriviaGame.tsx
+++ b/apps/web/src/app/components/games/TriviaGame.tsx
@@ -49,6 +49,7 @@ export default function TriviaGame({
   players,
   userId,
   isAdmin,
+  readOnly = false,
   move,
 }: GameViewProps<TriviaPublic, TriviaMe>) {
   const remaining = useRemaining(pub.deadline, pub.serverNow);
@@ -62,6 +63,7 @@ export default function TriviaGame({
         players={players}
         userId={userId}
         isAdmin={isAdmin}
+        readOnly={readOnly}
         startLabel="Start quiz"
         onStart={() => move("start")}
       />
@@ -148,7 +150,7 @@ export default function TriviaGame({
             bg = color.accentSoft;
             bd = color.accent;
           }
-          const locked = reveal || me.answered;
+          const locked = readOnly || reveal || me.answered;
           return (
             <button
               key={index}
@@ -207,7 +209,9 @@ export default function TriviaGame({
               : me.answered
                 ? "Not quite"
                 : "Time's up"
-            : me.answered
+            : readOnly
+              ? "Watching only"
+              : me.answered
               ? "Locked in"
               : "Pick an answer"}
         </span>
@@ -216,7 +220,7 @@ export default function TriviaGame({
         </span>
       </div>
 
-      {isAdmin ? (
+      {isAdmin && !readOnly ? (
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
           {reveal ? (
             <GhostButton onClick={() => move("next")}>Next →</GhostButton>

--- a/apps/web/src/app/components/games/WouldYouRatherGame.tsx
+++ b/apps/web/src/app/components/games/WouldYouRatherGame.tsx
@@ -74,6 +74,7 @@ export default function WouldYouRatherGame({
   players,
   userId,
   isAdmin,
+  readOnly = false,
   move,
 }: GameViewProps<WyrPublic, WyrMe>) {
   const remaining = useRemaining(pub.deadline, pub.serverNow);
@@ -87,6 +88,7 @@ export default function WouldYouRatherGame({
         players={players}
         userId={userId}
         isAdmin={isAdmin}
+        readOnly={readOnly}
         onStart={() => move("start")}
       />
     );
@@ -135,14 +137,14 @@ export default function WouldYouRatherGame({
           text={pub.optionA ?? ""}
           picked={me.choice === 0}
           accent={accentA}
-          disabled={reveal || me.choice !== null}
+          disabled={readOnly || reveal || me.choice !== null}
           onClick={() => move("choose", { option: 0 })}
         />
         <OptionCard
           text={pub.optionB ?? ""}
           picked={me.choice === 1}
           accent={accentB}
-          disabled={reveal || me.choice !== null}
+          disabled={readOnly || reveal || me.choice !== null}
           onClick={() => move("choose", { option: 1 })}
         />
       </div>
@@ -170,11 +172,15 @@ export default function WouldYouRatherGame({
         </div>
       ) : (
         <p style={{ fontSize: 12, color: color.textMuted, textAlign: "center", margin: 0 }}>
-          {me.choice !== null ? "Locked in" : "Pick a side"}
+          {readOnly
+            ? "Watching only"
+            : me.choice !== null
+              ? "Locked in"
+              : "Pick a side"}
         </p>
       )}
 
-      {isAdmin ? (
+      {isAdmin && !readOnly ? (
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
           {reveal ? (
             <GhostButton onClick={() => move("next")}>Next</GhostButton>

--- a/apps/web/src/app/components/games/gameUi.tsx
+++ b/apps/web/src/app/components/games/gameUi.tsx
@@ -175,6 +175,7 @@ export type GameViewProps<Pub = unknown, Me = unknown> = {
   me: Me;
   players: GamePlayer[];
   isAdmin: boolean;
+  readOnly?: boolean;
   userId: string | null;
   hostId: string | null;
   phase: string;
@@ -413,6 +414,7 @@ export function GameLobby({
   blurb,
   players,
   isAdmin,
+  readOnly = false,
   canStart = true,
   startLabel = "Start",
   disabledLabel,
@@ -425,6 +427,7 @@ export function GameLobby({
   players: GamePlayer[];
   isAdmin: boolean;
   userId?: string | null;
+  readOnly?: boolean;
   canStart?: boolean;
   startLabel?: string;
   disabledLabel?: string;
@@ -473,7 +476,7 @@ export function GameLobby({
         </p>
 
         <div style={{ width: "100%", maxWidth: 300, marginTop: 26 }}>
-          {isAdmin ? (
+          {isAdmin && !readOnly ? (
             <PrimaryButton full disabled={!canStart} onClick={onStart}>
               {canStart ? startLabel : disabledLabel ?? startLabel}
             </PrimaryButton>
@@ -491,8 +494,12 @@ export function GameLobby({
               }}
             >
               <span style={{ width: 7, height: 7, borderRadius: radius.pill, background: accent }} />
-              <span style={{ fontSize: 13, color: color.text }}>You&apos;re in</span>
-              <span style={{ fontSize: 13, color: color.textMuted }}>· {waitingText}</span>
+              <span style={{ fontSize: 13, color: color.text }}>
+                {readOnly ? "Watching" : "You're in"}
+              </span>
+              <span style={{ fontSize: 13, color: color.textMuted }}>
+                · {readOnly ? "observer mode" : waitingText}
+              </span>
             </div>
           )}
           <p style={{ fontSize: 12, color: color.textFaint, margin: "12px 0 0" }}>{count}</p>

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -3989,12 +3989,14 @@ export function useMeetSocket({
               ? Promise.resolve({ io: prewarm.io })
               : import("socket.io-client");
 
-            const cachedToken = prewarm?.getCachedToken?.(roomIdForJoin);
+            const cachedToken = ghostEnabled
+              ? null
+              : prewarm?.getCachedToken?.(roomIdForJoin);
             const tokenPromise = cachedToken
               ? Promise.resolve(cachedToken)
                 : getJoinInfo(roomIdForJoin, sessionIdRef.current, {
                     user,
-                    isHost: isAdmin || ghostEnabled,
+                    isHost: isAdmin,
                     isGhost: ghostEnabled,
                     joinMode,
                   });

--- a/apps/web/src/app/hooks/useSharedBrowser.ts
+++ b/apps/web/src/app/hooks/useSharedBrowser.ts
@@ -119,7 +119,7 @@ export function useSharedBrowser({
 
     useEffect(() => {
         const socket = socketRef.current;
-        if (!socket || !browserState.active) {
+        if (!socket || !browserState.active || !isAdmin) {
             if (activityIntervalRef.current) {
                 clearInterval(activityIntervalRef.current);
                 activityIntervalRef.current = null;
@@ -137,7 +137,7 @@ export function useSharedBrowser({
                 activityIntervalRef.current = null;
             }
         };
-    }, [browserState.active, socketRef]);
+    }, [browserState.active, isAdmin, socketRef]);
 
     const launchBrowser = useCallback(
         async (url: string): Promise<boolean> => {

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -934,6 +934,8 @@ export default function MeetsClient({
   const isWebinarAttendee =
     joinMode === "webinar_attendee" || webinarRole === "attendee";
   const ghostEnabled = canGhostJoinFlag && isGhostMode;
+  const isReadOnlyObserver = ghostEnabled || isWebinarAttendee;
+  const canModerateMeeting = isAdminFlag && !isReadOnlyObserver;
   const shouldRunVideoEffects = shouldRunVisualVideoEffects;
   const shouldPublishProcessedVideo = shouldRunVisualVideoEffects;
   const canSignOut = Boolean(
@@ -2197,7 +2199,7 @@ export default function MeetsClient({
     clearError: clearBrowserError,
   } = useSharedBrowser({
     socketRef: refs.socketRef,
-    isAdmin: isAdminFlag,
+    isAdmin: canModerateMeeting,
   });
   const showBrowserControls = Boolean(
     browserState?.active || isBrowserServiceAvailable,
@@ -2206,7 +2208,7 @@ export default function MeetsClient({
   const voiceAgent = useVoiceAgentParticipant({
     roomId,
     isJoined: connectionState === "joined",
-    isAdmin: isAdminFlag,
+    isAdmin: canModerateMeeting,
     isMuted,
     activeSpeakerId,
     localUserId: userId,
@@ -2335,10 +2337,10 @@ export default function MeetsClient({
 
   useEffect(() => {
     if (connectionState !== "joined") return;
-    if (!isAdminFlag) return;
+    if (!canModerateMeeting) return;
     void getMeetingConfig?.();
     void getWebinarConfig?.();
-  }, [connectionState, isAdminFlag, getMeetingConfig, getWebinarConfig]);
+  }, [connectionState, canModerateMeeting, getMeetingConfig, getWebinarConfig]);
 
   const handleGoHome = useCallback(() => {
     handleStopVoiceAgent();
@@ -2556,7 +2558,7 @@ export default function MeetsClient({
     });
 
   useHotkey(HOTKEYS.toggleLockMeeting.keys as RegisterableHotkey, () => {
-    if (isAdminFlag) {
+    if (canModerateMeeting) {
       socket.toggleRoomLock(!isRoomLocked);
     }
   }, {
@@ -2676,10 +2678,16 @@ export default function MeetsClient({
       <AppsProvider
         socket={appsSocket}
         user={appsUser}
-        isAdmin={isAdminFlag}
+        isAdmin={canModerateMeeting}
+        isReadOnly={isReadOnlyObserver}
         uploadAsset={uploadAsset}
       >
-        <GameProvider socket={appsSocket} user={appsUser} isAdmin={isAdminFlag}>
+        <GameProvider
+          socket={appsSocket}
+          user={appsUser}
+          isAdmin={canModerateMeeting}
+          isReadOnly={isReadOnlyObserver}
+        >
           <MeetVolumeProvider
             meetVolume={meetVolume}
             setMeetVolume={setMeetVolume}
@@ -2827,7 +2835,7 @@ export default function MeetsClient({
         waitingTitle={waitingTitle}
         waitingIntro={waitingIntro}
         roomId={roomId}
-        isAdmin={isAdminFlag}
+        isAdmin={canModerateMeeting}
       />,
     );
   }
@@ -2871,7 +2879,7 @@ export default function MeetsClient({
         allowGhostMode={canGhostJoinFlag}
         user={currentUser}
         userEmail={userEmail}
-        isAdmin={isAdminFlag}
+        isAdmin={canModerateMeeting}
         showPermissionHint={showPermissionHint}
         availableRooms={availableRooms}
         roomsStatus={roomsStatus}
@@ -2927,7 +2935,9 @@ export default function MeetsClient({
         toggleHandRaised={toggleHandRaised}
         sendReaction={sendReaction}
         leaveRoom={leaveRoom}
-        endRoomForEveryone={socket.endRoomForEveryone}
+        endRoomForEveryone={
+          canModerateMeeting ? socket.endRoomForEveryone : undefined
+        }
         onGoHome={handleGoHome}
         onStartNewMeeting={
           joinMode === "meeting" ? handleStartNewMeeting : undefined
@@ -2962,11 +2972,17 @@ export default function MeetsClient({
         isTtsDisabled={isTtsDisabled}
         isDmEnabled={isDmEnabled}
         isReactionsDisabled={isReactionsDisabled}
-        onToggleLock={() => socket.toggleRoomLock(!isRoomLocked)}
+        onToggleLock={() => {
+          if (canModerateMeeting) socket.toggleRoomLock(!isRoomLocked);
+        }}
         isNoGuests={isNoGuests}
-        onToggleNoGuests={() => socket.toggleNoGuests(!isNoGuests)}
+        onToggleNoGuests={() => {
+          if (canModerateMeeting) socket.toggleNoGuests(!isNoGuests);
+        }}
         isChatLocked={isChatLocked}
-        onToggleChatLock={() => socket.toggleChatLock(!isChatLocked)}
+        onToggleChatLock={() => {
+          if (canModerateMeeting) socket.toggleChatLock(!isChatLocked);
+        }}
         browserState={browserState}
         isBrowserLaunching={isBrowserLaunching}
         browserLaunchError={browserLaunchError}
@@ -2997,18 +3013,30 @@ export default function MeetsClient({
         webinarSpeakerUserId={webinarSpeakerUserId}
         webinarLink={webinarLink}
         onSetWebinarLink={setWebinarLink}
-        onGetMeetingConfig={socket.getMeetingConfig}
-        onUpdateMeetingConfig={socket.updateMeetingConfig}
-        onGetWebinarConfig={socket.getWebinarConfig}
-        onUpdateWebinarConfig={socket.updateWebinarConfig}
-        onGenerateWebinarLink={socket.generateWebinarLink}
-        onRotateWebinarLink={socket.rotateWebinarLink}
+        onGetMeetingConfig={
+          canModerateMeeting ? socket.getMeetingConfig : undefined
+        }
+        onUpdateMeetingConfig={
+          canModerateMeeting ? socket.updateMeetingConfig : undefined
+        }
+        onGetWebinarConfig={
+          canModerateMeeting ? socket.getWebinarConfig : undefined
+        }
+        onUpdateWebinarConfig={
+          canModerateMeeting ? socket.updateWebinarConfig : undefined
+        }
+        onGenerateWebinarLink={
+          canModerateMeeting ? socket.generateWebinarLink : undefined
+        }
+        onRotateWebinarLink={
+          canModerateMeeting ? socket.rotateWebinarLink : undefined
+        }
         transcript={transcript}
         isVoiceAgentRunning={voiceAgent.isRunning}
         isVoiceAgentStarting={voiceAgent.isStarting}
         voiceAgentError={voiceAgent.error}
-        onStartVoiceAgent={handleStartVoiceAgent}
-        onStopVoiceAgent={handleStopVoiceAgent}
+        onStartVoiceAgent={canModerateMeeting ? handleStartVoiceAgent : undefined}
+        onStopVoiceAgent={canModerateMeeting ? handleStopVoiceAgent : undefined}
         onClearVoiceAgentError={voiceAgent.clearError}
       />
       {inviteCodePrompt}

--- a/apps/web/src/app/sfu-admin/sfu-admin-dashboard.tsx
+++ b/apps/web/src/app/sfu-admin/sfu-admin-dashboard.tsx
@@ -275,7 +275,6 @@ export default function SfuAdminDashboard() {
   const [kickPresent, setKickPresent] = useState(true);
 
   const [removeReason, setRemoveReason] = useState("Stage reset by operator");
-  const [includeGhosts, setIncludeGhosts] = useState(false);
   const [includeAttendees, setIncludeAttendees] = useState(false);
   const [moderationReason, setModerationReason] = useState("Removed by operator");
 
@@ -1344,14 +1343,6 @@ export default function SfuAdminDashboard() {
                         placeholder="Remove non-admins reason"
                       />
                       <label className="flex items-center justify-between text-xs">
-                        <span>Include ghosts</span>
-                        <input
-                          type="checkbox"
-                          checked={includeGhosts}
-                          onChange={(event) => setIncludeGhosts(event.target.checked)}
-                        />
-                      </label>
-                      <label className="flex items-center justify-between text-xs">
                         <span>Include attendees</span>
                         <input
                           type="checkbox"
@@ -1368,7 +1359,6 @@ export default function SfuAdminDashboard() {
                             label: "Removed non-admins",
                             path: `rooms/${selectedRoomPath}/users/remove-non-admins`,
                             body: {
-                              includeGhosts,
                               includeAttendees,
                               reason: removeReason.trim() || undefined,
                             },

--- a/packages/apps-sdk/src/apps/dev-playground/web/components/DevPlaygroundWebApp.tsx
+++ b/packages/apps-sdk/src/apps/dev-playground/web/components/DevPlaygroundWebApp.tsx
@@ -56,13 +56,13 @@ const formatTime = (value: number | null): string => {
 
 export function DevPlaygroundWebApp() {
   const { doc, locked } = useAppDoc(APP_ID);
-  const { user, isAdmin } = useApps();
+  const { user, isAdmin, isReadOnly } = useApps();
   const { states, setLocalState } = useAppPresence(APP_ID);
 
   const [snapshot, setSnapshot] = useState<Snapshot>(() => readSnapshot(doc));
   const [draftItem, setDraftItem] = useState("");
 
-  const canEdit = !locked || Boolean(isAdmin);
+  const canEdit = !isReadOnly && (!locked || Boolean(isAdmin));
   const userId = user?.id ?? "guest";
   const userName = user?.name ?? user?.email ?? userId;
   const presenceColor = useMemo(() => stringToColor(userId), [userId]);

--- a/packages/apps-sdk/src/apps/whiteboard/web/components/WhiteboardWebApp.tsx
+++ b/packages/apps-sdk/src/apps/whiteboard/web/components/WhiteboardWebApp.tsx
@@ -9,13 +9,13 @@ import { WhiteboardCanvas, type WhiteboardStressResult } from "./WhiteboardCanva
 import { useWhiteboardPages } from "../../shared/hooks/useWhiteboardPages";
 
 export function WhiteboardWebApp() {
-  const { user, isAdmin } = useApps();
+  const { user, isAdmin, isReadOnly: appReadOnly } = useApps();
   const { doc, awareness, locked } = useAppDoc("whiteboard");
   const { states } = useAppPresence("whiteboard");
   const { tool, setTool, settings, setSettings } = useToolState();
   const { viewport, panBy, zoomAt, resetViewport, panStartRef } = useViewport();
   const lastPanPosRef = useRef<{ x: number; y: number } | null>(null);
-  const isReadOnly = locked && !isAdmin;
+  const isReadOnly = Boolean(appReadOnly) || (locked && !isAdmin);
   const {
     pages,
     activePageId,

--- a/packages/apps-sdk/src/games/GameProvider.tsx
+++ b/packages/apps-sdk/src/games/GameProvider.tsx
@@ -63,6 +63,7 @@ export type GameProviderProps = {
   socket: Socket | null;
   user?: GameUser;
   isAdmin?: boolean;
+  isReadOnly?: boolean;
   children: React.ReactNode;
 };
 
@@ -70,6 +71,7 @@ export function GameProvider({
   socket,
   user,
   isAdmin = false,
+  isReadOnly = false,
   children,
 }: GameProviderProps) {
   const [catalog, setCatalog] = useState<GameCatalogEntry[]>([]);
@@ -168,6 +170,9 @@ export function GameProvider({
 
   const startGame = useCallback(
     async (gameId: string, options?: GameConfig): Promise<GameMoveResult> => {
+      if (isReadOnly) {
+        return { success: false, error: "Observer mode is read-only" };
+      }
       if (!socket) return { success: false, error: "Not connected" };
       return emitWithAck<GameMoveResult>(
         socket,
@@ -177,10 +182,13 @@ export function GameProvider({
         START_GAME_ACK_TIMEOUT_MS,
       );
     },
-    [socket],
+    [socket, isReadOnly],
   );
 
   const endGame = useCallback(async (): Promise<GameMoveResult> => {
+    if (isReadOnly) {
+      return { success: false, error: "Observer mode is read-only" };
+    }
     if (!socket) return { success: false, error: "Not connected" };
     return emitWithAck<GameMoveResult>(
       socket,
@@ -188,10 +196,13 @@ export function GameProvider({
       undefined,
       { success: false, error: "Timed out" },
     );
-  }, [socket]);
+  }, [socket, isReadOnly]);
 
   const move = useCallback(
     async (type: string, payload?: unknown): Promise<GameMoveResult> => {
+      if (isReadOnly) {
+        return { success: false, error: "Observer mode is read-only" };
+      }
       if (!socket) return { success: false, error: "Not connected" };
       const gameId = activeGameIdRef.current;
       if (!gameId) return { success: false, error: "No active game" };
@@ -202,11 +213,14 @@ export function GameProvider({
         { success: false, error: "Timed out" },
       );
     },
-    [socket],
+    [socket, isReadOnly],
   );
 
   const openVote = useCallback(
     async (candidateIds?: string[]): Promise<GameMoveResult> => {
+      if (isReadOnly) {
+        return { success: false, error: "Observer mode is read-only" };
+      }
       if (!socket) return { success: false, error: "Not connected" };
       return emitWithAck<GameMoveResult>(
         socket,
@@ -215,11 +229,14 @@ export function GameProvider({
         { success: false, error: "Timed out" },
       );
     },
-    [socket],
+    [socket, isReadOnly],
   );
 
   const castVote = useCallback(
     async (gameId: string): Promise<GameMoveResult> => {
+      if (isReadOnly) {
+        return { success: false, error: "Observer mode is read-only" };
+      }
       if (!socket) return { success: false, error: "Not connected" };
       return emitWithAck<GameMoveResult>(
         socket,
@@ -228,10 +245,13 @@ export function GameProvider({
         { success: false, error: "Timed out" },
       );
     },
-    [socket],
+    [socket, isReadOnly],
   );
 
   const cancelVote = useCallback(async (): Promise<GameMoveResult> => {
+    if (isReadOnly) {
+      return { success: false, error: "Observer mode is read-only" };
+    }
     if (!socket) return { success: false, error: "Not connected" };
     return emitWithAck<GameMoveResult>(
       socket,
@@ -239,7 +259,7 @@ export function GameProvider({
       undefined,
       { success: false, error: "Timed out" },
     );
-  }, [socket]);
+  }, [socket, isReadOnly]);
 
   const value = useMemo<GameContextValue>(
     () => ({
@@ -248,7 +268,8 @@ export function GameProvider({
       view,
       vote,
       isActive: publicState !== null,
-      isAdmin,
+      isAdmin: isReadOnly ? false : isAdmin,
+      isReadOnly,
       userId,
       startGame,
       endGame,
@@ -258,7 +279,22 @@ export function GameProvider({
       cancelVote,
       refresh,
     }),
-    [catalog, publicState, view, vote, isAdmin, userId, startGame, endGame, move, openVote, castVote, cancelVote, refresh],
+    [
+      catalog,
+      publicState,
+      view,
+      vote,
+      isAdmin,
+      isReadOnly,
+      userId,
+      startGame,
+      endGame,
+      move,
+      openVote,
+      castVote,
+      cancelVote,
+      refresh,
+    ],
   );
 
   return <GameContext.Provider value={value}>{children}</GameContext.Provider>;

--- a/packages/apps-sdk/src/games/types.ts
+++ b/packages/apps-sdk/src/games/types.ts
@@ -90,6 +90,7 @@ export type GameContextValue = {
   vote: GameVote | null;
   isActive: boolean;
   isAdmin: boolean;
+  isReadOnly: boolean;
   userId: string | null;
   startGame: (gameId: string, options?: GameConfig) => Promise<GameMoveResult>;
   endGame: () => Promise<GameMoveResult>;

--- a/packages/apps-sdk/src/sdk/hooks/useAppPresence.ts
+++ b/packages/apps-sdk/src/sdk/hooks/useAppPresence.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Awareness } from "y-protocols/awareness";
 import { useAppDoc } from "./useAppDoc";
+import { useApps } from "./useApps";
 
 export type PresenceState = {
   clientId: number;
@@ -55,6 +56,7 @@ const snapshotAwareness = (awareness: Awareness): PresenceState[] => {
 
 export const useAppPresence = (appId: string) => {
   const { awareness } = useAppDoc(appId);
+  const { isReadOnly } = useApps();
   const [states, setStates] = useState<PresenceState[]>(() => snapshotAwareness(awareness));
 
   useEffect(() => {
@@ -67,9 +69,17 @@ export const useAppPresence = (appId: string) => {
     };
   }, [awareness]);
 
+  useEffect(() => {
+    if (!isReadOnly) return;
+    awareness.setLocalState(null);
+  }, [awareness, isReadOnly]);
+
   const setLocalState = useMemo(
-    () => awareness.setLocalState.bind(awareness) as (state: unknown) => void,
-    [awareness]
+    () =>
+      isReadOnly
+        ? ((() => {}) as (state: unknown) => void)
+        : (awareness.setLocalState.bind(awareness) as (state: unknown) => void),
+    [awareness, isReadOnly]
   );
 
   return { awareness, states, setLocalState };

--- a/packages/apps-sdk/src/sdk/runtime/AppsProvider.tsx
+++ b/packages/apps-sdk/src/sdk/runtime/AppsProvider.tsx
@@ -25,6 +25,7 @@ export type AppsProviderProps = {
   socket: Socket | null;
   user?: AppUser;
   isAdmin?: boolean;
+  isReadOnly?: boolean;
   uploadAsset?: AssetUploadHandler;
   children: React.ReactNode;
 };
@@ -114,6 +115,7 @@ export function AppsProvider({
   socket,
   user,
   isAdmin,
+  isReadOnly = false,
   uploadAsset,
   children,
 }: AppsProviderProps) {
@@ -131,6 +133,11 @@ export function AppsProvider({
     Map<string, (event: AwarenessUpdateEvent, origin: unknown) => void>
   >(new Map());
   const socketRef = useRef<Socket | null>(null);
+  const isReadOnlyRef = useRef(isReadOnly);
+
+  useEffect(() => {
+    isReadOnlyRef.current = isReadOnly;
+  }, [isReadOnly]);
 
   const resetLocalData = useCallback(() => {
     for (const [appId, doc] of docsRef.current.entries()) {
@@ -180,6 +187,7 @@ export function AppsProvider({
 
     const handler = (update: Uint8Array, origin: unknown) => {
       if (origin === "remote") return;
+      if (isReadOnlyRef.current) return;
       const currentSocket = socketRef.current;
       if (!currentSocket) return;
       const payload: AppsUpdatePayload = { appId, update };
@@ -192,6 +200,7 @@ export function AppsProvider({
 
   const queueInitialUpdate = useCallback((appId: string, doc: Y.Doc) => {
     if (initialUpdateSentRef.current.has(appId)) return;
+    if (isReadOnlyRef.current) return;
 
     const update = Y.encodeStateAsUpdate(doc);
     if (update.length === 0) return;
@@ -212,6 +221,7 @@ export function AppsProvider({
 
     const handler = ({ added, updated, removed }: AwarenessUpdateEvent, origin: unknown) => {
       if (origin === "remote") return;
+      if (isReadOnlyRef.current) return;
 
       const currentSocket = socketRef.current;
       if (!currentSocket || !currentSocket.connected) return;
@@ -309,7 +319,7 @@ export function AppsProvider({
           const serverVector = toUint8Array(response.stateVector);
           if (!serverVector) return;
           const updateForServer = Y.encodeStateAsUpdate(doc, serverVector);
-          if (updateForServer.length > 0) {
+          if (updateForServer.length > 0 && !isReadOnlyRef.current) {
             currentSocket.emit("apps:yjs:update", { appId, update: updateForServer });
           }
         }
@@ -367,6 +377,7 @@ export function AppsProvider({
     if (!socket) return;
 
     const flushPending = () => {
+      if (isReadOnlyRef.current) return;
       const pending = pendingInitialUpdatesRef.current;
       if (pending.size === 0) return;
 
@@ -392,6 +403,7 @@ export function AppsProvider({
   const openApp = useCallback(async (appId: string, options?: Record<string, unknown>) => {
     const currentSocket = socketRef.current;
     if (!currentSocket) return false;
+    if (isReadOnlyRef.current) return false;
     if (!getAppById(appId)) {
       console.warn(`[Apps] Attempted to open unregistered app: ${appId}`);
       return false;
@@ -418,6 +430,7 @@ export function AppsProvider({
   const closeApp = useCallback(async () => {
     const currentSocket = socketRef.current;
     if (!currentSocket) return false;
+    if (isReadOnlyRef.current) return false;
 
     return new Promise<boolean>((resolve) => {
       let completed = false;
@@ -439,6 +452,7 @@ export function AppsProvider({
   const setLocked = useCallback(async (locked: boolean) => {
     const currentSocket = socketRef.current;
     if (!currentSocket) return false;
+    if (isReadOnlyRef.current) return false;
 
     return new Promise<boolean>((resolve) => {
       let completed = false;
@@ -470,6 +484,7 @@ export function AppsProvider({
       getAwareness,
       user,
       isAdmin,
+      isReadOnly,
       uploadAsset,
     }),
     [
@@ -483,6 +498,7 @@ export function AppsProvider({
       getAwareness,
       user,
       isAdmin,
+      isReadOnly,
       uploadAsset,
     ]
   );

--- a/packages/apps-sdk/src/sdk/types/index.ts
+++ b/packages/apps-sdk/src/sdk/types/index.ts
@@ -74,6 +74,7 @@ export type AppsContextValue = {
   getAwareness: (appId: string) => Awareness;
   user?: AppUser;
   isAdmin?: boolean;
+  isReadOnly?: boolean;
   uploadAsset?: AssetUploadHandler;
 };
 

--- a/packages/sfu/API.md
+++ b/packages/sfu/API.md
@@ -201,7 +201,7 @@ curl -X POST "http://localhost:3031/admin/rooms/room-123/access/block?clientId=d
 curl -X POST "http://localhost:3031/admin/rooms/room-123/users/remove-non-admins?clientId=default" \
   -H "content-type: application/json" \
   -H "x-sfu-secret: development-secret" \
-  -d '{"includeGhosts":false,"includeAttendees":true,"reason":"Stage reset"}'
+  -d '{"includeAttendees":true,"reason":"Stage reset"}'
 ```
 
 ### End room

--- a/packages/sfu/config/classes/Room.ts
+++ b/packages/sfu/config/classes/Room.ts
@@ -227,12 +227,11 @@ export class Room {
   }
 
   getDisplayNameSnapshot(options?: {
-    includeGhosts?: boolean;
     includeWebinarAttendees?: boolean;
   }): { userId: string; displayName: string }[] {
     const snapshot: { userId: string; displayName: string }[] = [];
     for (const [userId, client] of this.clients.entries()) {
-      if (client.isGhost && !options?.includeGhosts) continue;
+      if (client.isGhost) continue;
       if (client.isWebinarAttendee && !options?.includeWebinarAttendees) {
         continue;
       }
@@ -310,6 +309,8 @@ export class Room {
   getHandRaisedSnapshot(): { userId: string; raised: boolean }[] {
     const snapshot: { userId: string; raised: boolean }[] = [];
     for (const userId of this.handRaisedByUserId) {
+      const client = this.clients.get(userId);
+      if (!client || client.isObserver) continue;
       snapshot.push({ userId, raised: true });
     }
     return snapshot;
@@ -348,10 +349,6 @@ export class Room {
       }
     }
     return others;
-  }
-
-  get clientCount(): number {
-    return this.clients.size;
   }
 
   getWebinarAttendeeCount(): number {
@@ -642,10 +639,7 @@ export class Room {
     }
   }
 
-  getAllProducers(
-    excludeClientId?: string,
-    options?: { includeGhostProducers?: boolean },
-  ): ProducerInfo[] {
+  getAllProducers(excludeClientId?: string): ProducerInfo[] {
     const producers: ProducerInfo[] = [];
 
     for (const [producerId, entry] of this.producerIndex) {
@@ -657,7 +651,7 @@ export class Room {
         continue;
       }
       const producerClient = this.clients.get(entry.userId);
-      if (producerClient?.isGhost && !options?.includeGhostProducers) {
+      if (producerClient?.isGhost) {
         continue;
       }
       producers.push(this.producerInfoFromIndexEntry(entry));
@@ -843,7 +837,7 @@ export class Room {
   getAdmins(): Admin[] {
     const admins: Admin[] = [];
     for (const client of this.clients.values()) {
-      if (client instanceof Admin) {
+      if (client instanceof Admin && !client.isGhost) {
         admins.push(client);
       }
     }
@@ -853,7 +847,7 @@ export class Room {
   getAdminUserIds(): string[] {
     const userIds: string[] = [];
     for (const client of this.clients.values()) {
-      if (client instanceof Admin) {
+      if (client instanceof Admin && !client.isGhost) {
         userIds.push(client.id);
       }
     }
@@ -888,7 +882,7 @@ export class Room {
       for (const [userId, userKey] of this.userKeysById.entries()) {
         if (userKey !== this.hostUserKey) continue;
         const client = this.clients.get(userId);
-        if (client instanceof Admin) {
+        if (client instanceof Admin && !client.isGhost) {
           return userId;
         }
       }
@@ -900,7 +894,7 @@ export class Room {
 
   hasActiveAdmin(): boolean {
     for (const client of this.clients.values()) {
-      if (client instanceof Admin) {
+      if (client instanceof Admin && !client.isGhost) {
         return true;
       }
     }

--- a/packages/sfu/server/admin/controlPlane.ts
+++ b/packages/sfu/server/admin/controlPlane.ts
@@ -11,7 +11,6 @@ import type { Room } from "../../config/classes/Room.js";
 import type { AppsAwarenessData } from "../../types.js";
 import { isGuestUserKey } from "../identity.js";
 import { cleanupRoom, getRoomChannelId } from "../rooms.js";
-import { emitUserLeft } from "../notifications.js";
 import type { SfuState } from "../state.js";
 import {
   emitWebinarAttendeeCountChanged,
@@ -296,6 +295,7 @@ export const toPendingUserSnapshots = (room: Room): PendingUserSnapshot[] => {
 
 export const toRoomSnapshot = (room: Room): RoomSnapshot => {
   const participants = Array.from(room.clients.values())
+    .filter((client) => !client.isGhost)
     .map((client) => toParticipantSnapshot(room, client));
   const pendingUsers = toPendingUserSnapshots(room);
   const adminCount = participants.filter(
@@ -309,8 +309,7 @@ export const toRoomSnapshot = (room: Room): RoomSnapshot => {
     (sum, participant) => sum + participant.consumerCount,
     0,
   );
-  const ghosts = participants.filter((participant) => participant.role === "ghost")
-    .length;
+  const ghosts = 0;
   const attendees = participants.filter(
     (participant) => participant.role === "attendee",
   ).length;
@@ -345,7 +344,7 @@ export const toRoomSnapshot = (room: Room): RoomSnapshot => {
       blockedUserKeys: Array.from(room.blockedUsers.values()).sort(),
     },
     counts: {
-      participants: room.clients.size,
+      participants: participants.length,
       activeParticipants: room.getMeetingParticipantCount(),
       admins: adminCount,
       guests,
@@ -371,7 +370,8 @@ export const toClusterSnapshot = (state: SfuState): ClusterSnapshot => {
         channelId: room.channelId,
         roomId: room.id,
         clientId: room.clientId,
-        participantCount: room.clients.size,
+        participantCount:
+          room.getMeetingParticipantCount() + room.getWebinarAttendeeCount(),
         pendingUserCount: room.pendingClients.size,
         adminCount: room.getAdmins().length,
       };
@@ -379,7 +379,11 @@ export const toClusterSnapshot = (state: SfuState): ClusterSnapshot => {
     .sort((a, b) => b.participantCount - a.participantCount)
     .slice(0, 10);
 
-  const participants = rooms.reduce((sum, room) => sum + room.clients.size, 0);
+  const participants = rooms.reduce(
+    (sum, room) =>
+      sum + room.getMeetingParticipantCount() + room.getWebinarAttendeeCount(),
+    0,
+  );
   const pendingUsers = rooms.reduce(
     (sum, room) => sum + room.pendingClients.size,
     0,
@@ -391,14 +395,14 @@ export const toClusterSnapshot = (state: SfuState): ClusterSnapshot => {
   );
   const producers = rooms.reduce((sum, room) => {
     const roomProducers = Array.from(room.clients.values()).reduce(
-      (inner, client) => inner + client.producers.size,
+      (inner, client) => inner + (client.isGhost ? 0 : client.producers.size),
       0,
     );
     return sum + roomProducers;
   }, 0);
   const consumers = rooms.reduce((sum, room) => {
     const roomConsumers = Array.from(room.clients.values()).reduce(
-      (inner, client) => inner + client.consumers.size,
+      (inner, client) => inner + (client.isGhost ? 0 : client.consumers.size),
       0,
     );
     return sum + roomConsumers;
@@ -830,7 +834,7 @@ export const forceRemoveClientNow = (options: {
   }
 
   const roomChannelId = room.channelId;
-  const wasAdmin = target instanceof Admin;
+  const wasAdmin = target instanceof Admin && !target.isObserver;
   const isGhost = target.isGhost;
   const isWebinarAttendee = target.isWebinarAttendee;
 
@@ -839,24 +843,26 @@ export const forceRemoveClientNow = (options: {
 
   // Clear awareness before removing the client so peers stop seeing its cursor.
   const awarenessRemovals = room.clearUserAwareness(userId);
-  for (const removal of awarenessRemovals) {
-    io.to(roomChannelId).emit("apps:awareness", {
-      appId: removal.appId,
-      awarenessUpdate: removal.awarenessUpdate,
-    } satisfies AppsAwarenessData);
+  if (!isGhost) {
+    for (const removal of awarenessRemovals) {
+      io.to(roomChannelId).emit("apps:awareness", {
+        appId: removal.appId,
+        awarenessUpdate: removal.awarenessUpdate,
+      } satisfies AppsAwarenessData);
+    }
   }
 
   // removeClient() closes the client's producers + transports => media stops now.
   room.removeClient(userId);
 
-  if (isGhost) {
-    emitUserLeft(room, userId, { ghostOnly: true, excludeUserId: userId });
-  } else if (!isWebinarAttendee) {
+  if (!isGhost && !isWebinarAttendee) {
     io.to(roomChannelId).emit("userLeft", { userId, roomId: room.id });
   }
 
-  emitWebinarAttendeeCountChanged(io, state, room);
-  emitWebinarFeedChanged(io, state, room);
+  if (!isGhost) {
+    emitWebinarAttendeeCountChanged(io, state, room);
+    emitWebinarFeedChanged(io, state, room);
+  }
 
   if (wasAdmin) {
     handleAdminRemoved(io, state, room);

--- a/packages/sfu/server/http/createApp.ts
+++ b/packages/sfu/server/http/createApp.ts
@@ -486,7 +486,8 @@ export const createSfuApp = ({
     return res.json({
       room: {
         id: room.id,
-        userCount: room.clientCount,
+        userCount:
+          room.getMeetingParticipantCount() + room.getWebinarAttendeeCount(),
       },
     });
   });
@@ -1025,7 +1026,6 @@ export const createSfuApp = ({
       return;
     }
 
-    const includeGhosts = req.body?.includeGhosts === true;
     const includeAttendees = req.body?.includeAttendees === true;
     const reason = normalizeOperatorReason(
       req.body?.reason,
@@ -1038,7 +1038,7 @@ export const createSfuApp = ({
       if (client instanceof Admin) {
         continue;
       }
-      if (!includeGhosts && client.isGhost) {
+      if (client.isGhost) {
         continue;
       }
       if (!includeAttendees && client.isWebinarAttendee) {

--- a/packages/sfu/server/notifications.ts
+++ b/packages/sfu/server/notifications.ts
@@ -4,19 +4,18 @@ export const emitUserJoined = (
   room: Room,
   userId: string,
   displayName: string,
-  options?: { ghostOnly?: boolean; excludeUserId?: string; isGhost?: boolean },
+  options?: { excludeUserId?: string },
 ): void => {
+  if (room.getClient(userId)?.isGhost) {
+    return;
+  }
   for (const client of room.clients.values()) {
     if (options?.excludeUserId && client.id === options.excludeUserId) {
-      continue;
-    }
-    if (options?.ghostOnly && !client.isGhost) {
       continue;
     }
     client.socket.emit("userJoined", {
       userId,
       displayName,
-      isGhost: options?.isGhost,
       roomId: room.id,
     });
   }
@@ -25,13 +24,13 @@ export const emitUserJoined = (
 export const emitUserLeft = (
   room: Room,
   userId: string,
-  options?: { ghostOnly?: boolean; excludeUserId?: string },
+  options?: { excludeUserId?: string },
 ): void => {
+  if (room.getClient(userId)?.isGhost) {
+    return;
+  }
   for (const client of room.clients.values()) {
     if (options?.excludeUserId && client.id === options.excludeUserId) {
-      continue;
-    }
-    if (options?.ghostOnly && !client.isGhost) {
       continue;
     }
     client.socket.emit("userLeft", { userId, roomId: room.id });

--- a/packages/sfu/server/socket/auth.ts
+++ b/packages/sfu/server/socket/auth.ts
@@ -5,6 +5,7 @@ import { config as defaultConfig } from "../../config/config.js";
 type SfuAuthPayload = JwtPayload & {
   clientId?: string;
   joinMode?: string;
+  canGhostJoin?: boolean;
 };
 
 const isSfuAuthPayload = (

--- a/packages/sfu/server/socket/handlers/adminHandlers.ts
+++ b/packages/sfu/server/socket/handlers/adminHandlers.ts
@@ -121,7 +121,7 @@ const ensureAdminRoom = (
     return { error: "Room not found" };
   }
 
-  if (!(currentClient instanceof Admin)) {
+  if (!(currentClient instanceof Admin) || currentClient.isObserver) {
     return { error: "Admin privileges required" };
   }
 
@@ -140,26 +140,22 @@ const toBulkMediaOptions = (
   value: unknown,
 ): {
   includeAdmins: boolean;
-  includeGhosts: boolean;
   includeAttendees: boolean;
 } => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return {
       includeAdmins: false,
-      includeGhosts: false,
       includeAttendees: false,
     };
   }
 
   const data = value as {
     includeAdmins?: unknown;
-    includeGhosts?: unknown;
     includeAttendees?: unknown;
   };
 
   return {
     includeAdmins: data.includeAdmins === true,
-    includeGhosts: data.includeGhosts === true,
     includeAttendees: data.includeAttendees === true,
   };
 };
@@ -262,7 +258,6 @@ const performBulkMediaClosure = (options: {
   };
   reason: string;
   includeAdmins?: boolean;
-  includeGhosts?: boolean;
   includeAttendees?: boolean;
 }): {
   affectedUsers: number;
@@ -282,7 +277,7 @@ const performBulkMediaClosure = (options: {
     if (!options.includeAdmins && client instanceof Admin) {
       continue;
     }
-    if (!options.includeGhosts && client.isGhost) {
+    if (client.isGhost) {
       continue;
     }
     if (!options.includeAttendees && client.isWebinarAttendee) {
@@ -591,7 +586,6 @@ export const registerAdminHandlers = (
       selector: { kinds: ["audio"] },
       reason: "Muted by host",
       includeAdmins: bulkOptions.includeAdmins,
-      includeGhosts: bulkOptions.includeGhosts,
       includeAttendees: bulkOptions.includeAttendees,
     });
 
@@ -620,7 +614,6 @@ export const registerAdminHandlers = (
       selector: { kinds: ["video"], types: ["webcam"] },
       reason: "Camera turned off by host",
       includeAdmins: bulkOptions.includeAdmins,
-      includeGhosts: bulkOptions.includeGhosts,
       includeAttendees: bulkOptions.includeAttendees,
     });
 
@@ -649,7 +642,6 @@ export const registerAdminHandlers = (
       selector: { types: ["screen"] },
       reason: "Screen share stopped by host",
       includeAdmins: bulkOptions.includeAdmins,
-      includeGhosts: bulkOptions.includeGhosts,
       includeAttendees: bulkOptions.includeAttendees,
     });
 
@@ -672,11 +664,9 @@ export const registerAdminHandlers = (
     }
 
     const currentRoom = context.currentRoom;
-    const isActiveAdmin = context.currentClient instanceof Admin;
-    const hasPersistedAdminRole = Boolean(
-      context.currentUserKey && currentRoom.isAdminUserKey(context.currentUserKey),
-    );
-    if (!isActiveAdmin && !hasPersistedAdminRole) {
+    const isActiveAdmin =
+      context.currentClient instanceof Admin && !context.currentClient.isObserver;
+    if (!isActiveAdmin) {
       respond(cb, { error: "Only hosts can promote another host." });
       return;
     }
@@ -806,7 +796,8 @@ export const registerAdminHandlers = (
       .filter((room) => room.clientId === clientId)
       .map((room) => ({
         id: room.id,
-        userCount: room.clientCount,
+        userCount:
+          room.getMeetingParticipantCount() + room.getWebinarAttendeeCount(),
       }));
     respond(cb, { rooms: roomList });
   });

--- a/packages/sfu/server/socket/handlers/appsHandlers.ts
+++ b/packages/sfu/server/socket/handlers/appsHandlers.ts
@@ -117,7 +117,7 @@ export const registerAppsHandlers = (context: ConnectionContext): void => {
         return;
       }
 
-      if (!(context.currentClient instanceof Admin)) {
+      if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) {
         respond(callback, { success: false, error: "Only admins can open apps" });
         return;
       }
@@ -153,7 +153,7 @@ export const registerAppsHandlers = (context: ConnectionContext): void => {
       return;
     }
 
-    if (!(context.currentClient instanceof Admin)) {
+    if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) {
       respond(callback, { success: false, error: "Only admins can close apps" });
       return;
     }
@@ -182,7 +182,7 @@ export const registerAppsHandlers = (context: ConnectionContext): void => {
         return;
       }
 
-      if (!(context.currentClient instanceof Admin)) {
+      if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) {
         respond(callback, { success: false, error: "Only admins can lock apps" });
         return;
       }
@@ -204,10 +204,6 @@ export const registerAppsHandlers = (context: ConnectionContext): void => {
     (data: AppsSyncData, callback: (response: AppsSyncResponse | { error: string }) => void) => {
       if (!context.currentRoom) {
         respond(callback, { error: "Not in a room" });
-        return;
-      }
-      if (context.currentClient?.isObserver) {
-        respond(callback, { error: "Watch-only attendees cannot use shared apps" });
         return;
       }
       if (!takeToken(socket, "apps:yjs:sync", RATE_LIMITS.appsYjsSync)) {
@@ -265,7 +261,10 @@ export const registerAppsHandlers = (context: ConnectionContext): void => {
     if (!appId) return;
     if (context.currentRoom.appsState.activeAppId !== appId) return;
 
-    if (context.currentRoom.appsState.locked && !(context.currentClient instanceof Admin)) {
+    if (
+      context.currentRoom.appsState.locked &&
+      (!(context.currentClient instanceof Admin) || context.currentClient.isObserver)
+    ) {
       return;
     }
 

--- a/packages/sfu/server/socket/handlers/chatHandlers.ts
+++ b/packages/sfu/server/socket/handlers/chatHandlers.ts
@@ -270,7 +270,8 @@ const resolveDirectMessageTarget = (
   );
 
   const candidates: DirectMessageTargetCandidate[] = [];
-  for (const [candidateUserId] of room.clients.entries()) {
+  for (const [candidateUserId, candidateClient] of room.clients.entries()) {
+    if (candidateClient.isObserver) continue;
     const displayName =
       room.getDisplayNameForUser(candidateUserId) ||
       fallbackDisplayNameFromUserId(candidateUserId);

--- a/packages/sfu/server/socket/handlers/disconnectHandlers.ts
+++ b/packages/sfu/server/socket/handlers/disconnectHandlers.ts
@@ -4,7 +4,6 @@ import { config } from "../../../config/config.js";
 import type { AppsAwarenessData } from "../../../types.js";
 import { Logger } from "../../../utilities/loggers.js";
 import { cleanupRoom } from "../../rooms.js";
-import { emitUserLeft } from "../../notifications.js";
 import {
   emitWebinarAttendeeCountChanged,
   emitWebinarFeedChanged,
@@ -61,16 +60,18 @@ export const registerDisconnectHandlers = (
           return;
         }
 
-        const wasAdmin = activeClient instanceof Admin;
+        const wasAdmin = activeClient instanceof Admin && !activeClient.isObserver;
         const isGhost = activeClient.isGhost;
         const isWebinarAttendee = activeClient.isWebinarAttendee;
         const awarenessRemovals = activeRoom.clearUserAwareness(userId);
 
-        for (const removal of awarenessRemovals) {
-          io.to(roomChannelId).emit("apps:awareness", {
-            appId: removal.appId,
-            awarenessUpdate: removal.awarenessUpdate,
-          } satisfies AppsAwarenessData);
+        if (!isGhost) {
+          for (const removal of awarenessRemovals) {
+            io.to(roomChannelId).emit("apps:awareness", {
+              appId: removal.appId,
+              awarenessUpdate: removal.awarenessUpdate,
+            } satisfies AppsAwarenessData);
+          }
         }
 
         activeRoom.removeClient(userId);
@@ -80,19 +81,16 @@ export const registerDisconnectHandlers = (
           canStopAnyRelay: false,
         });
         void state.transcriptRelays.syncRoom(activeRoom);
-        if (isGhost) {
-          emitUserLeft(activeRoom, userId, {
-            ghostOnly: true,
-            excludeUserId: userId,
-          });
-        } else if (!isWebinarAttendee) {
+        if (!isGhost && !isWebinarAttendee) {
           io.to(roomChannelId).emit("userLeft", {
             userId,
             roomId: activeRoom.id,
           });
         }
-        emitWebinarAttendeeCountChanged(io, state, activeRoom);
-        emitWebinarFeedChanged(io, state, activeRoom);
+        if (!isGhost) {
+          emitWebinarAttendeeCountChanged(io, state, activeRoom);
+          emitWebinarFeedChanged(io, state, activeRoom);
+        }
 
         if (wasAdmin) {
           if (!activeRoom.hasActiveAdmin()) {

--- a/packages/sfu/server/socket/handlers/displayNameHandlers.ts
+++ b/packages/sfu/server/socket/handlers/displayNameHandlers.ts
@@ -76,6 +76,8 @@ export const registerDisplayNameHandlers = (
         );
 
         for (const userId of updatedUserIds) {
+          const client = context.currentRoom.getClient(userId);
+          if (!client || client.isObserver) continue;
           io.to(context.currentRoom.channelId).emit("displayNameUpdated", {
             userId,
             displayName,

--- a/packages/sfu/server/socket/handlers/gameHandlers.ts
+++ b/packages/sfu/server/socket/handlers/gameHandlers.ts
@@ -73,7 +73,7 @@ const validatePlayerCount = (
 const collectAdminIds = (room: Room): string[] => {
   const ids: string[] = [];
   for (const client of room.clients.values()) {
-    if (client instanceof Admin) ids.push(client.id);
+    if (client instanceof Admin && !client.isObserver) ids.push(client.id);
   }
   return ids;
 };
@@ -215,7 +215,7 @@ export const registerGameHandlers = (context: ConnectionContext): void => {
         respond(callback, { success: false, error: "Not in a room" });
         return;
       }
-      if (!(context.currentClient instanceof Admin)) {
+      if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) {
         respond(callback, { success: false, error: "Only the host can start a game" });
         return;
       }
@@ -269,7 +269,7 @@ export const registerGameHandlers = (context: ConnectionContext): void => {
           return;
         }
         const hostClient = room.clients.get(hostId);
-        if (!(hostClient instanceof Admin)) {
+        if (!(hostClient instanceof Admin) || hostClient.isObserver) {
           respond(callback, { success: false, error: "Only the host can start a game" });
           return;
         }
@@ -310,7 +310,7 @@ export const registerGameHandlers = (context: ConnectionContext): void => {
         respond(callback, { success: false, error: "Not in a room" });
         return;
       }
-      if (!(context.currentClient instanceof Admin)) {
+      if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) {
         respond(callback, { success: false, error: "Only the host can open a vote" });
         return;
       }
@@ -372,7 +372,7 @@ export const registerGameHandlers = (context: ConnectionContext): void => {
       respond(callback, { success: false, error: "Not in a room" });
       return;
     }
-    if (!(context.currentClient instanceof Admin)) {
+    if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) {
       respond(callback, { success: false, error: "Only the host can cancel the vote" });
       return;
     }
@@ -436,7 +436,7 @@ export const registerGameHandlers = (context: ConnectionContext): void => {
       respond(callback, { success: false, error: "Not in a room" });
       return;
     }
-    if (!(context.currentClient instanceof Admin)) {
+    if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) {
       respond(callback, { success: false, error: "Only the host can end the game" });
       return;
     }

--- a/packages/sfu/server/socket/handlers/joinRoom.ts
+++ b/packages/sfu/server/socket/handlers/joinRoom.ts
@@ -15,7 +15,6 @@ import {
   isGuestUserKey,
   normalizeDisplayName,
 } from "../../identity.js";
-import { emitUserJoined, emitUserLeft } from "../../notifications.js";
 import {
   cleanupRoom,
   cleanupStaleRoom,
@@ -115,6 +114,14 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
             ? "webinar_attendee"
             : "meeting";
         const isWebinarAttendeeJoin = joinMode === "webinar_attendee";
+        const requestedGhostJoin =
+          !isWebinarAttendeeJoin && data?.ghost === true;
+        const canJoinAsGhost =
+          requestedGhostJoin && user?.canGhostJoin === true;
+        if (requestedGhostJoin && !canJoinAsGhost) {
+          respond(callback, { error: "Ghost mode is not available for this session" });
+          return;
+        }
         const tokenClientId =
           typeof user?.clientId === "string"
             ? normalizeIdentifier(user.clientId, MAX_CLIENT_ID_LENGTH)
@@ -297,6 +304,10 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
             respond(callback, { error: "Webinar is not live." });
             return;
           }
+          if (canJoinAsGhost) {
+            respond(callback, { error: "No room found." });
+            return;
+          }
           if (state.isDraining) {
             respond(callback, {
               error: "Meeting server is draining. Try again shortly.",
@@ -429,22 +440,19 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           if (!client) return;
 
           const awarenessRemovals = room.clearUserAwareness(targetUserId);
-          for (const removal of awarenessRemovals) {
-            io.to(roomChannelId).emit("apps:awareness", {
-              appId: removal.appId,
-              awarenessUpdate: removal.awarenessUpdate,
-            } satisfies AppsAwarenessData);
+          if (!client.isGhost) {
+            for (const removal of awarenessRemovals) {
+              io.to(roomChannelId).emit("apps:awareness", {
+                appId: removal.appId,
+                awarenessUpdate: removal.awarenessUpdate,
+              } satisfies AppsAwarenessData);
+            }
           }
 
           room.removeClient(targetUserId);
 
           if (!options?.notifyPeers) return;
-          if (client.isGhost) {
-            emitUserLeft(room, targetUserId, {
-              ghostOnly: true,
-              excludeUserId: targetUserId,
-            });
-          } else if (!client.isWebinarAttendee) {
+          if (!client.isGhost && !client.isWebinarAttendee) {
             io.to(roomChannelId).emit("userLeft", {
               userId: targetUserId,
               roomId: room.id,
@@ -473,13 +481,15 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
             isPersistedAdminForExistingRoom ||
             (hostRequested &&
               (clientPolicy.allowHostJoin || forcedHostJoin)));
-        const isAdminJoin = isWebinarAttendeeJoin
+        const isGhost = canJoinAsGhost;
+        const isAdminJoin = isWebinarAttendeeJoin || isGhost
           ? false
           : createdRoom
             ? true
             : isAdminForExistingRoom;
+        const hasPrivilegedJoinAccess = isAdminJoin || isGhost;
 
-        if (!isAdminJoin && room.isBlocked(userKey)) {
+        if (!hasPrivilegedJoinAccess && room.isBlocked(userKey)) {
           Logger.info(`Blocked identity ${userKey} denied access to room ${roomId}`);
           respond(callback, { error: "You are not allowed to join this meeting." });
           return;
@@ -500,7 +510,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
         const requiresMeetingInviteCode = room.requiresMeetingInviteCode;
         const shouldValidateMeetingInviteCode =
           !isWebinarAttendeeJoin &&
-          !isAdminJoin &&
+          !hasPrivilegedJoinAccess &&
           requiresMeetingInviteCode &&
           !isSameSessionMeetingParticipantRejoin;
 
@@ -528,7 +538,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
         if (
           !isWebinarAttendeeJoin &&
           room.noGuests &&
-          !isAdminJoin &&
+          !hasPrivilegedJoinAccess &&
           isGuestUserKey(userKey)
         ) {
           Logger.info(
@@ -558,14 +568,12 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           canSetDisplayName && displayNameCandidate ? displayNameCandidate : "";
         const displayName = requestedDisplayName || identity.displayName;
         const hasDisplayNameOverride = Boolean(requestedDisplayName);
-        const isGhost =
-          !isWebinarAttendeeJoin && data?.ghost === true && isAdminJoin;
         context.currentUserKey = userKey;
 
         if (
           !isWebinarAttendeeJoin &&
           room.isLocked &&
-          !isAdminJoin &&
+          !hasPrivilegedJoinAccess &&
           !room.isLockedAllowed(userKey)
         ) {
           Logger.info(
@@ -612,7 +620,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
         if (
           !isWebinarAttendeeJoin &&
           clientPolicy.useWaitingRoom &&
-          !isAdminJoin &&
+          !hasPrivilegedJoinAccess &&
           !room.isAllowed(userKey) &&
           !(room.isLocked && room.isLockedAllowed(userKey))
         ) {
@@ -693,21 +701,18 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
 
           const awarenessRemovals =
             previousRoom.clearUserAwareness(previousClientId);
-          for (const removal of awarenessRemovals) {
-            socket.to(previousChannelId).emit("apps:awareness", {
-              appId: removal.appId,
-              awarenessUpdate: removal.awarenessUpdate,
-            } satisfies AppsAwarenessData);
+          if (!context.currentClient.isGhost) {
+            for (const removal of awarenessRemovals) {
+              socket.to(previousChannelId).emit("apps:awareness", {
+                appId: removal.appId,
+                awarenessUpdate: removal.awarenessUpdate,
+              } satisfies AppsAwarenessData);
+            }
           }
 
           previousRoom.removeClient(previousClientId);
 
-          if (context.currentClient.isGhost) {
-            emitUserLeft(previousRoom, previousClientId, {
-              ghostOnly: true,
-              excludeUserId: previousClientId,
-            });
-          } else if (!context.currentClient.isWebinarAttendee) {
+          if (!context.currentClient.isGhost && !context.currentClient.isWebinarAttendee) {
             socket
               .to(previousChannelId)
               .emit("userLeft", {
@@ -716,8 +721,10 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
               });
           }
 
-          emitWebinarAttendeeCountChanged(io, state, previousRoom);
-          emitWebinarFeedChanged(io, state, previousRoom);
+          if (!context.currentClient.isGhost) {
+            emitWebinarAttendeeCountChanged(io, state, previousRoom);
+            emitWebinarFeedChanged(io, state, previousRoom);
+          }
 
           socket.leave(previousChannelId);
           cleanupRoom(state, previousChannelId);
@@ -761,16 +768,18 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
 
         socket.join(roomChannelId);
 
-        io.to(roomChannelId).emit("hostChanged", {
-          roomId: context.currentRoom.id,
-          hostUserId: context.currentRoom.getHostUserId(),
-        });
-        io.to(roomChannelId).emit("adminUsersChanged", {
-          roomId: context.currentRoom.id,
-          hostUserIds: context.currentRoom.getAdminUserIds(),
-        });
+        if (!context.currentClient.isGhost) {
+          io.to(roomChannelId).emit("hostChanged", {
+            roomId: context.currentRoom.id,
+            hostUserId: context.currentRoom.getHostUserId(),
+          });
+          io.to(roomChannelId).emit("adminUsersChanged", {
+            roomId: context.currentRoom.id,
+            hostUserIds: context.currentRoom.getAdminUserIds(),
+          });
+        }
 
-        if (context.currentClient instanceof Admin) {
+        if (context.currentClient instanceof Admin && !context.currentClient.isObserver) {
           const pendingUsers = Array.from(
             context.currentRoom.pendingClients.values(),
           ).map((pending) => ({
@@ -787,22 +796,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           context.currentRoom.getDisplayNameForUser(userId) || displayName;
         if (!wasReconnecting) {
           if (context.currentClient.isGhost) {
-            emitUserJoined(context.currentRoom, userId, resolvedDisplayName, {
-              ghostOnly: true,
-              excludeUserId: userId,
-              isGhost: true,
-            });
-            for (const [clientId, client] of context.currentRoom.clients) {
-              if (clientId === userId || !client.isGhost) continue;
-              const ghostDisplayName =
-                context.currentRoom.getDisplayNameForUser(clientId) || clientId;
-              socket.emit("userJoined", {
-                userId: clientId,
-                displayName: ghostDisplayName,
-                isGhost: true,
-                roomId: context.currentRoom.id,
-              });
-            }
+            // Ghost joins are intentionally invisible to every other room socket.
           } else if (!context.currentClient.isWebinarAttendee) {
             for (const [clientId, client] of context.currentRoom.clients) {
               if (clientId === userId) {
@@ -843,7 +837,6 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
         }
 
         const displayNameSnapshot = context.currentRoom.getDisplayNameSnapshot({
-          includeGhosts: context.currentClient.isGhost,
           includeWebinarAttendees: false,
         });
         socket.emit("displayNameSnapshot", {
@@ -856,7 +849,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           roomId: context.currentRoom.id,
         } satisfies HandRaisedSnapshot & { roomId: string });
 
-        if (context.currentClient instanceof Admin) {
+        if (context.currentClient instanceof Admin && !context.currentClient.isObserver) {
           emitChatHistorySnapshot(socket, context.currentRoom);
         }
 
@@ -908,17 +901,18 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
         const feedSnapshot = context.currentRoom.refreshWebinarFeedSnapshot();
         const existingProducers = context.currentClient.isWebinarAttendee
           ? feedSnapshot.producers
-          : context.currentRoom.getAllProducers(userId, {
-              includeGhostProducers: context.currentClient.isGhost,
-            });
+          : context.currentRoom.getAllProducers(userId);
 
-        emitWebinarAttendeeCountChanged(io, state, context.currentRoom);
-        emitWebinarFeedChanged(io, state, context.currentRoom);
+        if (!context.currentClient.isGhost) {
+          emitWebinarAttendeeCountChanged(io, state, context.currentRoom);
+          emitWebinarFeedChanged(io, state, context.currentRoom);
+        }
 
         if (
           webinarConfig.scheduledWebinarId &&
           !wasReconnecting &&
-          !existingClient
+          !existingClient &&
+          !context.currentClient.isGhost
         ) {
           const attendeeCount = context.currentRoom.getWebinarAttendeeCount();
           const webinarWithJoinMetric = recordWebinarJoin(
@@ -954,7 +948,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           }`,
         );
 
-        if (context.currentClient instanceof Admin) {
+        if (context.currentClient instanceof Admin && !context.currentClient.isObserver) {
           registerAdminHandlers(context, { roomId });
         }
 

--- a/packages/sfu/server/socket/handlers/mediaHandlers.ts
+++ b/packages/sfu/server/socket/handlers/mediaHandlers.ts
@@ -656,9 +656,7 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
 
         const producers = context.currentClient.isWebinarAttendee
           ? context.currentRoom.getWebinarFeedSnapshot().producers
-          : context.currentRoom.getAllProducers(context.currentClient.id, {
-              includeGhostProducers: context.currentClient.isGhost,
-            });
+          : context.currentRoom.getAllProducers(context.currentClient.id);
         respond(callback, { producers });
       } catch (error) {
         respond(callback, { error: (error as Error).message });

--- a/packages/sfu/server/socket/handlers/meetingHandlers.ts
+++ b/packages/sfu/server/socket/handlers/meetingHandlers.ts
@@ -38,7 +38,7 @@ const ensureAdminRoom = (
     return { error: "Not in a room" };
   }
 
-  if (!(context.currentClient instanceof Admin)) {
+  if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) {
     return { error: "Only admins can manage meeting settings" };
   }
 

--- a/packages/sfu/server/socket/handlers/sharedBrowserHandlers.ts
+++ b/packages/sfu/server/socket/handlers/sharedBrowserHandlers.ts
@@ -433,7 +433,7 @@ export const registerSharedBrowserHandlers = (context: ConnectionContext): void 
                     return;
                 }
 
-                if (!(context.currentClient instanceof Admin)) {
+                if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) {
                     respond(callback, { error: "Only admins can launch the shared browser" });
                     return;
                 }
@@ -532,7 +532,7 @@ export const registerSharedBrowserHandlers = (context: ConnectionContext): void 
                     return;
                 }
 
-                if (!(context.currentClient instanceof Admin)) {
+                if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) {
                     respond(callback, { error: "Only admins can control the shared browser" });
                     return;
                 }
@@ -615,7 +615,7 @@ export const registerSharedBrowserHandlers = (context: ConnectionContext): void 
                     return;
                 }
 
-                if (!(context.currentClient instanceof Admin)) {
+                if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) {
                     respond(callback, { error: "Only admins can close the shared browser" });
                     return;
                 }
@@ -680,6 +680,7 @@ export const registerSharedBrowserHandlers = (context: ConnectionContext): void 
 
     socket.on("browser:activity", async () => {
         if (!context.currentRoom || !context.currentClient) return;
+        if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) return;
         if (!takeToken(socket, "browser:activity", RATE_LIMITS.sharedBrowserControl)) return;
 
         const channelId = context.currentRoom.channelId;

--- a/packages/sfu/server/socket/handlers/transcriptHandlers.ts
+++ b/packages/sfu/server/socket/handlers/transcriptHandlers.ts
@@ -136,7 +136,7 @@ export const registerTranscriptHandlers = (
 
       const nowSeconds = Math.floor(Date.now() / 1000);
       const expiresAt = (nowSeconds + TRANSCRIPT_TOKEN_TTL_SECONDS) * 1000;
-      const isAdmin = client instanceof Admin;
+      const isAdmin = client instanceof Admin && !client.isObserver;
       const isHost = room.getHostUserId() === client.id;
       const isGhost = client.isGhost;
       const capabilities: TranscriptTokenCapabilities = {
@@ -239,7 +239,7 @@ export const registerTranscriptHandlers = (
       }
 
       const displayName = room.getDisplayNameForUser(client.id) || client.id;
-      const isAdmin = client instanceof Admin;
+      const isAdmin = client instanceof Admin && !client.isObserver;
       const isHost = room.getHostUserId() === client.id;
       const workerToken = createTranscriptRelayToken({
         roomId: room.id,
@@ -278,7 +278,7 @@ export const registerTranscriptHandlers = (
         });
         return;
       }
-      const isAdmin = client instanceof Admin;
+      const isAdmin = client instanceof Admin && !client.isObserver;
       const isHost = room.getHostUserId() === client.id;
       respond(
         callback,

--- a/packages/sfu/server/socket/handlers/webinarHandlers.ts
+++ b/packages/sfu/server/socket/handlers/webinarHandlers.ts
@@ -44,7 +44,7 @@ const ensureAdminRoom = (
     return { error: "Not in a room" };
   }
 
-  if (!(context.currentClient instanceof Admin)) {
+  if (!(context.currentClient instanceof Admin) || context.currentClient.isObserver) {
     return { error: "Only admins can manage webinar settings" };
   }
 


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR overhauls ghost mode to make ghost observers truly invisible: they are now created as plain `Client` instances (mode: `"ghost"`) instead of `Admin` instances, so they are excluded from all admin lists, participant counts, producer snapshots, room broadcasts, and webinar feeds. A new server-side `canGhostJoin` JWT claim gates ghost access to super-admins only, and a corresponding `isReadOnlyObserver` / `canModerateMeeting` split on the frontend prevents ghost and webinar-attendee users from triggering any admin socket operations.

- **SFU server**: Ghost join logic is rewritten around `canJoinAsGhost` (JWT-validated) and `hasPrivilegedJoinAccess`; all socket handlers (`apps`, `games`, `chat`, `meeting`, `webinar`, `sharedBrowser`) add `!isObserver` guards; `Room` helpers (`getAdmins`, `getHostUserId`, `hasActiveAdmin`, `getAllProducers`) filter out ghosts.
- **Apps/Games SDK**: `AppsProvider` and `GameProvider` receive an `isReadOnly` flag that short-circuits every Y.js and game-mutation emission at the source.
- **Frontend layouts**: Ghost users no longer render a local video tile; shared browser iframes become non-interactive; chat switches from fully hidden to read-only with updated copy; game panels expose a `readOnly` prop across all game renderers.

<h3>Confidence Score: 3/5</h3>

The ghost-to-Client rearchitecture is largely correct, but ghost users will silently arrive in rooms without receiving chat history even though the updated UI tells them they can watch the chat.

Ghost clients are now created as `Client` instances rather than `Admin` instances, so the `instanceof Admin` guard that gates `emitChatHistorySnapshot` on join never fires for them — every ghost entering a room mid-conversation sees an empty chat panel despite the UI copy reading 'Messages stay visible here.' The `emitUserLeft`/`emitUserJoined` exports in `notifications.ts` are now dead code containing a ghost-check that would fail silently if ever re-invoked. These two issues, combined with the broad scope of the ghost-mode rewrite across 45 files, warrant a second look before merging.

`packages/sfu/server/socket/handlers/joinRoom.ts` (chat history gate for ghost clients) and `packages/sfu/server/notifications.ts` (dead exports with incorrect post-removal ghost check).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/sfu/join/route.ts | Ghost join now requires `isSuperAdmin` and `!isWebinarAttendeeJoin`; `canGhostJoin` added to JWT payload; ghost users no longer get forced-host status. |
| packages/sfu/server/socket/handlers/joinRoom.ts | Ghost clients are now plain `Client` instances (mode: "ghost") instead of `Admin` instances; `hasPrivilegedJoinAccess` added for block/lock bypass; chat history inadvertently excluded because the `instanceof Admin` guard no longer matches ghosts. |
| packages/sfu/config/classes/Room.ts | Ghosts universally excluded from display name snapshots, admin lists, producer lists, host resolution, and hand-raise snapshots; `clientCount` removed in favour of `getMeetingParticipantCount()`. |
| packages/sfu/server/notifications.ts | `emitUserJoined`/`emitUserLeft` are now dead exports with no callers; the ghost check inside `emitUserLeft` would silently fail if ever re-invoked because it runs after client removal. |
| packages/sfu/server/admin/controlPlane.ts | Room and cluster snapshots now exclude ghost clients; participant counts, producer/consumer tallies, and webinar feeds all filter out ghosts; awareness updates suppressed for ghost departures. |
| apps/web/src/app/meets-client.tsx | Introduces `isReadOnlyObserver` and `canModerateMeeting` derived flags; all admin-only socket operations gated on `canModerateMeeting`; ghost token cache bypassed so fresh tokens always carry `canGhostJoin`. |
| packages/apps-sdk/src/sdk/runtime/AppsProvider.tsx | All Y.js update emissions (doc updates, awareness, initial sync, flush) gated on `isReadOnlyRef.current`; `openApp`, `closeApp`, and `setLocked` also return early for read-only clients. |
| packages/apps-sdk/src/games/GameProvider.tsx | Every game mutation (startGame, endGame, move, openVote, castVote, cancelVote) now short-circuits with an error when `isReadOnly`; `isAdmin` exposed as `false` to consumers when read-only. |
| packages/sfu/server/socket/handlers/adminHandlers.ts | `ensureAdminRoom`, bulk media operations, and host promotion all add `!isObserver` guard; `hasPersistedAdminRole` fallback removed from host promotion; `includeGhosts` option removed from bulk operations. |
| apps/web/src/app/components/ChatPanel.tsx | Ghost mode now shows chat read-only ("watching") instead of hiding it; reply button and reply target UI hidden when `isChatDisabled`; placeholder text updated. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant FE as Frontend (meets-client)
    participant API as /api/sfu/join
    participant SFU as SFU Socket
    participant Room as Room

    FE->>API: "POST join {isGhost: true}"
    API->>API: "canGhostJoin = !isWebinarAttendee && requestedGhost && isSuperAdmin"
    alt not super admin
        API-->>FE: 403 Ghost mode not available
    else super admin
        API-->>FE: "JWT {canGhostJoin: true, ...}"
    end

    FE->>SFU: "socket connect + joinRoom {ghost: true}"
    SFU->>SFU: validate canGhostJoin from JWT
    alt canGhostJoin false
        SFU-->>FE: error Ghost mode not available
    else room not found
        SFU-->>FE: error No room found
    else room found
        SFU->>Room: "new Client({mode: ghost})"
        SFU->>Room: addClient(ghostClient)
        Note over SFU,Room: No hostChanged/adminUsersChanged broadcast
        Note over SFU,Room: No userJoined broadcast to peers
        Note over SFU,Room: No emitWebinarAttendeeCountChanged
        SFU-->>FE: join ACK (producers, displayNames, handRaises - ghosts excluded)
        Note over FE: UI: no local tile, chat read-only, browser non-interactive, games read-only
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant FE as Frontend (meets-client)
    participant API as /api/sfu/join
    participant SFU as SFU Socket
    participant Room as Room

    FE->>API: "POST join {isGhost: true}"
    API->>API: "canGhostJoin = !isWebinarAttendee && requestedGhost && isSuperAdmin"
    alt not super admin
        API-->>FE: 403 Ghost mode not available
    else super admin
        API-->>FE: "JWT {canGhostJoin: true, ...}"
    end

    FE->>SFU: "socket connect + joinRoom {ghost: true}"
    SFU->>SFU: validate canGhostJoin from JWT
    alt canGhostJoin false
        SFU-->>FE: error Ghost mode not available
    else room not found
        SFU-->>FE: error No room found
    else room found
        SFU->>Room: "new Client({mode: ghost})"
        SFU->>Room: addClient(ghostClient)
        Note over SFU,Room: No hostChanged/adminUsersChanged broadcast
        Note over SFU,Room: No userJoined broadcast to peers
        Note over SFU,Room: No emitWebinarAttendeeCountChanged
        SFU-->>FE: join ACK (producers, displayNames, handRaises - ghosts excluded)
        Note over FE: UI: no local tile, chat read-only, browser non-interactive, games read-only
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/sfu/server/notifications.ts`, line 24-39 ([link](https://github.com/acm-vit/conclave/blob/512f377feacb644d93115ecd22e0c855c827c07f/packages/sfu/server/notifications.ts#L24-L39)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead export with a ghost-check that would silently mis-fire**

   All call-sites for `emitUserLeft` (and `emitUserJoined`) were removed in this PR — grep shows zero remaining callers. The functions are now unreachable dead exports. More subtly, the new ghost guard `room.getClient(userId)?.isGhost` inside `emitUserLeft` checks the room *after* callers historically removed the client first; once the client is removed, `getClient` returns `undefined`, `undefined?.isGhost` is `undefined` (falsy), so the early-return never fires and the `userLeft` event would broadcast to all clients including ghost ones. If either function is ever re-introduced as a call-site, this silent failure could leak ghost identities. Consider deleting both exports if they are truly unused.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fsfu%2Fserver%2Fnotifications.ts%0ALine%3A%2024-39%0A%0AComment%3A%0A**Dead%20export%20with%20a%20ghost-check%20that%20would%20silently%20mis-fire**%0A%0AAll%20call-sites%20for%20%60emitUserLeft%60%20%28and%20%60emitUserJoined%60%29%20were%20removed%20in%20this%20PR%20%E2%80%94%20grep%20shows%20zero%20remaining%20callers.%20The%20functions%20are%20now%20unreachable%20dead%20exports.%20More%20subtly%2C%20the%20new%20ghost%20guard%20%60room.getClient%28userId%29%3F.isGhost%60%20inside%20%60emitUserLeft%60%20checks%20the%20room%20*after*%20callers%20historically%20removed%20the%20client%20first%3B%20once%20the%20client%20is%20removed%2C%20%60getClient%60%20returns%20%60undefined%60%2C%20%60undefined%3F.isGhost%60%20is%20%60undefined%60%20%28falsy%29%2C%20so%20the%20early-return%20never%20fires%20and%20the%20%60userLeft%60%20event%20would%20broadcast%20to%20all%20clients%20including%20ghost%20ones.%20If%20either%20function%20is%20ever%20re-introduced%20as%20a%20call-site%2C%20this%20silent%20failure%20could%20leak%20ghost%20identities.%20Consider%20deleting%20both%20exports%20if%20they%20are%20truly%20unused.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=115&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fsfu%2Fserver%2Fnotifications.ts%0ALine%3A%2024-39%0A%0AComment%3A%0A**Dead%20export%20with%20a%20ghost-check%20that%20would%20silently%20mis-fire**%0A%0AAll%20call-sites%20for%20%60emitUserLeft%60%20%28and%20%60emitUserJoined%60%29%20were%20removed%20in%20this%20PR%20%E2%80%94%20grep%20shows%20zero%20remaining%20callers.%20The%20functions%20are%20now%20unreachable%20dead%20exports.%20More%20subtly%2C%20the%20new%20ghost%20guard%20%60room.getClient%28userId%29%3F.isGhost%60%20inside%20%60emitUserLeft%60%20checks%20the%20room%20*after*%20callers%20historically%20removed%20the%20client%20first%3B%20once%20the%20client%20is%20removed%2C%20%60getClient%60%20returns%20%60undefined%60%2C%20%60undefined%3F.isGhost%60%20is%20%60undefined%60%20%28falsy%29%2C%20so%20the%20early-return%20never%20fires%20and%20the%20%60userLeft%60%20event%20would%20broadcast%20to%20all%20clients%20including%20ghost%20ones.%20If%20either%20function%20is%20ever%20re-introduced%20as%20a%20call-site%2C%20this%20silent%20failure%20could%20leak%20ghost%20identities.%20Consider%20deleting%20both%20exports%20if%20they%20are%20truly%20unused.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=115&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fsfu%2Fserver%2Fnotifications.ts%0ALine%3A%2024-39%0A%0AComment%3A%0A**Dead%20export%20with%20a%20ghost-check%20that%20would%20silently%20mis-fire**%0A%0AAll%20call-sites%20for%20%60emitUserLeft%60%20%28and%20%60emitUserJoined%60%29%20were%20removed%20in%20this%20PR%20%E2%80%94%20grep%20shows%20zero%20remaining%20callers.%20The%20functions%20are%20now%20unreachable%20dead%20exports.%20More%20subtly%2C%20the%20new%20ghost%20guard%20%60room.getClient%28userId%29%3F.isGhost%60%20inside%20%60emitUserLeft%60%20checks%20the%20room%20*after*%20callers%20historically%20removed%20the%20client%20first%3B%20once%20the%20client%20is%20removed%2C%20%60getClient%60%20returns%20%60undefined%60%2C%20%60undefined%3F.isGhost%60%20is%20%60undefined%60%20%28falsy%29%2C%20so%20the%20early-return%20never%20fires%20and%20the%20%60userLeft%60%20event%20would%20broadcast%20to%20all%20clients%20including%20ghost%20ones.%20If%20either%20function%20is%20ever%20re-introduced%20as%20a%20call-site%2C%20this%20silent%20failure%20could%20leak%20ghost%20identities.%20Consider%20deleting%20both%20exports%20if%20they%20are%20truly%20unused.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=115&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FjoinRoom.ts%3A850-854%0A**Ghost%20users%20miss%20chat%20history%20on%20join**%0A%0AGhost%20clients%20are%20now%20created%20as%20%60Client%60%20instances%20%28%60new%20Client%28%7B%20mode%3A%20%22ghost%22%20%7D%29%60%29%2C%20so%20%60instanceof%20Admin%60%20is%20always%20%60false%60.%20This%20guard%20therefore%20never%20fires%20for%20ghost%20users%2C%20meaning%20they%20receive%20no%20%60emitChatHistorySnapshot%60.%20The%20frontend's%20updated%20ghost-mode%20chat%20UI%20explicitly%20says%20%22Messages%20stay%20visible%20here%22%20%E2%80%94%20a%20ghost%20joining%20a%20meeting%20mid-conversation%20will%20see%20an%20empty%20chat%20panel%20until%20new%20messages%20arrive%2C%20contradicting%20that%20promise.%20This%20is%20a%20regression%20from%20the%20previous%20model%20where%20ghosts%20%28as%20Admin%20instances%29%20did%20receive%20history.%20Consider%20sending%20the%20history%20snapshot%20to%20ghost%20clients%20directly%20%E2%80%94%20e.g.%2C%20add%20an%20%60else%20if%20%28context.currentClient.isGhost%29%60%20branch%20that%20also%20calls%20%60emitChatHistorySnapshot%60.%0A%0A%23%23%23%20Issue%202%20of%204%0Apackages%2Fsfu%2Fserver%2Fnotifications.ts%3A24-39%0A**Dead%20export%20with%20a%20ghost-check%20that%20would%20silently%20mis-fire**%0A%0AAll%20call-sites%20for%20%60emitUserLeft%60%20%28and%20%60emitUserJoined%60%29%20were%20removed%20in%20this%20PR%20%E2%80%94%20grep%20shows%20zero%20remaining%20callers.%20The%20functions%20are%20now%20unreachable%20dead%20exports.%20More%20subtly%2C%20the%20new%20ghost%20guard%20%60room.getClient%28userId%29%3F.isGhost%60%20inside%20%60emitUserLeft%60%20checks%20the%20room%20*after*%20callers%20historically%20removed%20the%20client%20first%3B%20once%20the%20client%20is%20removed%2C%20%60getClient%60%20returns%20%60undefined%60%2C%20%60undefined%3F.isGhost%60%20is%20%60undefined%60%20%28falsy%29%2C%20so%20the%20early-return%20never%20fires%20and%20the%20%60userLeft%60%20event%20would%20broadcast%20to%20all%20clients%20including%20ghost%20ones.%20If%20either%20function%20is%20ever%20re-introduced%20as%20a%20call-site%2C%20this%20silent%20failure%20could%20leak%20ghost%20identities.%20Consider%20deleting%20both%20exports%20if%20they%20are%20truly%20unused.%0A%0A%23%23%23%20Issue%203%20of%204%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FadminHandlers.ts%3A664-672%0A**%60hasPersistedAdminRole%60%20fallback%20silently%20dropped**%0A%0AThe%20previous%20guard%20allowed%20host%20promotion%20when%20a%20user%20had%20a%20persisted%20admin%20user-key%20in%20the%20room%20even%20if%20their%20live%20client%20wasn't%20an%20%60Admin%60%20instance%20%28e.g.%2C%20a%20reconnecting%20host%20whose%20old%20client%20was%20still%20cleaning%20up%29.%20That%20fallback%20path%20is%20now%20removed%20%E2%80%94%20only%20active%2C%20non-observer%20%60Admin%60%20instances%20may%20promote.%20In%20edge%20cases%20%28rapid%20reconnect%2C%20split-brain%20between%20client%20state%20and%20room%20key%20registry%29%20this%20could%20block%20a%20legitimate%20host%20from%20promoting%20a%20co-host.%20If%20the%20removal%20is%20intentional%2C%20a%20brief%20comment%20explaining%20the%20rationale%20would%20prevent%20this%20being%20re-added%20later.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fweb%2Fsrc%2Fapp%2Fapi%2Fsfu%2Fjoin%2Froute.ts%3A515-522%0A**Commit%20message%20quality**%0A%0AThe%20PR%20title%20and%20commit%20message%20are%20simply%20%22fixes%22%2C%20which%20makes%20it%20very%20difficult%20to%20understand%20what%20was%20changed%20and%20why%20when%20reviewing%20history.%20Consider%20a%20message%20like%20%60fix%28ghost%29%3A%20make%20ghost%20joins%20truly%20invisible%20-%20run%20as%20Client%20not%20Admin%2C%20skip%20broadcasts%2Fcounts%60%20that%20captures%20the%20intent.%20Good%20commit%20messages%20save%20significant%20time%20during%20incident%20investigation%20and%20code%20archaeology.%0A%0A&repo=acm-vit%2Fconclave&pr=115&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FjoinRoom.ts%3A850-854%0A**Ghost%20users%20miss%20chat%20history%20on%20join**%0A%0AGhost%20clients%20are%20now%20created%20as%20%60Client%60%20instances%20%28%60new%20Client%28%7B%20mode%3A%20%22ghost%22%20%7D%29%60%29%2C%20so%20%60instanceof%20Admin%60%20is%20always%20%60false%60.%20This%20guard%20therefore%20never%20fires%20for%20ghost%20users%2C%20meaning%20they%20receive%20no%20%60emitChatHistorySnapshot%60.%20The%20frontend's%20updated%20ghost-mode%20chat%20UI%20explicitly%20says%20%22Messages%20stay%20visible%20here%22%20%E2%80%94%20a%20ghost%20joining%20a%20meeting%20mid-conversation%20will%20see%20an%20empty%20chat%20panel%20until%20new%20messages%20arrive%2C%20contradicting%20that%20promise.%20This%20is%20a%20regression%20from%20the%20previous%20model%20where%20ghosts%20%28as%20Admin%20instances%29%20did%20receive%20history.%20Consider%20sending%20the%20history%20snapshot%20to%20ghost%20clients%20directly%20%E2%80%94%20e.g.%2C%20add%20an%20%60else%20if%20%28context.currentClient.isGhost%29%60%20branch%20that%20also%20calls%20%60emitChatHistorySnapshot%60.%0A%0A%23%23%23%20Issue%202%20of%204%0Apackages%2Fsfu%2Fserver%2Fnotifications.ts%3A24-39%0A**Dead%20export%20with%20a%20ghost-check%20that%20would%20silently%20mis-fire**%0A%0AAll%20call-sites%20for%20%60emitUserLeft%60%20%28and%20%60emitUserJoined%60%29%20were%20removed%20in%20this%20PR%20%E2%80%94%20grep%20shows%20zero%20remaining%20callers.%20The%20functions%20are%20now%20unreachable%20dead%20exports.%20More%20subtly%2C%20the%20new%20ghost%20guard%20%60room.getClient%28userId%29%3F.isGhost%60%20inside%20%60emitUserLeft%60%20checks%20the%20room%20*after*%20callers%20historically%20removed%20the%20client%20first%3B%20once%20the%20client%20is%20removed%2C%20%60getClient%60%20returns%20%60undefined%60%2C%20%60undefined%3F.isGhost%60%20is%20%60undefined%60%20%28falsy%29%2C%20so%20the%20early-return%20never%20fires%20and%20the%20%60userLeft%60%20event%20would%20broadcast%20to%20all%20clients%20including%20ghost%20ones.%20If%20either%20function%20is%20ever%20re-introduced%20as%20a%20call-site%2C%20this%20silent%20failure%20could%20leak%20ghost%20identities.%20Consider%20deleting%20both%20exports%20if%20they%20are%20truly%20unused.%0A%0A%23%23%23%20Issue%203%20of%204%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FadminHandlers.ts%3A664-672%0A**%60hasPersistedAdminRole%60%20fallback%20silently%20dropped**%0A%0AThe%20previous%20guard%20allowed%20host%20promotion%20when%20a%20user%20had%20a%20persisted%20admin%20user-key%20in%20the%20room%20even%20if%20their%20live%20client%20wasn't%20an%20%60Admin%60%20instance%20%28e.g.%2C%20a%20reconnecting%20host%20whose%20old%20client%20was%20still%20cleaning%20up%29.%20That%20fallback%20path%20is%20now%20removed%20%E2%80%94%20only%20active%2C%20non-observer%20%60Admin%60%20instances%20may%20promote.%20In%20edge%20cases%20%28rapid%20reconnect%2C%20split-brain%20between%20client%20state%20and%20room%20key%20registry%29%20this%20could%20block%20a%20legitimate%20host%20from%20promoting%20a%20co-host.%20If%20the%20removal%20is%20intentional%2C%20a%20brief%20comment%20explaining%20the%20rationale%20would%20prevent%20this%20being%20re-added%20later.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fweb%2Fsrc%2Fapp%2Fapi%2Fsfu%2Fjoin%2Froute.ts%3A515-522%0A**Commit%20message%20quality**%0A%0AThe%20PR%20title%20and%20commit%20message%20are%20simply%20%22fixes%22%2C%20which%20makes%20it%20very%20difficult%20to%20understand%20what%20was%20changed%20and%20why%20when%20reviewing%20history.%20Consider%20a%20message%20like%20%60fix%28ghost%29%3A%20make%20ghost%20joins%20truly%20invisible%20-%20run%20as%20Client%20not%20Admin%2C%20skip%20broadcasts%2Fcounts%60%20that%20captures%20the%20intent.%20Good%20commit%20messages%20save%20significant%20time%20during%20incident%20investigation%20and%20code%20archaeology.%0A%0A&repo=acm-vit%2Fconclave&pr=115&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FjoinRoom.ts%3A850-854%0A**Ghost%20users%20miss%20chat%20history%20on%20join**%0A%0AGhost%20clients%20are%20now%20created%20as%20%60Client%60%20instances%20%28%60new%20Client%28%7B%20mode%3A%20%22ghost%22%20%7D%29%60%29%2C%20so%20%60instanceof%20Admin%60%20is%20always%20%60false%60.%20This%20guard%20therefore%20never%20fires%20for%20ghost%20users%2C%20meaning%20they%20receive%20no%20%60emitChatHistorySnapshot%60.%20The%20frontend's%20updated%20ghost-mode%20chat%20UI%20explicitly%20says%20%22Messages%20stay%20visible%20here%22%20%E2%80%94%20a%20ghost%20joining%20a%20meeting%20mid-conversation%20will%20see%20an%20empty%20chat%20panel%20until%20new%20messages%20arrive%2C%20contradicting%20that%20promise.%20This%20is%20a%20regression%20from%20the%20previous%20model%20where%20ghosts%20%28as%20Admin%20instances%29%20did%20receive%20history.%20Consider%20sending%20the%20history%20snapshot%20to%20ghost%20clients%20directly%20%E2%80%94%20e.g.%2C%20add%20an%20%60else%20if%20%28context.currentClient.isGhost%29%60%20branch%20that%20also%20calls%20%60emitChatHistorySnapshot%60.%0A%0A%23%23%23%20Issue%202%20of%204%0Apackages%2Fsfu%2Fserver%2Fnotifications.ts%3A24-39%0A**Dead%20export%20with%20a%20ghost-check%20that%20would%20silently%20mis-fire**%0A%0AAll%20call-sites%20for%20%60emitUserLeft%60%20%28and%20%60emitUserJoined%60%29%20were%20removed%20in%20this%20PR%20%E2%80%94%20grep%20shows%20zero%20remaining%20callers.%20The%20functions%20are%20now%20unreachable%20dead%20exports.%20More%20subtly%2C%20the%20new%20ghost%20guard%20%60room.getClient%28userId%29%3F.isGhost%60%20inside%20%60emitUserLeft%60%20checks%20the%20room%20*after*%20callers%20historically%20removed%20the%20client%20first%3B%20once%20the%20client%20is%20removed%2C%20%60getClient%60%20returns%20%60undefined%60%2C%20%60undefined%3F.isGhost%60%20is%20%60undefined%60%20%28falsy%29%2C%20so%20the%20early-return%20never%20fires%20and%20the%20%60userLeft%60%20event%20would%20broadcast%20to%20all%20clients%20including%20ghost%20ones.%20If%20either%20function%20is%20ever%20re-introduced%20as%20a%20call-site%2C%20this%20silent%20failure%20could%20leak%20ghost%20identities.%20Consider%20deleting%20both%20exports%20if%20they%20are%20truly%20unused.%0A%0A%23%23%23%20Issue%203%20of%204%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FadminHandlers.ts%3A664-672%0A**%60hasPersistedAdminRole%60%20fallback%20silently%20dropped**%0A%0AThe%20previous%20guard%20allowed%20host%20promotion%20when%20a%20user%20had%20a%20persisted%20admin%20user-key%20in%20the%20room%20even%20if%20their%20live%20client%20wasn't%20an%20%60Admin%60%20instance%20%28e.g.%2C%20a%20reconnecting%20host%20whose%20old%20client%20was%20still%20cleaning%20up%29.%20That%20fallback%20path%20is%20now%20removed%20%E2%80%94%20only%20active%2C%20non-observer%20%60Admin%60%20instances%20may%20promote.%20In%20edge%20cases%20%28rapid%20reconnect%2C%20split-brain%20between%20client%20state%20and%20room%20key%20registry%29%20this%20could%20block%20a%20legitimate%20host%20from%20promoting%20a%20co-host.%20If%20the%20removal%20is%20intentional%2C%20a%20brief%20comment%20explaining%20the%20rationale%20would%20prevent%20this%20being%20re-added%20later.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fweb%2Fsrc%2Fapp%2Fapi%2Fsfu%2Fjoin%2Froute.ts%3A515-522%0A**Commit%20message%20quality**%0A%0AThe%20PR%20title%20and%20commit%20message%20are%20simply%20%22fixes%22%2C%20which%20makes%20it%20very%20difficult%20to%20understand%20what%20was%20changed%20and%20why%20when%20reviewing%20history.%20Consider%20a%20message%20like%20%60fix%28ghost%29%3A%20make%20ghost%20joins%20truly%20invisible%20-%20run%20as%20Client%20not%20Admin%2C%20skip%20broadcasts%2Fcounts%60%20that%20captures%20the%20intent.%20Good%20commit%20messages%20save%20significant%20time%20during%20incident%20investigation%20and%20code%20archaeology.%0A%0A&pr=115&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fixes"](https://github.com/acm-vit/conclave/commit/512f377feacb644d93115ecd22e0c855c827c07f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40662500)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - Encourage people to write better commit messages ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->