### PR TITLE
fix

### DIFF
--- a/apps/web/test/transcript-utils.test.ts
+++ b/apps/web/test/transcript-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  analyzePcm16Base64,
   createSilentPcm16Base64,
   estimatePcm16Base64SampleCount,
   redactSensitiveText,
@@ -32,5 +33,29 @@ describe("PCM16 base64 helpers", () => {
     const audio = createSilentPcm16Base64(2400);
 
     expect(estimatePcm16Base64SampleCount(audio)).toBe(2400);
+  });
+
+  it("analyzes PCM16 audio without exposing sample data", () => {
+    const audio = btoa(
+      String.fromCharCode(
+        0x00,
+        0x00,
+        0xff,
+        0x7f,
+        0x00,
+        0x80,
+        0x00,
+        0x00,
+      ),
+    );
+
+    expect(analyzePcm16Base64(audio, 24_000)).toEqual({
+      samples: 4,
+      durationMs: 0,
+      rms: 0.707096,
+      peak: 1,
+      meanAbs: 0.499992,
+      zeroCrossingRate: 0.25,
+    });
   });
 });

--- a/apps/web/transcript-worker/src/room.ts
+++ b/apps/web/transcript-worker/src/room.ts
@@ -14,6 +14,7 @@ import {
   type TranscriptTranscriptionProvider,
 } from "@conclave/meeting-core/transcript-models";
 import {
+  TRANSCRIPT_PCM_SAMPLE_RATE,
   DEFAULT_MAX_SEGMENTS,
   DEFAULT_QA_MODEL,
   DEFAULT_TRANSCRIPT_MODEL,
@@ -85,6 +86,7 @@ import {
   parsePositiveInt,
   redactSensitiveText,
   safeJsonParse,
+  analyzePcm16Base64,
   createSilentPcm16Base64,
   estimatePcm16Base64SampleCount,
   trimText,
@@ -726,12 +728,13 @@ export class TranscriptRoom {
       this.audioDebugStats.acceptedSamples += sampleCount;
       this.logAudioDebug(
         "accepted audio chunk",
-        {
+        () => ({
           samples: sampleCount,
           pendingSamples: this.pendingAudioSamples,
           speakerUserId: normalizedSpeaker.userId,
           source: normalizedSpeaker.source,
-        },
+          pcm: analyzePcm16Base64(audio, TRANSCRIPT_PCM_SAMPLE_RATE),
+        }),
         this.audioDebugStats.acceptedChunks === 1,
       );
       if (this.isController(viewer) && this.session?.controller) {
@@ -1162,7 +1165,7 @@ export class TranscriptRoom {
 
   private logAudioDebug(
     event: string,
-    details: Record<string, unknown> = {},
+    details: Record<string, unknown> | (() => Record<string, unknown>) = {},
     force = false,
   ): void {
     const now = Date.now();
@@ -1174,6 +1177,8 @@ export class TranscriptRoom {
       return;
     }
     this.audioDebugStats.lastAudioLogAt = now;
+    const resolvedDetails =
+      typeof details === "function" ? details() : details;
     console.info("[TranscriptWorker] audio", {
       event,
       roomId: this.session?.roomId,
@@ -1184,7 +1189,7 @@ export class TranscriptRoom {
       commits: this.audioDebugStats.commits,
       providerCommittedItems: this.audioDebugStats.providerCommittedItems,
       providerFinals: this.audioDebugStats.providerFinals,
-      ...details,
+      ...resolvedDetails,
     });
   }
 

--- a/apps/web/transcript-worker/src/utils.ts
+++ b/apps/web/transcript-worker/src/utils.ts
@@ -115,6 +115,56 @@ export const estimatePcm16Base64SampleCount = (value: string): number => {
   return Math.floor(byteLength / 2);
 };
 
+export const analyzePcm16Base64 = (
+  value: string,
+  sampleRate: number,
+): Record<string, number> => {
+  const binary = atob(value.replace(/\s+/g, ""));
+  const samples = Math.floor(binary.length / 2);
+  if (samples === 0) {
+    return {
+      samples: 0,
+      durationMs: 0,
+      rms: 0,
+      peak: 0,
+      meanAbs: 0,
+      zeroCrossingRate: 0,
+    };
+  }
+
+  let sumSquares = 0;
+  let sumAbs = 0;
+  let peak = 0;
+  let zeroCrossings = 0;
+  let previousSign = 0;
+  for (let index = 0; index < samples; index += 1) {
+    const offset = index * 2;
+    const unsigned =
+      (binary.charCodeAt(offset) & 0xff) |
+      ((binary.charCodeAt(offset + 1) & 0xff) << 8);
+    const sample = unsigned >= 0x8000 ? unsigned - 0x10000 : unsigned;
+    const normalized = sample / 32768;
+    const abs = Math.abs(normalized);
+    sumSquares += normalized * normalized;
+    sumAbs += abs;
+    peak = Math.max(peak, abs);
+    const sign = sample === 0 ? previousSign : sample > 0 ? 1 : -1;
+    if (previousSign !== 0 && sign !== 0 && sign !== previousSign) {
+      zeroCrossings += 1;
+    }
+    previousSign = sign;
+  }
+
+  return {
+    samples,
+    durationMs: Math.round((samples / sampleRate) * 1000),
+    rms: Number(Math.sqrt(sumSquares / samples).toFixed(6)),
+    peak: Number(peak.toFixed(6)),
+    meanAbs: Number((sumAbs / samples).toFixed(6)),
+    zeroCrossingRate: Number((zeroCrossings / samples).toFixed(6)),
+  };
+};
+
 export const createSilentPcm16Base64 = (samples: number): string => {
   const sampleCount = Math.max(0, Math.floor(samples));
   if (sampleCount === 0) return "";


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds aggregate audio diagnostics for transcript-worker debug logging. The main changes are:

- Added `analyzePcm16Base64` for safe PCM16 metrics such as sample count, duration, RMS, peak, mean absolute value, and zero-crossing rate.
- Added lazy audio debug detail construction so PCM analysis only runs when a log is emitted.
- Added unit coverage for the new PCM16 analysis helper.

<h3>Confidence Score: 5/5</h3>

The changes are limited to transcript-worker audio diagnostics and unit coverage, with no review comments requiring code changes.

The modified helper and logging paths are narrowly scoped and covered by tests for the new PCM16 analysis behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the audio PCM debug run and captured the before-state, which shows SOURCE\_HAS\_PCM false, SOURCE\_HAS\_LAZY\_DETAILS false, and an accepted log without PCM.
- Captured the after-state, which shows SOURCE\_HAS\_PCM true, SOURCE\_HAS\_LAZY\_DETAILS true, and an accepted log containing pcm with 4 samples, durationMs 0, rms 0.707096, peak 1, meanAbs 0.499992, and zeroCrossingRate 0.25.
- Noted that HARNESS\_FIRST\_ATOB\_CALLS is 1 and HARNESS\_TOTAL\_ATOB\_CALLS is 1 after the after-state, indicating the second throttled append did not eagerly analyze or decode audio.

<a href="https://app.greptile.com/trex/runs/12858239/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/9b62686589a746c0e6a47de4a61001f56ff4b9f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40981319)</sub>

<!-- /greptile_comment -->