### PR TITLE
fix

### DIFF
--- a/apps/web/test/transcript-openai.test.ts
+++ b/apps/web/test/transcript-openai.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { TranscriptSegment } from "@conclave/meeting-core/transcript-types";
+import type { Env } from "../transcript-worker/src/types";
 import {
   QA_SYSTEM_PROMPT,
   buildQaTranscriptContext,
   buildRealtimeTranscriptionConfig,
   buildTranscriptionPrompt,
+  realtimeEndpoint,
 } from "../transcript-worker/src/openai";
 
 const segment = (
@@ -26,6 +28,20 @@ const segment = (
 });
 
 describe("transcript OpenAI request helpers", () => {
+  it("builds realtime transcription endpoint with intent and model", () => {
+    const endpoint = realtimeEndpoint(
+      {
+        OPENAI_REALTIME_URL: "wss://api.openai.com/v1/realtime",
+      } as Partial<Env> as Env,
+      "gpt-realtime-whisper",
+    );
+    const url = new URL(endpoint);
+
+    expect(url.protocol).toBe("https:");
+    expect(url.searchParams.get("intent")).toBe("transcription");
+    expect(url.searchParams.get("model")).toBe("gpt-realtime-whisper");
+  });
+
   it("sends delay only for gpt-realtime-whisper", () => {
     expect(
       buildRealtimeTranscriptionConfig({

--- a/apps/web/test/transcript-sarvam.test.ts
+++ b/apps/web/test/transcript-sarvam.test.ts
@@ -46,6 +46,7 @@ describe("Sarvam transcription provider helpers", () => {
     expect(url.searchParams.get("input_audio_codec")).toBe("pcm_s16le");
     expect(url.searchParams.get("flush_signal")).toBe("true");
     expect(url.searchParams.get("high_vad_sensitivity")).toBe("true");
+    expect(url.searchParams.get("vad_signals")).toBe("true");
   });
 
   it("normalizes websocket schemes for Cloudflare Worker fetch", () => {

--- a/apps/web/transcript-worker/src/openai.ts
+++ b/apps/web/transcript-worker/src/openai.ts
@@ -153,13 +153,21 @@ const createOpenAiClient = (env: Env, apiKey: string): OpenAI => {
   });
 };
 
-export const realtimeEndpoint = (env: Env): string => {
+export const realtimeEndpoint = (env: Env, model?: string): string => {
   const base = (env.OPENAI_REALTIME_URL || OPENAI_REALTIME_URL).replace(
     /\/+$/,
     "",
   );
   const url = new URL(base);
+  if (url.protocol === "wss:") {
+    url.protocol = "https:";
+  } else if (url.protocol === "ws:") {
+    url.protocol = "http:";
+  }
   url.searchParams.set("intent", OPENAI_REALTIME_TRANSCRIPTION_INTENT);
+  if (model) {
+    url.searchParams.set("model", normalizeRealtimeTranscriptModel(model));
+  }
   return url.toString();
 };
 

--- a/apps/web/transcript-worker/src/transcription/openai-realtime.ts
+++ b/apps/web/transcript-worker/src/transcription/openai-realtime.ts
@@ -2,12 +2,14 @@ import {
   buildRealtimeTranscriptionConfig,
   realtimeEndpoint,
 } from "../openai";
-import { safeJsonParse } from "../utils";
+import { safeJsonParse, trimText } from "../utils";
 import type {
   LiveTranscriptionCallbacks,
   LiveTranscriptionConnectOptions,
   LiveTranscriptionSession,
 } from "./types";
+
+const OPENAI_EVENT_LOG_INTERVAL_MS = 15_000;
 
 type OpenAiRealtimeEvent = {
   type?: string;
@@ -17,6 +19,41 @@ type OpenAiRealtimeEvent = {
   transcript?: string;
   error?: {
     message?: string;
+    code?: string;
+    type?: string;
+  };
+};
+
+const summarizeOpenAiRealtimeEvent = (
+  raw: string,
+): Record<string, unknown> | null => {
+  const parsed = safeJsonParse(raw);
+  if (!parsed || typeof parsed !== "object") {
+    return { validJson: false };
+  }
+  const event = parsed as OpenAiRealtimeEvent;
+  return {
+    validJson: true,
+    eventType: event.type ?? null,
+    hasItemId: typeof event.item_id === "string" && event.item_id.length > 0,
+    hasDelta: typeof event.delta === "string" && event.delta.length > 0,
+    deltaLength: typeof event.delta === "string" ? event.delta.length : 0,
+    hasTranscript:
+      typeof event.transcript === "string" && event.transcript.length > 0,
+    transcriptLength:
+      typeof event.transcript === "string" ? event.transcript.length : 0,
+    errorMessage:
+      typeof event.error?.message === "string"
+        ? trimText(event.error.message, 300)
+        : null,
+    errorCode:
+      typeof event.error?.code === "string"
+        ? trimText(event.error.code, 120)
+        : null,
+    errorType:
+      typeof event.error?.type === "string"
+        ? trimText(event.error.type, 120)
+        : null,
   };
 };
 
@@ -24,6 +61,9 @@ class OpenAiRealtimeTranscriptionSession implements LiveTranscriptionSession {
   readonly provider = "openai" as const;
 
   private closed = false;
+  private receivedEvents = 0;
+  private ignoredEvents = 0;
+  private lastEventLogAt = 0;
 
   constructor(
     private readonly socket: WebSocket,
@@ -68,16 +108,30 @@ class OpenAiRealtimeTranscriptionSession implements LiveTranscriptionSession {
   }
 
   private async handleEvent(raw: string): Promise<void> {
+    this.receivedEvents += 1;
     const parsed = safeJsonParse(raw);
-    if (!parsed || typeof parsed !== "object") return;
+    if (!parsed || typeof parsed !== "object") {
+      this.ignoredEvents += 1;
+      this.logProviderEvent("invalid_json", raw, this.ignoredEvents === 1);
+      return;
+    }
     const event = parsed as OpenAiRealtimeEvent;
     if (event.type === "error") {
+      this.logProviderEvent("error", raw, true);
       await this.callbacks.onFailure(
         event.error?.message || "Realtime transcription error.",
       );
       return;
     }
+    if (event.type === "conversation.item.input_audio_transcription.failed") {
+      this.logProviderEvent("failed", raw, true);
+      await this.callbacks.onFailure(
+        event.error?.message || "Realtime input audio transcription failed.",
+      );
+      return;
+    }
     if (event.type === "input_audio_buffer.committed" && event.item_id) {
+      this.logProviderEvent("committed", raw, this.receivedEvents === 1);
       this.callbacks.onCommitted(event.item_id);
       return;
     }
@@ -86,6 +140,7 @@ class OpenAiRealtimeTranscriptionSession implements LiveTranscriptionSession {
       event.item_id &&
       event.delta
     ) {
+      this.logProviderEvent("delta", raw, this.receivedEvents === 1);
       this.callbacks.onDelta(event.item_id, event.delta);
       return;
     }
@@ -93,20 +148,45 @@ class OpenAiRealtimeTranscriptionSession implements LiveTranscriptionSession {
       event.type === "conversation.item.input_audio_transcription.completed" &&
       event.item_id
     ) {
+      this.logProviderEvent("completed", raw, this.receivedEvents === 1);
       await this.callbacks.onFinal(event.item_id, event.transcript || "");
+      return;
     }
+    this.ignoredEvents += 1;
+    this.logProviderEvent("ignored", raw, this.ignoredEvents === 1);
+  }
+
+  private logProviderEvent(
+    outcome: string,
+    raw: string,
+    force = false,
+  ): void {
+    const now = Date.now();
+    if (!force && now - this.lastEventLogAt < OPENAI_EVENT_LOG_INTERVAL_MS) {
+      return;
+    }
+    this.lastEventLogAt = now;
+    console.info("[TranscriptWorker] openai realtime event", {
+      outcome,
+      receivedEvents: this.receivedEvents,
+      ignoredEvents: this.ignoredEvents,
+      ...summarizeOpenAiRealtimeEvent(raw),
+    });
   }
 }
 
 export const connectOpenAiRealtimeTranscription = async (
   options: LiveTranscriptionConnectOptions,
 ): Promise<LiveTranscriptionSession> => {
-  const response = await fetch(realtimeEndpoint(options.env), {
-    headers: {
-      Authorization: `Bearer ${options.apiKey}`,
-      Upgrade: "websocket",
+  const response = await fetch(
+    realtimeEndpoint(options.env, options.transcriptModel),
+    {
+      headers: {
+        Authorization: `Bearer ${options.apiKey}`,
+        Upgrade: "websocket",
+      },
     },
-  });
+  );
   const socket = response.webSocket;
   if (!socket) {
     throw new Error(

--- a/apps/web/transcript-worker/src/transcription/sarvam.ts
+++ b/apps/web/transcript-worker/src/transcription/sarvam.ts
@@ -8,10 +8,12 @@ import type {
 
 const SARVAM_STT_WS_URL = "wss://api.sarvam.ai/speech-to-text/ws";
 const SARVAM_SAMPLE_RATE = 16_000;
+const SARVAM_SAMPLE_RATE_PARAM = String(SARVAM_SAMPLE_RATE);
 const SARVAM_AUDIO_ENCODING = "audio/wav";
 const SARVAM_INPUT_AUDIO_CODEC = "pcm_s16le";
 const SARVAM_DEFAULT_LANGUAGE_CODE = "unknown";
 const SARVAM_DEFAULT_MODE = "codemix";
+const SARVAM_EVENT_LOG_INTERVAL_MS = 15_000;
 const SARVAM_SUPPORTED_LANGUAGE_CODES = new Set([
   "unknown",
   "en-IN",
@@ -100,10 +102,11 @@ export const sarvamEndpoint = (options: {
   );
   url.searchParams.set("model", options.model || "saaras:v3");
   url.searchParams.set("mode", normalizeSarvamMode(options.mode));
-  url.searchParams.set("sample_rate", String(SARVAM_SAMPLE_RATE));
+  url.searchParams.set("sample_rate", SARVAM_SAMPLE_RATE_PARAM);
   url.searchParams.set("input_audio_codec", SARVAM_INPUT_AUDIO_CODEC);
   url.searchParams.set("flush_signal", "true");
   url.searchParams.set("high_vad_sensitivity", "true");
+  url.searchParams.set("vad_signals", "true");
   return url.toString();
 };
 
@@ -182,10 +185,44 @@ export const buildSarvamAudioMessage = (audioBase64: string): string =>
   JSON.stringify({
     audio: {
       data: audioBase64,
-      sample_rate: String(SARVAM_SAMPLE_RATE),
+      sample_rate: SARVAM_SAMPLE_RATE_PARAM,
       encoding: SARVAM_AUDIO_ENCODING,
     },
   });
+
+const summarizeSarvamEvent = (
+  raw: string,
+): Record<string, unknown> | null => {
+  const parsed = safeJsonParse(raw);
+  if (!parsed || typeof parsed !== "object") {
+    return { validJson: false };
+  }
+  const response = parsed as SarvamResponse;
+  const data =
+    response.data && typeof response.data === "object"
+      ? (response.data as Record<string, unknown>)
+      : {};
+  return {
+    validJson: true,
+    responseType: response.type ?? null,
+    dataKeys: Object.keys(data),
+    hasTranscript:
+      typeof data.transcript === "string" ||
+      typeof response.transcript === "string",
+    hasText:
+      typeof data.text === "string" || typeof response.text === "string",
+    requestId:
+      typeof data.request_id === "string"
+        ? data.request_id
+        : typeof response.request_id === "string"
+          ? response.request_id
+          : null,
+    hasError:
+      typeof data.error === "string" ||
+      typeof response.error === "string" ||
+      typeof response.message === "string",
+  };
+};
 
 export const createSarvamSegmentItemId = (
   baseItemId: string,
@@ -257,6 +294,9 @@ class SarvamTranscriptionSession implements LiveTranscriptionSession {
   private closed = false;
   private readonly downsampler = new Pcm24To16Downsampler();
   private finalSequence = 0;
+  private receivedEvents = 0;
+  private ignoredEvents = 0;
+  private lastEventLogAt = 0;
 
   constructor(
     private readonly socket: WebSocket,
@@ -301,8 +341,14 @@ class SarvamTranscriptionSession implements LiveTranscriptionSession {
   }
 
   private async handleEvent(raw: string): Promise<void> {
+    this.receivedEvents += 1;
     const event = parseSarvamEvent(raw);
-    if (event.type === "ignore") return;
+    if (event.type === "ignore") {
+      this.ignoredEvents += 1;
+      this.logProviderEvent("ignored", raw, this.ignoredEvents === 1);
+      return;
+    }
+    this.logProviderEvent(event.type, raw, this.receivedEvents === 1);
     if (event.type === "error") {
       await this.callbacks.onFailure(event.message);
       return;
@@ -314,6 +360,24 @@ class SarvamTranscriptionSession implements LiveTranscriptionSession {
     );
     this.callbacks.onCommitted(itemId);
     await this.callbacks.onFinal(itemId, event.transcript);
+  }
+
+  private logProviderEvent(
+    outcome: string,
+    raw: string,
+    force = false,
+  ): void {
+    const now = Date.now();
+    if (!force && now - this.lastEventLogAt < SARVAM_EVENT_LOG_INTERVAL_MS) {
+      return;
+    }
+    this.lastEventLogAt = now;
+    console.info("[TranscriptWorker] sarvam event", {
+      outcome,
+      receivedEvents: this.receivedEvents,
+      ignoredEvents: this.ignoredEvents,
+      ...summarizeSarvamEvent(raw),
+    });
   }
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR updates the live transcription provider paths. The main changes are:

- OpenAI realtime endpoint construction now normalizes websocket schemes and includes the transcript model.
- OpenAI realtime transcription now logs summarized provider events and handles transcription failure events.
- Sarvam transcription now sends `vad_signals=true` and logs summarized provider events.
- Tests cover the updated OpenAI and Sarvam endpoint behavior.

<h3>Confidence Score: 5/5</h3>

The changes are focused on provider connection setup and event handling, with no review comments requiring follow-up.

The touched paths are covered by targeted tests for the updated OpenAI and Sarvam endpoint behavior, and no issues were identified in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The realtime transcription fetch was switched to use the head endpoint with model gpt-realtime-whisper, and the callback log now records a failure:bad audio after the event.
- The Sarvam transcription fetch URLs were updated to include vad\_signals=true and the audio sample rate was preserved at 16000; console.info now summarizes ignored Sarvam metadata, and error events trigger onFailure while transcript events call onCommitted/onFinal with finalized item IDs.

<a href="https://app.greptile.com/trex/runs/12855394/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/43fa7b19fb0efcab1226ef7738eef6fd35b557b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40976313)</sub>

<!-- /greptile_comment -->