### PR TITLE
fix

### DIFF
--- a/apps/web/src/app/hooks/useMeetingTranscript.ts
+++ b/apps/web/src/app/hooks/useMeetingTranscript.ts
@@ -177,6 +177,7 @@ const VERSION_POLL_INTERVAL_MS = 30_000;
 const SFU_SESSION_READY_TIMEOUT_MS = 12_000;
 const SFU_RELAY_TOKEN_TIMEOUT_MS = 5_000;
 const SFU_RELAY_STOP_TIMEOUT_MS = 3_000;
+const SFU_EXPLICIT_STOP_SUPPRESS_TAKEOVER_MS = 10_000;
 
 const toWorkerVersionUrl = (workerUrl: string): string => {
   const base = workerUrl.replace(/\/+$/, "");
@@ -277,6 +278,7 @@ export function useMeetingTranscript({
   >(new Set());
   const serviceVersionRef = useRef<TranscriptServiceVersion | null>(null);
   const autoTakeoverAttemptRef = useRef<string | null>(null);
+  const suppressAutoTakeoverUntilRef = useRef(0);
 
   const transcriptSources = useMemo<TranscriptRelaySource[]>(() => {
     const sources: TranscriptRelaySource[] = [];
@@ -848,6 +850,7 @@ export function useMeetingTranscript({
       }
       const connected = await connect();
       if (!connected) return false;
+      suppressAutoTakeoverUntilRef.current = 0;
       const transportMode = options.transportMode ?? "browser";
       if (transportMode === "sfu" && !(await ensureSfuRelayAvailable())) {
         return false;
@@ -908,6 +911,7 @@ export function useMeetingTranscript({
       }
       const connected = await connect();
       if (!connected) return false;
+      suppressAutoTakeoverUntilRef.current = 0;
       const transportMode = options.transportMode ?? session.transportMode;
       if (transportMode === "sfu" && !(await ensureSfuRelayAvailable())) {
         return false;
@@ -973,6 +977,9 @@ export function useMeetingTranscript({
     ) {
       return;
     }
+    if (Date.now() < suppressAutoTakeoverUntilRef.current) {
+      return;
+    }
 
     const attemptKey = [
       session.controller.connectionId,
@@ -1002,13 +1009,15 @@ export function useMeetingTranscript({
       return;
     }
     const transportMode = session.transportMode;
+    suppressAutoTakeoverUntilRef.current =
+      Date.now() + SFU_EXPLICIT_STOP_SUPPRESS_TAKEOVER_MS;
+    send({ type: "session.stop" });
     if (transportMode === "sfu") {
       await withTimeout(
         stopTranscriptSfuRelay?.() ?? Promise.resolve(null),
         SFU_RELAY_STOP_TIMEOUT_MS,
       );
     }
-    send({ type: "session.stop" });
   }, [
     canStop,
     send,

--- a/apps/web/transcript-worker/src/room.ts
+++ b/apps/web/transcript-worker/src/room.ts
@@ -103,6 +103,26 @@ const createIdleSession = (roomId: string): TranscriptSessionState => ({
   error: null,
 });
 
+const TRANSCRIPT_AUDIO_DEBUG_INTERVAL_MS = 15_000;
+
+type TranscriptAudioDebugStats = {
+  acceptedChunks: number;
+  acceptedSamples: number;
+  commits: number;
+  providerCommittedItems: number;
+  providerFinals: number;
+  lastAudioLogAt: number;
+};
+
+const createAudioDebugStats = (): TranscriptAudioDebugStats => ({
+  acceptedChunks: 0,
+  acceptedSamples: 0,
+  commits: 0,
+  providerCommittedItems: 0,
+  providerFinals: 0,
+  lastAudioLogAt: 0,
+});
+
 export class TranscriptRoom {
   private readonly state: DurableObjectState;
   private readonly env: Env;
@@ -133,6 +153,7 @@ export class TranscriptRoom {
   private audioPaused = false;
   private suppressSfuRelayDisconnectsUntil = 0;
   private suppressSfuRelayDisconnectCount = 0;
+  private audioDebugStats = createAudioDebugStats();
 
   constructor(state: DurableObjectState, env: Env) {
     this.state = state;
@@ -595,6 +616,8 @@ export class TranscriptRoom {
       return;
     }
 
+    this.suppressSfuRelayDisconnectsUntil = Date.now() + 5000;
+    this.suppressSfuRelayDisconnectCount += 1;
     this.closeTranscriptionProvider();
     const roomId = this.session?.roomId || "unknown";
     this.responseApiKey = null;
@@ -699,6 +722,18 @@ export class TranscriptRoom {
       this.latestSpeaker = normalizedSpeaker;
       this.hasPendingAudio = true;
       this.pendingAudioSamples += sampleCount;
+      this.audioDebugStats.acceptedChunks += 1;
+      this.audioDebugStats.acceptedSamples += sampleCount;
+      this.logAudioDebug(
+        "accepted audio chunk",
+        {
+          samples: sampleCount,
+          pendingSamples: this.pendingAudioSamples,
+          speakerUserId: normalizedSpeaker.userId,
+          source: normalizedSpeaker.source,
+        },
+        this.audioDebugStats.acceptedChunks === 1,
+      );
       if (this.isController(viewer) && this.session?.controller) {
         this.session.controller.lastSeenAt = Date.now();
       }
@@ -754,6 +789,15 @@ export class TranscriptRoom {
       this.speakerAttribution.enqueueCommit(speaker);
       this.hasPendingAudio = false;
       this.pendingAudioSamples = 0;
+      this.audioDebugStats.commits += 1;
+      this.logAudioDebug(
+        "committed audio buffer",
+        {
+          speakerUserId: speaker.userId,
+          source: speaker.source,
+        },
+        this.audioDebugStats.commits === 1,
+      );
       return true;
     } catch {
       void this.handleTranscriptionFailure(failureMessage);
@@ -864,6 +908,12 @@ export class TranscriptRoom {
         onFailure: (message) => this.handleTranscriptionFailure(message),
       },
     });
+    console.info("[TranscriptWorker] transcription provider connected", {
+      roomId: this.session?.roomId,
+      provider: this.transcriptionSession.provider,
+      model: options.transcriptModel,
+      transportMode: this.session?.transportMode,
+    });
   }
 
   private closeTranscriptionProvider(): void {
@@ -882,12 +932,19 @@ export class TranscriptRoom {
     this.latestSpeaker = null;
     this.hasPendingAudio = false;
     this.pendingAudioSamples = 0;
+    this.audioDebugStats = createAudioDebugStats();
     if (hadPartials) {
       this.broadcast({ type: "partials.reset" });
     }
   }
 
   private handleTranscriptItemCommitted(itemId: string): void {
+    this.audioDebugStats.providerCommittedItems += 1;
+    this.logAudioDebug(
+      "provider committed transcript item",
+      { itemId },
+      this.audioDebugStats.providerCommittedItems === 1,
+    );
     const speaker = this.speakerAttribution.bindCommittedItem(itemId);
     if (speaker) {
       this.reassignSegmentSpeaker(itemId, speaker);
@@ -896,6 +953,13 @@ export class TranscriptRoom {
 
   private async handleTranscriptionFailure(message: string): Promise<void> {
     const redactedMessage = redactSensitiveText(message);
+    console.warn("[TranscriptWorker] transcription provider failure", {
+      roomId: this.session?.roomId,
+      status: this.session?.status,
+      transportMode: this.session?.transportMode,
+      provider: this.transcriptionSession?.provider ?? null,
+      message: redactedMessage,
+    });
     this.broadcast({
       type: "error",
       message: redactedMessage,
@@ -1037,6 +1101,12 @@ export class TranscriptRoom {
     const text = transcript.trim() || segment.text.trim();
     this.partialSegments.delete(itemId);
     if (!text) return;
+    this.audioDebugStats.providerFinals += 1;
+    this.logAudioDebug(
+      "provider finalized transcript item",
+      { itemId, textLength: text.length },
+      this.audioDebugStats.providerFinals === 1,
+    );
 
     const now = Date.now();
     const finalSegment: TranscriptSegment = {
@@ -1088,6 +1158,34 @@ export class TranscriptRoom {
       updatedAt: Date.now(),
       error: redactSensitiveText(error),
     };
+  }
+
+  private logAudioDebug(
+    event: string,
+    details: Record<string, unknown> = {},
+    force = false,
+  ): void {
+    const now = Date.now();
+    if (
+      !force &&
+      now - this.audioDebugStats.lastAudioLogAt <
+        TRANSCRIPT_AUDIO_DEBUG_INTERVAL_MS
+    ) {
+      return;
+    }
+    this.audioDebugStats.lastAudioLogAt = now;
+    console.info("[TranscriptWorker] audio", {
+      event,
+      roomId: this.session?.roomId,
+      status: this.session?.status,
+      transportMode: this.session?.transportMode,
+      provider: this.transcriptionSession?.provider ?? null,
+      acceptedChunks: this.audioDebugStats.acceptedChunks,
+      commits: this.audioDebugStats.commits,
+      providerCommittedItems: this.audioDebugStats.providerCommittedItems,
+      providerFinals: this.audioDebugStats.providerFinals,
+      ...details,
+    });
   }
 
   private hasMinutesContent(minutes: TranscriptMinutesSnapshot): boolean {

--- a/packages/sfu/server/transcript/sfuTranscriptRelay.ts
+++ b/packages/sfu/server/transcript/sfuTranscriptRelay.ts
@@ -27,6 +27,7 @@ type ActiveAudioConsumer = {
   packetsReceived: number;
   decodedFrames: number;
   queuedFrames: number;
+  commitsSent: number;
   decodeFailures: number;
   lastDecodeFailureLogAt: number;
   lastDropLogAt: number;
@@ -229,6 +230,7 @@ export class SfuTranscriptRelay implements TranscriptAudioBatchSink {
       packetsReceived: 0,
       decodedFrames: 0,
       queuedFrames: 0,
+      commitsSent: 0,
       decodeFailures: 0,
       lastDecodeFailureLogAt: 0,
       lastDropLogAt: 0,
@@ -321,11 +323,25 @@ export class SfuTranscriptRelay implements TranscriptAudioBatchSink {
   }
 
   private commitIfNeeded(active: ActiveAudioConsumer): void {
-    active.batcher.commitIfNeeded();
+    const committed = active.batcher.commitIfNeeded();
+    if (!committed) return;
+    active.commitsSent += 1;
+    if (active.commitsSent === 1) {
+      Logger.info(
+        `Transcript SFU relay committed first audio batch for producer ${active.consumer.producerId} in room ${this.options.room.id}.`,
+      );
+    }
   }
 
   private flushAndCommit(active: ActiveAudioConsumer): void {
-    active.batcher.flushAndCommit();
+    const committed = active.batcher.flushAndCommit();
+    if (!committed) return;
+    active.commitsSent += 1;
+    if (active.commitsSent === 1) {
+      Logger.info(
+        `Transcript SFU relay committed first audio batch for producer ${active.consumer.producerId} in room ${this.options.room.id}.`,
+      );
+    }
   }
 
   sendAudioChunk(audio: string, speaker: TranscriptSpeaker): boolean {


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adjusts SFU transcript stop handling and adds audio-flow diagnostics. The main changes are:

- A short client-side suppression window after explicit transcript stops.
- Worker-side suppression for expected SFU relay disconnects during stop.
- Rate-limited transcript worker logs for audio chunks, commits, provider items, finals, and failures.
- First-commit logging for SFU transcript relay audio batches.

<h3>Confidence Score: 4/5</h3>

The changes appear narrowly scoped to transcript stop handling and diagnostic logging.

The modified areas are limited and no concrete blocking issues were identified in the changed files.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed that when the mocked controller-disconnect takeover\_needed state arrived, the head emitted session.stop and no takeover within the suppression window, and a subsequent manual start({}) emitted session.start, demonstrating suppression clear.
- Verified that enabling provider/worker diagnostics shows the head emitting provider connected, first accepted chunk, buffer commit, provider committed/finalized item, redacted provider failure, reset stats, and exactly one SFU first-commit log after the first true commit, with false commit/flush attempts not incrementing commits or logging.

<a href="https://app.greptile.com/trex/runs/12852154/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/7efb64b2b252741ca2d5726a41bf83961165d0e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40970087)</sub>

<!-- /greptile_comment -->