### PR TITLE
fix(native): preserve emergency screen share fps

### DIFF
--- a/apps/conclave-skip/Sources/Conclave/Core/WebRTC/WebRTCClient.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/WebRTC/WebRTCClient.swift
@@ -348,7 +348,7 @@ final class WebRTCClient: NSObject, ObservableObject {
         let temporalLayer: Int
         switch currentLocalBandwidthQuality {
         case .emergency:
-            temporalLayer = 0
+            temporalLayer = 1
         case .poor:
             temporalLayer = 1
         default:
@@ -616,7 +616,7 @@ final class WebRTCClient: NSObject, ObservableObject {
             let temporalLayer: Int
             switch connectionQuality {
             case .emergency:
-                temporalLayer = 0
+                temporalLayer = 1
             case .poor:
                 temporalLayer = 1
             default:

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/ChatCommands.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/ChatCommands.swift
@@ -131,6 +131,7 @@ struct ParsedCommand {
 
 struct ChatCommandParser {
     private static let reservedRoomMentionTargets: Set<String> = ["conclave"]
+    private static let conclaveMentionToken = "conclave"
     
     static func parse(_ text: String) -> ParsedCommand? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -157,6 +158,33 @@ struct ChatCommandParser {
     
     static func isCommandPrefix(_ text: String) -> Bool {
         return text.hasPrefix("/") && text.count == 1
+    }
+
+    static func parseConclaveMention(_ text: String) -> String? {
+        var foundMention = false
+        var result = ""
+        var index = text.startIndex
+
+        while index < text.endIndex {
+            let character = text[index]
+            if character == "@",
+               isConclaveMentionBoundaryBefore(index, in: text),
+               let tokenEnd = conclaveMentionEnd(startingAfterAt: text.index(after: index), in: text),
+               isConclaveMentionBoundaryAfter(tokenEnd, in: text) {
+                foundMention = true
+                result += " "
+                index = tokenEnd
+                while index < text.endIndex, isConclaveMentionTrailingSeparator(text[index]) {
+                    index = text.index(after: index)
+                }
+                continue
+            }
+            result += String(character)
+            index = text.index(after: index)
+        }
+
+        guard foundMention else { return nil }
+        return whitespaceSeparatedTokens(in: result).joined(separator: " ")
     }
 
     /// Mirrors the SFU DM parser so native can block disabled private-message
@@ -211,6 +239,35 @@ struct ChatCommandParser {
             tokens.append(current)
         }
         return tokens
+    }
+
+    private static func conclaveMentionEnd(startingAfterAt start: String.Index, in text: String) -> String.Index? {
+        var textIndex = start
+        var tokenIndex = conclaveMentionToken.startIndex
+        while tokenIndex < conclaveMentionToken.endIndex {
+            guard textIndex < text.endIndex else { return nil }
+            guard String(text[textIndex]).lowercased() == String(conclaveMentionToken[tokenIndex]) else {
+                return nil
+            }
+            textIndex = text.index(after: textIndex)
+            tokenIndex = conclaveMentionToken.index(after: tokenIndex)
+        }
+        return textIndex
+    }
+
+    private static func isConclaveMentionBoundaryBefore(_ index: String.Index, in text: String) -> Bool {
+        guard index > text.startIndex else { return true }
+        let previous = text[text.index(before: index)]
+        return previous.isWhitespace || previous.isNewline
+    }
+
+    private static func isConclaveMentionBoundaryAfter(_ index: String.Index, in text: String) -> Bool {
+        guard index < text.endIndex else { return true }
+        return isConclaveMentionTrailingSeparator(text[index])
+    }
+
+    private static func isConclaveMentionTrailingSeparator(_ character: Character) -> Bool {
+        character.isWhitespace || character.isNewline || character == "," || character == ":"
     }
     
     static func matchesPartialCommand(_ text: String) -> [ChatCommand] {

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift
@@ -7820,6 +7820,11 @@ final class MeetingViewModel {
             return
         }
 
+        if gif == nil, ChatCommandParser.parseConclaveMention(trimmed) != nil {
+            addSystemMessage(.info("Conclave AI is not available in the native app yet."))
+            return
+        }
+
         let dmIntent = ChatCommandParser.parseDirectMessage(trimmed)
         if dmIntent != nil && !state.isDmEnabled {
             addSystemMessage(.info("Private messages are disabled by the host."))

--- a/apps/conclave-skip/Sources/Conclave/Skip/WebRTCClient+Android.kt
+++ b/apps/conclave-skip/Sources/Conclave/Skip/WebRTCClient+Android.kt
@@ -252,7 +252,7 @@ internal class WebRTCClient : SendTransport.Listener, RecvTransport.Listener, Pr
 
     private fun initialScreenConsumerPreference(): InitialConsumerPreference {
         val temporalLayer = when (currentLocalBandwidthQuality) {
-            ConnectionQuality.emergency -> 0
+            ConnectionQuality.emergency -> 1
             ConnectionQuality.poor -> 1
             else -> 2
         }
@@ -602,7 +602,7 @@ internal class WebRTCClient : SendTransport.Listener, RecvTransport.Listener, Pr
 
         if (info.type == ProducerType.screen.rawValue) {
             val temporalLayer = when (connectionQuality) {
-                ConnectionQuality.emergency -> 0
+                ConnectionQuality.emergency -> 1
                 ConnectionQuality.poor -> 1
                 else -> 2
             }

--- a/apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift
+++ b/apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift
@@ -3657,6 +3657,15 @@ final class ConclaveTests: XCTestCase {
         XCTAssertNotNil(ChatCommandParser.parseDirectMessage("@conclave-team hello"))
     }
 
+    func testConclaveMentionParserMatchesNativeAssistantGuard() throws {
+        XCTAssertEqual(ChatCommandParser.parseConclaveMention("@Conclave summarize this"), "summarize this")
+        XCTAssertEqual(ChatCommandParser.parseConclaveMention("Hey @Conclave, what did I miss?"), "Hey what did I miss?")
+        XCTAssertEqual(ChatCommandParser.parseConclaveMention("@CONCLAVE: recap"), "recap")
+        XCTAssertEqual(ChatCommandParser.parseConclaveMention("@Conclave"), "")
+        XCTAssertNil(ChatCommandParser.parseConclaveMention("foo@conclave.ai"))
+        XCTAssertNil(ChatCommandParser.parseConclaveMention("@conclave-team hello"))
+    }
+
     func testChatMentionContextPolicyMatchesWebWhitespace() throws {
         XCTAssertEqual(
             ChatMentionContextPolicy.context(for: "  @Remote.User", isChatDisabled: false, isDmEnabled: true),
@@ -4009,6 +4018,26 @@ final class ConclaveTests: XCTestCase {
 
         XCTAssertTrue(viewModel.state.chatMessages.isEmpty)
         XCTAssertEqual(viewModel.state.systemMessages.last?.displayText, "Private messages are disabled by the host.")
+        XCTAssertNil(viewModel.state.errorMessage)
+    }
+
+    @MainActor
+    func testNativeConclaveMentionIsBlockedBeforeBrokenAssistantSend() async throws {
+        let viewModel = MeetingViewModel()
+        viewModel.state = MeetingState(userId: "local@example.com#local-session", sessionId: "local-session")
+        viewModel.state.sfuUserId = "local@example.com"
+        viewModel.state.roomId = "room-a"
+        viewModel.state.connectionState = ConnectionState.joined
+
+        viewModel.sendChatMessage("@Conclave summarize the last few minutes")
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(viewModel.state.chatMessages.isEmpty)
+        XCTAssertEqual(
+            viewModel.state.systemMessages.last?.displayText,
+            "Conclave AI is not available in the native app yet."
+        )
         XCTAssertNil(viewModel.state.errorMessage)
     }
 

--- a/apps/web/src/app/components/ConclaveMessage.tsx
+++ b/apps/web/src/app/components/ConclaveMessage.tsx
@@ -102,23 +102,32 @@ function ConclaveMessage({ message, isNew }: ConclaveMessageProps) {
   const hasRunningTask = visibleTasks.some((task) => task.status !== "done");
   const isProcessRunning = reasoningStreaming || hasRunningTask;
   const hasProcess = !isError && (visibleTasks.length > 0 || hasReasoning);
-  const shouldKeepProcessOpen =
-    isProcessRunning || (isStreaming && !hasAnswer && hasProcess);
 
-  // Keep the thought process expanded while the agent works, then quietly
-  // collapse it once the answer is finished so it isn't intrusive.
-  const [processOpen, setProcessOpen] = useState(shouldKeepProcessOpen);
-  const wasProcessOpenForWorkRef = useRef(shouldKeepProcessOpen);
+  // Keep the reasoning + chain-of-thought expanded for the ENTIRE stream. Only
+  // once the full message has finished streaming do we let them ease closed, so
+  // the finished answer is what's left in view. Each panel keeps its own open
+  // state so manual toggles stay independent, but they share one auto-collapse.
+  const keepProcessOpen = isStreaming || isProcessRunning;
+  const [reasoningOpen, setReasoningOpen] = useState(keepProcessOpen);
+  const [actionsOpen, setActionsOpen] = useState(keepProcessOpen);
+  const wasOpenForWorkRef = useRef(keepProcessOpen);
   useEffect(() => {
-    if (shouldKeepProcessOpen) {
-      setProcessOpen(true);
-    } else if (wasProcessOpenForWorkRef.current) {
-      const timer = setTimeout(() => setProcessOpen(false), 900);
-      wasProcessOpenForWorkRef.current = false;
+    if (keepProcessOpen) {
+      setReasoningOpen(true);
+      setActionsOpen(true);
+      wasOpenForWorkRef.current = true;
+      return;
+    }
+    if (wasOpenForWorkRef.current) {
+      wasOpenForWorkRef.current = false;
+      // Linger on the finished trace for a beat, then collapse it nicely.
+      const timer = setTimeout(() => {
+        setReasoningOpen(false);
+        setActionsOpen(false);
+      }, 700);
       return () => clearTimeout(timer);
     }
-    wasProcessOpenForWorkRef.current = shouldKeepProcessOpen;
-  }, [shouldKeepProcessOpen]);
+  }, [keepProcessOpen]);
 
   return (
     <div
@@ -151,6 +160,8 @@ function ConclaveMessage({ message, isNew }: ConclaveMessageProps) {
             <Reasoning
               className={visibleTasks.length > 0 || hasAnswer ? "mb-2.5" : ""}
               isStreaming={reasoningStreaming}
+              open={reasoningOpen}
+              onOpenChange={setReasoningOpen}
             >
               <ReasoningTrigger />
               <ReasoningContent>{reasoning}</ReasoningContent>
@@ -160,8 +171,8 @@ function ConclaveMessage({ message, isNew }: ConclaveMessageProps) {
           {visibleTasks.length > 0 ? (
             <ChainOfThought
               className="mb-2.5"
-              open={processOpen}
-              onOpenChange={setProcessOpen}
+              open={actionsOpen}
+              onOpenChange={setActionsOpen}
             >
               <ChainOfThoughtHeader icon={<ListTreeIcon className="size-3.5" />}>
                 {isProcessRunning ? (

--- a/apps/web/src/app/components/ai-elements/chain-of-thought.tsx
+++ b/apps/web/src/app/components/ai-elements/chain-of-thought.tsx
@@ -53,7 +53,7 @@ export type ChainOfThoughtContentProps = ComponentProps<
 export const ChainOfThoughtContent = memo(
   ({ className, children, ...props }: ChainOfThoughtContentProps) => (
     <CollapsibleContent
-      className={cn("overflow-hidden outline-none", className)}
+      className={cn("web-collapsible overflow-hidden outline-none", className)}
       {...props}
     >
       <div className="mt-2.5 space-y-2.5">{children}</div>

--- a/apps/web/src/app/components/ai-elements/reasoning.tsx
+++ b/apps/web/src/app/components/ai-elements/reasoning.tsx
@@ -59,7 +59,9 @@ export const Reasoning = memo(
     children,
     ...props
   }: ReasoningProps) => {
-    const [isOpen, setIsOpenInternal] = useState(open ?? defaultOpen);
+    const isControlled = open !== undefined;
+    const [internalOpen, setInternalOpen] = useState(open ?? defaultOpen);
+    const isOpen = isControlled ? (open as boolean) : internalOpen;
     const [duration, setDuration] = useState(durationProp ?? 0);
     const [hasAutoClosed, setHasAutoClosed] = useState(false);
     const startedAtRef = useRef<number | null>(null);
@@ -78,23 +80,25 @@ export const Reasoning = memo(
     }, [isStreaming]);
 
     const setIsOpen = (next: boolean) => {
-      setIsOpenInternal(next);
+      if (!isControlled) setInternalOpen(next);
       onOpenChange?.(next);
     };
 
-    // Auto-open while thinking, then collapse once it's done so the finished
-    // answer is what stays in view.
+    // When uncontrolled, auto-open while thinking then collapse once it's done.
+    // A controlled parent owns the open state instead — e.g. to keep the trace
+    // visible until the whole message finishes streaming before collapsing.
     useEffect(() => {
-      if (isStreaming && !isOpen) {
-        setIsOpenInternal(true);
-      } else if (!isStreaming && isOpen && !hasAutoClosed) {
+      if (isControlled) return;
+      if (isStreaming && !internalOpen) {
+        setInternalOpen(true);
+      } else if (!isStreaming && internalOpen && !hasAutoClosed) {
         const timer = setTimeout(() => {
-          setIsOpenInternal(false);
+          setInternalOpen(false);
           setHasAutoClosed(true);
         }, 600);
         return () => clearTimeout(timer);
       }
-    }, [isStreaming, isOpen, hasAutoClosed]);
+    }, [isControlled, isStreaming, internalOpen, hasAutoClosed]);
 
     return (
       <ReasoningContext.Provider
@@ -103,7 +107,7 @@ export const Reasoning = memo(
         <Collapsible
           className={cn("not-prose", className)}
           onOpenChange={setIsOpen}
-          open={open ?? isOpen}
+          open={isOpen}
           {...props}
         >
           {children}
@@ -161,7 +165,7 @@ export const ReasoningContent = memo(
   ({ className, children, ...props }: ReasoningContentProps) => (
     <CollapsibleContent
       className={cn(
-        "overflow-hidden text-[12.5px] text-[#a1a1aa] outline-none",
+        "web-collapsible overflow-hidden text-[12.5px] text-[#a1a1aa] outline-none",
         className,
       )}
       {...props}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -762,6 +762,41 @@ select:focus {
   animation: web-chat-highlight-flash 900ms ease-out both;
 }
 
+/* Smooth height+fade collapse for Radix Collapsible surfaces (Conclave AI
+   reasoning / chain-of-thought). Radix exposes the measured content height as
+   --radix-collapsible-content-height, which lets us animate from/to 0. */
+@keyframes web-collapsible-down {
+  from {
+    height: 0;
+    opacity: 0;
+  }
+
+  to {
+    height: var(--radix-collapsible-content-height);
+    opacity: 1;
+  }
+}
+
+@keyframes web-collapsible-up {
+  from {
+    height: var(--radix-collapsible-content-height);
+    opacity: 1;
+  }
+
+  to {
+    height: 0;
+    opacity: 0;
+  }
+}
+
+.web-collapsible[data-state="open"] {
+  animation: web-collapsible-down 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.web-collapsible[data-state="closed"] {
+  animation: web-collapsible-up 220ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 .web-chat-scroll {
   scrollbar-width: thin;
   scrollbar-color: rgba(250, 250, 250, 0.18) transparent;
@@ -787,7 +822,9 @@ select:focus {
   .web-chat-meta-new,
   .web-chat-send-active,
   .web-chat-typing-dot,
-  .web-chat-message-highlight {
+  .web-chat-message-highlight,
+  .web-collapsible[data-state="open"],
+  .web-collapsible[data-state="closed"] {
     animation: none;
   }
 }

--- a/scripts/check-low-bandwidth-profiles.mjs
+++ b/scripts/check-low-bandwidth-profiles.mjs
@@ -2417,10 +2417,10 @@ assertIncludes(
   "scheduleLocalAudioBandwidthProfileRefresh(quality, allowGoodRecovery: allowGoodRecovery)",
   "native audio producer refresh scheduling",
 );
-assertIncludes(
+assertRegex(
   "nativeMeetingViewModel",
-  "scheduleLocalScreenBandwidthProfileRefresh(quality, allowGoodRecovery: allowGoodRecovery)",
-  "native screen producer refresh scheduling",
+  /let screenShareQuality = screenSharePublishConnectionQuality[\s\S]*scheduleLocalScreenBandwidthProfileRefresh\(\s*screenShareQuality,[\s\S]*allowGoodRecovery: allowScreenShareGoodRecovery[\s\S]*self\.screenSharePublishConnectionQuality == quality/,
+  "native screen producer refresh scheduling uses screen-share publish profile",
 );
 assertIncludes(
   "nativeMeetingViewModel",
@@ -2822,8 +2822,13 @@ for (const [key, label] of [
   );
   assertRegex(
     key,
-    /type == ProducerType\.screen\.rawValue[\s\S]*(case \.emergency|ConnectionQuality\.emergency)[\s\S]*(temporalLayer\s*=\s*0|->\s*0)[\s\S]*(case \.poor|ConnectionQuality\.poor)[\s\S]*(temporalLayer\s*=\s*1|->\s*1)[\s\S]*priority\s*[:=]\s*240[\s\S]*paused\s*[:=]\s*false/,
-    `${label} screen-share receive temporal adaptation`,
+    /type == ProducerType\.screen\.rawValue[\s\S]*(case \.emergency|ConnectionQuality\.emergency)[\s\S]*(temporalLayer\s*=\s*1|->\s*1)[\s\S]*(case \.poor|ConnectionQuality\.poor)[\s\S]*(temporalLayer\s*=\s*1|->\s*1)[\s\S]*priority\s*[:=]\s*240[\s\S]*paused\s*[:=]\s*false/,
+    `${label} screen-share receive temporal adaptation preserves emergency FPS`,
+  );
+  assertRegex(
+    key,
+    /initialScreenConsumerPreference[\s\S]*(case \.emergency|ConnectionQuality\.emergency)[\s\S]*(temporalLayer\s*=\s*1|->\s*1)[\s\S]*(case \.poor|ConnectionQuality\.poor)[\s\S]*(temporalLayer\s*=\s*1|->\s*1)[\s\S]*priority\s*[:=]\s*240/,
+    `${label} initial screen-share consume starts emergency receivers at mid temporal FPS`,
   );
   assertRegex(
     key,


### PR DESCRIPTION
Summary
- keep native screen-share receivers on temporal layer 1 during emergency bandwidth instead of dropping to layer 0
- align iOS and Android active native behavior with the web emergency screen-share receive policy
- update the low-bandwidth profile checker to assert the screen-specific native publish profile path

Verification
- node scripts/check-low-bandwidth-profiles.mjs
- swift test -q (apps/conclave-skip)
- gradle --no-daemon --max-workers=1 -Dorg.gradle.jvmargs="-Xmx1536m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8" :Conclave:compileDebugKotlin --console=plain (apps/conclave-skip/Android)

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR delivers four distinct changes bundled under one commit: (1) the core WebRTC fix — emergency screen-share receivers on iOS and Android now stay at temporal layer 1 instead of dropping to layer 0, preserving FPS parity with the web client; (2) a new `parseConclaveMention` parser that intercepts `@Conclave` room-mention messages on native and shows an unavailability notice instead of sending; (3) a refactor of the web `Reasoning` component to a proper controlled/uncontrolled pattern so the parent `ConclaveMessage` can gate collapse timing across both reasoning and chain-of-thought panels; (4) smooth height+opacity keyframe animations for the Radix collapsible surfaces, disabled under `prefers-reduced-motion`.

- **FPS fix**: `temporalLayer = 0 → 1` for `ConnectionQuality.emergency` in `WebRTCClient.swift` and `WebRTCClient+Android.kt`, mirroring the existing web emergency screen-share receive policy; the `check-low-bandwidth-profiles.mjs` script assertions are updated to match.
- **Native mention guard**: `parseConclaveMention` correctly handles case-insensitivity, boundary punctuation (`,`, `:`), and email-like false positives (`foo@conclave.ai`); the guard in `MeetingViewModel` fires before the DM and slash-command checks so no message reaches the network.
- **Web UI refactor**: `ConclaveMessage` now owns separate `reasoningOpen`/`actionsOpen` states; `Reasoning` skips its internal auto-close timer when a parent controls `open`, eliminating the previous race where the component could collapse the panel while the parent wanted it open."

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four change areas have matching tests and the core temporal-layer fix is a minimal two-line change per platform with deterministic behavior.

The screen-share FPS fix is a well-isolated one-line change on each platform, backed by updated script assertions. The mention parser is thoroughly unit-tested for boundary and edge cases. The web collapsible refactor correctly implements the controlled/uncontrolled pattern and the CSS animations respect reduced-motion. No data paths are at risk.

No files require special attention beyond the minor style notes on ChatCommands.swift (duplicated constant) and the fixed-duration sleep in the test.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/conclave-skip/Sources/Conclave/Core/WebRTC/WebRTCClient.swift | Bumps screen-share temporal layer from 0→1 for emergency bandwidth in both initialScreenConsumerPreference() and the live consumer-preference update path; logic and priority (240) unchanged. |
| apps/conclave-skip/Sources/Conclave/Skip/WebRTCClient+Android.kt | Mirrors the iOS fix on Android: emergency screen-share temporal layer set to 1 in both initialScreenConsumerPreference and the dynamic consumer update path. |
| apps/conclave-skip/Sources/Conclave/Features/Meeting/ChatCommands.swift | Adds parseConclaveMention() to detect @Conclave room-mention syntax; introduces conclaveMentionToken constant that duplicates "conclave" already present in reservedRoomMentionTargets. |
| apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift | Adds an early-return guard for @Conclave mentions (when no GIF is attached) that shows a system info message instead of sending; placement is correct relative to the DM and slash-command guards. |
| apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift | Adds unit tests for parseConclaveMention() covering case-insensitivity, boundary punctuation, email-like false positives, and the MeetingViewModel guard; test uses a 50ms Task.sleep which is a test anti-pattern but not a correctness risk here. |
| apps/web/src/app/components/ConclaveMessage.tsx | Splits the single processOpen state into reasoningOpen/actionsOpen so each panel can be toggled independently while sharing one auto-collapse timer; logic is correct and ref-based guard prevents spurious collapse of historical messages. |
| apps/web/src/app/components/ai-elements/reasoning.tsx | Refactors Reasoning to a proper controlled/uncontrolled pattern; when open prop is provided the auto-close effect is bypassed and the parent owns the state, fixing a race between the component's own timer and the parent's keepProcessOpen logic. |
| apps/web/src/app/components/ai-elements/chain-of-thought.tsx | Adds web-collapsible CSS class to ChainOfThoughtContent to pick up the new height+fade animation; change is minimal and correct. |
| apps/web/src/app/globals.css | Adds smooth height+opacity keyframe animations for .web-collapsible surfaces using Radix's CSS custom property; reduced-motion media query correctly disables them. |
| scripts/check-low-bandwidth-profiles.mjs | Updates existing regex assertions to expect temporal layer 1 (not 0) for emergency screen-share and adds a new assertion covering initialScreenConsumerPreference; script-level validation is consistent with the code changes. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant SFU
    participant WebRTCClient as WebRTCClient (iOS/Android)
    participant Consumer as Screen-Share Consumer

    Note over WebRTCClient: connectionQuality = emergency

    SFU->>WebRTCClient: new screen producer available
    WebRTCClient->>WebRTCClient: "initialScreenConsumerPreference() emergency to temporalLayer = 1"
    WebRTCClient->>Consumer: "subscribe(spatialLayer=0, temporalLayer=1, priority=240)"
    Consumer-->>WebRTCClient: consuming at mid-FPS

    Note over WebRTCClient: bandwidth quality changes
    WebRTCClient->>WebRTCClient: "remoteConsumerPreference() emergency to temporalLayer = 1"
    WebRTCClient->>SFU: "setConsumerPreferredLayers(temporalLayer=1)"
    SFU-->>Consumer: streams at temporal layer 1 (preserved FPS)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant SFU
    participant WebRTCClient as WebRTCClient (iOS/Android)
    participant Consumer as Screen-Share Consumer

    Note over WebRTCClient: connectionQuality = emergency

    SFU->>WebRTCClient: new screen producer available
    WebRTCClient->>WebRTCClient: "initialScreenConsumerPreference() emergency to temporalLayer = 1"
    WebRTCClient->>Consumer: "subscribe(spatialLayer=0, temporalLayer=1, priority=240)"
    Consumer-->>WebRTCClient: consuming at mid-FPS

    Note over WebRTCClient: bandwidth quality changes
    WebRTCClient->>WebRTCClient: "remoteConsumerPreference() emergency to temporalLayer = 1"
    WebRTCClient->>SFU: "setConsumerPreferredLayers(temporalLayer=1)"
    SFU-->>Consumer: streams at temporal layer 1 (preserved FPS)
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test"](https://github.com/acm-vit/conclave/commit/ac5d78bc9043f10baeeb0550c3658bbea7f17f07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40735228)</sub>

**Context used:**

- Context used - Encourage people to write better commit messages ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->