### PR TITLE
feat: add redirects for favicon.ico to favicon.svg

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -40,6 +40,15 @@ const nextConfig: NextConfig = {
   experimental: {
     turbopackFileSystemCacheForBuild: true,
   },
+  async redirects() {
+    return [
+      {
+        source: "/favicon.ico",
+        destination: "/favicon.svg",
+        permanent: true,
+      },
+    ];
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds a Next.js `redirects()` entry that sends any request for `/favicon.ico` to `/favicon.svg` (which already exists in `public/`). It is a small, targeted change to ensure browsers that automatically request `/favicon.ico` are served the SVG icon instead.

- Adds a single permanent (301) redirect from `/favicon.ico` → `/favicon.svg` in `next.config.ts`.
- The destination `favicon.svg` exists in `apps/web/public/`, so the redirect will resolve correctly.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a single redirect rule with a valid destination file already in place.

The redirect destination (favicon.svg) exists, the config is syntactically correct, and the change is isolated. The only concern is that permanent: true bakes a 301 into browser caches, which could complicate serving a real .ico file later — but this is speculative and not a current breakage.

No files require special attention beyond the permanent: true flag in apps/web/next.config.ts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/next.config.ts | Adds a permanent (301) redirect from /favicon.ico to /favicon.svg; destination file exists in public/. The use of permanent: true could make it hard to serve a real .ico file later if needed. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant NextJS as Next.js Server
    participant PublicDir as /public

    Browser->>NextJS: GET /favicon.ico
    Note over NextJS: redirects() matches /favicon.ico
    NextJS-->>Browser: 301 Moved Permanently → /favicon.svg
    Browser->>NextJS: GET /favicon.svg
    NextJS->>PublicDir: serve favicon.svg
    PublicDir-->>NextJS: SVG file
    NextJS-->>Browser: 200 OK (image/svg+xml)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant NextJS as Next.js Server
    participant PublicDir as /public

    Browser->>NextJS: GET /favicon.ico
    Note over NextJS: redirects() matches /favicon.ico
    NextJS-->>Browser: 301 Moved Permanently → /favicon.svg
    Browser->>NextJS: GET /favicon.svg
    NextJS->>PublicDir: serve favicon.svg
    PublicDir-->>NextJS: SVG file
    NextJS-->>Browser: 200 OK (image/svg+xml)
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fnext.config.ts%3A46-48%0AUsing%20%60permanent%3A%20true%60%20%28HTTP%20301%29%20instructs%20browsers%20to%20cache%20this%20redirect%20indefinitely.%20If%20a%20real%20%60favicon.ico%60%20is%20ever%20placed%20in%20%60public%2F%60%20or%20the%20%60app%2F%60%20directory%2C%20browsers%20that%20already%20cached%20the%20301%20will%20never%20reach%20it%20until%20their%20cache%20expires%20%28potentially%20never%2C%20without%20a%20cache-bust%29.%20A%20temporary%20redirect%20%28%60permanent%3A%20false%60%2C%20HTTP%20302%29%20is%20safer%20here%20since%20there's%20no%20SEO%20benefit%20to%20permanently%20redirecting%20a%20favicon.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20source%3A%20%22%2Ffavicon.ico%22%2C%0A%20%20%20%20%20%20%20%20destination%3A%20%22%2Ffavicon.svg%22%2C%0A%20%20%20%20%20%20%20%20permanent%3A%20false%2C%0A%60%60%60%0A%0A&repo=acm-vit%2Fconclave&pr=127&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fnext.config.ts%3A46-48%0AUsing%20%60permanent%3A%20true%60%20%28HTTP%20301%29%20instructs%20browsers%20to%20cache%20this%20redirect%20indefinitely.%20If%20a%20real%20%60favicon.ico%60%20is%20ever%20placed%20in%20%60public%2F%60%20or%20the%20%60app%2F%60%20directory%2C%20browsers%20that%20already%20cached%20the%20301%20will%20never%20reach%20it%20until%20their%20cache%20expires%20%28potentially%20never%2C%20without%20a%20cache-bust%29.%20A%20temporary%20redirect%20%28%60permanent%3A%20false%60%2C%20HTTP%20302%29%20is%20safer%20here%20since%20there's%20no%20SEO%20benefit%20to%20permanently%20redirecting%20a%20favicon.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20source%3A%20%22%2Ffavicon.ico%22%2C%0A%20%20%20%20%20%20%20%20destination%3A%20%22%2Ffavicon.svg%22%2C%0A%20%20%20%20%20%20%20%20permanent%3A%20false%2C%0A%60%60%60%0A%0A&repo=acm-vit%2Fconclave&pr=127&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fnext.config.ts%3A46-48%0AUsing%20%60permanent%3A%20true%60%20%28HTTP%20301%29%20instructs%20browsers%20to%20cache%20this%20redirect%20indefinitely.%20If%20a%20real%20%60favicon.ico%60%20is%20ever%20placed%20in%20%60public%2F%60%20or%20the%20%60app%2F%60%20directory%2C%20browsers%20that%20already%20cached%20the%20301%20will%20never%20reach%20it%20until%20their%20cache%20expires%20%28potentially%20never%2C%20without%20a%20cache-bust%29.%20A%20temporary%20redirect%20%28%60permanent%3A%20false%60%2C%20HTTP%20302%29%20is%20safer%20here%20since%20there's%20no%20SEO%20benefit%20to%20permanently%20redirecting%20a%20favicon.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20source%3A%20%22%2Ffavicon.ico%22%2C%0A%20%20%20%20%20%20%20%20destination%3A%20%22%2Ffavicon.svg%22%2C%0A%20%20%20%20%20%20%20%20permanent%3A%20false%2C%0A%60%60%60%0A%0A&pr=127&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: add redirects for favicon.ico to f..."](https://github.com/acm-vit/conclave/commit/b4a4aca7f0461646b984bd9fa8f636b0f2e1ac63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40795528)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->