### PR TITLE
fix

### DIFF
--- a/apps/web/src/app/[code]/page.tsx
+++ b/apps/web/src/app/[code]/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { Viewport } from "next";
 import { headers as nextHeaders } from "next/headers";
 import MeetsClientShell from "../meets-client-shell";
 import RouteLoadingState from "../components/RouteLoadingState";
@@ -18,6 +19,12 @@ type MeetRoomPageProps = {
 
 export const instant = true;
 export const prefetch = "allow-runtime";
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#131316",
+  colorScheme: "dark",
+};
 
 const getParamValue = (
   value: string | string[] | undefined,

--- a/apps/web/src/app/book/[username]/[eventSlug]/page.tsx
+++ b/apps/web/src/app/book/[username]/[eventSlug]/page.tsx
@@ -1,8 +1,15 @@
 import { Suspense } from "react";
+import type { Viewport } from "next";
 import RouteLoadingState from "../../../components/RouteLoadingState";
 import BookingClient from "./booking-client";
 
 export const instant = true;
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#131316",
+  colorScheme: "dark",
+};
 
 type BookingPageProps = {
   params: Promise<{ username: string; eventSlug: string }>;

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,9 +1,16 @@
 import { Suspense } from "react";
+import type { Viewport } from "next";
 import RouteLoadingState from "./components/RouteLoadingState";
 import MeetsClientShell from "./meets-client-shell";
 
 export const instant = true;
 export const prefetch = "allow-runtime";
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#131316",
+  colorScheme: "dark",
+};
 
 export default function HomePage() {
   return (

--- a/apps/web/src/app/schedule/page.tsx
+++ b/apps/web/src/app/schedule/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { Viewport } from "next";
 import { headers as nextHeaders } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
@@ -7,6 +8,12 @@ import ScheduleClient from "./schedule-client";
 
 export const instant = true;
 export const prefetch = "allow-runtime";
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#131316",
+  colorScheme: "dark",
+};
 
 export default function SchedulePage() {
   return (

--- a/apps/web/src/app/sign-in/page.tsx
+++ b/apps/web/src/app/sign-in/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { Viewport } from "next";
 import RouteLoadingState from "../components/RouteLoadingState";
 import SignInClient from "./sign-in-client";
 
@@ -8,6 +9,12 @@ type SignInPageProps = {
 
 export const instant = true;
 export const prefetch = "allow-runtime";
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#131316",
+  colorScheme: "dark",
+};
 
 const getParamValue = (
   value: string | string[] | undefined,

--- a/apps/web/src/app/w/[code]/page.tsx
+++ b/apps/web/src/app/w/[code]/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { Viewport } from "next";
 import { headers as nextHeaders } from "next/headers";
 import RouteLoadingState from "../../components/RouteLoadingState";
 import { sanitizeWebinarLinkCode } from "../../lib/utils";
@@ -17,6 +18,12 @@ type WebinarRoomPageProps = {
 
 export const instant = true;
 export const prefetch = "allow-runtime";
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#131316",
+  colorScheme: "dark",
+};
 
 const lookupScheduledWebinar = async (
   slug: string,


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds a `viewport` export (setting `width`, `initialScale`, `themeColor`, and `colorScheme`) to six Next.js page files. However, an identical `viewport` is already exported from the root layout (`app/layout.tsx`), which Next.js automatically applies to all child routes.

- **6 pages updated** (`page.tsx`, `sign-in/page.tsx`, `schedule/page.tsx`, `[code]/page.tsx`, `w/[code]/page.tsx`, `book/[username]/[eventSlug]/page.tsx`) each receive a new `viewport` export that is character-for-character identical to the one in the root layout.
- **No functional change** — because the values match the inherited layout viewport exactly, this has no observable effect on the rendered pages.
- **Commit message** — the message "fix" gives no indication of what was changed or why; consider something like `chore: add viewport export to page files` or, better, removing the duplication with a message like `fix: remove duplicate viewport exports already covered by root layout`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the added viewport values are identical to the root layout so no page behavior changes.

The change is purely additive and copies values already present in the root layout, so no route is broken. The only concern is ongoing maintenance: six extra files now need to be kept in sync with the layout if the theme color or viewport config ever changes.

No files require special attention; all six changes are identical and trivially reviewable.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/page.tsx | Adds a `viewport` export identical to the one already present in the root layout — redundant but harmless. |
| apps/web/src/app/sign-in/page.tsx | Same redundant `viewport` export added, duplicating the root layout definition. |
| apps/web/src/app/schedule/page.tsx | Same redundant `viewport` export added, duplicating the root layout definition. |
| apps/web/src/app/[code]/page.tsx | Same redundant `viewport` export added, duplicating the root layout definition. |
| apps/web/src/app/w/[code]/page.tsx | Same redundant `viewport` export added, duplicating the root layout definition. |
| apps/web/src/app/book/[username]/[eventSlug]/page.tsx | Same redundant `viewport` export added, duplicating the root layout definition. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Root Layout\napp/layout.tsx] -->|exports viewport| B[Viewport Config\nwidth, initialScale\nthemeColor, colorScheme]
    B -->|inherited by all child routes| C[page.tsx]
    B -->|inherited by all child routes| D[sign-in/page.tsx]
    B -->|inherited by all child routes| E[schedule/page.tsx]
    B -->|inherited by all child routes| F["[code]/page.tsx"]
    B -->|inherited by all child routes| G["w/[code]/page.tsx"]
    B -->|inherited by all child routes| H["book/[username]/[eventSlug]/page.tsx"]
    C -->|also re-exports same viewport| B2[Duplicate Viewport ⚠️]
    D -->|also re-exports same viewport| B2
    E -->|also re-exports same viewport| B2
    F -->|also re-exports same viewport| B2
    G -->|also re-exports same viewport| B2
    H -->|also re-exports same viewport| B2
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Root Layout\napp/layout.tsx] -->|exports viewport| B[Viewport Config\nwidth, initialScale\nthemeColor, colorScheme]
    B -->|inherited by all child routes| C[page.tsx]
    B -->|inherited by all child routes| D[sign-in/page.tsx]
    B -->|inherited by all child routes| E[schedule/page.tsx]
    B -->|inherited by all child routes| F["[code]/page.tsx"]
    B -->|inherited by all child routes| G["w/[code]/page.tsx"]
    B -->|inherited by all child routes| H["book/[username]/[eventSlug]/page.tsx"]
    C -->|also re-exports same viewport| B2[Duplicate Viewport ⚠️]
    D -->|also re-exports same viewport| B2
    E -->|also re-exports same viewport| B2
    F -->|also re-exports same viewport| B2
    G -->|also re-exports same viewport| B2
    H -->|also re-exports same viewport| B2
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fpage.tsx%3A6-12%0A**Duplicate%20viewport%20%E2%80%94%20root%20layout%20already%20covers%20this**%0A%0A%60apps%2Fweb%2Fsrc%2Fapp%2Flayout.tsx%60%20%28lines%2052-57%29%20already%20exports%20an%20identical%20%60viewport%60%20with%20the%20same%20%60width%60%2C%20%60initialScale%60%2C%20%60themeColor%60%2C%20and%20%60colorScheme%60%20values.%20In%20Next.js%2C%20a%20viewport%20export%20in%20the%20root%20layout%20automatically%20applies%20to%20every%20child%20page%2C%20so%20re-declaring%20it%20in%20each%20page%20file%20is%20redundant%20and%20creates%20a%20maintenance%20burden%3A%20if%20the%20theme%20color%20or%20scheme%20ever%20changes%2C%20all%206%20files%20will%20need%20updating%20instead%20of%20just%20the%20layout.%20This%20applies%20to%20all%20six%20pages%20changed%20in%20this%20PR%20%28%60page.tsx%60%2C%20%60sign-in%2Fpage.tsx%60%2C%20%60schedule%2Fpage.tsx%60%2C%20%60%5Bcode%5D%2Fpage.tsx%60%2C%20%60w%2F%5Bcode%5D%2Fpage.tsx%60%2C%20%60book%2F%5Busername%5D%2F%5BeventSlug%5D%2Fpage.tsx%60%29.%0A%0A&repo=acm-vit%2Fconclave&pr=126&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fpage.tsx%3A6-12%0A**Duplicate%20viewport%20%E2%80%94%20root%20layout%20already%20covers%20this**%0A%0A%60apps%2Fweb%2Fsrc%2Fapp%2Flayout.tsx%60%20%28lines%2052-57%29%20already%20exports%20an%20identical%20%60viewport%60%20with%20the%20same%20%60width%60%2C%20%60initialScale%60%2C%20%60themeColor%60%2C%20and%20%60colorScheme%60%20values.%20In%20Next.js%2C%20a%20viewport%20export%20in%20the%20root%20layout%20automatically%20applies%20to%20every%20child%20page%2C%20so%20re-declaring%20it%20in%20each%20page%20file%20is%20redundant%20and%20creates%20a%20maintenance%20burden%3A%20if%20the%20theme%20color%20or%20scheme%20ever%20changes%2C%20all%206%20files%20will%20need%20updating%20instead%20of%20just%20the%20layout.%20This%20applies%20to%20all%20six%20pages%20changed%20in%20this%20PR%20%28%60page.tsx%60%2C%20%60sign-in%2Fpage.tsx%60%2C%20%60schedule%2Fpage.tsx%60%2C%20%60%5Bcode%5D%2Fpage.tsx%60%2C%20%60w%2F%5Bcode%5D%2Fpage.tsx%60%2C%20%60book%2F%5Busername%5D%2F%5BeventSlug%5D%2Fpage.tsx%60%29.%0A%0A&repo=acm-vit%2Fconclave&pr=126&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fpage.tsx%3A6-12%0A**Duplicate%20viewport%20%E2%80%94%20root%20layout%20already%20covers%20this**%0A%0A%60apps%2Fweb%2Fsrc%2Fapp%2Flayout.tsx%60%20%28lines%2052-57%29%20already%20exports%20an%20identical%20%60viewport%60%20with%20the%20same%20%60width%60%2C%20%60initialScale%60%2C%20%60themeColor%60%2C%20and%20%60colorScheme%60%20values.%20In%20Next.js%2C%20a%20viewport%20export%20in%20the%20root%20layout%20automatically%20applies%20to%20every%20child%20page%2C%20so%20re-declaring%20it%20in%20each%20page%20file%20is%20redundant%20and%20creates%20a%20maintenance%20burden%3A%20if%20the%20theme%20color%20or%20scheme%20ever%20changes%2C%20all%206%20files%20will%20need%20updating%20instead%20of%20just%20the%20layout.%20This%20applies%20to%20all%20six%20pages%20changed%20in%20this%20PR%20%28%60page.tsx%60%2C%20%60sign-in%2Fpage.tsx%60%2C%20%60schedule%2Fpage.tsx%60%2C%20%60%5Bcode%5D%2Fpage.tsx%60%2C%20%60w%2F%5Bcode%5D%2Fpage.tsx%60%2C%20%60book%2F%5Busername%5D%2F%5BeventSlug%5D%2Fpage.tsx%60%29.%0A%0A&pr=126&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/a6c79bc8ab7c8da7b94bc83088db67af77248fee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40793590)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Encourage people to write better commit messages ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->