### PR TITLE
Staging

### DIFF
--- a/apps/conclave-skip/Darwin/Conclave.xcodeproj/project.pbxproj
+++ b/apps/conclave-skip/Darwin/Conclave.xcodeproj/project.pbxproj
@@ -187,8 +187,8 @@
 				499CD43E2AC5B799001AE8D8 /* Resources */,
 				499CD4452AC5B869001AE8D8 /* Run skip gradle */,
 				499CD44A2AC5B9C6001AE8D8 /* Embed Frameworks */,
-				8D0E0D6B2E5A4A71B57E90C1 /* Apply embedded privacy metadata */,
 				DED5F813849FF18CBE9AFB5A /* Embed App Extensions */,
+				8D0E0D6B2E5A4A71B57E90C1 /* Apply embedded privacy metadata */,
 			);
 			buildRules = (
 			);
@@ -305,6 +305,7 @@
 				"$(SRCROOT)/Scripts/apply-embedded-privacy-metadata.sh",
 				"$(SRCROOT)/PrivacyManifests/ConclaveFramework.xcprivacy",
 				"$(SRCROOT)/PrivacyManifests/WebRTCFramework.xcprivacy",
+				"$(SRCROOT)/PrivacyManifests/MediasoupFramework.xcprivacy",
 			);
 			name = "Apply embedded privacy metadata";
 			outputFileListPaths = (

--- a/apps/conclave-skip/Darwin/Scripts/apply-embedded-privacy-metadata.sh
+++ b/apps/conclave-skip/Darwin/Scripts/apply-embedded-privacy-metadata.sh
@@ -3,9 +3,11 @@ set -eu
 
 FRAMEWORKS_DIR="${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH:-${WRAPPER_NAME}/Frameworks}"
 APP_RESOURCES_DIR="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH:-${WRAPPER_NAME}}"
+APP_INFO_PLIST="${TARGET_BUILD_DIR}/${INFOPLIST_PATH:-${WRAPPER_NAME}/Info.plist}"
+PLUGINS_DIR="${TARGET_BUILD_DIR}/${PLUGINS_FOLDER_PATH:-${WRAPPER_NAME}/PlugIns}"
 MANIFEST_DIR="${SRCROOT}/PrivacyManifests"
 
-if [ ! -d "${FRAMEWORKS_DIR}" ] && [ ! -d "${APP_RESOURCES_DIR}" ]; then
+if [ ! -f "${APP_INFO_PLIST}" ] && [ ! -d "${FRAMEWORKS_DIR}" ] && [ ! -d "${APP_RESOURCES_DIR}" ] && [ ! -d "${PLUGINS_DIR}" ]; then
   exit 0
 fi
 
@@ -100,8 +102,8 @@ set_all_purpose_strings() {
   set_file_purpose_strings "${plist_path}"
 }
 
-resign_framework_if_needed() {
-  framework_path="$1"
+resign_code_bundle_if_needed() {
+  bundle_path="$1"
 
   if [ "${CODE_SIGNING_ALLOWED:-YES}" = "NO" ] || [ "${CODE_SIGNING_REQUIRED:-NO}" = "NO" ]; then
     return
@@ -109,7 +111,7 @@ resign_framework_if_needed() {
 
   identity="${EXPANDED_CODE_SIGN_IDENTITY:-}"
   if [ -z "${identity}" ] || [ "${identity}" = "-" ]; then
-    echo "warning: skipping privacy metadata re-sign for ${framework_path}; no code signing identity is available"
+    echo "warning: skipping privacy metadata re-sign for ${bundle_path}; no code signing identity is available"
     return
   fi
 
@@ -118,7 +120,15 @@ resign_framework_if_needed() {
     --sign "${identity}" \
     --preserve-metadata=identifier,entitlements,flags \
     --timestamp=none \
-    "${framework_path}"
+    "${bundle_path}"
+}
+
+patch_host_app_plist() {
+  if [ ! -f "${APP_INFO_PLIST}" ]; then
+    return
+  fi
+
+  set_all_purpose_strings "${APP_INFO_PLIST}"
 }
 
 patch_conclave_framework() {
@@ -132,7 +142,7 @@ patch_conclave_framework() {
   set_all_purpose_strings "${plist_path}"
 
   copy_privacy_manifest "ConclaveFramework.xcprivacy" "${framework_path}"
-  resign_framework_if_needed "${framework_path}"
+  resign_code_bundle_if_needed "${framework_path}"
 }
 
 patch_webrtc_framework() {
@@ -146,7 +156,7 @@ patch_webrtc_framework() {
   set_all_purpose_strings "${plist_path}"
 
   copy_privacy_manifest "WebRTCFramework.xcprivacy" "${framework_path}"
-  resign_framework_if_needed "${framework_path}"
+  resign_code_bundle_if_needed "${framework_path}"
 }
 
 patch_mediasoup_framework() {
@@ -160,7 +170,7 @@ patch_mediasoup_framework() {
   set_all_purpose_strings "${plist_path}"
 
   copy_privacy_manifest "MediasoupFramework.xcprivacy" "${framework_path}"
-  resign_framework_if_needed "${framework_path}"
+  resign_code_bundle_if_needed "${framework_path}"
 }
 
 patch_remaining_frameworks() {
@@ -182,7 +192,7 @@ patch_remaining_frameworks() {
     fi
 
     set_all_purpose_strings "${plist_path}"
-    resign_framework_if_needed "${framework_path}"
+    resign_code_bundle_if_needed "${framework_path}"
   done
 }
 
@@ -200,8 +210,22 @@ patch_embedded_bundles() {
     done
 }
 
+patch_embedded_app_extensions() {
+  if [ ! -d "${PLUGINS_DIR}" ]; then
+    return
+  fi
+
+  find "${PLUGINS_DIR}" -path "*.appex/Info.plist" -print |
+    while IFS= read -r plist_path; do
+      set_all_purpose_strings "${plist_path}"
+      resign_code_bundle_if_needed "$(dirname "${plist_path}")"
+    done
+}
+
+patch_host_app_plist
 patch_conclave_framework
 patch_webrtc_framework
 patch_mediasoup_framework
 patch_remaining_frameworks
 patch_embedded_bundles
+patch_embedded_app_extensions

--- a/apps/conclave-skip/Sources/Conclave/Core/State/MeetingState.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/State/MeetingState.swift
@@ -166,6 +166,8 @@ final class MeetingState {
 
     static let browserAudioUserIdPrefix = "shared-browser:"
     static let browserVideoUserIdPrefix = "shared-browser-video:"
+    static let voiceAgentUserIdPrefix = "voice-agent-"
+    static let voiceAgentEmailSuffix = "@agent.conclave"
     static let overflowTileId = "__conclave_overflow__"
 
     static func isBrowserAudioUserId(_ userId: String) -> Bool {
@@ -176,11 +178,24 @@ final class MeetingState {
         userId.hasPrefix(browserVideoUserIdPrefix)
     }
 
+    static func isVoiceAgentUserId(_ userId: String) -> Bool {
+        let normalized = userId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.hasPrefix(voiceAgentUserIdPrefix) ||
+            normalized.contains(voiceAgentEmailSuffix)
+    }
+
     static func isSystemUserId(_ userId: String) -> Bool {
         isBrowserAudioUserId(userId) || isBrowserVideoUserId(userId)
     }
 
+    static func isSyntheticRosterUserId(_ userId: String) -> Bool {
+        isSystemUserId(userId) || isVoiceAgentUserId(userId)
+    }
+
     static func systemDisplayName(for userId: String) -> String? {
+        if isVoiceAgentUserId(userId) {
+            return "Voice Agent"
+        }
         if isBrowserVideoUserId(userId) {
             return "Shared Browser"
         }
@@ -221,7 +236,7 @@ final class MeetingState {
         let normalized = id.trimmingCharacters(in: .whitespacesAndNewlines)
         return !normalized.isEmpty
             && !isLocalIdentityUserId(normalized)
-            && !Self.isSystemUserId(normalized)
+            && !Self.isSyntheticRosterUserId(normalized)
             && normalized != Self.overflowTileId
     }
 

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift
@@ -4813,6 +4813,9 @@ final class MeetingViewModel {
             }
             return
         }
+        if MeetingState.isVoiceAgentUserId(producerUserId) {
+            return
+        }
         guard !MeetingState.isSystemUserId(producerUserId) else { return }
         if state.isLocalIdentityUserId(producerUserId) {
             if producer.kind == "audio", producer.type == ProducerType.webcam.rawValue {

--- a/apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift
+++ b/apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift
@@ -970,6 +970,54 @@ final class ConclaveTests: XCTestCase {
     }
 
     @MainActor
+    func testVoiceAgentIdentityIsHiddenFromNativeRosterAndLayout() throws {
+        let state = MeetingState(userId: "local@example.com#local-session", sessionId: "local-session")
+        state.sfuUserId = "local@example.com"
+        state.displayName = "Local"
+        state.connectionState = ConnectionState.joined
+        state.viewMode = MeetingViewMode.auto
+        state.selfViewMode = MeetingSelfViewMode.auto
+        let agentUserId = "voice-agent-123@agent.conclave#agent-session"
+        state.participants["remote@example.com#remote-session"] = Participant(
+            id: "remote@example.com#remote-session",
+            displayName: "Remote"
+        )
+        state.participants[agentUserId] = Participant(
+            id: agentUserId,
+            displayName: "Voice Agent"
+        )
+
+        XCTAssertTrue(MeetingState.isVoiceAgentUserId("voice-agent-123"))
+        XCTAssertTrue(MeetingState.isVoiceAgentUserId(agentUserId))
+        XCTAssertTrue(MeetingState.isSyntheticRosterUserId(agentUserId))
+        XCTAssertFalse(MeetingState.isSystemUserId(agentUserId))
+        XCTAssertEqual(state.displayName(for: agentUserId), "Voice Agent")
+        XCTAssertNil(state.participant(for: agentUserId))
+        XCTAssertEqual(state.participantCount, 2)
+        XCTAssertEqual(state.sortedParticipants.map(\.id), ["remote@example.com#remote-session"])
+        XCTAssertEqual(state.visibleGridUserIds, ["remote@example.com#remote-session"])
+    }
+
+    @MainActor
+    func testVoiceAgentProducerStateDoesNotCreateNativeRosterParticipant() throws {
+        let viewModel = MeetingViewModel()
+        let agentUserId = "voice-agent-456@agent.conclave#agent-session"
+
+        viewModel.handleProducerState(ProducerInfo(
+            producerId: "agent-audio-producer",
+            producerUserId: agentUserId,
+            kind: "audio",
+            type: ProducerType.webcam.rawValue,
+            paused: false,
+            roomId: "room-a"
+        ))
+
+        XCTAssertNil(viewModel.state.participants[agentUserId])
+        XCTAssertEqual(viewModel.state.participantCount, 1)
+        XCTAssertEqual(viewModel.state.visibleGridUserIds, [viewModel.state.userId])
+    }
+
+    @MainActor
     func testVisibleLayoutSnapshotsPreserveGridAndRailSemantics() throws {
         let state = MeetingState(userId: "local@example.com#local-session", sessionId: "local-session")
         state.sfuUserId = "local@example.com"
@@ -6604,12 +6652,18 @@ final class ConclaveTests: XCTestCase {
 
     func testDarwinEmbeddedFrameworkPrivacyPatchCoversMediaFrameworks() throws {
         let script = try String(contentsOf: sourceFileURL("Darwin/Scripts/apply-embedded-privacy-metadata.sh"))
+        let project = try sourceFileContents("Darwin/Conclave.xcodeproj/project.pbxproj")
 
+        XCTAssertTrue(script.contains("patch_host_app_plist"))
         XCTAssertTrue(script.contains("patch_conclave_framework"))
         XCTAssertTrue(script.contains("patch_webrtc_framework"))
         XCTAssertTrue(script.contains("patch_mediasoup_framework"))
         XCTAssertTrue(script.contains("patch_remaining_frameworks"))
         XCTAssertTrue(script.contains("patch_embedded_bundles"))
+        XCTAssertTrue(script.contains("patch_embedded_app_extensions"))
+        XCTAssertTrue(script.contains("${APP_INFO_PLIST}"))
+        XCTAssertTrue(script.contains("${PLUGINS_DIR}"))
+        XCTAssertTrue(script.contains("resign_code_bundle_if_needed \"$(dirname \""))
         XCTAssertTrue(script.contains("${FRAMEWORKS_DIR}/WebRTC.framework"))
         XCTAssertTrue(script.contains("${FRAMEWORKS_DIR}/Mediasoup.framework"))
         XCTAssertTrue(script.contains("\"*.bundle/Info.plist\""))
@@ -6632,7 +6686,9 @@ final class ConclaveTests: XCTestCase {
         XCTAssertTrue(script.contains("\"NSUserNotificationsUsageDescription\""))
         XCTAssertTrue(script.contains("\"NFCReaderUsageDescription\""))
         XCTAssertTrue(script.contains("\"NSHealthClinicalHealthRecordsShareUsageDescription\""))
-        XCTAssertEqual(script.components(separatedBy: "set_all_purpose_strings \"${plist_path}\"").count - 1, 5)
+        XCTAssertEqual(script.components(separatedBy: "set_all_purpose_strings \"${plist_path}\"").count - 1, 6)
+        XCTAssertTrue(project.contains("DED5F813849FF18CBE9AFB5A /* Embed App Extensions */,\n\t\t\t\t8D0E0D6B2E5A4A71B57E90C1 /* Apply embedded privacy metadata */,"))
+        XCTAssertTrue(project.contains("\"$(SRCROOT)/PrivacyManifests/MediasoupFramework.xcprivacy\""))
     }
 #endif
 

--- a/packages/sfu/tsconfig.json
+++ b/packages/sfu/tsconfig.json
@@ -11,6 +11,7 @@
     "declaration": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
+    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "forceConsistentCasingInFileNames": true,
     "noEmit": true

--- a/packages/ui-tokens/src/core/index.ts
+++ b/packages/ui-tokens/src/core/index.ts
@@ -2,7 +2,7 @@
  * Platform-agnostic helpers shared by the web and native primitives so the two
  * implementations cannot diverge in behavior. No React, no react-native, no DOM.
  */
-import { color } from "../tokens.js";
+import { color } from "../tokens.ts";
 
 /* ------------------------------------------------------------------ avatars */
 

--- a/packages/ui-tokens/src/index.ts
+++ b/packages/ui-tokens/src/index.ts
@@ -4,5 +4,5 @@
  * "@conclave/ui-tokens/native" so the wrong platform's React renderer is never
  * pulled into a bundle.
  */
-export * from "./tokens.js";
-export * from "./core/index.js";
+export * from "./tokens.ts";
+export * from "./core/index.ts";


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR merges staging into main, delivering three areas of change: voice-agent identity filtering in the iOS Swift SDK (hiding agent participants from roster and layout), an expanded privacy-metadata build script (host-app plist patching, app-extension re-signing, Mediasoup manifest), and a shift from `.js` to `.ts` import extensions in `packages/ui-tokens` paired with an `allowImportingTsExtensions` flag in the SFU package.

- **Voice agent filtering (Swift):** `isVoiceAgentUserId` / `isSyntheticRosterUserId` predicates added to `MeetingState`; `MeetingViewModel` early-returns on voice-agent producer events; well-covered by two new XCTest cases.
- **Privacy metadata script:** Build phase reordered after "Embed App Extensions", adds `patch_host_app_plist` and `patch_embedded_app_extensions`, renames `resign_framework_if_needed` → `resign_code_bundle_if_needed`.
- **`ui-tokens` import extensions:** `.js` → `.ts` extension change requires `allowImportingTsExtensions: true` in every consuming tsconfig; only `packages/sfu` was updated — `apps/web` and `apps/mobile` were not, which will cause TypeScript TS5097 errors in those projects.

> **Note on commit message:** The PR title "Staging" gives no indication of what was changed. Descriptive commit messages like `feat: hide voice-agent participants from roster and layout` make the git history far easier to navigate for the whole team.

<h3>Confidence Score: 3/5</h3>

The Swift and build-script changes are solid and well-tested, but the ui-tokens import-extension change is incomplete — apps/web and apps/mobile are missing the required TypeScript compiler flag, which will break tsc --noEmit type-checking in those apps.

The voice-agent filtering and privacy-script improvements are correct and covered by tests. The allowImportingTsExtensions flag was added only to packages/sfu, while apps/web (moduleResolution: bundler, no flag) and apps/mobile (Expo base config, no flag) both resolve directly into ui-tokens source files and will error on the .ts extension specifiers during type-checking.

packages/ui-tokens/src/index.ts and packages/ui-tokens/src/core/index.ts — the .ts extension imports will cause TypeScript errors in apps/web and apps/mobile until those projects' tsconfigs are updated.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui-tokens/src/index.ts | Changed re-export extension specifiers from `.js` to `.ts`; breaks TypeScript type-checking in `apps/web` and `apps/mobile` which lack `allowImportingTsExtensions`. |
| packages/ui-tokens/src/core/index.ts | Same `.js` → `.ts` extension change as in `src/index.ts`; inherits the same `allowImportingTsExtensions` gap in consuming projects. |
| packages/sfu/tsconfig.json | Added `allowImportingTsExtensions: true`; correctly paired with the existing `noEmit: true` and `moduleResolution: NodeNext`. |
| apps/conclave-skip/Sources/Conclave/Core/State/MeetingState.swift | Adds voice-agent identity detection (`isVoiceAgentUserId`, `isSyntheticRosterUserId`) and hides voice agents from roster/layout; case-normalisation is asymmetric vs. other ID predicates but likely benign if SFU always sends lowercase IDs. |
| apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift | Early-returns on voice-agent producer state to prevent roster insertion; the subsequent `isSystemUserId` guard is now unreachable for agent IDs but remains a harmless safety net. |
| apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift | New tests cover voice-agent roster exclusion and producer-state no-op; also adds privacy-script assertions for host-app plist and app-extension patching. |
| apps/conclave-skip/Darwin/Scripts/apply-embedded-privacy-metadata.sh | Renames `resign_framework_if_needed` → `resign_code_bundle_if_needed`, adds host-app plist patching and app-extension patching, and adds `MediasoupFramework.xcprivacy` to the input list. |
| apps/conclave-skip/Darwin/Conclave.xcodeproj/project.pbxproj | Reorders build phases so 'Apply embedded privacy metadata' runs after 'Embed App Extensions', ensuring the PlugIns directory is populated when the privacy script executes. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SFU producer event\nproducerUserId] --> B{isBrowserAudioUserId?}
    B -- Yes --> C[refreshBrowserAudioPresence\nreturn]
    B -- No --> D{isBrowserVideoUserId?}
    D -- Yes --> E[clear activeScreenShare\nreturn]
    D -- No --> F{isVoiceAgentUserId?\nnew check}
    F -- Yes --> G[early return\nno roster entry]
    F -- No --> H{isSystemUserId?}
    H -- Yes --> I[return guard]
    H -- No --> J{isLocalIdentityUserId?}
    J -- Yes --> K[update local mute/camera/screen state]
    J -- No --> L[upsert remote Participant\nupdate roster]

    subgraph MeetingState predicates
        P1[isBrowserAudioUserId\ncase-sensitive prefix]
        P2[isBrowserVideoUserId\ncase-sensitive prefix]
        P3[isVoiceAgentUserId\nlowercased prefix OR suffix]
        P4[isSystemUserId = P1 OR P2]
        P5[isSyntheticRosterUserId = P4 OR P3]
    end

    subgraph Roster visibility
        V1[isRemoteParticipantUserId uses isSyntheticRosterUserId]
        V2[Voice agents hidden from sortedParticipants + visibleGridUserIds]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SFU producer event\nproducerUserId] --> B{isBrowserAudioUserId?}
    B -- Yes --> C[refreshBrowserAudioPresence\nreturn]
    B -- No --> D{isBrowserVideoUserId?}
    D -- Yes --> E[clear activeScreenShare\nreturn]
    D -- No --> F{isVoiceAgentUserId?\nnew check}
    F -- Yes --> G[early return\nno roster entry]
    F -- No --> H{isSystemUserId?}
    H -- Yes --> I[return guard]
    H -- No --> J{isLocalIdentityUserId?}
    J -- Yes --> K[update local mute/camera/screen state]
    J -- No --> L[upsert remote Participant\nupdate roster]

    subgraph MeetingState predicates
        P1[isBrowserAudioUserId\ncase-sensitive prefix]
        P2[isBrowserVideoUserId\ncase-sensitive prefix]
        P3[isVoiceAgentUserId\nlowercased prefix OR suffix]
        P4[isSystemUserId = P1 OR P2]
        P5[isSyntheticRosterUserId = P4 OR P3]
    end

    subgraph Roster visibility
        V1[isRemoteParticipantUserId uses isSyntheticRosterUserId]
        V2[Voice agents hidden from sortedParticipants + visibleGridUserIds]
    end
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fui-tokens%2Fsrc%2Findex.ts%3A7-8%0A**%60.ts%60%20extension%20imports%20break%20TypeScript%20type-checking%20in%20consuming%20packages**%0A%0ASwitching%20from%20%60.js%60%20to%20%60.ts%60%20extension%20specifiers%20requires%20%60allowImportingTsExtensions%3A%20true%60%20in%20every%20tsconfig%20that%20resolves%20into%20these%20files.%20%60packages%2Fsfu%2Ftsconfig.json%60%20was%20updated%2C%20but%20%60apps%2Fweb%2Ftsconfig.json%60%20%28%60moduleResolution%3A%20%22bundler%22%60%2C%20no%20%60allowImportingTsExtensions%60%29%20and%20%60apps%2Fmobile%2Ftsconfig.json%60%20%28extends%20%60expo%2Ftsconfig.base%60%2C%20no%20such%20flag%29%20both%20resolve%20%60%40conclave%2Fui-tokens%60%20directly%20to%20these%20source%20files%20via%20path%20aliases%20or%20package%20exports.%20TypeScript%20will%20emit%20TS5097%20%28%22An%20import%20path%20can%20only%20end%20with%20a%20'.ts'%20extension%20when%20'allowImportingTsExtensions'%20is%20enabled%22%29%20when%20it%20traverses%20into%20these%20files%20during%20type-checking.%20The%20same%20problem%20exists%20in%20%60packages%2Fui-tokens%2Fsrc%2Fcore%2Findex.ts%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FCore%2FState%2FMeetingState.swift%3A181-185%0A**Case-normalisation%20asymmetry%20between%20%60isVoiceAgentUserId%60%20and%20other%20ID%20predicates**%0A%0A%60isVoiceAgentUserId%60%20lowercases%20the%20input%20before%20matching%2C%20while%20%60isBrowserAudioUserId%60%20and%20%60isBrowserVideoUserId%60%20use%20case-sensitive%20%60hasPrefix%60.%20This%20means%20a%20userId%20like%20%60%22Shared-Browser%3Afoo%22%60%20is%20NOT%20treated%20as%20a%20system%20user%2C%20but%20%60%22Voice-Agent-123%22%60%20IS%20treated%20as%20a%20voice%20agent.%20If%20IDs%20arriving%20from%20the%20SFU%20are%20always%20already%20lowercase%2C%20the%20asymmetry%20is%20harmless%2C%20but%20if%20they%20can%20carry%20mixed%20case%2C%20%60isVoiceAgentUserId%60%20silently%20accepts%20them%20while%20the%20browser%20checks%20would%20miss%20their%20equivalents.%20Worth%20confirming%20the%20casing%20guarantee%20from%20the%20SFU.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FFeatures%2FMeeting%2FMeetingViewModel.swift%3A4816-4819%0A**%60isSystemUserId%60%20guard%20is%20now%20unreachable%20for%20voice-agent%20IDs**%0A%0AThe%20new%20%60isVoiceAgentUserId%60%20early%20return%20on%20line%204816%20fires%20before%20%60guard%20!MeetingState.isSystemUserId%28producerUserId%29%60%20on%20line%204819.%20Since%20%60isVoiceAgentUserId%60%20covers%20the%20new%20prefix%2Fsuffix%20and%20the%20two%20browser-prefix%20checks%20above%20handle%20the%20legacy%20system%20IDs%2C%20the%20%60isSystemUserId%60%20guard%20is%20now%20dead%20code%20on%20the%20voice-agent%20path.%20The%20guard%20still%20protects%20against%20future%20unknown%20system%20ID%20variants%2C%20but%20its%20intent%20is%20partially%20superseded.%0A%0A&repo=acm-vit%2Fconclave&pr=118&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fui-tokens%2Fsrc%2Findex.ts%3A7-8%0A**%60.ts%60%20extension%20imports%20break%20TypeScript%20type-checking%20in%20consuming%20packages**%0A%0ASwitching%20from%20%60.js%60%20to%20%60.ts%60%20extension%20specifiers%20requires%20%60allowImportingTsExtensions%3A%20true%60%20in%20every%20tsconfig%20that%20resolves%20into%20these%20files.%20%60packages%2Fsfu%2Ftsconfig.json%60%20was%20updated%2C%20but%20%60apps%2Fweb%2Ftsconfig.json%60%20%28%60moduleResolution%3A%20%22bundler%22%60%2C%20no%20%60allowImportingTsExtensions%60%29%20and%20%60apps%2Fmobile%2Ftsconfig.json%60%20%28extends%20%60expo%2Ftsconfig.base%60%2C%20no%20such%20flag%29%20both%20resolve%20%60%40conclave%2Fui-tokens%60%20directly%20to%20these%20source%20files%20via%20path%20aliases%20or%20package%20exports.%20TypeScript%20will%20emit%20TS5097%20%28%22An%20import%20path%20can%20only%20end%20with%20a%20'.ts'%20extension%20when%20'allowImportingTsExtensions'%20is%20enabled%22%29%20when%20it%20traverses%20into%20these%20files%20during%20type-checking.%20The%20same%20problem%20exists%20in%20%60packages%2Fui-tokens%2Fsrc%2Fcore%2Findex.ts%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FCore%2FState%2FMeetingState.swift%3A181-185%0A**Case-normalisation%20asymmetry%20between%20%60isVoiceAgentUserId%60%20and%20other%20ID%20predicates**%0A%0A%60isVoiceAgentUserId%60%20lowercases%20the%20input%20before%20matching%2C%20while%20%60isBrowserAudioUserId%60%20and%20%60isBrowserVideoUserId%60%20use%20case-sensitive%20%60hasPrefix%60.%20This%20means%20a%20userId%20like%20%60%22Shared-Browser%3Afoo%22%60%20is%20NOT%20treated%20as%20a%20system%20user%2C%20but%20%60%22Voice-Agent-123%22%60%20IS%20treated%20as%20a%20voice%20agent.%20If%20IDs%20arriving%20from%20the%20SFU%20are%20always%20already%20lowercase%2C%20the%20asymmetry%20is%20harmless%2C%20but%20if%20they%20can%20carry%20mixed%20case%2C%20%60isVoiceAgentUserId%60%20silently%20accepts%20them%20while%20the%20browser%20checks%20would%20miss%20their%20equivalents.%20Worth%20confirming%20the%20casing%20guarantee%20from%20the%20SFU.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FFeatures%2FMeeting%2FMeetingViewModel.swift%3A4816-4819%0A**%60isSystemUserId%60%20guard%20is%20now%20unreachable%20for%20voice-agent%20IDs**%0A%0AThe%20new%20%60isVoiceAgentUserId%60%20early%20return%20on%20line%204816%20fires%20before%20%60guard%20!MeetingState.isSystemUserId%28producerUserId%29%60%20on%20line%204819.%20Since%20%60isVoiceAgentUserId%60%20covers%20the%20new%20prefix%2Fsuffix%20and%20the%20two%20browser-prefix%20checks%20above%20handle%20the%20legacy%20system%20IDs%2C%20the%20%60isSystemUserId%60%20guard%20is%20now%20dead%20code%20on%20the%20voice-agent%20path.%20The%20guard%20still%20protects%20against%20future%20unknown%20system%20ID%20variants%2C%20but%20its%20intent%20is%20partially%20superseded.%0A%0A&repo=acm-vit%2Fconclave&pr=118&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fui-tokens%2Fsrc%2Findex.ts%3A7-8%0A**%60.ts%60%20extension%20imports%20break%20TypeScript%20type-checking%20in%20consuming%20packages**%0A%0ASwitching%20from%20%60.js%60%20to%20%60.ts%60%20extension%20specifiers%20requires%20%60allowImportingTsExtensions%3A%20true%60%20in%20every%20tsconfig%20that%20resolves%20into%20these%20files.%20%60packages%2Fsfu%2Ftsconfig.json%60%20was%20updated%2C%20but%20%60apps%2Fweb%2Ftsconfig.json%60%20%28%60moduleResolution%3A%20%22bundler%22%60%2C%20no%20%60allowImportingTsExtensions%60%29%20and%20%60apps%2Fmobile%2Ftsconfig.json%60%20%28extends%20%60expo%2Ftsconfig.base%60%2C%20no%20such%20flag%29%20both%20resolve%20%60%40conclave%2Fui-tokens%60%20directly%20to%20these%20source%20files%20via%20path%20aliases%20or%20package%20exports.%20TypeScript%20will%20emit%20TS5097%20%28%22An%20import%20path%20can%20only%20end%20with%20a%20'.ts'%20extension%20when%20'allowImportingTsExtensions'%20is%20enabled%22%29%20when%20it%20traverses%20into%20these%20files%20during%20type-checking.%20The%20same%20problem%20exists%20in%20%60packages%2Fui-tokens%2Fsrc%2Fcore%2Findex.ts%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FCore%2FState%2FMeetingState.swift%3A181-185%0A**Case-normalisation%20asymmetry%20between%20%60isVoiceAgentUserId%60%20and%20other%20ID%20predicates**%0A%0A%60isVoiceAgentUserId%60%20lowercases%20the%20input%20before%20matching%2C%20while%20%60isBrowserAudioUserId%60%20and%20%60isBrowserVideoUserId%60%20use%20case-sensitive%20%60hasPrefix%60.%20This%20means%20a%20userId%20like%20%60%22Shared-Browser%3Afoo%22%60%20is%20NOT%20treated%20as%20a%20system%20user%2C%20but%20%60%22Voice-Agent-123%22%60%20IS%20treated%20as%20a%20voice%20agent.%20If%20IDs%20arriving%20from%20the%20SFU%20are%20always%20already%20lowercase%2C%20the%20asymmetry%20is%20harmless%2C%20but%20if%20they%20can%20carry%20mixed%20case%2C%20%60isVoiceAgentUserId%60%20silently%20accepts%20them%20while%20the%20browser%20checks%20would%20miss%20their%20equivalents.%20Worth%20confirming%20the%20casing%20guarantee%20from%20the%20SFU.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FFeatures%2FMeeting%2FMeetingViewModel.swift%3A4816-4819%0A**%60isSystemUserId%60%20guard%20is%20now%20unreachable%20for%20voice-agent%20IDs**%0A%0AThe%20new%20%60isVoiceAgentUserId%60%20early%20return%20on%20line%204816%20fires%20before%20%60guard%20!MeetingState.isSystemUserId%28producerUserId%29%60%20on%20line%204819.%20Since%20%60isVoiceAgentUserId%60%20covers%20the%20new%20prefix%2Fsuffix%20and%20the%20two%20browser-prefix%20checks%20above%20handle%20the%20legacy%20system%20IDs%2C%20the%20%60isSystemUserId%60%20guard%20is%20now%20dead%20code%20on%20the%20voice-agent%20path.%20The%20guard%20still%20protects%20against%20future%20unknown%20system%20ID%20variants%2C%20but%20its%20intent%20is%20partially%20superseded.%0A%0A&pr=118&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/5037b29e16756a2d982b80e89ffa89c1502ee507) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40711965)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - Encourage people to write better commit messages ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->