### PR TITLE
add test

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,9 +1,29 @@
 import type { NextConfig } from "next";
+import { execSync } from "node:child_process";
 import path from "path";
 import { fileURLToPath } from "url";
 
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(currentDir, "../..");
+const readGitSha = (): string | null => {
+  try {
+    return execSync("git rev-parse HEAD", {
+      cwd: workspaceRoot,
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+};
+const conclaveClientVersion =
+  process.env.NEXT_PUBLIC_CONCLAVE_CLIENT_VERSION ||
+  process.env.CF_PAGES_COMMIT_SHA ||
+  process.env.VERCEL_GIT_COMMIT_SHA ||
+  process.env.GITHUB_SHA ||
+  readGitSha() ||
+  "local";
 const yjsTurbopackAlias = "./node_modules/yjs/dist/yjs.mjs";
 const yProtocolsTurbopackAlias = "./node_modules/y-protocols";
 const yjsWebpackAlias = path.resolve(
@@ -18,6 +38,11 @@ const yProtocolsWebpackAlias = path.resolve(
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   reactCompiler: true,
+  deploymentId:
+    conclaveClientVersion === "local" ? undefined : conclaveClientVersion,
+  env: {
+    NEXT_PUBLIC_CONCLAVE_CLIENT_VERSION: conclaveClientVersion,
+  },
   images: {
     unoptimized: true,
   },

--- a/apps/web/src/app/api/version/route.ts
+++ b/apps/web/src/app/api/version/route.ts
@@ -1,33 +1,8 @@
-import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { NextResponse } from "next/server";
-import {
-  type ConclaveSiteVersionResponse,
-  normalizeConclaveSiteVersion,
-} from "@/app/lib/site-version";
-
-
-type VersionedCloudflareEnv = {
-  CF_VERSION_METADATA?: unknown;
-};
-
-const readCloudflareVersionMetadata = async (): Promise<unknown> => {
-  try {
-    const { env } = await getCloudflareContext({ async: true });
-    return (env as VersionedCloudflareEnv).CF_VERSION_METADATA;
-  } catch {
-    return null;
-  }
-};
+import { getConclaveVersionResponse } from "@/app/lib/site-version.server";
 
 export async function GET() {
-  const metadata = await readCloudflareVersionMetadata();
-  const fallbackId =
-    process.env.NEXT_PUBLIC_CONCLAVE_WEB_VERSION ??
-    process.env.CONCLAVE_WEB_VERSION ??
-    "local";
-  const body: ConclaveSiteVersionResponse = {
-    serviceVersion: normalizeConclaveSiteVersion(metadata, fallbackId),
-  };
+  const body = await getConclaveVersionResponse();
 
   return NextResponse.json(body, {
     headers: {

--- a/apps/web/src/app/components/ConclaveUpdatePill.tsx
+++ b/apps/web/src/app/components/ConclaveUpdatePill.tsx
@@ -6,22 +6,21 @@ import {
   type ConclaveSiteVersion,
   formatConclaveSiteVersionLabel,
   isConclaveSiteVersionResponse,
-  isSameConclaveSiteVersion,
+  resolveAvailableConclaveVersion,
 } from "../lib/site-version";
 
 const VERSION_POLL_INTERVAL_MS = 30_000;
-const AUTO_DISMISS_MS = 15_000;
-
-const shouldIgnoreVersion = (version: ConclaveSiteVersion): boolean =>
-  version.id === "local";
 
 const getVersionDismissalKey = (version: ConclaveSiteVersion): string =>
   [version.id, version.tag ?? "", version.timestamp ?? ""].join(":");
 
-export function ConclaveUpdatePill() {
-  // The first real version we observe becomes the baseline; any later
-  // version that differs from it means a deploy happened mid-session.
-  const baselineVersionRef = useRef<ConclaveSiteVersion | null>(null);
+export function ConclaveUpdatePill({
+  currentVersion,
+}: {
+  currentVersion: ConclaveSiteVersion;
+}) {
+  const currentVersionRef = useRef(currentVersion);
+  const fallbackBaselineRef = useRef<ConclaveSiteVersion | null>(null);
   const [availableVersion, setAvailableVersion] =
     useState<ConclaveSiteVersion | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -33,6 +32,10 @@ export function ConclaveUpdatePill() {
     : null;
   const isDismissed =
     availableVersionKey !== null && dismissedVersionKey === availableVersionKey;
+
+  useEffect(() => {
+    currentVersionRef.current = currentVersion;
+  }, [currentVersion]);
 
   const checkVersion = useCallback(async () => {
     try {
@@ -47,16 +50,28 @@ export function ConclaveUpdatePill() {
       const payload: unknown = await response.json();
       if (!isConclaveSiteVersionResponse(payload)) return;
 
-      const nextVersion = payload.serviceVersion;
-      if (shouldIgnoreVersion(nextVersion)) return;
-
-      if (!baselineVersionRef.current) {
-        baselineVersionRef.current = nextVersion;
+      const available = resolveAvailableConclaveVersion(
+        currentVersionRef.current,
+        payload,
+      );
+      if (available) {
+        setAvailableVersion(available);
         return;
       }
 
-      if (!isSameConclaveSiteVersion(baselineVersionRef.current, nextVersion)) {
-        setAvailableVersion(nextVersion);
+      const fallbackVersion = payload.clientVersion ?? payload.serviceVersion;
+      if (fallbackVersion.id === "local") return;
+      if (!fallbackBaselineRef.current) {
+        fallbackBaselineRef.current = fallbackVersion;
+        return;
+      }
+
+      const fallbackAvailable = resolveAvailableConclaveVersion(
+        fallbackBaselineRef.current,
+        payload,
+      );
+      if (fallbackAvailable) {
+        setAvailableVersion(fallbackAvailable);
       }
     } catch {
       // A version check should never interrupt the active page.
@@ -82,17 +97,6 @@ export function ConclaveUpdatePill() {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [checkVersion]);
-
-  // Auto-dismiss the pill a short while after it appears.
-  useEffect(() => {
-    if (!availableVersionKey || isDismissed) return;
-
-    const timeoutId = window.setTimeout(
-      () => setDismissedVersionKey(availableVersionKey),
-      AUTO_DISMISS_MS,
-    );
-    return () => window.clearTimeout(timeoutId);
-  }, [availableVersionKey, isDismissed]);
 
   const handleRefresh = useCallback(() => {
     setIsRefreshing(true);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import "./globals.css";
 import ConclaveUpdatePill from "./components/ConclaveUpdatePill";
 import TelemetryProvider from "./components/TelemetryProvider";
+import { getConclaveClientVersion } from "./lib/site-version.server";
 import { getPublicSiteUrl } from "@/lib/site-url";
 
 const siteUrl = getPublicSiteUrl();
@@ -58,12 +59,14 @@ export const viewport: Viewport = {
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const clientVersion = getConclaveClientVersion();
+
   return (
     <html lang="en">
       <body suppressHydrationWarning>
         <TelemetryProvider>
           {children}
-          <ConclaveUpdatePill />
+          <ConclaveUpdatePill currentVersion={clientVersion} />
         </TelemetryProvider>
       </body>
     </html>

--- a/apps/web/src/app/lib/site-version.server.ts
+++ b/apps/web/src/app/lib/site-version.server.ts
@@ -1,0 +1,48 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import {
+  type ConclaveSiteVersion,
+  type ConclaveSiteVersionResponse,
+  normalizeConclaveSiteVersion,
+} from "./site-version";
+
+type VersionedCloudflareEnv = {
+  CF_VERSION_METADATA?: unknown;
+};
+
+const readCloudflareVersionMetadata = async (): Promise<unknown> => {
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    return (env as VersionedCloudflareEnv).CF_VERSION_METADATA;
+  } catch {
+    return null;
+  }
+};
+
+export const getConclaveClientVersion = (): ConclaveSiteVersion =>
+  normalizeConclaveSiteVersion({
+    id:
+      process.env.NEXT_PUBLIC_CONCLAVE_CLIENT_VERSION ??
+      process.env.NEXT_PUBLIC_CONCLAVE_WEB_VERSION ??
+      process.env.CONCLAVE_WEB_VERSION ??
+      process.env.NEXT_BUILD_ID ??
+      process.env.OPEN_NEXT_BUILD_ID ??
+      "local",
+    tag:
+      process.env.NEXT_PUBLIC_CONCLAVE_CLIENT_VERSION_TAG ??
+      process.env.NEXT_PUBLIC_CONCLAVE_WEB_VERSION_TAG ??
+      null,
+    timestamp:
+      process.env.NEXT_PUBLIC_CONCLAVE_CLIENT_VERSION_TIMESTAMP ??
+      process.env.NEXT_PUBLIC_CONCLAVE_WEB_VERSION_TIMESTAMP ??
+      null,
+  });
+
+export const getConclaveVersionResponse =
+  async (): Promise<ConclaveSiteVersionResponse> => {
+    const clientVersion = getConclaveClientVersion();
+    const metadata = await readCloudflareVersionMetadata();
+    return {
+      serviceVersion: normalizeConclaveSiteVersion(metadata, clientVersion.id),
+      clientVersion,
+    };
+  };

--- a/apps/web/src/app/lib/site-version.ts
+++ b/apps/web/src/app/lib/site-version.ts
@@ -6,6 +6,7 @@ export interface ConclaveSiteVersion {
 
 export interface ConclaveSiteVersionResponse {
   serviceVersion: ConclaveSiteVersion;
+  clientVersion?: ConclaveSiteVersion;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -56,7 +57,10 @@ export const isConclaveSiteVersion = (
 export const isConclaveSiteVersionResponse = (
   value: unknown,
 ): value is ConclaveSiteVersionResponse =>
-  isRecord(value) && isConclaveSiteVersion(value.serviceVersion);
+  isRecord(value) &&
+  isConclaveSiteVersion(value.serviceVersion) &&
+  (value.clientVersion === undefined ||
+    isConclaveSiteVersion(value.clientVersion));
 
 export const isSameConclaveSiteVersion = (
   current: ConclaveSiteVersion,
@@ -82,4 +86,20 @@ export const formatConclaveSiteVersionLabel = (
   }
 
   return version.id === "local" ? "local" : version.id.slice(0, 8);
+};
+
+export const resolveAvailableConclaveVersion = (
+  currentClientVersion: ConclaveSiteVersion,
+  latest: ConclaveSiteVersionResponse,
+): ConclaveSiteVersion | null => {
+  const latestClientVersion = latest.clientVersion ?? latest.serviceVersion;
+  if (
+    currentClientVersion.id === "local" ||
+    latestClientVersion.id === "local"
+  ) {
+    return null;
+  }
+  return isSameConclaveSiteVersion(currentClientVersion, latestClientVersion)
+    ? null
+    : latest.serviceVersion;
 };

--- a/apps/web/test/site-version.test.ts
+++ b/apps/web/test/site-version.test.ts
@@ -4,6 +4,7 @@ import {
   isConclaveSiteVersionResponse,
   isSameConclaveSiteVersion,
   normalizeConclaveSiteVersion,
+  resolveAvailableConclaveVersion,
 } from "../src/app/lib/site-version";
 
 describe("site version helpers", () => {
@@ -37,12 +38,29 @@ describe("site version helpers", () => {
           tag: null,
           timestamp: null,
         },
+        clientVersion: {
+          id: "build-123",
+          tag: null,
+          timestamp: null,
+        },
       }),
     ).toBe(true);
     expect(
       isConclaveSiteVersionResponse({
         serviceVersion: {
           id: "version-123",
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isConclaveSiteVersionResponse({
+        serviceVersion: {
+          id: "version-123",
+          tag: null,
+          timestamp: null,
+        },
+        clientVersion: {
+          id: "build-123",
         },
       }),
     ).toBe(false);
@@ -64,5 +82,50 @@ describe("site version helpers", () => {
     expect(isSameConclaveSiteVersion(first, second)).toBe(false);
     expect(formatConclaveSiteVersionLabel(first)).toBe("abcdef12");
     expect(formatConclaveSiteVersionLabel(second)).toBe("main");
+  });
+
+  it("detects an available deploy from the rendered client build version", () => {
+    const currentClientVersion = {
+      id: "old-build",
+      tag: null,
+      timestamp: null,
+    };
+    const serviceVersion = {
+      id: "cloudflare-version",
+      tag: null,
+      timestamp: "2026-07-01T01:00:49.864152Z",
+    };
+
+    expect(
+      resolveAvailableConclaveVersion(currentClientVersion, {
+        serviceVersion,
+        clientVersion: {
+          id: "new-build",
+          tag: null,
+          timestamp: null,
+        },
+      }),
+    ).toEqual(serviceVersion);
+    expect(
+      resolveAvailableConclaveVersion(currentClientVersion, {
+        serviceVersion,
+        clientVersion: currentClientVersion,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not prompt for local builds", () => {
+    expect(
+      resolveAvailableConclaveVersion(
+        { id: "local", tag: null, timestamp: null },
+        {
+          serviceVersion: {
+            id: "new-version",
+            tag: null,
+            timestamp: null,
+          },
+        },
+      ),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR refactors the "new version available" detection system to compare the server-polled `clientVersion` against the version baked into the currently-rendered page, making update detection more reliable across Cloudflare Pages deployments. It also adds Vitest tests for the new `resolveAvailableConclaveVersion` helper and the updated `isConclaveSiteVersionResponse` type guard.

- `next.config.ts` now resolves the build SHA at build time (env vars → `git rev-parse HEAD` fallback) and injects it as `NEXT_PUBLIC_CONCLAVE_CLIENT_VERSION`, which `site-version.server.ts` reads to produce a `ConclaveSiteVersion` that is passed as a prop to `ConclaveUpdatePill`.
- The `/api/version` route now returns both `serviceVersion` (Cloudflare metadata) and `clientVersion` (the deployed build's ID), and `ConclaveUpdatePill` uses `resolveAvailableConclaveVersion` to diff the rendered version against the polled `clientVersion` before showing the update pill; the auto-dismiss timeout is removed.
- The test file covers the main happy paths for `resolveAvailableConclaveVersion` but leaves two branches untested: `latestClientVersion.id === "local"` (second guard condition) and the no-`clientVersion` differing-version path (exercises `?? latest.serviceVersion` as the comparison target).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the version-detection logic is correct and the fallback chain is well-guarded.

The refactor is sound and the new `resolveAvailableConclaveVersion` function handles all the meaningful edge cases (local builds, absent `clientVersion`, same-version no-ops). The only gaps are in the test file itself: two branches of the function under test go uncovered, and `getConclaveClientVersion` has a subtle coupling to `normalizeConclaveSiteVersion`'s internal field names that could silently break on a future refactor. Neither affects current behavior.

`apps/web/test/site-version.test.ts` would benefit from two more test cases; `apps/web/src/app/lib/site-version.server.ts` has the `normalizeConclaveSiteVersion` coupling worth watching.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/next.config.ts | Adds build-time SHA resolution via `readGitSha()` fallback chain and sets `NEXT_PUBLIC_CONCLAVE_CLIENT_VERSION` / `deploymentId` in the config; error-safe with try/catch. |
| apps/web/src/app/api/version/route.ts | Simplified to delegate to `getConclaveVersionResponse()`; now returns both `serviceVersion` and `clientVersion` in the API response. |
| apps/web/src/app/components/ConclaveUpdatePill.tsx | Refactored to accept `currentVersion` as a prop from the server layout; uses `resolveAvailableConclaveVersion` for primary detection with a fallback baseline ref; removes auto-dismiss timeout. |
| apps/web/src/app/layout.tsx | Calls `getConclaveClientVersion()` at render time and passes the resolved version to `ConclaveUpdatePill` as a prop. |
| apps/web/src/app/lib/site-version.server.ts | New server-only module; `getConclaveClientVersion()` passes a pre-formed ConclaveSiteVersion object to `normalizeConclaveSiteVersion` (works but creates field-name coupling); `getConclaveVersionResponse()` consolidates Cloudflare metadata + client version into the API response shape. |
| apps/web/src/app/lib/site-version.ts | Adds optional `clientVersion` to `ConclaveSiteVersionResponse`, updates the type guard accordingly, and introduces `resolveAvailableConclaveVersion` to compare server-polled client build against the rendered version. |
| apps/web/test/site-version.test.ts | Adds tests for `isConclaveSiteVersionResponse` with `clientVersion` and for `resolveAvailableConclaveVersion`; missing coverage for the `latestClientVersion.id === "local"` guard and the no-`clientVersion` differing-version path. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Build as next.config.ts
    participant Layout as RootLayout (SSR)
    participant Server as site-version.server.ts
    participant Client as ConclaveUpdatePill (client)
    participant API as /api/version

    Build->>Build: resolve conclaveClientVersion
    Build->>Build: set NEXT_PUBLIC_CONCLAVE_CLIENT_VERSION

    Layout->>Server: getConclaveClientVersion()
    Server-->>Layout: ConclaveSiteVersion (from env)
    Layout->>Client: currentVersion prop (SSR hydration)

    loop Every 30s / on tab focus
        Client->>API: GET /api/version
        API->>Server: getConclaveVersionResponse()
        Server->>Server: readCloudflareVersionMetadata()
        Server-->>API: "{ serviceVersion, clientVersion }"
        API-->>Client: JSON response

        alt clientVersion differs from currentVersion
            Client->>Client: setAvailableVersion(serviceVersion)
        else same version
            Client->>Client: accumulate fallbackBaselineRef
        end
    end

    Client->>Client: show update pill if availableVersion set
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Build as next.config.ts
    participant Layout as RootLayout (SSR)
    participant Server as site-version.server.ts
    participant Client as ConclaveUpdatePill (client)
    participant API as /api/version

    Build->>Build: resolve conclaveClientVersion
    Build->>Build: set NEXT_PUBLIC_CONCLAVE_CLIENT_VERSION

    Layout->>Server: getConclaveClientVersion()
    Server-->>Layout: ConclaveSiteVersion (from env)
    Layout->>Client: currentVersion prop (SSR hydration)

    loop Every 30s / on tab focus
        Client->>API: GET /api/version
        API->>Server: getConclaveVersionResponse()
        Server->>Server: readCloudflareVersionMetadata()
        Server-->>API: "{ serviceVersion, clientVersion }"
        API-->>Client: JSON response

        alt clientVersion differs from currentVersion
            Client->>Client: setAvailableVersion(serviceVersion)
        else same version
            Client->>Client: accumulate fallbackBaselineRef
        end
    end

    Client->>Client: show update pill if availableVersion set
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/test/site-version.test.ts`, line 1-10 ([link](https://github.com/acm-vit/conclave/blob/2f0c2a53dd48d9e22f024e3424d6f000fefba46b/apps/web/test/site-version.test.ts#L1-L10)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Commit message "add test" is too broad for this change**

   The commit message doesn't reflect the full scope of the PR, which also introduces `site-version.server.ts`, adds `clientVersion` to the API response shape, refactors `ConclaveUpdatePill` to accept a `currentVersion` prop, removes auto-dismiss behavior, and wires the build SHA into `next.config.ts`. A more descriptive message (e.g., `refactor: pass client build version to UpdatePill, add resolveAvailableConclaveVersion tests`) would make bisect, changelog generation, and code archaeology meaningfully easier.

   **Context Used:** Encourage people to write better commit messages ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Ftest%2Fsite-version.test.ts%0ALine%3A%201-10%0A%0AComment%3A%0A**Commit%20message%20%22add%20test%22%20is%20too%20broad%20for%20this%20change**%0A%0AThe%20commit%20message%20doesn't%20reflect%20the%20full%20scope%20of%20the%20PR%2C%20which%20also%20introduces%20%60site-version.server.ts%60%2C%20adds%20%60clientVersion%60%20to%20the%20API%20response%20shape%2C%20refactors%20%60ConclaveUpdatePill%60%20to%20accept%20a%20%60currentVersion%60%20prop%2C%20removes%20auto-dismiss%20behavior%2C%20and%20wires%20the%20build%20SHA%20into%20%60next.config.ts%60.%20A%20more%20descriptive%20message%20%28e.g.%2C%20%60refactor%3A%20pass%20client%20build%20version%20to%20UpdatePill%2C%20add%20resolveAvailableConclaveVersion%20tests%60%29%20would%20make%20bisect%2C%20changelog%20generation%2C%20and%20code%20archaeology%20meaningfully%20easier.%0A%0A**Context%20Used%3A**%20Encourage%20people%20to%20write%20better%20commit%20messages%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dinstruction-0%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=140&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Ftest%2Fsite-version.test.ts%0ALine%3A%201-10%0A%0AComment%3A%0A**Commit%20message%20%22add%20test%22%20is%20too%20broad%20for%20this%20change**%0A%0AThe%20commit%20message%20doesn't%20reflect%20the%20full%20scope%20of%20the%20PR%2C%20which%20also%20introduces%20%60site-version.server.ts%60%2C%20adds%20%60clientVersion%60%20to%20the%20API%20response%20shape%2C%20refactors%20%60ConclaveUpdatePill%60%20to%20accept%20a%20%60currentVersion%60%20prop%2C%20removes%20auto-dismiss%20behavior%2C%20and%20wires%20the%20build%20SHA%20into%20%60next.config.ts%60.%20A%20more%20descriptive%20message%20%28e.g.%2C%20%60refactor%3A%20pass%20client%20build%20version%20to%20UpdatePill%2C%20add%20resolveAvailableConclaveVersion%20tests%60%29%20would%20make%20bisect%2C%20changelog%20generation%2C%20and%20code%20archaeology%20meaningfully%20easier.%0A%0A**Context%20Used%3A**%20Encourage%20people%20to%20write%20better%20commit%20messages%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dinstruction-0%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=140&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Ftest%2Fsite-version.test.ts%0ALine%3A%201-10%0A%0AComment%3A%0A**Commit%20message%20%22add%20test%22%20is%20too%20broad%20for%20this%20change**%0A%0AThe%20commit%20message%20doesn't%20reflect%20the%20full%20scope%20of%20the%20PR%2C%20which%20also%20introduces%20%60site-version.server.ts%60%2C%20adds%20%60clientVersion%60%20to%20the%20API%20response%20shape%2C%20refactors%20%60ConclaveUpdatePill%60%20to%20accept%20a%20%60currentVersion%60%20prop%2C%20removes%20auto-dismiss%20behavior%2C%20and%20wires%20the%20build%20SHA%20into%20%60next.config.ts%60.%20A%20more%20descriptive%20message%20%28e.g.%2C%20%60refactor%3A%20pass%20client%20build%20version%20to%20UpdatePill%2C%20add%20resolveAvailableConclaveVersion%20tests%60%29%20would%20make%20bisect%2C%20changelog%20generation%2C%20and%20code%20archaeology%20meaningfully%20easier.%0A%0A**Context%20Used%3A**%20Encourage%20people%20to%20write%20better%20commit%20messages%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dinstruction-0%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=140&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Ftest%2Fsite-version.test.ts%3A117-130%0A**Missing%20test%20for%20%60latestClientVersion.id%20%3D%3D%3D%20%22local%22%60%20guard**%0A%0AThe%20%22does%20not%20prompt%20for%20local%20builds%22%20test%20only%20covers%20the%20%60currentClientVersion.id%20%3D%3D%3D%20%22local%22%60%20branch.%20The%20second%20condition%20in%20%60resolveAvailableConclaveVersion%60%20%E2%80%94%20%60latestClientVersion.id%20%3D%3D%3D%20%22local%22%60%20%E2%80%94%20is%20never%20exercised.%20This%20matters%20because%20%60latestClientVersion%60%20falls%20back%20to%20%60latest.serviceVersion%60%20when%20%60clientVersion%60%20is%20absent%2C%20so%20passing%20a%20response%20with%20no%20%60clientVersion%60%20and%20%60serviceVersion.id%20%3D%3D%3D%20%22local%22%60%20should%20also%20return%20%60null%60.%20Additionally%2C%20there%20is%20no%20test%20for%20the%20case%20where%20%60clientVersion%60%20is%20absent%20from%20the%20response%20but%20%60serviceVersion.id%60%20differs%20from%20%60currentClientVersion.id%60%2C%20which%20would%20exercise%20the%20%60%3F%3F%20latest.serviceVersion%60%20path%20as%20the%20comparison%20target%20and%20expect%20a%20non-null%20return.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Flib%2Fsite-version.server.ts%3A21-38%0A**%60normalizeConclaveSiteVersion%60%20used%20with%20a%20pre-formed%20object**%0A%0A%60getConclaveClientVersion%60%20passes%20a%20hand-constructed%20%60%7B%20id%2C%20tag%2C%20timestamp%20%7D%60%20object%20to%20%60normalizeConclaveSiteVersion%60%2C%20a%20helper%20designed%20for%20raw%20Cloudflare%20metadata.%20It%20happens%20to%20work%20because%20the%20field%20names%20%28%60id%60%2C%20%60tag%60%2C%20%60timestamp%60%29%20match%20the%20metadata%20keys%20the%20normalizer%20looks%20for%2C%20but%20any%20future%20refactor%20that%20changes%20those%20keys%20%28e.g.%2C%20renaming%20%60metadata.tag%60%20to%20%60metadata.version_tag%60%20as%20the%20primary%20lookup%29%20would%20silently%20break%20this%20call%20site.%20Returning%20a%20plain%20%60ConclaveSiteVersion%60%20literal%20directly%20would%20make%20the%20intent%20clearer%20and%20decouple%20%60getConclaveClientVersion%60%20from%20%60normalizeConclaveSiteVersion%60's%20internal%20field-name%20assumptions.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Ftest%2Fsite-version.test.ts%3A1-10%0A**Commit%20message%20%22add%20test%22%20is%20too%20broad%20for%20this%20change**%0A%0AThe%20commit%20message%20doesn't%20reflect%20the%20full%20scope%20of%20the%20PR%2C%20which%20also%20introduces%20%60site-version.server.ts%60%2C%20adds%20%60clientVersion%60%20to%20the%20API%20response%20shape%2C%20refactors%20%60ConclaveUpdatePill%60%20to%20accept%20a%20%60currentVersion%60%20prop%2C%20removes%20auto-dismiss%20behavior%2C%20and%20wires%20the%20build%20SHA%20into%20%60next.config.ts%60.%20A%20more%20descriptive%20message%20%28e.g.%2C%20%60refactor%3A%20pass%20client%20build%20version%20to%20UpdatePill%2C%20add%20resolveAvailableConclaveVersion%20tests%60%29%20would%20make%20bisect%2C%20changelog%20generation%2C%20and%20code%20archaeology%20meaningfully%20easier.%0A%0A&repo=acm-vit%2Fconclave&pr=140&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Ftest%2Fsite-version.test.ts%3A117-130%0A**Missing%20test%20for%20%60latestClientVersion.id%20%3D%3D%3D%20%22local%22%60%20guard**%0A%0AThe%20%22does%20not%20prompt%20for%20local%20builds%22%20test%20only%20covers%20the%20%60currentClientVersion.id%20%3D%3D%3D%20%22local%22%60%20branch.%20The%20second%20condition%20in%20%60resolveAvailableConclaveVersion%60%20%E2%80%94%20%60latestClientVersion.id%20%3D%3D%3D%20%22local%22%60%20%E2%80%94%20is%20never%20exercised.%20This%20matters%20because%20%60latestClientVersion%60%20falls%20back%20to%20%60latest.serviceVersion%60%20when%20%60clientVersion%60%20is%20absent%2C%20so%20passing%20a%20response%20with%20no%20%60clientVersion%60%20and%20%60serviceVersion.id%20%3D%3D%3D%20%22local%22%60%20should%20also%20return%20%60null%60.%20Additionally%2C%20there%20is%20no%20test%20for%20the%20case%20where%20%60clientVersion%60%20is%20absent%20from%20the%20response%20but%20%60serviceVersion.id%60%20differs%20from%20%60currentClientVersion.id%60%2C%20which%20would%20exercise%20the%20%60%3F%3F%20latest.serviceVersion%60%20path%20as%20the%20comparison%20target%20and%20expect%20a%20non-null%20return.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Flib%2Fsite-version.server.ts%3A21-38%0A**%60normalizeConclaveSiteVersion%60%20used%20with%20a%20pre-formed%20object**%0A%0A%60getConclaveClientVersion%60%20passes%20a%20hand-constructed%20%60%7B%20id%2C%20tag%2C%20timestamp%20%7D%60%20object%20to%20%60normalizeConclaveSiteVersion%60%2C%20a%20helper%20designed%20for%20raw%20Cloudflare%20metadata.%20It%20happens%20to%20work%20because%20the%20field%20names%20%28%60id%60%2C%20%60tag%60%2C%20%60timestamp%60%29%20match%20the%20metadata%20keys%20the%20normalizer%20looks%20for%2C%20but%20any%20future%20refactor%20that%20changes%20those%20keys%20%28e.g.%2C%20renaming%20%60metadata.tag%60%20to%20%60metadata.version_tag%60%20as%20the%20primary%20lookup%29%20would%20silently%20break%20this%20call%20site.%20Returning%20a%20plain%20%60ConclaveSiteVersion%60%20literal%20directly%20would%20make%20the%20intent%20clearer%20and%20decouple%20%60getConclaveClientVersion%60%20from%20%60normalizeConclaveSiteVersion%60's%20internal%20field-name%20assumptions.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Ftest%2Fsite-version.test.ts%3A1-10%0A**Commit%20message%20%22add%20test%22%20is%20too%20broad%20for%20this%20change**%0A%0AThe%20commit%20message%20doesn't%20reflect%20the%20full%20scope%20of%20the%20PR%2C%20which%20also%20introduces%20%60site-version.server.ts%60%2C%20adds%20%60clientVersion%60%20to%20the%20API%20response%20shape%2C%20refactors%20%60ConclaveUpdatePill%60%20to%20accept%20a%20%60currentVersion%60%20prop%2C%20removes%20auto-dismiss%20behavior%2C%20and%20wires%20the%20build%20SHA%20into%20%60next.config.ts%60.%20A%20more%20descriptive%20message%20%28e.g.%2C%20%60refactor%3A%20pass%20client%20build%20version%20to%20UpdatePill%2C%20add%20resolveAvailableConclaveVersion%20tests%60%29%20would%20make%20bisect%2C%20changelog%20generation%2C%20and%20code%20archaeology%20meaningfully%20easier.%0A%0A&repo=acm-vit%2Fconclave&pr=140&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Ftest%2Fsite-version.test.ts%3A117-130%0A**Missing%20test%20for%20%60latestClientVersion.id%20%3D%3D%3D%20%22local%22%60%20guard**%0A%0AThe%20%22does%20not%20prompt%20for%20local%20builds%22%20test%20only%20covers%20the%20%60currentClientVersion.id%20%3D%3D%3D%20%22local%22%60%20branch.%20The%20second%20condition%20in%20%60resolveAvailableConclaveVersion%60%20%E2%80%94%20%60latestClientVersion.id%20%3D%3D%3D%20%22local%22%60%20%E2%80%94%20is%20never%20exercised.%20This%20matters%20because%20%60latestClientVersion%60%20falls%20back%20to%20%60latest.serviceVersion%60%20when%20%60clientVersion%60%20is%20absent%2C%20so%20passing%20a%20response%20with%20no%20%60clientVersion%60%20and%20%60serviceVersion.id%20%3D%3D%3D%20%22local%22%60%20should%20also%20return%20%60null%60.%20Additionally%2C%20there%20is%20no%20test%20for%20the%20case%20where%20%60clientVersion%60%20is%20absent%20from%20the%20response%20but%20%60serviceVersion.id%60%20differs%20from%20%60currentClientVersion.id%60%2C%20which%20would%20exercise%20the%20%60%3F%3F%20latest.serviceVersion%60%20path%20as%20the%20comparison%20target%20and%20expect%20a%20non-null%20return.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Flib%2Fsite-version.server.ts%3A21-38%0A**%60normalizeConclaveSiteVersion%60%20used%20with%20a%20pre-formed%20object**%0A%0A%60getConclaveClientVersion%60%20passes%20a%20hand-constructed%20%60%7B%20id%2C%20tag%2C%20timestamp%20%7D%60%20object%20to%20%60normalizeConclaveSiteVersion%60%2C%20a%20helper%20designed%20for%20raw%20Cloudflare%20metadata.%20It%20happens%20to%20work%20because%20the%20field%20names%20%28%60id%60%2C%20%60tag%60%2C%20%60timestamp%60%29%20match%20the%20metadata%20keys%20the%20normalizer%20looks%20for%2C%20but%20any%20future%20refactor%20that%20changes%20those%20keys%20%28e.g.%2C%20renaming%20%60metadata.tag%60%20to%20%60metadata.version_tag%60%20as%20the%20primary%20lookup%29%20would%20silently%20break%20this%20call%20site.%20Returning%20a%20plain%20%60ConclaveSiteVersion%60%20literal%20directly%20would%20make%20the%20intent%20clearer%20and%20decouple%20%60getConclaveClientVersion%60%20from%20%60normalizeConclaveSiteVersion%60's%20internal%20field-name%20assumptions.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Ftest%2Fsite-version.test.ts%3A1-10%0A**Commit%20message%20%22add%20test%22%20is%20too%20broad%20for%20this%20change**%0A%0AThe%20commit%20message%20doesn't%20reflect%20the%20full%20scope%20of%20the%20PR%2C%20which%20also%20introduces%20%60site-version.server.ts%60%2C%20adds%20%60clientVersion%60%20to%20the%20API%20response%20shape%2C%20refactors%20%60ConclaveUpdatePill%60%20to%20accept%20a%20%60currentVersion%60%20prop%2C%20removes%20auto-dismiss%20behavior%2C%20and%20wires%20the%20build%20SHA%20into%20%60next.config.ts%60.%20A%20more%20descriptive%20message%20%28e.g.%2C%20%60refactor%3A%20pass%20client%20build%20version%20to%20UpdatePill%2C%20add%20resolveAvailableConclaveVersion%20tests%60%29%20would%20make%20bisect%2C%20changelog%20generation%2C%20and%20code%20archaeology%20meaningfully%20easier.%0A%0A&pr=140&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["add test"](https://github.com/acm-vit/conclave/commit/2f0c2a53dd48d9e22f024e3424d6f000fefba46b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40986703)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - Encourage people to write better commit messages ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->