### PR TITLE
fix

### DIFF
--- a/apps/conclave-skip/Darwin/Info.plist
+++ b/apps/conclave-skip/Darwin/Info.plist
@@ -140,7 +140,7 @@
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>Conclave updates health data only when you explicitly choose a health-sharing action.</string>
 	<key>SFU_CLIENT_ID</key>
-	<string>public</string>
+	<string>conclave</string>
 	<key>SFU_JOIN_URL</key>
 	<string>$(SFU_JOIN_URL)</string>
 	<key>UIApplicationSceneManifest</key>

--- a/apps/conclave-skip/Sources/Conclave/Core/Networking/SfuJoinService.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/Networking/SfuJoinService.swift
@@ -312,7 +312,7 @@ enum SfuJoinService {
             return plistClient
         }
 
-        return "public"
+        return "conclave"
     }
 
     static func resolveJoinURL() -> URL {

--- a/apps/conclave-skip/Sources/Conclave/Features/Join/JoinView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Join/JoinView.swift
@@ -254,10 +254,11 @@ enum JoinAdminIntentPolicy {
         joinMode: JoinMode
     ) -> Bool {
         guard joinMode == .meeting else { return false }
-        return effectiveClientId(
+        let clientId = effectiveClientId(
             resolvedClientId: resolvedClientId,
             targetClientId: targetClientId
-        ).lowercased() != "public"
+        ).lowercased()
+        return clientId != "conclave" && clientId != "public"
     }
 
     static func effectiveClientId(
@@ -269,7 +270,7 @@ enum JoinAdminIntentPolicy {
             return target
         }
         let resolved = resolvedClientId.trimmingCharacters(in: .whitespacesAndNewlines)
-        return resolved.isEmpty ? "public" : resolved
+        return resolved.isEmpty ? "conclave" : resolved
     }
 }
 

--- a/apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift
+++ b/apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift
@@ -535,7 +535,7 @@ final class ConclaveTests: XCTestCase {
         ))
     }
 
-    func testJoinAdminIntentRequestsMeetingAdminForNonPublicClients() throws {
+    func testJoinAdminIntentRequestsMeetingAdminForCustomClients() throws {
         XCTAssertTrue(JoinAdminIntentPolicy.shouldRequestAdminJoin(
             resolvedClientId: "internal",
             targetClientId: nil,
@@ -548,7 +548,17 @@ final class ConclaveTests: XCTestCase {
         ))
     }
 
-    func testJoinAdminIntentDoesNotRequestAdminForPublicOrWebinarJoins() throws {
+    func testJoinAdminIntentDoesNotRequestAdminForSharedConclaveOrWebinarJoins() throws {
+        XCTAssertFalse(JoinAdminIntentPolicy.shouldRequestAdminJoin(
+            resolvedClientId: "conclave",
+            targetClientId: nil,
+            joinMode: JoinMode.meeting
+        ))
+        XCTAssertFalse(JoinAdminIntentPolicy.shouldRequestAdminJoin(
+            resolvedClientId: " Conclave ",
+            targetClientId: nil,
+            joinMode: JoinMode.meeting
+        ))
         XCTAssertFalse(JoinAdminIntentPolicy.shouldRequestAdminJoin(
             resolvedClientId: "public",
             targetClientId: nil,

--- a/apps/web/src/app/[code]/page.tsx
+++ b/apps/web/src/app/[code]/page.tsx
@@ -8,8 +8,10 @@ import {
   isMeetingJoinable,
   lookupPublicScheduledMeetingByRoomCode,
   lookupScheduledMeetingHostEmail,
+  type PublicScheduledMeeting,
 } from "@/lib/scheduled-meetings";
 import { auth } from "@/lib/auth";
+import { resolveSfuClientIdCandidates } from "@/lib/sfu-client-id";
 
 type MeetRoomPageProps = {
   params: Promise<{ code: string }>;
@@ -51,6 +53,22 @@ const resolveSessionEmail = async (): Promise<string | null> => {
   } catch {
     return null;
   }
+};
+
+const lookupScheduledMeetingCandidate = async (
+  roomCode: string,
+  preferredClientId?: string,
+): Promise<{ clientId: string; meeting: PublicScheduledMeeting } | null> => {
+  for (const clientId of resolveSfuClientIdCandidates(preferredClientId)) {
+    const meeting = await lookupPublicScheduledMeetingByRoomCode(
+      clientId,
+      roomCode,
+    );
+    if (meeting) {
+      return { clientId, meeting };
+    }
+  }
+  return null;
 };
 
 export default function MeetRoomPage({
@@ -108,18 +126,22 @@ async function MeetRoomContent({ params, searchParams }: MeetRoomPageProps) {
     devOverridesEnabled && isTruthyParam(resolvedSearchParams.admin);
 
   if (sanitizedRoomCode && !bypassMediaPermissions) {
-    const clientIdForLookup = sfuClientId || "default";
-    const scheduled = await lookupPublicScheduledMeetingByRoomCode(
-      clientIdForLookup,
+    const scheduledCandidate = await lookupScheduledMeetingCandidate(
       sanitizedRoomCode,
+      sfuClientId,
     );
-    if (scheduled) {
-      resolvedSfuClientId = clientIdForLookup;
+    const scheduled = scheduledCandidate?.meeting ?? null;
+    if (scheduledCandidate) {
+      resolvedSfuClientId = scheduledCandidate.clientId;
     }
-    if (scheduled && !isMeetingJoinable(scheduled)) {
+    if (scheduledCandidate && scheduled && !isMeetingJoinable(scheduled)) {
+      const scheduledClientId = scheduledCandidate.clientId;
       const [sessionEmail, hostEmail] = await Promise.all([
         resolveSessionEmail(),
-        lookupScheduledMeetingHostEmail(clientIdForLookup, sanitizedRoomCode),
+        lookupScheduledMeetingHostEmail(
+          scheduledClientId,
+          sanitizedRoomCode,
+        ),
       ]);
       const viewerIsHost = Boolean(
         sessionEmail && hostEmail && sessionEmail === hostEmail,

--- a/apps/web/src/app/api/scheduling/calendar/google/connect/route.ts
+++ b/apps/web/src/app/api/scheduling/calendar/google/connect/route.ts
@@ -1,5 +1,6 @@
 import { SignJWT } from "jose";
 import { NextResponse } from "next/server";
+import { resolveServerSfuClientId } from "@/lib/sfu-client-id";
 import { requireSfuSessionUser } from "@/lib/sfu-user-auth";
 
 
@@ -48,9 +49,7 @@ export async function GET(request: Request) {
     userId: authResult.user.id,
     clientId:
       request.headers.get("x-sfu-client") ||
-      process.env.SFU_CLIENT_ID ||
-      process.env.NEXT_PUBLIC_SFU_CLIENT_ID ||
-      "default",
+      resolveServerSfuClientId(),
   })
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
@@ -81,4 +80,3 @@ export async function GET(request: Request) {
   });
   return response;
 }
-

--- a/apps/web/src/app/api/sfu/join/route.ts
+++ b/apps/web/src/app/api/sfu/join/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { resolveHostGrant } from "@conclave/meeting-core";
 import { auth } from "@/lib/auth";
 import { isSfuAllowlistedUser } from "@/lib/sfu-admin-auth";
+import { resolveServerSfuClientId } from "@/lib/sfu-client-id";
 import { lookupScheduledWebinarByRoomId } from "@/lib/sfu-user-auth";
 import {
   normalizeRoutedSfuUrl,
@@ -445,15 +446,9 @@ const resolveIceServers = async (): Promise<IceServer[]> => {
 };
 
 const resolveClientId = (request: Request, body?: JoinRequestBody) => {
-  const envClientId =
-    process.env.SFU_CLIENT_ID || process.env.NEXT_PUBLIC_SFU_CLIENT_ID;
-  if (envClientId?.trim()) {
-    return envClientId.trim();
-  }
-
   const headerClientId = request.headers.get("x-sfu-client")?.trim() || "";
   const bodyClientId = body?.clientId?.trim() || "";
-  return headerClientId || bodyClientId || "default";
+  return headerClientId || bodyClientId || resolveServerSfuClientId();
 };
 
 export async function POST(request: Request) {

--- a/apps/web/src/app/api/sfu/rooms/[roomId]/route.ts
+++ b/apps/web/src/app/api/sfu/rooms/[roomId]/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: Request, context: RouteContext) {
     return NextResponse.json({ error: "Missing room ID" }, { status: 400 });
   }
 
-  const clientId = resolveSfuClientId(request, { fallback: "public" });
+  const clientId = resolveSfuClientId(request);
   const targetUrl = new URL(
     `/rooms/${encodeURIComponent(normalizedRoomId)}`,
     resolveSfuUrl(),

--- a/apps/web/src/app/api/sfu/rooms/route.ts
+++ b/apps/web/src/app/api/sfu/rooms/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: Request) {
 
   const sfuUrl = resolveSfuUrl();
   const secret = resolveSfuSecret();
-  const clientId = resolveSfuClientId(request, { fallback: "public" });
+  const clientId = resolveSfuClientId(request);
 
   try {
     const targetUrl = new URL("/admin/rooms", sfuUrl);

--- a/apps/web/src/app/api/webinars/by-slug/[slug]/route.ts
+++ b/apps/web/src/app/api/webinars/by-slug/[slug]/route.ts
@@ -55,7 +55,7 @@ const buildPublicProjection = (webinar: ScheduledWebinarSnapshot) => ({
 export async function GET(request: Request, context: RouteContext) {
   const { slug } = await context.params;
   const sfuUrl = resolveSfuUrl();
-  const clientId = resolveSfuClientId(request, { fallback: "default" });
+  const clientId = resolveSfuClientId(request);
   const url = `${sfuUrl}/scheduled-webinars/by-slug/${encodeURIComponent(slug)}`;
 
   try {

--- a/apps/web/src/app/components/DevMeetToolsPanel.tsx
+++ b/apps/web/src/app/components/DevMeetToolsPanel.tsx
@@ -25,7 +25,7 @@ const parseNumberInput = (
   return clampNumber(parsed, min, max);
 };
 
-const clientId = process.env.NEXT_PUBLIC_SFU_CLIENT_ID || "public";
+const clientId = process.env.NEXT_PUBLIC_SFU_CLIENT_ID || "conclave";
 
 const readError = async (response: Response) => {
   const data = await response.json().catch(() => null);

--- a/apps/web/src/app/hooks/useVoiceAgentParticipant.ts
+++ b/apps/web/src/app/hooks/useVoiceAgentParticipant.ts
@@ -99,7 +99,8 @@ const getJoinRoomRedirectError = (
   const redirectUrl = normalizeJoinRedirectUrl(response.redirectUrl);
   return redirectUrl ? new JoinRoomRedirectError(response, redirectUrl) : null;
 };
-const SFU_CLIENT_ID = process.env.NEXT_PUBLIC_SFU_CLIENT_ID || "public";
+const SFU_CLIENT_ID =
+  process.env.NEXT_PUBLIC_SFU_CLIENT_ID || "conclave";
 const TURN_URL_PATTERN = /^turns?:/i;
 const ACTIVE_SPEAKER_HOLD_MS = 50;
 

--- a/apps/web/src/app/meets-client-page.tsx
+++ b/apps/web/src/app/meets-client-page.tsx
@@ -3,6 +3,7 @@
 import { useCallback } from "react";
 import MeetsClient from "./meets-client";
 import type { JoinMode } from "./lib/types";
+import { resolveBrowserSfuClientId } from "@/lib/sfu-client-id";
 
 const reactionAssets = [
   "aura.gif",
@@ -21,7 +22,7 @@ const readError = async (response: Response) => {
   return response.statusText || "Request failed";
 };
 
-const defaultClientId = process.env.NEXT_PUBLIC_SFU_CLIENT_ID || "public";
+const defaultClientId = resolveBrowserSfuClientId();
 const normalizeClientId = (value: string | undefined): string | null => {
   const normalized = value?.trim();
   if (!normalized) return null;
@@ -61,7 +62,8 @@ export default function MeetsClientPage({
   const resolvedIsAdmin = isAdmin;
   const resolvedCanGhostJoin = canGhostJoin;
   const resolvedClientId = normalizeClientId(sfuClientId) || defaultClientId;
-  const isPublicClient = resolvedClientId === "public";
+  const usesRoomRouting =
+    resolvedClientId === "conclave" || resolvedClientId === "public";
 
   const getJoinInfo = useCallback(
     async (
@@ -148,13 +150,13 @@ export default function MeetsClientPage({
   }, [resolvedClientId]);
 
   const resolvedInitialRoomId =
-    initialRoomId ?? (isPublicClient ? "" : "default-room");
+    initialRoomId ?? (usesRoomRouting ? "" : "default-room");
 
   return (
     <div className="w-full h-full min-h-[100dvh] bg-[#0a0a0b] overflow-auto relative">
       <MeetsClient
         initialRoomId={resolvedInitialRoomId}
-        enableRoomRouting={isPublicClient}
+        enableRoomRouting={usesRoomRouting}
         forceJoinOnly={forceJoinOnly}
         allowGhostMode={true}
         bypassMediaPermissions={bypassMediaPermissions}

--- a/apps/web/src/app/sfu-admin/sfu-admin-dashboard.tsx
+++ b/apps/web/src/app/sfu-admin/sfu-admin-dashboard.tsx
@@ -249,7 +249,7 @@ function Metric({ label, value }: { label: string; value: string | number }) {
 }
 
 export default function SfuAdminDashboard() {
-  const initialClientId = process.env.NEXT_PUBLIC_SFU_CLIENT_ID || "default";
+  const initialClientId = process.env.NEXT_PUBLIC_SFU_CLIENT_ID || "conclave";
 
   const [clientId, setClientId] = useState(initialClientId);
   const [clientIdDraft, setClientIdDraft] = useState(initialClientId);

--- a/apps/web/src/app/w/[code]/page.tsx
+++ b/apps/web/src/app/w/[code]/page.tsx
@@ -22,7 +22,7 @@ const lookupScheduledWebinar = async (
   const sfuUrl = resolveSfuUrl();
   const headers = await nextHeaders();
   const fakeRequest = new Request("http://internal/lookup", { headers });
-  const clientId = resolveSfuClientId(fakeRequest, { fallback: "default" });
+  const clientId = resolveSfuClientId(fakeRequest);
 
   try {
     const response = await fetch(

--- a/apps/web/src/lib/scheduling.ts
+++ b/apps/web/src/lib/scheduling.ts
@@ -13,6 +13,7 @@ import {
   readScheduledMeetingError,
 } from "@/lib/scheduled-meetings";
 import type { SfuAuthenticatedUser } from "@/lib/sfu-user-auth";
+import { resolveServerSfuClientId } from "@/lib/sfu-client-id";
 
 export type {
   AvailableSlot,
@@ -71,9 +72,7 @@ export const buildPublicSchedulingHeaders = (request?: Request): Headers => {
   headers.set("content-type", "application/json");
   const clientId =
     request?.headers.get("x-sfu-client")?.trim() ||
-    process.env.SFU_CLIENT_ID?.trim() ||
-    process.env.NEXT_PUBLIC_SFU_CLIENT_ID?.trim() ||
-    "default";
+    resolveServerSfuClientId();
   headers.set("x-sfu-client", clientId);
   return headers;
 };

--- a/apps/web/src/lib/sfu-admin-auth.ts
+++ b/apps/web/src/lib/sfu-admin-auth.ts
@@ -1,4 +1,5 @@
 import { auth } from "@/lib/auth";
+import { resolveServerSfuClientId } from "@/lib/sfu-client-id";
 export { resolveSfuUrl } from "@/lib/sfu-url";
 
 const firstNonEmpty = (...values: Array<string | undefined>): string | undefined => {
@@ -131,11 +132,7 @@ export const resolveSfuClientId = (
 ): string => {
   const fromQuery = new URL(request.url).searchParams.get("clientId")?.trim() || "";
   const fromHeader = request.headers.get("x-sfu-client")?.trim() || "";
-  const fromEnv =
-    process.env.SFU_CLIENT_ID?.trim() ||
-    process.env.NEXT_PUBLIC_SFU_CLIENT_ID?.trim() ||
-    "";
-  return fromQuery || fromHeader || fromEnv || options?.fallback || "";
+  return fromQuery || fromHeader || resolveServerSfuClientId() || options?.fallback || "";
 };
 
 export const requireSfuAdminUser = async (

--- a/apps/web/src/lib/sfu-client-id.ts
+++ b/apps/web/src/lib/sfu-client-id.ts
@@ -1,0 +1,33 @@
+export const CONCLAVE_SFU_CLIENT_ID = "conclave";
+
+const normalizeSfuClientId = (value: string | undefined): string | null => {
+  const normalized = value?.trim();
+  if (!normalized) return null;
+  return /^[a-zA-Z0-9._:-]{1,64}$/.test(normalized) ? normalized : null;
+};
+
+export const resolveBrowserSfuClientId = (): string =>
+  normalizeSfuClientId(process.env.NEXT_PUBLIC_SFU_CLIENT_ID) ||
+  CONCLAVE_SFU_CLIENT_ID;
+
+export const resolveServerSfuClientId = (): string =>
+  normalizeSfuClientId(process.env.SFU_CLIENT_ID) ||
+  resolveBrowserSfuClientId();
+
+export const resolveSfuClientIdCandidates = (
+  preferred?: string | null,
+): string[] => {
+  const seen = new Set<string>();
+  const candidates = [
+    normalizeSfuClientId(preferred ?? undefined),
+    resolveServerSfuClientId(),
+    CONCLAVE_SFU_CLIENT_ID,
+    "default",
+    "public",
+  ];
+  return candidates.filter((candidate): candidate is string => {
+    if (!candidate || seen.has(candidate)) return false;
+    seen.add(candidate);
+    return true;
+  });
+};

--- a/apps/web/src/lib/sfu-user-auth.ts
+++ b/apps/web/src/lib/sfu-user-auth.ts
@@ -90,7 +90,7 @@ export const buildScheduledWebinarHeaders = (
   headers.set("x-sfu-secret", resolveSfuSecret());
   headers.set("accept", "application/json");
   headers.set("content-type", "application/json");
-  const clientId = resolveSfuClientId(request, { fallback: "default" });
+  const clientId = resolveSfuClientId(request);
   if (clientId) {
     headers.set("x-sfu-client", clientId);
   }

--- a/packages/sfu/config/config.ts
+++ b/packages/sfu/config/config.ts
@@ -140,6 +140,12 @@ const defaultClientPolicies: Record<string, ClientPolicy> = {
     useWaitingRoom: false,
     allowDisplayNameUpdate: true,
   },
+  conclave: {
+    allowNonHostRoomCreation: false,
+    allowHostJoin: false,
+    useWaitingRoom: false,
+    allowDisplayNameUpdate: true,
+  },
   internal: {
     allowNonHostRoomCreation: false,
     allowHostJoin: true,

--- a/packages/sfu/server/http/createApp.ts
+++ b/packages/sfu/server/http/createApp.ts
@@ -475,7 +475,7 @@ export const createSfuApp = ({
       return res.status(400).json({ error: "Room ID is required" });
     }
 
-    const clientId = resolveClientId(req) || "default";
+    const clientId = resolveClientId(req) || "conclave";
     const channelId = getRoomChannelId(clientId, roomId);
     const room = state.rooms.get(channelId);
     res.set("Cache-Control", "no-store");

--- a/packages/sfu/server/http/scheduledMeetingRoutes.ts
+++ b/packages/sfu/server/http/scheduledMeetingRoutes.ts
@@ -30,6 +30,12 @@ const MAX_EMAIL_LENGTH = 320;
 const MAX_NAME_LENGTH = 120;
 const MAX_STATUS_FILTER_LENGTH = 128;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
+const CONCLAVE_CLIENT_ID = "conclave";
+
+const resolveDefaultClientId = (): string =>
+  process.env.SFU_CLIENT_ID?.trim() ||
+  process.env.NEXT_PUBLIC_SFU_CLIENT_ID?.trim() ||
+  CONCLAVE_CLIENT_ID;
 
 const hasValidSecret = (req: Request, secret: string): boolean => {
   const provided = req.header("x-sfu-secret");
@@ -57,7 +63,10 @@ const normalizeEmail = (value: unknown): string | null => {
   return normalized || null;
 };
 
-const resolveClientId = (req: Request, fallback = "default"): string => {
+const resolveClientId = (
+  req: Request,
+  fallback = resolveDefaultClientId(),
+): string => {
   const fromQuery = normalizeIdentifier(req.query.clientId) || "";
   const fromHeader = normalizeIdentifier(req.header("x-sfu-client")) || "";
   return fromQuery || fromHeader || fallback;

--- a/packages/sfu/server/http/scheduledWebinarRoutes.ts
+++ b/packages/sfu/server/http/scheduledWebinarRoutes.ts
@@ -72,7 +72,10 @@ const normalizeEmail = (value: unknown): string | null => {
 
 const resolveClientId = (
   req: Request,
-  fallback = "default",
+  fallback =
+    process.env.SFU_CLIENT_ID?.trim() ||
+    process.env.NEXT_PUBLIC_SFU_CLIENT_ID?.trim() ||
+    "conclave",
 ): string => {
   const fromQuery = normalizeIdentifier(req.query.clientId) || "";
   const fromHeader = normalizeIdentifier(req.header("x-sfu-client")) || "";

--- a/packages/sfu/server/http/schedulingRoutes.ts
+++ b/packages/sfu/server/http/schedulingRoutes.ts
@@ -8,10 +8,12 @@ import {
   ensureSchedulingProfile,
   generateAvailableSlots,
   getCalendarSummary,
+  getProfileByUser,
   getProfileAvailability,
   getPublicEventType,
   getPublicProfile,
   listEventTypes,
+  moveSchedulingProfileToClient,
   persistScheduling,
   setGoogleCalendarConnection,
   setProfileAvailability,
@@ -22,6 +24,7 @@ import {
 import {
   createScheduledMeeting,
   deleteScheduledMeeting,
+  moveScheduledMeetingToClient,
   persistScheduledMeetingChanges,
   updateScheduledMeeting,
   type BookingSlotLease,
@@ -60,6 +63,25 @@ const GOOGLE_FREEBUSY_URL = "https://www.googleapis.com/calendar/v3/freeBusy";
 const GOOGLE_CALENDAR_API = "https://www.googleapis.com/calendar/v3";
 const localBookingSlotLocks = new Set<string>();
 
+const CONCLAVE_CLIENT_ID = "conclave";
+const LEGACY_WEB_CLIENT_IDS = ["default", "public"];
+
+const resolveDefaultClientId = (): string =>
+  process.env.SFU_CLIENT_ID?.trim() ||
+  process.env.NEXT_PUBLIC_SFU_CLIENT_ID?.trim() ||
+  CONCLAVE_CLIENT_ID;
+
+const clientIdCandidates = (primary: string): string[] => {
+  const seen = new Set<string>();
+  return [primary, resolveDefaultClientId(), CONCLAVE_CLIENT_ID, ...LEGACY_WEB_CLIENT_IDS]
+    .map((clientId) => clientId.trim())
+    .filter((clientId) => {
+      if (!clientId || seen.has(clientId)) return false;
+      seen.add(clientId);
+      return true;
+    });
+};
+
 const hasValidSecret = (req: Request, secret: string): boolean => {
   const provided = req.header("x-sfu-secret");
   return Boolean(provided && secretsMatch(provided, secret));
@@ -91,7 +113,10 @@ const normalizeText = (value: unknown, maxLength = MAX_TEXT_LENGTH): string =>
     ? value.trim().replace(/\s+/g, " ").slice(0, maxLength)
     : "";
 
-const resolveClientId = (req: Request, fallback = "default"): string => {
+const resolveClientId = (
+  req: Request,
+  fallback = resolveDefaultClientId(),
+): string => {
   const fromQuery = normalizeIdentifier(req.query.clientId) || "";
   const fromHeader = normalizeIdentifier(req.header("x-sfu-client")) || "";
   return fromQuery || fromHeader || fallback;
@@ -149,6 +174,54 @@ const profilePayload = (
   calendar: getCalendarSummary(state.scheduling, profile.id),
 });
 
+const migrateProfileNamespace = async (
+  state: SfuState,
+  profile: SchedulingProfile,
+  clientId: string,
+): Promise<void> => {
+  const previousClientId = profile.clientId;
+  if (previousClientId === clientId) return;
+  const eventTypeIds = new Set(
+    Array.from(state.scheduling.eventTypesById.values())
+      .filter((eventType) => eventType.profileId === profile.id)
+      .map((eventType) => eventType.id),
+  );
+
+  moveSchedulingProfileToClient(state.scheduling, profile, clientId);
+
+  const changedMeetings: ScheduledMeeting[] = [];
+  for (const meeting of state.scheduledMeetings.byId.values()) {
+    if (meeting.clientId !== previousClientId) continue;
+    if (meeting.source !== "booking_link") continue;
+    const belongsToProfile =
+      (meeting.eventTypeId && eventTypeIds.has(meeting.eventTypeId)) ||
+      (meeting.hostUserId && meeting.hostUserId === profile.userId) ||
+      meeting.hostEmail.trim().toLowerCase() === profile.email;
+    if (!belongsToProfile) continue;
+    try {
+      const moved = moveScheduledMeetingToClient(
+        state.scheduledMeetings,
+        meeting.id,
+        clientId,
+      );
+      if (moved) changedMeetings.push(moved);
+    } catch (error) {
+      Logger.warn(
+        `Skipped scheduled meeting namespace migration for ${meeting.id}`,
+        error,
+      );
+    }
+  }
+
+  if (changedMeetings.length > 0 && state.scheduledMeetingPersistence) {
+    await persistScheduledMeetingChanges(
+      state.scheduledMeetings,
+      state.scheduledMeetingPersistence,
+      changedMeetings,
+    );
+  }
+};
+
 const requireHostProfile = async (
   req: Request,
   res: Response,
@@ -159,8 +232,26 @@ const requireHostProfile = async (
     res.status(400).json({ error: "User context required" });
     return null;
   }
+  const clientId = resolveClientId(req);
+  const existingProfile = getProfileByUser(
+    state.scheduling,
+    clientId,
+    user.userId,
+  );
+  if (!existingProfile) {
+    for (const legacyClientId of clientIdCandidates(clientId).slice(1)) {
+      const legacyProfile = getProfileByUser(
+        state.scheduling,
+        legacyClientId,
+        user.userId,
+      );
+      if (!legacyProfile) continue;
+      await migrateProfileNamespace(state, legacyProfile, clientId);
+      break;
+    }
+  }
   const profile = ensureSchedulingProfile(state.scheduling, {
-    clientId: resolveClientId(req),
+    clientId,
     userId: user.userId,
     email: user.email,
     name: user.name,
@@ -488,7 +579,9 @@ const createGoogleCalendarEvent = async (
 const meetingMatchesProfile = (
   meeting: ScheduledMeeting,
   profile: SchedulingProfile,
+  eventType?: SchedulingEventType | null,
 ): boolean => {
+  if (eventType?.profileId === profile.id) return true;
   if (meeting.clientId !== profile.clientId) return false;
   if (meeting.hostUserId && profile.userId) {
     return meeting.hostUserId === profile.userId;
@@ -519,7 +612,10 @@ const collectInternalBusy = (
         (eventType?.bufferAfterMinutes ?? 0) * MINUTE_MS,
     }))
     .filter(({ meeting, startAt, endAt }) => {
-      if (!meetingMatchesProfile(meeting, profile)) return false;
+      const eventType = meeting.eventTypeId
+        ? state.scheduling.eventTypesById.get(meeting.eventTypeId) ?? null
+        : null;
+      if (!meetingMatchesProfile(meeting, profile, eventType)) return false;
       if (meeting.status === "cancelled" || meeting.status === "ended") return false;
       return startAt < to && from < endAt;
     })
@@ -545,6 +641,30 @@ const resolvePublicTarget = (
   }
   const calendar = requireConnectedCalendar(state, profile);
   return { profile, eventType, calendar };
+};
+
+const resolvePublicTargetForClients = (
+  state: SfuState,
+  clientId: string,
+  username: string,
+  slug: string,
+): ReturnType<typeof resolvePublicTarget> => {
+  let lastNotFound: ReturnType<typeof resolvePublicTarget> = {
+    error: "Scheduling page not found.",
+    status: 404,
+  };
+  for (const candidateClientId of clientIdCandidates(clientId)) {
+    const target = resolvePublicTarget(
+      state,
+      candidateClientId,
+      username,
+      slug,
+    );
+    if (!("error" in target)) return target;
+    if (target.status !== 404) return target;
+    lastNotFound = target;
+  }
+  return lastNotFound;
 };
 
 const buildConfirmation = (
@@ -761,9 +881,15 @@ export const registerSchedulingRoutes = (
     if (!profile) return;
     const bookings = Array.from(state.scheduledMeetings.byId.values())
       .filter(
-        (meeting) =>
-          meetingMatchesProfile(meeting, profile) &&
-          meeting.source === "booking_link",
+        (meeting) => {
+          const eventType = meeting.eventTypeId
+            ? state.scheduling.eventTypesById.get(meeting.eventTypeId) ?? null
+            : null;
+          return (
+            meetingMatchesProfile(meeting, profile, eventType) &&
+            meeting.source === "booking_link"
+          );
+        },
       )
       .sort((a, b) => b.scheduledStartAt - a.scheduledStartAt);
     res.json({ bookings });
@@ -771,7 +897,7 @@ export const registerSchedulingRoutes = (
 
   app.get("/scheduling/public/:username/:slug", (req, res) => {
     if (!requireSecret(req, res)) return;
-    const target = resolvePublicTarget(
+    const target = resolvePublicTargetForClients(
       state,
       resolveClientId(req),
       req.params.username,
@@ -806,7 +932,7 @@ export const registerSchedulingRoutes = (
 
   app.get("/scheduling/public/:username/:slug/slots", async (req, res) => {
     if (!requireSecret(req, res)) return;
-    const target = resolvePublicTarget(
+    const target = resolvePublicTargetForClients(
       state,
       resolveClientId(req),
       req.params.username,
@@ -877,7 +1003,7 @@ export const registerSchedulingRoutes = (
 
   app.post("/scheduling/public/:username/:slug/book", async (req, res) => {
     if (!requireSecret(req, res)) return;
-    const target = resolvePublicTarget(
+    const target = resolvePublicTargetForClients(
       state,
       resolveClientId(req),
       req.params.username,

--- a/packages/sfu/server/scheduledMeetings.ts
+++ b/packages/sfu/server/scheduledMeetings.ts
@@ -407,6 +407,26 @@ export const getScheduledMeetingByRoomCode = (
   return owner ? store.byId.get(owner) ?? null : null;
 };
 
+export const moveScheduledMeetingToClient = (
+  store: ScheduledMeetingStore,
+  meetingId: string,
+  clientId: string,
+): ScheduledMeeting | null => {
+  const meeting = store.byId.get(meetingId);
+  const nextClientId = clientId.trim();
+  if (!meeting || !nextClientId || meeting.clientId === nextClientId) {
+    return meeting ?? null;
+  }
+  if (isCodeTaken(store, nextClientId, meeting.roomCode, meeting.id)) {
+    throw new Error("That meeting code already exists in the target client.");
+  }
+  store.byRoomCode.delete(roomCodeKey(meeting.clientId, meeting.roomCode));
+  meeting.clientId = nextClientId;
+  meeting.updatedAt = Date.now();
+  store.byRoomCode.set(roomCodeKey(meeting.clientId, meeting.roomCode), meeting.id);
+  return meeting;
+};
+
 export const listScheduledMeetings = (
   store: ScheduledMeetingStore,
   filter: {

--- a/packages/sfu/server/scheduling.ts
+++ b/packages/sfu/server/scheduling.ts
@@ -432,6 +432,40 @@ export const getProfileByUser = (
   return id ? store.profilesById.get(id) ?? null : null;
 };
 
+export const moveSchedulingProfileToClient = (
+  store: SchedulingStore,
+  profile: SchedulingProfile,
+  clientId: string,
+): SchedulingProfile => {
+  const nextClientId = clientId.trim();
+  if (!nextClientId || profile.clientId === nextClientId) return profile;
+
+  store.profileIdByUserKey.delete(userKey(profile.clientId, profile.userId));
+  store.profileIdByUsername.delete(
+    `${profile.clientId}:${profile.username.toLowerCase()}`,
+  );
+
+  profile.clientId = nextClientId;
+  profile.username = uniqueUsername(store, nextClientId, profile.username, profile.id);
+  profile.updatedAt = Date.now();
+  registerProfile(store, profile);
+
+  for (const eventType of store.eventTypesById.values()) {
+    if (eventType.profileId !== profile.id) continue;
+    eventType.clientId = nextClientId;
+    eventType.updatedAt = profile.updatedAt;
+    registerEventType(store, eventType);
+  }
+
+  const calendar = store.calendarByProfileId.get(profile.id);
+  if (calendar) {
+    calendar.clientId = nextClientId;
+    calendar.updatedAt = profile.updatedAt;
+  }
+
+  return profile;
+};
+
 export const getPublicProfile = (
   store: SchedulingStore,
   clientId: string,
@@ -1063,7 +1097,7 @@ export const createSqliteSchedulingPersistence = (
           upsert.run(
             "availability",
             entry.profileId,
-            profile?.clientId ?? "default",
+            profile?.clientId ?? "conclave",
             Date.now(),
             JSON.stringify(entry),
           );


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR moves the shared SFU default client id to `conclave`. The main changes are:

- Adds shared browser and server helpers for resolving SFU client ids.
- Updates web, Skip, admin, join, room, webinar, and scheduling paths to use `conclave` as the default.
- Keeps legacy `default` and `public` candidates for scheduled meeting and scheduling lookups.
- Adds server-side helpers to move scheduling profiles, event types, calendars, and booking-link meetings into the new client namespace.
- Adds a `conclave` SFU client policy.

<h3>Confidence Score: 5/5</h3>

The changes look safe to merge based on the reviewed client-id migration paths.

The update consistently introduces shared helpers and preserves legacy lookup candidates where existing data may still live, reducing compatibility risk across web and SFU scheduling surfaces.

No specific files require follow-up.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed and compared the SFU fallback behavior before and after the changes described in proof 0.
- Compared the scheduling-legacy test results before and after, confirming the host profile and booking changes described in proof 1.
- Tracked the meeting routing attempt, noting the initial Chromium launch failure and subsequent blocker, with a Playwright capture script generated as described in proof 2.
- Monitored the native client policy checks; both before and after runs could not execute Swift checks due to a missing toolchain, as described in proof 3.

<a href="https://app.greptile.com/trex/runs/12825360/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/ee732f7bedb12fc699b76cb2be176f1177389059) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40922780)</sub>

<!-- /greptile_comment -->