### PR TITLE
fix

### DIFF
--- a/packages/sfu/server/transcript/sfuTranscriptRelay.ts
+++ b/packages/sfu/server/transcript/sfuTranscriptRelay.ts
@@ -28,6 +28,7 @@ type ActiveAudioConsumer = {
   decodedFrames: number;
   queuedFrames: number;
   commitsSent: number;
+  turnClearsSent: number;
   decodeFailures: number;
   lastDecodeFailureLogAt: number;
   lastDropLogAt: number;
@@ -231,13 +232,15 @@ export class SfuTranscriptRelay implements TranscriptAudioBatchSink {
       decodedFrames: 0,
       queuedFrames: 0,
       commitsSent: 0,
+      turnClearsSent: 0,
       decodeFailures: 0,
       lastDecodeFailureLogAt: 0,
       lastDropLogAt: 0,
     };
     this.consumers.set(entry.producerId, active);
+    const codec = entry.producer.rtpParameters.codecs[0];
     Logger.info(
-      `Transcript SFU relay attached audio producer ${entry.producerId} for ${entry.displayName} (${entry.userId}) in room ${this.options.room.id}.`,
+      `Transcript SFU relay attached audio producer ${entry.producerId} for ${entry.displayName} (${entry.userId}) in room ${this.options.room.id} codec=${codec?.mimeType ?? "unknown"} clockRate=${codec?.clockRate ?? "unknown"} channels=${codec?.channels ?? "unknown"}.`,
     );
 
     consumer.on("rtp", (packet) => {
@@ -318,7 +321,7 @@ export class SfuTranscriptRelay implements TranscriptAudioBatchSink {
     this.commitTimer = setInterval(() => {
       for (const active of this.consumers.values()) {
         this.commitIfNeeded(active);
-        active.batcher.clearEndedTurn();
+        this.clearEndedTurnIfNeeded(active);
       }
     }, TRANSCRIPT_AUDIO_COMMIT_INTERVAL_MS);
   }
@@ -341,6 +344,17 @@ export class SfuTranscriptRelay implements TranscriptAudioBatchSink {
     if (active.commitsSent === 1) {
       Logger.info(
         `Transcript SFU relay committed first audio batch for producer ${active.consumer.producerId} in room ${this.options.room.id}.`,
+      );
+    }
+  }
+
+  private clearEndedTurnIfNeeded(active: ActiveAudioConsumer): void {
+    const cleared = active.batcher.clearEndedTurn();
+    if (!cleared) return;
+    active.turnClearsSent += 1;
+    if (active.turnClearsSent === 1) {
+      Logger.info(
+        `Transcript SFU relay cleared first ended speech turn for producer ${active.consumer.producerId} in room ${this.options.room.id}.`,
       );
     }
   }


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds transcript SFU relay diagnostics. The main changes are:

- Logs codec metadata when attaching an audio producer.
- Tracks ended-turn clears per active audio consumer.
- Logs the first ended speech turn clear for each producer.

<h3>Confidence Score: 5/5</h3>

The change is limited to transcript SFU relay diagnostics and appears safe to merge.

The modified surface is narrow and focused on logging and counters without altering the main relay control flow.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the before and after transcript captures to verify the relay code path now attaches codec metadata in the log.
- Validated the after capture shows clearEndedTurn progression from false to true, and turnClearsSent equals 1 with a cleared-first-ended-speech-turn log.
- Confirmed the captures include the command, cwd, exit code, runtime logs, and harness-driven execution of the changed relay code path.

<a href="https://app.greptile.com/trex/runs/12858309/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/479821ab87633a0e4a2002b60a2c7afbe7687384) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40981424)</sub>

<!-- /greptile_comment -->