### PR TITLE
add

### DIFF
--- a/apps/conclave-skip/Sources/Conclave/Core/State/MeetingState.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/State/MeetingState.swift
@@ -48,6 +48,7 @@ final class MeetingState {
     var connectionState: ConnectionState = .disconnected
     var errorMessage: String?
     var joinFormErrorMessage: String?
+    var meetingEndedNoticeMessage: String?
     var serverRestartNotice: String?
     var adminNoticeMessage: String?
     var adminNoticeLevel: AdminNoticeLevel = .info

--- a/apps/conclave-skip/Sources/Conclave/Features/Join/JoinView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Join/JoinView.swift
@@ -742,6 +742,7 @@ struct JoinView: View {
                 }
 
                 authErrorBanner
+                meetingEndedNoticeBanner
                 
                 VStack(alignment: .leading, spacing: 10) {
                     Text("Your name")
@@ -1174,6 +1175,7 @@ struct JoinView: View {
     private var newMeetingForm: some View {
         VStack(spacing: joinFormContentSpacing) {
             authErrorBanner
+            meetingEndedNoticeBanner
             identityInputSection
             joinFormErrorBanner
             startMeetingButton
@@ -1319,6 +1321,7 @@ struct JoinView: View {
     private var joinMeetingForm: some View {
         VStack(spacing: joinFormContentSpacing) {
             authErrorBanner
+            meetingEndedNoticeBanner
             identityInputSection
             roomNameInputSection
             if shouldRenderInviteCodeInput {
@@ -1517,6 +1520,41 @@ struct JoinView: View {
                 RoundedRectangle(cornerRadius: ACMRadius.md)
                     .strokeBorder(lineWidth: 1)
                     .foregroundStyle(ACMColors.error.opacity(0.28))
+            }
+            .clipShape(RoundedRectangle(cornerRadius: ACMRadius.md))
+        }
+    }
+
+    @ViewBuilder
+    private var meetingEndedNoticeBanner: some View {
+        if let message = viewModel.state.meetingEndedNoticeMessage, !message.isEmpty {
+            HStack(alignment: .top, spacing: 8) {
+                ACMSystemIcon.icon("info.circle.fill", android: "info", size: 14, tint: "accent")
+                    .foregroundStyle(ACMColors.primaryOrange)
+                    .frame(width: 18, height: 18)
+
+                Text(message)
+                    .font(ACMFont.trial(13))
+                    .foregroundStyle(ACMColors.text)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Button {
+                    viewModel.dismissMeetingEndedNotice()
+                } label: {
+                    ACMSystemIcon.icon("xmark", android: "close", size: 12, tint: "muted")
+                        .foregroundStyle(ACMColors.textMuted)
+                        .frame(width: 22, height: 22)
+                }
+                .buttonStyle(.plain)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .acmColorBackground(ACMColors.primaryOrange.opacity(0.12))
+            .overlay {
+                RoundedRectangle(cornerRadius: ACMRadius.md)
+                    .strokeBorder(lineWidth: 1)
+                    .foregroundStyle(ACMColors.primaryOrange.opacity(0.28))
             }
             .clipShape(RoundedRectangle(cornerRadius: ACMRadius.md))
         }

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift
@@ -1078,7 +1078,10 @@ final class MeetingViewModel {
             Task { @MainActor in
                 guard self.isCurrentSocketEvent(eventContext, roomId: notification.roomId) else { return }
                 let message = notification.message?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                await self.finishTerminalRoomError(message.isEmpty ? "The host ended the meeting" : message)
+                await self.finishRoomEnded(
+                    message.isEmpty ? "This meeting has been ended by the host." : message,
+                    endedBy: notification.endedBy
+                )
             }
         }
 
@@ -5045,6 +5048,7 @@ final class MeetingViewModel {
         // (ErrorView) still show it after teardown — so the fresh-join path is
         // where we wipe it, or it would leak into the next meeting's banner.
         self.state.errorMessage = nil
+        self.state.meetingEndedNoticeMessage = nil
         self.isIntentionalLeave = false
         self.isIntentionalTeardownInProgress = false
         self.shouldRejoinAfterReconnect = false
@@ -5897,6 +5901,7 @@ final class MeetingViewModel {
         shouldRejoinAfterReconnect = false
         isRejoinInFlight = false
         resetReconnectRetryState()
+        state.meetingEndedNoticeMessage = nil
         socketManager.disconnect()
         Task {
             await cleanup(lifecycleGeneration: leavingGeneration)
@@ -5915,12 +5920,61 @@ final class MeetingViewModel {
         state.errorMessage = message
         state.waitingMessage = nil
         state.joinFormErrorMessage = nil
+        state.meetingEndedNoticeMessage = nil
         state.serverRestartNotice = nil
         socketManager.disconnect()
         #if !SKIP
         HapticManager.shared.trigger(.error)
         #endif
         await cleanup()
+    }
+
+    private func finishRoomEnded(_ message: String, endedBy: String?) async {
+        await finishMeetingEnded(showNotice: !isRoomEndedByLocalUser(endedBy), message: message)
+    }
+
+    private func finishLocalMeetingEnded() async {
+        await finishMeetingEnded(showNotice: false, message: nil)
+    }
+
+    private func finishMeetingEnded(showNotice: Bool, message: String?) async {
+        guard !isIntentionalTeardownInProgress else { return }
+        let endingGeneration = meetingLifecycleGeneration
+        isIntentionalLeave = true
+        isIntentionalTeardownInProgress = true
+        shouldRejoinAfterReconnect = false
+        isRejoinInFlight = false
+        resetReconnectRetryState()
+        state.connectionState = ConnectionState.disconnected
+        state.errorMessage = nil
+        state.waitingMessage = nil
+        state.joinFormErrorMessage = nil
+        state.meetingEndedNoticeMessage = showNotice ? meetingEndedNotice(message) : nil
+        state.serverRestartNotice = nil
+        clearAdminNotice()
+        socketManager.disconnect()
+        await cleanup(lifecycleGeneration: endingGeneration)
+        guard meetingLifecycleGeneration == endingGeneration else { return }
+        isIntentionalTeardownInProgress = false
+    }
+
+    private func isRoomEndedByLocalUser(_ endedBy: String?) -> Bool {
+        let normalizedEndedBy = endedBy?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !normalizedEndedBy.isEmpty else { return false }
+
+        let localUserId = state.userId.trimmingCharacters(in: .whitespacesAndNewlines)
+        let localSfuUserId = state.sfuUserId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if normalizedEndedBy == localUserId || normalizedEndedBy == localSfuUserId {
+            return true
+        }
+
+        let localUserKey = localUserId.components(separatedBy: "#").first ?? ""
+        return !localUserKey.isEmpty && normalizedEndedBy == localUserKey
+    }
+
+    private func meetingEndedNotice(_ message: String?) -> String {
+        let trimmed = message?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "The host ended this meeting. You are back on the home screen." : trimmed
     }
 
     private func finishJoinFailure(_ message: String) async {
@@ -6378,6 +6432,7 @@ final class MeetingViewModel {
         state.connectionState = ConnectionState.disconnected
         state.errorMessage = nil
         state.joinFormErrorMessage = nil
+        state.meetingEndedNoticeMessage = nil
         state.serverRestartNotice = nil
         clearAdminNotice()
         state.waitingMessage = nil
@@ -6389,6 +6444,10 @@ final class MeetingViewModel {
     /// surfaces visibly instead of being silently dropped while still joined.
     func dismissError() {
         state.errorMessage = nil
+    }
+
+    func dismissMeetingEndedNotice() {
+        state.meetingEndedNoticeMessage = nil
     }
 
     func dismissAdminNotice() {
@@ -9478,6 +9537,7 @@ final class MeetingViewModel {
             if response.success == false {
                 throw MeetingActionResponseError(message: response.error ?? "Failed to end meeting.")
             }
+            await finishLocalMeetingEnded()
             return true
         } catch {
             applyActionError(error, context: actionContext)

--- a/apps/web/src/app/components/JoinScreen.tsx
+++ b/apps/web/src/app/components/JoinScreen.tsx
@@ -14,6 +14,8 @@ import {
   ChevronDown,
   Check,
   Link2,
+  Info,
+  X,
   type LucideIcon,
 } from "lucide-react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
@@ -139,6 +141,8 @@ interface JoinScreenProps {
   onUserChange: (user: { id: string; email: string; name: string } | null) => void;
   onIsAdminChange: (isAdmin: boolean) => void;
   meetError?: MeetError | null;
+  meetingEndedNotice?: string | null;
+  onDismissMeetingEndedNotice?: () => void;
   videoEffects: VideoEffectsState;
   onVideoEffectsChange: Dispatch<SetStateAction<VideoEffectsState>>;
   onPrejoinMediaCommit?: (handoff: PrejoinMediaHandoff) => void;
@@ -286,6 +290,8 @@ function JoinScreen({
   onUserChange,
   onIsAdminChange,
   meetError,
+  meetingEndedNotice,
+  onDismissMeetingEndedNotice,
   videoEffects,
   onVideoEffectsChange,
   onPrejoinMediaCommit,
@@ -1082,6 +1088,29 @@ function JoinScreen({
                   : "Create a room, or join one with a code."}
               </p>
             </div>
+            {meetingEndedNotice ? (
+              <div
+                role="status"
+                className="flex items-start gap-2 rounded-xl border border-[#F95F4A]/25 bg-[#F95F4A]/10 px-3.5 py-3 text-left text-[13px] leading-snug text-[#fafafa]"
+              >
+                <Info
+                  size={16}
+                  className="mt-0.5 shrink-0 text-[#F95F4A]"
+                  aria-hidden="true"
+                />
+                <p className="min-w-0 flex-1">{meetingEndedNotice}</p>
+                {onDismissMeetingEndedNotice ? (
+                  <button
+                    type="button"
+                    onClick={onDismissMeetingEndedNotice}
+                    aria-label="Dismiss meeting ended notice"
+                    className="-mr-1 -mt-1 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[#fafafa]/55 transition-colors hover:bg-white/[0.08] hover:text-[#fafafa]"
+                  >
+                    <X size={14} aria-hidden="true" />
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
               {isSignedInUser ? (
                 <div className="flex items-center justify-between rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3">
                   <div className="min-w-0">

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -219,6 +219,8 @@ interface MeetsMainContentProps {
   isBrowserAudioMuted: boolean;
   onToggleBrowserAudio: () => void;
   meetError?: MeetError | null;
+  meetingEndedNotice?: string | null;
+  onDismissMeetingEndedNotice?: () => void;
   browserAudioNeedsGesture: boolean;
   onBrowserAudioAutoplayBlocked: () => void;
   isVoiceAgentRunning?: boolean;
@@ -472,6 +474,8 @@ export default function MeetsMainContent({
   onStopVoiceAgent,
   onClearVoiceAgentError,
   meetError,
+  meetingEndedNotice,
+  onDismissMeetingEndedNotice,
   isPopoutActive,
   isPopoutSupported,
   onOpenPopout,
@@ -1239,6 +1243,12 @@ export default function MeetsMainContent({
     },
     [onPendingUserStale, setPendingUsers],
   );
+
+  const handleEndRoomForEveryone = useCallback(() => {
+    if (!endRoomForEveryone) return;
+    void endRoomForEveryone();
+  }, [endRoomForEveryone]);
+
   const hasBrowserAudio = useMemo(
     () =>
       participantsArray.some(
@@ -1558,6 +1568,8 @@ export default function MeetsMainContent({
             onUserChange={onUserChange}
             onIsAdminChange={onIsAdminChange}
             meetError={meetError}
+            meetingEndedNotice={meetingEndedNotice}
+            onDismissMeetingEndedNotice={onDismissMeetingEndedNotice}
             videoEffects={videoEffects}
             onVideoEffectsChange={onVideoEffectsChange}
             onPrejoinMediaCommit={onPrejoinMediaCommit}
@@ -1792,7 +1804,9 @@ export default function MeetsMainContent({
                 onToggleHandRaised={toggleHandRaised}
                 onSendReaction={sendReaction}
                 onLeave={leaveRoom}
-                onEndForEveryone={endRoomForEveryone}
+                onEndForEveryone={
+                  endRoomForEveryone ? handleEndRoomForEveryone : undefined
+                }
                 selectedAudioInputDeviceId={selectedAudioInputDeviceId}
                 selectedAudioOutputDeviceId={selectedAudioOutputDeviceId}
                 selectedVideoInputDeviceId={selectedVideoInputDeviceId}

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -609,6 +609,28 @@ const streamNeedsMediaRefresh = (
   return false;
 };
 
+const isRoomEndedByLocalUser = (
+  endedBy: string | null | undefined,
+  localUserId: string,
+): boolean => {
+  const normalizedEndedBy = endedBy?.trim() ?? "";
+  if (!normalizedEndedBy) return false;
+
+  const normalizedLocalUserId = localUserId.trim();
+  if (normalizedEndedBy === normalizedLocalUserId) return true;
+
+  const localUserKey = normalizedLocalUserId.split("#")[0] ?? "";
+  return localUserKey.length > 0 && normalizedEndedBy === localUserKey;
+};
+
+const resolveRoomEndedNoticeMessage = (message?: string): string => {
+  const trimmed = message?.trim() ?? "";
+  if (!trimmed || trimmed === "This meeting has been ended by the host.") {
+    return "The host ended this meeting. You are no longer connected.";
+  }
+  return trimmed;
+};
+
 interface UseMeetSocketOptions {
   refs: MeetRefs;
   roomId: string;
@@ -644,6 +666,7 @@ interface UseMeetSocketOptions {
   setPendingUsers: React.Dispatch<React.SetStateAction<Map<string, string>>>;
   setConnectionState: (state: ConnectionState) => void;
   setMeetError: (error: MeetError | null) => void;
+  setMeetingEndedNotice?: (message: string | null) => void;
   setWaitingMessage: (message: string | null) => void;
   setHostUserId: (userId: string | null) => void;
   setHostUserIds: React.Dispatch<React.SetStateAction<string[]>>;
@@ -710,6 +733,7 @@ interface UseMeetSocketOptions {
     getCachedToken?: (roomId: string) => JoinInfo | null;
   };
   onSocketReady?: (socket: Socket | null) => void;
+  onLocalRoomEnded?: () => void;
   bypassMediaPermissions?: boolean;
 }
 
@@ -736,6 +760,7 @@ export function useMeetSocket({
   setPendingUsers,
   setConnectionState,
   setMeetError,
+  setMeetingEndedNotice,
   setWaitingMessage,
   setHostUserId,
   setHostUserIds,
@@ -776,6 +801,7 @@ export function useMeetSocket({
   onTtsMessage,
   prewarm,
   onSocketReady,
+  onLocalRoomEnded,
   bypassMediaPermissions = false,
 }: UseMeetSocketOptions) {
   const participantIdsRef = useRef<Set<string>>(new Set([userId]));
@@ -812,6 +838,7 @@ export function useMeetSocket({
     new Map(),
   );
   const closeConsumerRetryTimeoutsRef = useRef<Map<string, number>>(new Map());
+  const localRoomEndedHandledRef = useRef(false);
   const mutedConsumerSinceRef = useRef<Map<string, number>>(new Map());
   const producerPausedStateRef = useRef<Map<string, boolean>>(new Map());
   // Per-video-consumer decode progress for the freeze watchdog: last
@@ -1540,6 +1567,22 @@ export function useMeetSocket({
     producerSyncIntervalRef,
     updateReconnectRecoveryStatus,
     onSocketReady,
+  ]);
+
+  const finishLocalRoomEnded = useCallback(() => {
+    if (localRoomEndedHandledRef.current) return;
+    localRoomEndedHandledRef.current = true;
+    setMeetError(null);
+    setMeetingEndedNotice?.(null);
+    setWaitingMessage(null);
+    cleanup();
+    onLocalRoomEnded?.();
+  }, [
+    cleanup,
+    onLocalRoomEnded,
+    setMeetError,
+    setMeetingEndedNotice,
+    setWaitingMessage,
   ]);
 
   const resolveMediaPublishIntent = useCallback(
@@ -4369,18 +4412,25 @@ export function useMeetSocket({
               cleanup();
             });
 
-            // Host ended the meeting (admin:endRoom). The SFU emits roomEnded to
-            // everyone (incl. pending) then disconnects them; without this the
-            // client just went silently dark. Tear down + show a terminal notice.
+            // Host ended the meeting (admin:endRoom). Local hosts go straight
+            // home; everyone else lands back in the lobby with a non-error note.
             socket.on(
               "roomEnded",
-              ({ message }: { message?: string }) => {
-                console.log("[Meets] Room ended by host");
-                setMeetError({
-                  code: "UNKNOWN",
-                  message: message || "The host ended the meeting.",
-                  recoverable: false,
-                });
+              ({
+                message,
+                endedBy,
+              }: {
+                message?: string;
+                endedBy?: string;
+              }) => {
+                console.log("[Meets] Room ended", { endedBy });
+                if (isRoomEndedByLocalUser(endedBy, userId)) {
+                  finishLocalRoomEnded();
+                  return;
+                }
+
+                setMeetError(null);
+                setMeetingEndedNotice?.(resolveRoomEndedNoticeMessage(message));
                 setWaitingMessage(null);
                 cleanup();
               },
@@ -5693,6 +5743,7 @@ export function useMeetSocket({
       isMuted,
       isAdmin,
       ghostEnabled,
+      finishLocalRoomEnded,
       setIsAdmin,
       isRoomEvent,
       joinOptionsRef,
@@ -5736,6 +5787,7 @@ export function useMeetSocket({
       setAdminNotice,
       setLocalStream,
       setMeetError,
+      setMeetingEndedNotice,
       setPendingUsers,
       setWaitingMessage,
       setNetworkManagedVideoQuality,
@@ -6189,7 +6241,9 @@ export function useMeetSocket({
         isAdmin,
       });
 
+      localRoomEndedHandledRef.current = false;
       setMeetError(null);
+      setMeetingEndedNotice?.(null);
       updateReconnectRecoveryStatus(null);
       setConnectionState("connecting");
       primeAudioOutput();
@@ -6378,6 +6432,7 @@ export function useMeetSocket({
       setConnectionState,
       setLocalStream,
       setMeetError,
+      setMeetingEndedNotice,
       setRoomId,
       socketRef,
       stopLocalTrack,
@@ -6566,12 +6621,15 @@ export function useMeetSocket({
               resolve(false);
               return;
             }
+            if (response.success) {
+              finishLocalRoomEnded();
+            }
             resolve(response.success);
           },
         );
       });
     },
-    [socketRef],
+    [finishLocalRoomEnded, socketRef],
   );
 
   const getTranscriptToken =

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -394,6 +394,9 @@ export default function MeetsClient({
   const [currentCanGhostJoin, setCurrentCanGhostJoin] = useState(canGhostJoin);
   const [pendingNewMeetingRoomId, setPendingNewMeetingRoomId] =
     useState<string | null>(null);
+  const [meetingEndedNotice, setMeetingEndedNotice] = useState<string | null>(
+    null,
+  );
   const [guestStorageReady, setGuestStorageReady] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [appsSocket, setAppsSocket] = useState<Socket | null>(null);
@@ -2079,6 +2082,19 @@ export default function MeetsClient({
     };
   }, []);
 
+  const handleLocalRoomEnded = useCallback(() => {
+    setMeetingEndedNotice(null);
+    setMeetError(null);
+    setWaitingMessage(null);
+    setPendingNewMeetingRoomId(null);
+    setCurrentIsAdmin(false);
+    setIsGhostMode(false);
+    setRoomId("");
+    if (typeof window !== "undefined") {
+      window.location.assign("/");
+    }
+  }, [setIsGhostMode, setMeetError, setRoomId, setWaitingMessage]);
+
   const socket = useMeetSocket({
     refs,
     roomId,
@@ -2103,6 +2119,7 @@ export default function MeetsClient({
     setPendingUsers,
     setConnectionState,
     setMeetError,
+    setMeetingEndedNotice,
     setWaitingMessage,
     setHostUserId,
     setHostUserIds,
@@ -2148,6 +2165,7 @@ export default function MeetsClient({
     onTtsMessage: handleTtsMessage,
     prewarm,
     onSocketReady: setAppsSocket,
+    onLocalRoomEnded: handleLocalRoomEnded,
     bypassMediaPermissions,
   });
 
@@ -2373,6 +2391,7 @@ export default function MeetsClient({
     handleStopVoiceAgent();
     socket.cleanup();
     setMeetError(null);
+    setMeetingEndedNotice(null);
     setWaitingMessage(null);
     setPendingNewMeetingRoomId(null);
     setCurrentIsAdmin(false);
@@ -2395,6 +2414,7 @@ export default function MeetsClient({
     handleStopVoiceAgent();
     socket.cleanup();
     setMeetError(null);
+    setMeetingEndedNotice(null);
     setWaitingMessage(null);
     setIsGhostMode(false);
     setCurrentIsAdmin(true);
@@ -2687,6 +2707,7 @@ export default function MeetsClient({
   const handleEnterMeetingStart = useCallback(
     (action: "new" | "join") => {
       setMeetError(null);
+      setMeetingEndedNotice(null);
       setEnterErrored(false);
       setEnterAction(action);
     },
@@ -2695,6 +2716,7 @@ export default function MeetsClient({
 
   const handleEnterRetry = useCallback(() => {
     setMeetError(null);
+    setMeetingEndedNotice(null);
     setEnterErrored(false);
     setConnectionState("connecting");
     if (enterAction === "new") {
@@ -2715,6 +2737,7 @@ export default function MeetsClient({
     setEnterAction(null);
     setEnterErrored(false);
     setMeetError(null);
+    setMeetingEndedNotice(null);
     setConnectionState("disconnected");
   }, [setConnectionState, setMeetError]);
 
@@ -3115,6 +3138,8 @@ export default function MeetsClient({
         browserAudioNeedsGesture={browserAudioNeedsGesture}
         onBrowserAudioAutoplayBlocked={handleBrowserAudioAutoplayBlocked}
         meetError={meetError}
+        meetingEndedNotice={meetingEndedNotice}
+        onDismissMeetingEndedNotice={() => setMeetingEndedNotice(null)}
         isPopoutActive={isPopoutActive}
         isPopoutSupported={isPopoutSupported}
         onOpenPopout={openPopout}

--- a/apps/web/transcript-worker/src/room.ts
+++ b/apps/web/transcript-worker/src/room.ts
@@ -102,7 +102,7 @@ const createIdleSession = (roomId: string): TranscriptSessionState => ({
   updatedAt: Date.now(),
   error: null,
 });
-
+  
 const TRANSCRIPT_AUDIO_DEBUG_INTERVAL_MS = 15_000;
 
 type TranscriptAudioDebugStats = {


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR updates room-ended handling across the web and Swift clients. The main changes are:

- Shows a dismissible meeting-ended notice for non-host participants after the room ends.
- Sends the local host back home after ending the room for everyone.
- Clears stale meeting-ended notices when starting, joining, retrying, or leaving meeting flows.
- Adds the notice state and UI banner to the Swift join screen and web join screen.

<h3>Confidence Score: 5/5</h3>

The room-ended flow changes appear safe to merge.

The changes are focused on state cleanup and user-facing notices across the web and Swift clients, with no outstanding code issues identified.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the remote-room-ended-notice flow: the head cleared meetError, cleanup ran, a status message was rendered, a Dismiss meeting ended notice control appeared, and the notice was removed after dismissal.
- Executed the local-end-room-home harness and observed that the After state shows acknowledged success, cleanup, a redirect to the root, cleared notices and errors, reset room/admin/ghost state, and the contract check passed.
- Captured UI state transitions on the Join screen, noting statusVisible changed from false to true, the dismissedCallback was set to true, and afterDismissVisible became false; screenshots document the Before and After states.

<a href="https://app.greptile.com/trex/runs/12852939/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["add"](https://github.com/acm-vit/conclave/commit/6926e77ee2c1363da54d7acb0eff7d13a9ab5107) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40971386)</sub>

<!-- /greptile_comment -->