### PR TITLE
fix

### DIFF
--- a/apps/web/src/app/hooks/useMeetingTranscript.ts
+++ b/apps/web/src/app/hooks/useMeetingTranscript.ts
@@ -1214,6 +1214,9 @@ export function useMeetingTranscript({
         onCommit: (speaker) => {
           send({ type: "audio.commit", speaker });
         },
+        onClear: (speaker) => {
+          send({ type: "audio.clear", speaker });
+        },
       });
     }
     relayRef.current

--- a/apps/web/src/app/lib/transcript-audio.ts
+++ b/apps/web/src/app/lib/transcript-audio.ts
@@ -13,6 +13,7 @@ export interface TranscriptRelaySource {
 export interface TranscriptAudioRelayOptions {
   onAudioChunk: (audioBase64: string, speaker: TranscriptSpeaker) => void;
   onCommit: (speaker: TranscriptSpeaker) => void;
+  onClear: (speaker: TranscriptSpeaker) => void;
 }
 
 type ConnectedSource = {
@@ -24,6 +25,7 @@ type ConnectedSource = {
   speechUntil: number;
   lastChunkAt: number;
   lastCommitAt: number;
+  turnOpen: boolean;
   pendingChunks: Int16Array[];
   pendingSampleCount: number;
   flushResolvers: Array<() => void>;
@@ -216,6 +218,7 @@ export class TranscriptAudioRelay {
       speechUntil: 0,
       lastChunkAt: 0,
       lastCommitAt: 0,
+      turnOpen: false,
       pendingChunks: [],
       pendingSampleCount: 0,
       flushResolvers: [],
@@ -308,6 +311,7 @@ export class TranscriptAudioRelay {
     this.commitTimer = window.setInterval(() => {
       for (const connected of this.connectedSources.values()) {
         this.commitIfNeeded(connected);
+        this.clearEndedTurn(connected);
       }
     }, COMMIT_INTERVAL_MS);
   }
@@ -322,6 +326,23 @@ export class TranscriptAudioRelay {
   private async flushAndCommit(connected: ConnectedSource): Promise<void> {
     await this.flushProcessor(connected);
     this.commitIfNeeded(connected);
+    if (connected.turnOpen) {
+      this.options.onClear(connected.speaker);
+      connected.turnOpen = false;
+    }
+  }
+
+  private clearEndedTurn(connected: ConnectedSource): void {
+    if (
+      !connected.turnOpen ||
+      connected.speechUntil === 0 ||
+      Date.now() <= connected.speechUntil
+    ) {
+      return;
+    }
+    this.commitIfNeeded(connected);
+    this.options.onClear(connected.speaker);
+    connected.turnOpen = false;
   }
 
   private flushProcessor(connected: ConnectedSource): Promise<void> {
@@ -353,6 +374,7 @@ export class TranscriptAudioRelay {
     samples: Int16Array,
   ): void {
     if (samples.length === 0) return;
+    connected.turnOpen = true;
     connected.pendingChunks.push(samples);
     connected.pendingSampleCount += samples.length;
     if (connected.pendingSampleCount >= AUDIO_BATCH_TARGET_SAMPLES) {

--- a/apps/web/test/transcript-openai.test.ts
+++ b/apps/web/test/transcript-openai.test.ts
@@ -28,18 +28,17 @@ const segment = (
 });
 
 describe("transcript OpenAI request helpers", () => {
-  it("builds realtime transcription endpoint with intent and model", () => {
+  it("builds realtime transcription endpoint without a URL model parameter", () => {
     const endpoint = realtimeEndpoint(
       {
         OPENAI_REALTIME_URL: "wss://api.openai.com/v1/realtime",
       } as Partial<Env> as Env,
-      "gpt-realtime-whisper",
     );
     const url = new URL(endpoint);
 
     expect(url.protocol).toBe("https:");
     expect(url.searchParams.get("intent")).toBe("transcription");
-    expect(url.searchParams.get("model")).toBe("gpt-realtime-whisper");
+    expect(url.searchParams.has("model")).toBe(false);
   });
 
   it("sends delay only for gpt-realtime-whisper", () => {

--- a/apps/web/test/transcript-sarvam.test.ts
+++ b/apps/web/test/transcript-sarvam.test.ts
@@ -82,7 +82,7 @@ describe("Sarvam transcription provider helpers", () => {
     expect(JSON.parse(buildSarvamAudioMessage("abc"))).toEqual({
       audio: {
         data: "abc",
-        sample_rate: "16000",
+        sample_rate: 16000,
         encoding: "audio/wav",
       },
     });

--- a/apps/web/transcript-worker/src/openai.ts
+++ b/apps/web/transcript-worker/src/openai.ts
@@ -153,7 +153,7 @@ const createOpenAiClient = (env: Env, apiKey: string): OpenAI => {
   });
 };
 
-export const realtimeEndpoint = (env: Env, model?: string): string => {
+export const realtimeEndpoint = (env: Env): string => {
   const base = (env.OPENAI_REALTIME_URL || OPENAI_REALTIME_URL).replace(
     /\/+$/,
     "",
@@ -165,9 +165,6 @@ export const realtimeEndpoint = (env: Env, model?: string): string => {
     url.protocol = "http:";
   }
   url.searchParams.set("intent", OPENAI_REALTIME_TRANSCRIPTION_INTENT);
-  if (model) {
-    url.searchParams.set("model", normalizeRealtimeTranscriptModel(model));
-  }
   return url.toString();
 };
 

--- a/apps/web/transcript-worker/src/transcription/openai-realtime.ts
+++ b/apps/web/transcript-worker/src/transcription/openai-realtime.ts
@@ -179,7 +179,7 @@ export const connectOpenAiRealtimeTranscription = async (
   options: LiveTranscriptionConnectOptions,
 ): Promise<LiveTranscriptionSession> => {
   const response = await fetch(
-    realtimeEndpoint(options.env, options.transcriptModel),
+    realtimeEndpoint(options.env),
     {
       headers: {
         Authorization: `Bearer ${options.apiKey}`,

--- a/apps/web/transcript-worker/src/transcription/sarvam.ts
+++ b/apps/web/transcript-worker/src/transcription/sarvam.ts
@@ -185,7 +185,19 @@ export const buildSarvamAudioMessage = (audioBase64: string): string =>
   JSON.stringify({
     audio: {
       data: audioBase64,
-      sample_rate: SARVAM_SAMPLE_RATE_PARAM,
+      sample_rate: SARVAM_SAMPLE_RATE,
+      encoding: SARVAM_AUDIO_ENCODING,
+    },
+  });
+
+const buildSarvamFlushMessage = (): string => JSON.stringify({ type: "flush" });
+
+const buildSarvamEndOfStreamMessage = (): string =>
+  JSON.stringify({
+    type: "end_of_stream",
+    audio: {
+      data: "",
+      sample_rate: SARVAM_SAMPLE_RATE,
       encoding: SARVAM_AUDIO_ENCODING,
     },
   });
@@ -310,16 +322,21 @@ class SarvamTranscriptionSession implements LiveTranscriptionSession {
   }
 
   commitAudio(): void {
-    this.socket.send(JSON.stringify({ type: "flush" }));
+    // Sarvam is a continuous streaming STT socket. The room/SFU sends periodic
+    // commits for OpenAI's input buffer API; treating those as Sarvam flushes
+    // fragments speech before server-side VAD can finalize an utterance.
   }
 
   clearAudio(): void {
+    this.socket.send(buildSarvamFlushMessage());
     this.downsampler.reset();
   }
 
   close(): void {
     this.closed = true;
     try {
+      this.socket.send(buildSarvamFlushMessage());
+      this.socket.send(buildSarvamEndOfStreamMessage());
       this.socket.close();
     } catch {}
   }

--- a/packages/sfu/server/transcript/audioBatcher.ts
+++ b/packages/sfu/server/transcript/audioBatcher.ts
@@ -20,6 +20,7 @@ export class TranscriptAudioBatcher {
   private lastChunkAt = 0;
   private lastCommitAt = 0;
   private speechUntil = 0;
+  private turnOpen = false;
 
   constructor(
     private readonly options: {
@@ -34,6 +35,7 @@ export class TranscriptAudioBatcher {
 
   pushPcm(pcm: Buffer): boolean {
     if (pcm.length === 0 || !this.isSpeechPcm(pcm)) return false;
+    this.turnOpen = true;
     this.pendingChunks.push(pcm);
     this.pendingSampleCount += Math.floor(pcm.length / PCM16_BYTES_PER_SAMPLE);
     if (this.pendingSampleCount >= this.batchTargetSamples) {
@@ -51,10 +53,25 @@ export class TranscriptAudioBatcher {
 
   flushAndCommit(): boolean {
     const committed = this.commitIfNeeded();
-    if (committed) {
+    if (committed || this.turnOpen) {
       this.options.sink.clearAudio(this.options.speaker);
+      this.turnOpen = false;
     }
     return committed;
+  }
+
+  clearEndedTurn(): boolean {
+    if (
+      !this.turnOpen ||
+      this.speechUntil === 0 ||
+      this.now() <= this.speechUntil
+    ) {
+      return false;
+    }
+    this.commitIfNeeded();
+    this.options.sink.clearAudio(this.options.speaker);
+    this.turnOpen = false;
+    return true;
   }
 
   private flushQueuedAudio(): void {

--- a/packages/sfu/server/transcript/sfuTranscriptRelay.ts
+++ b/packages/sfu/server/transcript/sfuTranscriptRelay.ts
@@ -318,6 +318,7 @@ export class SfuTranscriptRelay implements TranscriptAudioBatchSink {
     this.commitTimer = setInterval(() => {
       for (const active of this.consumers.values()) {
         this.commitIfNeeded(active);
+        active.batcher.clearEndedTurn();
       }
     }, TRANSCRIPT_AUDIO_COMMIT_INTERVAL_MS);
   }

--- a/packages/sfu/test/transcript-audio-batcher.test.ts
+++ b/packages/sfu/test/transcript-audio-batcher.test.ts
@@ -121,6 +121,30 @@ describe("TranscriptAudioBatcher", () => {
     ]);
   });
 
+  it("clears the worker buffer when a speech turn ends", () => {
+    const events: AudioEvent[] = [];
+    let now = 1000;
+    const ada = speaker("u1", "Ada");
+    const batcher = new TranscriptAudioBatcher({
+      speaker: ada,
+      sink: createSink(events),
+      now: () => now,
+      batchTargetSamples: 4,
+    });
+
+    expect(batcher.pushPcm(pcm(4, 2200))).toBe(true);
+    expect(batcher.commitIfNeeded()).toBe(true);
+    expect(batcher.clearEndedTurn()).toBe(false);
+    now += 451;
+    expect(batcher.clearEndedTurn()).toBe(true);
+
+    expect(events).toEqual([
+      { type: "chunk", speaker: ada, bytes: 8 },
+      { type: "commit", speaker: ada },
+      { type: "clear", speaker: ada },
+    ]);
+  });
+
   it("keeps quiet but non-silent mic input", () => {
     const events: AudioEvent[] = [];
     const ada = speaker("u1", "Ada");


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR updates transcript audio buffering and provider-specific live transcription behavior. The main changes are:

- Browser and SFU relays now clear transcript worker buffers after a speech turn ends.
- Sarvam periodic commits are no-ops, while explicit clears send provider flush messages.
- Sarvam close now sends flush and end-of-stream messages before closing the socket.
- OpenAI realtime model selection moved out of the endpoint URL and remains in `session.update`.
- Tests were updated for OpenAI endpoint construction, Sarvam message shape, and audio batch turn clearing.
- The PR title/commit message `fix` is vague; a more descriptive message would make the change history easier to understand.

<h3>Confidence Score: 5/5</h3>

The transcript buffering and provider behavior changes appear safe to merge.

No correctness issues were identified in the reviewed changes, and the updated tests cover the key OpenAI, Sarvam, and audio batch clearing behavior touched by the PR.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the OpenAI realtime endpoint behavior before and after the change, noting the endpoint URL construction differences and the presence of the transcriptModel in the before state but not in the after state.
- Compared audio streaming behavior before and after the change, including how commitAudio, clearAudio, and close affect sample counts, end-of-stream signaling, and finalCount.
- Compared transcript turn clearing behavior before and after the change, including whether clearEndedTurn is recorded and how FINAL\_EVENTS, relay onClear, and hook audio.clear switch after the speech flow.

<a href="https://app.greptile.com/trex/runs/12857242/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/03b2e68a33d5447bf9382dbed933304bb92fc364) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40979628)</sub>

<!-- /greptile_comment -->