### PR TITLE
fix(web): improve screen share low-bandwidth quality

### DIFF
--- a/apps/web/src/app/components/GridLayout.tsx
+++ b/apps/web/src/app/components/GridLayout.tsx
@@ -95,6 +95,7 @@ interface GridLayoutProps {
   onViewSettingsChange?: Dispatch<SetStateAction<MeetViewSettings>>;
   presentationStream?: MediaStream | null;
   presenterName?: string;
+  presentationPresenterId?: string | null;
   /** True when the presentation stream above is YOUR own screen share —
    *  the stage tile defaults to a chooser instead of mirroring it back. */
   isLocalPresenter?: boolean;
@@ -383,6 +384,13 @@ type MeetRoomTilingMetadataBase = {
   autoStageMode: string;
   dynamicCrop: boolean;
   presenting: boolean;
+  presentation: {
+    tileId: string;
+    presenterId: string | null;
+    visible: boolean;
+    primary: boolean;
+    focus: boolean;
+  };
   pinnedId: string | null;
   primaryIds: string[];
   focusIds: string[];
@@ -963,6 +971,7 @@ function GridLayout({
   onViewSettingsChange,
   presentationStream = null,
   presenterName = "Someone",
+  presentationPresenterId = null,
   isLocalPresenter = false,
   screenShareControlState,
   screenShareCaptureController = null,
@@ -2135,6 +2144,17 @@ function GridLayout({
       autoStageMode,
       dynamicCrop: usesAutoDynamicCrop,
       presenting: hasPresentation,
+      presentation: {
+        tileId: PRESENTATION_TILE_ID,
+        presenterId: presentationPresenterId,
+        visible: hasPresentation,
+        primary:
+          hasGridPresentationTile ||
+          (usesStageLayout && stageMainKind === "presentation"),
+        focus:
+          hasGridPresentationTile ||
+          (usesStageLayout && stageMainKind === "presentation"),
+      },
       pinnedId,
       primaryIds: roomTilingPrimaryIds,
       focusIds: roomTilingFocusIds,
@@ -2233,6 +2253,7 @@ function GridLayout({
       gridSize.height,
       gridSize.width,
       gridVideoObjectFit,
+      hasGridPresentationTile,
       hasPresentation,
       hiddenParticipantsCount,
       gridTilePlacements,
@@ -2247,6 +2268,7 @@ function GridLayout({
       localVideoTracking,
       maxGridTiles,
       orderedRemoteParticipants,
+      presentationPresenterId,
       pinnedId,
       renderedViewMode,
       requestedMaxTiles,
@@ -2576,6 +2598,7 @@ function GridLayout({
           viewSettings.mode === "auto" ? autoStageMode : undefined
         }
         data-meet-view-presenting={hasPresentation ? "true" : "false"}
+        data-meet-view-presentation-presenter={presentationPresenterId ?? ""}
         data-meet-view-grid-presentation={
           hasGridPresentationTile ? "true" : "false"
         }
@@ -2641,6 +2664,9 @@ function GridLayout({
         data-meet-room-tiling-fallback-level={roomTilingFallbackLevel}
         data-meet-room-tiling-active-speaker={activeSpeakerId ?? ""}
         data-meet-room-tiling-featured-speaker={featuredSpeakerId ?? ""}
+        data-meet-room-tiling-presentation-presenter={
+          presentationPresenterId ?? ""
+        }
         data-meet-room-tiling-primary-ids={roomTilingPrimaryIds.join(",")}
         data-meet-room-tiling-visible-ids={roomTilingRemoteVisibleIds.join(",")}
         data-meet-room-tiling-hidden-ids={roomTilingHiddenIds.join(",")}
@@ -2677,6 +2703,7 @@ function GridLayout({
               <PresentationVideoTile
                 stream={presentationStream}
                 presenterName={presenterName}
+                presenterId={presentationPresenterId}
                 size="stage"
                 selfView={presentationSelfView}
                 captureControl={presentationCaptureControl}
@@ -2824,6 +2851,7 @@ function GridLayout({
                 <PresentationVideoTile
                   stream={presentationStream}
                   presenterName={presenterName}
+                  presenterId={presentationPresenterId}
                   size="stage"
                   selfView={presentationSelfView}
                   captureControl={presentationCaptureControl}
@@ -2903,6 +2931,7 @@ function GridLayout({
                     <PresentationVideoTile
                       stream={presentationStream}
                       presenterName={presenterName}
+                      presenterId={presentationPresenterId}
                       size="rail"
                       captureControl={presentationCaptureControl}
                       isPinned={pinnedId === PRESENTATION_TILE_ID}
@@ -2975,6 +3004,7 @@ function GridLayout({
             <PresentationVideoTile
               stream={presentationStream}
               presenterName={presenterName}
+              presenterId={presentationPresenterId}
               size="grid"
               selfView={presentationSelfView}
               captureControl={presentationCaptureControl}
@@ -3416,6 +3446,7 @@ const OverflowPreviewTile = memo(function OverflowPreviewTile({
 const PresentationVideoTile = memo(function PresentationVideoTile({
   stream,
   presenterName,
+  presenterId,
   size,
   selfView,
   captureControl,
@@ -3424,6 +3455,7 @@ const PresentationVideoTile = memo(function PresentationVideoTile({
 }: {
   stream: MediaStream;
   presenterName: string;
+  presenterId?: string | null;
   size: "stage" | "grid" | "rail";
   /** Only set when this presentation IS your own screen share — lets the
    *  presenter choose between a flat "you're presenting" placeholder and an
@@ -3646,6 +3678,7 @@ const PresentationVideoTile = memo(function PresentationVideoTile({
         compact ? "h-28 shrink-0" : "h-full w-full"
       }`}
       data-meet-presentation-tile
+      data-meet-presentation-presenter-id={presenterId ?? undefined}
       data-meet-captured-surface-control={
         showCaptureControls ? "available" : "unavailable"
       }
@@ -3656,6 +3689,7 @@ const PresentationVideoTile = memo(function PresentationVideoTile({
         muted
         playsInline
         data-meet-presentation-video="true"
+        data-meet-video-stream-type="screen"
         className={`h-full w-full bg-black object-contain ${
           showChooser ? "opacity-0" : ""
         }`}

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -636,6 +636,32 @@ export default function MeetsMainContent({
     : devPresentationStream
       ? "Dev presentation"
       : presenterName;
+  const presentationPresenterId = useMemo(() => {
+    if (!presentationStream) return null;
+
+    const activeScreenShareParticipant = activeScreenShareId
+      ? nonSystemParticipants.find(
+          (participant) =>
+            participant.screenShareProducerId === activeScreenShareId &&
+            getLiveVideoStream(participant.screenShareStream),
+        )
+      : null;
+    const fallbackScreenShareParticipant = nonSystemParticipants.find(
+      (participant) => getLiveVideoStream(participant.screenShareStream),
+    );
+
+    return (
+      activeScreenShareParticipant?.userId ??
+      fallbackScreenShareParticipant?.userId ??
+      (isScreenSharing ? currentUserId : null)
+    );
+  }, [
+    activeScreenShareId,
+    currentUserId,
+    isScreenSharing,
+    nonSystemParticipants,
+    presentationStream,
+  ]);
   const shouldUseDevCameraStream =
     Boolean(devCameraStream) && !getLiveVideoStream(localStream);
   const effectiveLocalStream = shouldUseDevCameraStream
@@ -1680,6 +1706,7 @@ export default function MeetsMainContent({
           onViewSettingsChange={setViewSettings}
           presentationStream={effectivePresentationStream}
           presenterName={effectivePresenterName}
+          presentationPresenterId={presentationPresenterId}
           isLocalPresenter={isLocalPresenter}
           screenShareControlState={screenShareControlState}
           screenShareCaptureController={screenShareCaptureController}

--- a/apps/web/src/app/components/PresentationLayout.tsx
+++ b/apps/web/src/app/components/PresentationLayout.tsx
@@ -181,6 +181,8 @@ function PresentationLayout({
           autoPlay
           muted
           playsInline
+          data-meet-presentation-video="true"
+          data-meet-video-stream-type="screen"
           className="max-h-full max-w-full object-contain"
         />
         <div className="absolute left-3 top-3 flex max-w-[calc(100%-1.5rem)] items-center gap-2 rounded-full border border-[#fafafa]/10 bg-[#0a0a0b]/70 px-3 py-1.5">

--- a/apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts
+++ b/apps/web/src/app/hooks/useAdaptiveConsumerPreferences.ts
@@ -87,6 +87,12 @@ type RoomTilingHints = {
   hiddenIds: Set<string>;
   warmIds: Set<string>;
   orderedRemoteRanks: Map<string, number>;
+  presentation: {
+    presenterId: string | null;
+    visible: boolean;
+    primary: boolean;
+    focus: boolean;
+  };
 };
 
 type ConsumerPreferenceDebugStatus =
@@ -200,6 +206,22 @@ const readStringArray = (
   return raw.filter((entry): entry is string => typeof entry === "string");
 };
 
+const readNullableString = (value: unknown, key: string): string | null => {
+  if (!isRecord(value)) return null;
+  const raw = value[key];
+  return typeof raw === "string" && raw.length > 0 ? raw : null;
+};
+
+const readBoolean = (
+  value: unknown,
+  key: string,
+  fallback = false,
+): boolean => {
+  if (!isRecord(value)) return fallback;
+  const raw = value[key];
+  return typeof raw === "boolean" ? raw : fallback;
+};
+
 const readRoomTilingHints = (): RoomTilingHints | null => {
   if (typeof window === "undefined") return null;
 
@@ -209,6 +231,9 @@ const readRoomTilingHints = (): RoomTilingHints | null => {
     debugWindow.__conclaveMeetRoomTilingDebug;
   const current = snapshot?.current;
   if (!isRecord(current)) return null;
+  const presentation = isRecord(current.presentation)
+    ? current.presentation
+    : null;
 
   return {
     primaryIds: new Set(readStringArray(current, "primaryIds")),
@@ -222,19 +247,34 @@ const readRoomTilingHints = (): RoomTilingHints | null => {
         index,
       ]),
     ),
+    presentation: {
+      presenterId: readNullableString(presentation, "presenterId"),
+      visible: readBoolean(presentation, "visible"),
+      primary: readBoolean(presentation, "primary"),
+      focus: readBoolean(presentation, "focus"),
+    },
   };
 };
 
 const getLayoutRole = (
   hints: RoomTilingHints | null,
   userId: string,
+  type: ProducerMapEntry["type"],
 ): LayoutRole | null => {
   if (!hints) return null;
+  const isPresentedScreen =
+    type === "screen" &&
+    hints.presentation.visible &&
+    hints.presentation.presenterId === userId;
   return {
-    primary: hints.primaryIds.has(userId),
-    focus: hints.focusIds.has(userId),
-    visible: hints.visibleRemoteIds.has(userId),
-    hidden: hints.hiddenIds.has(userId),
+    primary:
+      hints.primaryIds.has(userId) ||
+      (isPresentedScreen && hints.presentation.primary),
+    focus:
+      hints.focusIds.has(userId) ||
+      (isPresentedScreen && hints.presentation.focus),
+    visible: hints.visibleRemoteIds.has(userId) || isPresentedScreen,
+    hidden: hints.hiddenIds.has(userId) && !isPresentedScreen,
     warm: hints.warmIds.has(userId),
     rank: hints.orderedRemoteRanks.get(userId) ?? null,
   };
@@ -462,13 +502,18 @@ const getDesiredPreferences = (
     const screenShareEmergency =
       options.emergencyMode ||
       isScreenShareReceiveEmergencyBitrate(options.availableIncomingBitrateBps);
+    const screenShareVisible =
+      !options.layout ||
+      options.layout.visible ||
+      options.layout.primary ||
+      options.layout.focus;
     return {
       preferredLayers: bounds
         ? buildLayerPreference(
             0,
             screenShareEmergency
               ? 0
-              : screenShareQuality === "poor"
+              : screenShareQuality === "poor" && !screenShareVisible
                 ? 1
                 : bounds.maxTemporalLayer,
             bounds,
@@ -856,7 +901,7 @@ export function useAdaptiveConsumerPreferences({
             return null;
           }
 
-          const layout = getLayoutRole(layoutHints, info.userId);
+          const layout = getLayoutRole(layoutHints, info.userId, info.type);
           return {
             producerId,
             active: info.userId === activeSpeakerId,
@@ -921,7 +966,7 @@ export function useAdaptiveConsumerPreferences({
       }
 
       const bounds = inferLayerBounds(consumer, info);
-      const layout = getLayoutRole(layoutHints, info.userId);
+      const layout = getLayoutRole(layoutHints, info.userId, info.type);
       const emergencyKeepVideo =
         emergencyMode &&
         info.kind === "video" &&

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -320,8 +320,6 @@ const getInitialConsumerPreferences = (
         temporalLayer:
           networkProfile === "emergency"
             ? 0
-            : networkProfile === "poor"
-            ? 1
             : 2,
       },
       priority: 240,

--- a/packages/sfu/tsconfig.json
+++ b/packages/sfu/tsconfig.json
@@ -11,7 +11,6 @@
     "declaration": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "forceConsistentCasingInFileNames": true,
     "noEmit": true

--- a/packages/ui-tokens/src/core/index.js
+++ b/packages/ui-tokens/src/core/index.js
@@ -1,0 +1,1 @@
+export * from "./index.ts";

--- a/packages/ui-tokens/src/core/index.ts
+++ b/packages/ui-tokens/src/core/index.ts
@@ -2,7 +2,7 @@
  * Platform-agnostic helpers shared by the web and native primitives so the two
  * implementations cannot diverge in behavior. No React, no react-native, no DOM.
  */
-import { color } from "../tokens.ts";
+import { color } from "../tokens";
 
 /* ------------------------------------------------------------------ avatars */
 

--- a/packages/ui-tokens/src/core/index.ts
+++ b/packages/ui-tokens/src/core/index.ts
@@ -2,7 +2,7 @@
  * Platform-agnostic helpers shared by the web and native primitives so the two
  * implementations cannot diverge in behavior. No React, no react-native, no DOM.
  */
-import { color } from "../tokens";
+import { color } from "../tokens.js";
 
 /* ------------------------------------------------------------------ avatars */
 

--- a/packages/ui-tokens/src/index.ts
+++ b/packages/ui-tokens/src/index.ts
@@ -4,5 +4,5 @@
  * "@conclave/ui-tokens/native" so the wrong platform's React renderer is never
  * pulled into a bundle.
  */
-export * from "./tokens.ts";
-export * from "./core/index.ts";
+export * from "./tokens";
+export * from "./core";

--- a/packages/ui-tokens/src/index.ts
+++ b/packages/ui-tokens/src/index.ts
@@ -4,5 +4,5 @@
  * "@conclave/ui-tokens/native" so the wrong platform's React renderer is never
  * pulled into a bundle.
  */
-export * from "./tokens";
-export * from "./core";
+export * from "./tokens.js";
+export * from "./core/index.js";

--- a/packages/ui-tokens/src/tokens.js
+++ b/packages/ui-tokens/src/tokens.js
@@ -1,0 +1,1 @@
+export * from "./tokens.ts";

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -418,13 +418,13 @@ assertIncludes(
 );
 assertRegex(
   "webAdaptiveConsumerPreferences",
-  /if \(info\.type === "screen"\) \{[\s\S]*const screenShareQuality = worstQuality\([\s\S]*getConsumerScoreQualityHint\(options\.consumerScoreQuality\)[\s\S]*screenShareEmergency[\s\S]*\? 0[\s\S]*: screenShareQuality === "poor"[\s\S]*\? 1[\s\S]*: bounds\.maxTemporalLayer[\s\S]*priority: 240,[\s\S]*paused: false,/,
-  "web screen-share receive adaptation keeps full temporal FPS on fair links",
+  /if \(info\.type === "screen"\) \{[\s\S]*const screenShareQuality = worstQuality\([\s\S]*getConsumerScoreQualityHint\(options\.consumerScoreQuality\)[\s\S]*const screenShareVisible =[\s\S]*options\.layout\.primary[\s\S]*screenShareEmergency[\s\S]*\? 0[\s\S]*: screenShareQuality === "poor" && !screenShareVisible[\s\S]*\? 1[\s\S]*: bounds\.maxTemporalLayer[\s\S]*priority: 240,[\s\S]*paused: false,/,
+  "web visible screen-share receive adaptation keeps full temporal FPS above emergency bitrate",
 );
 assertRegex(
   "webMeetSocket",
-  /producerInfo\.type === "screen"[\s\S]*networkProfile === "emergency"[\s\S]*\? 0[\s\S]*: networkProfile === "poor"[\s\S]*\? 1[\s\S]*: 2,[\s\S]*priority: 240,/,
-  "web initial screen-share consume keeps fair links on full temporal FPS",
+  /producerInfo\.type === "screen"[\s\S]*networkProfile === "emergency"[\s\S]*\? 0[\s\S]*: 2,[\s\S]*priority: 240,/,
+  "web initial screen-share consume keeps full temporal FPS above emergency bitrate",
 );
 assertRegex(
   "sfuMediaHandlers",
@@ -498,6 +498,21 @@ assertRegex(
   "webGridLayout",
   /isRenderingParticipantScreenShare\([\s\S]*data-meet-video-stream-type=\{[\s\S]*isRenderingScreenShare \? "screen" : "webcam"/,
   "web overflow gallery video tags rendered screen-share streams",
+);
+assertRegex(
+  "webGridLayout",
+  /data-meet-presentation-video="true"[\s\S]*data-meet-video-stream-type="screen"/,
+  "web presentation tile tags rendered screen-share streams",
+);
+assertRegex(
+  "webPresentationLayout",
+  /data-meet-presentation-video="true"[\s\S]*data-meet-video-stream-type="screen"/,
+  "web legacy presentation layout tags rendered screen-share streams",
+);
+assertRegex(
+  "webMeetsMainContent",
+  /const presentationPresenterId = useMemo\([\s\S]*participant\.screenShareProducerId === activeScreenShareId[\s\S]*presentationPresenterId=\{presentationPresenterId\}/,
+  "web screen-share presenter id flows into grid tiling metadata",
 );
 assertIncludes(
   "webMobileParticipantVideo",
@@ -651,13 +666,18 @@ assertRegex(
 );
 assertRegex(
   "webAdaptiveConsumerPreferences",
-  /SCREEN_SHARE_RECEIVE_FAIR_BPS = 1500000[\s\S]*SCREEN_SHARE_RECEIVE_POOR_BPS = 550000[\s\S]*SCREEN_SHARE_RECEIVE_EMERGENCY_BPS = 300000[\s\S]*getScreenShareReceiveQualityForAvailableBitrate[\s\S]*availableIncomingBitrateBps <= SCREEN_SHARE_RECEIVE_POOR_BPS[\s\S]*availableIncomingBitrateBps <= SCREEN_SHARE_RECEIVE_FAIR_BPS[\s\S]*isScreenShareReceiveEmergencyBitrate[\s\S]*screenShareEmergency[\s\S]*screenShareQuality === "poor"[\s\S]*bounds\.maxTemporalLayer/,
-  "web screen-share receive layers use incoming bitrate while keeping fair-link FPS",
+  /SCREEN_SHARE_RECEIVE_FAIR_BPS = 1500000[\s\S]*SCREEN_SHARE_RECEIVE_POOR_BPS = 550000[\s\S]*SCREEN_SHARE_RECEIVE_EMERGENCY_BPS = 300000[\s\S]*getScreenShareReceiveQualityForAvailableBitrate[\s\S]*availableIncomingBitrateBps <= SCREEN_SHARE_RECEIVE_POOR_BPS[\s\S]*availableIncomingBitrateBps <= SCREEN_SHARE_RECEIVE_FAIR_BPS[\s\S]*isScreenShareReceiveEmergencyBitrate[\s\S]*screenShareEmergency[\s\S]*screenShareVisible[\s\S]*screenShareQuality === "poor" && !screenShareVisible[\s\S]*bounds\.maxTemporalLayer/,
+  "web visible screen-share receive layers use incoming bitrate while preserving FPS",
 );
 assertRegex(
   "webLowBandwidthProbe",
   /meetVideoStreamType: video\.dataset\.meetVideoStreamType[\s\S]*visibleScreenRenderedVideos = visibleRenderedVideos\.filter[\s\S]*meetVideoStreamType === "screen"[\s\S]*largestRenderedScreenVideo[\s\S]*expected full-resolution decoded screen-share video/,
   "web screen receive probe verifies the actual rendered screen-share video",
+);
+assertRegex(
+  "webLowBandwidthProbe",
+  /const isVisibleScreenShare =[\s\S]*entry\.layout\?\.visible === true[\s\S]*entry\.layout\?\.primary === true[\s\S]*entry\.bounds\?\.maxTemporalLayer \?\? 2/,
+  "web screen receive probe allows visible presentations to keep full temporal FPS",
 );
 assertIncludes(
   "webAdaptiveConsumerPreferences",

--- a/scripts/probe-low-bandwidth-meet.mjs
+++ b/scripts/probe-low-bandwidth-meet.mjs
@@ -3323,7 +3323,15 @@ const validateScreenReceiveSnapshot = (
             `expected screen spatial layer 0 for ${entry.producerId}, got ${layers.spatialLayer}`,
           );
         }
-        const maxTemporalLayer = expectEmergencyMode ? 0 : 1;
+        const isVisibleScreenShare =
+          entry.layout?.visible === true ||
+          entry.layout?.primary === true ||
+          entry.layout?.focus === true;
+        const maxTemporalLayer = expectEmergencyMode
+          ? 0
+          : isVisibleScreenShare
+            ? entry.bounds?.maxTemporalLayer ?? 2
+            : 1;
         if ((layers.temporalLayer ?? 0) > maxTemporalLayer) {
           errors.push(
             `expected screen temporal layer <=${maxTemporalLayer} for ${entry.producerId}, got ${layers.temporalLayer}`,


### PR DESCRIPTION
## Summary
- keep active screen shares identifiable through the meeting layout so consumer preferences can prioritize the presented feed
- request full temporal layers for visible screen shares outside emergency bitrate mode while keeping hidden/poor streams conservative
- tag presentation video elements for low-bandwidth probes and extend static/runtime checks for screen-share behavior
- fix ui-tokens internal imports so the web TypeScript check passes

## Verification
- node scripts/check-low-bandwidth-profiles.mjs
- node --check scripts/probe-low-bandwidth-meet.mjs
- pnpm -C apps/web run lint
- pnpm -C apps/web exec tsc --noEmit
- screen receive probe: visible 1920x1080 screen share rendered, stream type tagged as screen, temporal layer 2 requested
- screen publish probe: VP8 maintain-resolution screen capture at 1600x900, 5 fps, 450 kbps, Opus screen audio profile observed

## Notes
- Runtime screen receive probe used CONCLAVE_LOW_BANDWIDTH_REQUIRE_SCREEN_AUDIO=0 because fake display-media audio is not reliable for the video-priority check.

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR improves screen-share handling under low bandwidth. The main changes are:

- Passes the active screen-share presenter id into the meeting grid layout.
- Publishes presentation visibility and focus metadata for adaptive consumer preferences.
- Keeps visible screen shares on full temporal layers outside emergency bitrate mode.
- Tags presentation video elements as screen-share media for runtime probes.
- Updates low-bandwidth profile checks and the screen receive probe.
- Fixes `ui-tokens` internal imports with `.js` bridge entrypoints.

<h3>Confidence Score: 5/5</h3>

The changes are focused on screen-share metadata, adaptive receive preferences, probe coverage, and token import compatibility, with no reported blocking issues.

The implementation scope is well-contained and accompanied by static checks plus targeted low-bandwidth screen-share probe updates.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the before and after screen receive quality logs to confirm the head screen-share contract checks moved from failing on base to passing on head, including the updated probe syntax.
- Compared the base and head low-bandwidth profile checks, observed both pass, and noted the head state introduces additional checks (such as visible screen-share FPS and related metadata) along with a UI token import change from TypeScript to JavaScript paths.
- Reviewed the screen-publish profile run, observing an ENOENT error for Chrome on both base and head paths but no contradictions with the publish contract.

<a href="https://app.greptile.com/trex/runs/12727250/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/ea4f605a5d23dcdf621e12522c24494392e16913) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40712859)</sub>

<!-- /greptile_comment -->