### PR TITLE
feat(game): add votedPlayerIds to track players who have locked in votes

### DIFF
--- a/apps/web/src/app/[code]/page.tsx
+++ b/apps/web/src/app/[code]/page.tsx
@@ -149,6 +149,7 @@ async function MeetRoomContent({ params, searchParams }: MeetRoomPageProps) {
       return (
         <ScheduledMeetingLanding
           meeting={scheduled}
+          clientId={scheduledClientId}
           viewerIsHost={viewerIsHost}
         />
       );

--- a/apps/web/src/app/api/sfu/join/route.ts
+++ b/apps/web/src/app/api/sfu/join/route.ts
@@ -81,6 +81,11 @@ type SfuStatusResponse = {
   rooms?: number;
 };
 
+type AvailableSfu = {
+  index: number;
+  url: string;
+};
+
 const splitUrls = (value: string | undefined): string[] =>
   (value ?? "")
     .split(",")
@@ -147,6 +152,19 @@ const fetchWithTimeout = async (
   }
 };
 
+const pickStableSfuUrl = (
+  available: AvailableSfu[],
+  routingKey: string,
+): string | null => {
+  if (available.length === 0) return null;
+  if (available.length === 1) return available[0]?.url ?? null;
+
+  const ordered = [...available].sort((a, b) => a.index - b.index);
+  const digest = createHash("sha256").update(routingKey).digest();
+  const index = digest.readUInt32BE(0) % ordered.length;
+  return ordered[index]?.url ?? null;
+};
+
 const resolveRoomOwnerSfuUrl = async (options: {
   candidateSfuUrls: string[];
   secret: string;
@@ -211,6 +229,7 @@ const resolveRoomOwnerSfuUrl = async (options: {
 const resolveNonDrainingSfuUrl = async (options: {
   candidateSfuUrls: string[];
   secret: string;
+  routingKey: string;
 }): Promise<string | null> => {
   const statuses = await Promise.allSettled(
     options.candidateSfuUrls.map(async (candidateSfuUrl, index) => {
@@ -235,11 +254,7 @@ const resolveNonDrainingSfuUrl = async (options: {
         return null;
       }
 
-      const rooms =
-        typeof status.rooms === "number" && Number.isFinite(status.rooms)
-          ? status.rooms
-          : Number.MAX_SAFE_INTEGER;
-      return { index, rooms, url: candidateSfuUrl };
+      return { index, url: candidateSfuUrl } satisfies AvailableSfu;
     }),
   );
 
@@ -265,8 +280,10 @@ const resolveNonDrainingSfuUrl = async (options: {
     return null;
   }
 
-  available.sort((a, b) => a.rooms - b.rooms || a.index - b.index);
-  return available[0]?.url ?? null;
+  // Before any SFU owns a room, concurrent first joins for the same link must
+  // still land on the same instance. Otherwise a degraded/missing registry can
+  // split one meeting code into parallel rooms.
+  return pickStableSfuUrl(available, options.routingKey);
 };
 
 const resolveRoutedSfuUrl = async (options: {
@@ -293,6 +310,7 @@ const resolveRoutedSfuUrl = async (options: {
   const availableSfuUrl = await resolveNonDrainingSfuUrl({
     candidateSfuUrls,
     secret: options.secret,
+    routingKey: `${options.clientId}:${options.roomId}`,
   });
   return availableSfuUrl ?? fallbackSfuUrl;
 };

--- a/apps/web/src/app/api/youtube/rate-limit.ts
+++ b/apps/web/src/app/api/youtube/rate-limit.ts
@@ -1,0 +1,146 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { NextResponse } from "next/server";
+
+type RateLimitBucket = {
+  windowStartedAt: number;
+  count: number;
+};
+
+type RateLimitOptions = {
+  scope: string;
+  binding: "YOUTUBE_SEARCH_RATE_LIMITER" | "YOUTUBE_TRENDING_RATE_LIMITER";
+  limit: number;
+  windowMs: number;
+};
+
+type RateLimitResult =
+  | { ok: true }
+  | { ok: false; retryAfterSeconds: number; status: 429 | 503; error: string };
+
+type CloudflareRateLimitBinding = {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+};
+
+type YouTubeCloudflareEnv = Partial<
+  Record<RateLimitOptions["binding"], CloudflareRateLimitBinding>
+>;
+
+const MAX_BUCKETS = 1_000;
+const buckets = new Map<string, RateLimitBucket>();
+
+const clientKey = (request: Request): string => {
+  const forwardedFor = request.headers
+    .get("x-forwarded-for")
+    ?.split(",")
+    .at(0)
+    ?.trim();
+  const candidate =
+    [
+      request.headers.get("cf-connecting-ip")?.trim(),
+      request.headers.get("x-real-ip")?.trim(),
+      forwardedFor,
+      request.headers.get("user-agent")?.trim(),
+    ].find((value): value is string => Boolean(value)) ?? "anonymous";
+
+  return candidate.slice(0, 128);
+};
+
+const trimBuckets = (): void => {
+  while (buckets.size > MAX_BUCKETS) {
+    const oldest = buckets.keys().next().value;
+    if (oldest === undefined) return;
+    buckets.delete(oldest);
+  }
+};
+
+const readCloudflareRateLimitBinding = async (
+  binding: RateLimitOptions["binding"],
+): Promise<CloudflareRateLimitBinding | null> => {
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    const limiter = (env as YouTubeCloudflareEnv)[binding];
+    return limiter && typeof limiter.limit === "function" ? limiter : null;
+  } catch {
+    return null;
+  }
+};
+
+const takeLocalRateLimit = (
+  key: string,
+  options: RateLimitOptions,
+): RateLimitResult => {
+  const now = Date.now();
+  const current = buckets.get(key);
+
+  if (!current || now - current.windowStartedAt >= options.windowMs) {
+    buckets.set(key, { windowStartedAt: now, count: 1 });
+    trimBuckets();
+    return { ok: true };
+  }
+
+  if (current.count >= options.limit) {
+    return {
+      ok: false,
+      status: 429,
+      error: "Too many YouTube requests",
+      retryAfterSeconds: Math.max(
+        1,
+        Math.ceil((options.windowMs - (now - current.windowStartedAt)) / 1_000),
+      ),
+    };
+  }
+
+  current.count += 1;
+  return { ok: true };
+};
+
+export const takeYouTubeRateLimit = async (
+  request: Request,
+  options: RateLimitOptions,
+): Promise<RateLimitResult> => {
+  const key = `${options.scope}:${clientKey(request)}`;
+  const limiter = await readCloudflareRateLimitBinding(options.binding);
+
+  if (limiter) {
+    try {
+      const { success } = await limiter.limit({ key });
+      return success
+        ? { ok: true }
+        : {
+            ok: false,
+            status: 429,
+            error: "Too many YouTube requests",
+            retryAfterSeconds: Math.max(1, Math.ceil(options.windowMs / 1_000)),
+          };
+    } catch {
+      // Fall through to the production fail-closed branch below.
+    }
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    return {
+      ok: false,
+      status: 503,
+      error: "YouTube rate limiter is not configured",
+      retryAfterSeconds: Math.max(1, Math.ceil(options.windowMs / 1_000)),
+    };
+  }
+
+  return takeLocalRateLimit(key, options);
+};
+
+// Typed as plain Response: @opennextjs/cloudflare pulls its own copy of the
+// next types, and annotating the richer NextResponse here trips a structural
+// mismatch between the two copies. Route handlers accept Response fine.
+export const youtubeRateLimitResponse = (
+  result: Extract<RateLimitResult, { ok: false }>,
+): Response =>
+  NextResponse.json(
+    { error: result.error },
+    {
+      status: result.status,
+      headers: {
+        "Retry-After": String(result.retryAfterSeconds),
+      },
+    },
+  );

--- a/apps/web/src/app/api/youtube/search/route.ts
+++ b/apps/web/src/app/api/youtube/search/route.ts
@@ -1,0 +1,200 @@
+import { NextResponse } from "next/server";
+import {
+  takeYouTubeRateLimit,
+  youtubeRateLimitResponse,
+} from "../rate-limit";
+
+// Server-side proxy for YouTube Data API search, so the API key never reaches
+// the client. Only embeddable videos are returned, since the watch app plays
+// through the iframe player. Search costs 100 quota units per call (plus one
+// unit to enrich results with duration and view counts), so results are cached
+// briefly and the client only searches on submit.
+
+const YOUTUBE_SEARCH_URL = "https://www.googleapis.com/youtube/v3/search";
+const YOUTUBE_VIDEOS_URL = "https://www.googleapis.com/youtube/v3/videos";
+const MAX_QUERY_LENGTH = 100;
+const MAX_RESULTS = 12;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_MAX_ENTRIES = 64;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_REQUESTS = 8;
+
+export type YouTubeSearchItem = {
+  videoId: string;
+  title: string;
+  channel: string;
+  thumbnail: string | null;
+  durationSeconds: number | null;
+  views: number | null;
+  publishedAt: string | null;
+};
+
+const cache = new Map<string, { at: number; items: YouTubeSearchItem[] }>();
+
+const readCache = (key: string): YouTubeSearchItem[] | null => {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.at > CACHE_TTL_MS) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.items;
+};
+
+const writeCache = (key: string, items: YouTubeSearchItem[]): void => {
+  if (cache.size >= CACHE_MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(key, { at: Date.now(), items });
+};
+
+/** Parse an ISO 8601 duration (PT1H2M3S) into seconds; null when unknown. */
+export const parseIsoDuration = (value: unknown): number | null => {
+  if (typeof value !== "string") return null;
+  const match = value.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/);
+  if (!match) return null;
+  const hours = Number(match[1] ?? 0);
+  const minutes = Number(match[2] ?? 0);
+  const seconds = Number(match[3] ?? 0);
+  return hours * 3600 + minutes * 60 + seconds;
+};
+
+type SearchResponse = {
+  items?: Array<{
+    id?: { videoId?: unknown };
+    snippet?: {
+      title?: unknown;
+      channelTitle?: unknown;
+      publishedAt?: unknown;
+      thumbnails?: { medium?: { url?: unknown }; default?: { url?: unknown } };
+    };
+  }>;
+};
+
+type VideoDetailsResponse = {
+  items?: Array<{
+    id?: unknown;
+    contentDetails?: { duration?: unknown };
+    statistics?: { viewCount?: unknown };
+  }>;
+};
+
+export async function GET(request: Request): Promise<Response> {
+  const apiKey = process.env.YOUTUBE_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "YouTube search is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const query = new URL(request.url).searchParams
+    .get("q")
+    ?.trim()
+    .slice(0, MAX_QUERY_LENGTH);
+  if (!query) {
+    return NextResponse.json({ error: "Missing query" }, { status: 400 });
+  }
+
+  const cacheKey = query.toLowerCase();
+  const cached = readCache(cacheKey);
+  if (cached) {
+    return NextResponse.json({ items: cached });
+  }
+
+  const rateLimit = await takeYouTubeRateLimit(request, {
+    scope: "search",
+    binding: "YOUTUBE_SEARCH_RATE_LIMITER",
+    limit: RATE_LIMIT_REQUESTS,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+  });
+  if (!rateLimit.ok) {
+    return youtubeRateLimitResponse(rateLimit);
+  }
+
+  const searchUrl = new URL(YOUTUBE_SEARCH_URL);
+  searchUrl.searchParams.set("part", "snippet");
+  searchUrl.searchParams.set("type", "video");
+  searchUrl.searchParams.set("videoEmbeddable", "true");
+  searchUrl.searchParams.set("maxResults", String(MAX_RESULTS));
+  searchUrl.searchParams.set("regionCode", "US");
+  searchUrl.searchParams.set("relevanceLanguage", "en");
+  searchUrl.searchParams.set("q", query);
+  searchUrl.searchParams.set("key", apiKey);
+
+  try {
+    const searchResponse = await fetch(searchUrl, { cache: "no-store" });
+    if (!searchResponse.ok) {
+      return NextResponse.json(
+        { error: "YouTube search failed" },
+        { status: 502 },
+      );
+    }
+    const payload = (await searchResponse.json()) as SearchResponse;
+
+    const base: YouTubeSearchItem[] = [];
+    for (const item of payload.items ?? []) {
+      const videoId = item.id?.videoId;
+      const title = item.snippet?.title;
+      if (typeof videoId !== "string" || typeof title !== "string") continue;
+      const thumb =
+        item.snippet?.thumbnails?.medium?.url ??
+        item.snippet?.thumbnails?.default?.url;
+      base.push({
+        videoId,
+        title,
+        channel:
+          typeof item.snippet?.channelTitle === "string"
+            ? item.snippet.channelTitle
+            : "",
+        thumbnail: typeof thumb === "string" ? thumb : null,
+        durationSeconds: null,
+        views: null,
+        publishedAt:
+          typeof item.snippet?.publishedAt === "string"
+            ? item.snippet.publishedAt
+            : null,
+      });
+    }
+
+    // Enrich with duration and views in one cheap batch call; best effort.
+    if (base.length > 0) {
+      const detailsUrl = new URL(YOUTUBE_VIDEOS_URL);
+      detailsUrl.searchParams.set("part", "contentDetails,statistics");
+      detailsUrl.searchParams.set("id", base.map((v) => v.videoId).join(","));
+      detailsUrl.searchParams.set("key", apiKey);
+      try {
+        const detailsResponse = await fetch(detailsUrl, { cache: "no-store" });
+        if (detailsResponse.ok) {
+          const details =
+            (await detailsResponse.json()) as VideoDetailsResponse;
+          const byId = new Map(
+            (details.items ?? [])
+              .filter((item) => typeof item.id === "string")
+              .map((item) => [item.id as string, item]),
+          );
+          for (const item of base) {
+            const info = byId.get(item.videoId);
+            if (!info) continue;
+            item.durationSeconds = parseIsoDuration(
+              info.contentDetails?.duration,
+            );
+            const views = Number(info.statistics?.viewCount);
+            item.views = Number.isFinite(views) ? views : null;
+          }
+        }
+      } catch {
+        /* enrichment is optional */
+      }
+    }
+
+    writeCache(cacheKey, base);
+    return NextResponse.json({ items: base });
+  } catch {
+    return NextResponse.json(
+      { error: "YouTube search failed" },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/src/app/api/youtube/trending/route.ts
+++ b/apps/web/src/app/api/youtube/trending/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from "next/server";
+import { parseIsoDuration, type YouTubeSearchItem } from "../search/route";
+import {
+  takeYouTubeRateLimit,
+  youtubeRateLimitResponse,
+} from "../rate-limit";
+
+// Trending videos for the watch app's browse surface. Cheap (1 quota unit) but
+// cached server-side anyway so a busy meeting does not refetch it per client.
+
+const YOUTUBE_VIDEOS_URL = "https://www.googleapis.com/youtube/v3/videos";
+const REGION_CODE = "US";
+const MAX_RESULTS = 12;
+const CACHE_TTL_MS = 15 * 60 * 1000;
+const CACHE_MAX_ENTRIES = 16;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_REQUESTS = 30;
+
+type TrendingPage = {
+  at: number;
+  items: YouTubeSearchItem[];
+  nextPageToken: string | null;
+};
+
+// One entry per page token ("" = first page), so infinite scroll stays cached.
+const pageCache = new Map<string, TrendingPage>();
+
+type VideosResponse = {
+  items?: Array<{
+    id?: unknown;
+    snippet?: {
+      title?: unknown;
+      channelTitle?: unknown;
+      publishedAt?: unknown;
+      thumbnails?: { medium?: { url?: unknown }; default?: { url?: unknown } };
+    };
+    contentDetails?: { duration?: unknown };
+    statistics?: { viewCount?: unknown };
+  }>;
+};
+
+const mapItems = (payload: VideosResponse): YouTubeSearchItem[] => {
+  const items: YouTubeSearchItem[] = [];
+  for (const item of payload.items ?? []) {
+    const videoId = item.id;
+    const title = item.snippet?.title;
+    if (typeof videoId !== "string" || typeof title !== "string") continue;
+    const thumb =
+      item.snippet?.thumbnails?.medium?.url ??
+      item.snippet?.thumbnails?.default?.url;
+    const views = Number(item.statistics?.viewCount);
+    items.push({
+      videoId,
+      title,
+      channel:
+        typeof item.snippet?.channelTitle === "string"
+          ? item.snippet.channelTitle
+          : "",
+      thumbnail: typeof thumb === "string" ? thumb : null,
+      durationSeconds: parseIsoDuration(item.contentDetails?.duration),
+      views: Number.isFinite(views) ? views : null,
+      publishedAt:
+        typeof item.snippet?.publishedAt === "string"
+          ? item.snippet.publishedAt
+          : null,
+    });
+  }
+  return items;
+};
+
+export async function GET(request: Request): Promise<Response> {
+  const apiKey = process.env.YOUTUBE_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "YouTube browse is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const pageToken =
+    new URL(request.url).searchParams.get("pageToken")?.trim().slice(0, 64) ??
+    "";
+
+  const cached = pageCache.get(pageToken);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return NextResponse.json({
+      items: cached.items,
+      nextPageToken: cached.nextPageToken,
+    });
+  }
+
+  const rateLimit = await takeYouTubeRateLimit(request, {
+    scope: "trending",
+    binding: "YOUTUBE_TRENDING_RATE_LIMITER",
+    limit: RATE_LIMIT_REQUESTS,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+  });
+  if (!rateLimit.ok) {
+    return youtubeRateLimitResponse(rateLimit);
+  }
+
+  const url = new URL(YOUTUBE_VIDEOS_URL);
+  url.searchParams.set("part", "snippet,contentDetails,statistics");
+  url.searchParams.set("chart", "mostPopular");
+  url.searchParams.set("regionCode", REGION_CODE);
+  url.searchParams.set("maxResults", String(MAX_RESULTS));
+  if (pageToken) url.searchParams.set("pageToken", pageToken);
+  url.searchParams.set("key", apiKey);
+
+  try {
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: "YouTube browse failed" },
+        { status: 502 },
+      );
+    }
+    const payload = (await response.json()) as VideosResponse & {
+      nextPageToken?: unknown;
+    };
+    const items = mapItems(payload);
+    const nextPageToken =
+      typeof payload.nextPageToken === "string" ? payload.nextPageToken : null;
+    if (pageCache.size >= CACHE_MAX_ENTRIES) {
+      const oldest = pageCache.keys().next().value;
+      if (oldest !== undefined) pageCache.delete(oldest);
+    }
+    pageCache.set(pageToken, { at: Date.now(), items, nextPageToken });
+    return NextResponse.json({ items, nextPageToken });
+  } catch {
+    return NextResponse.json(
+      { error: "YouTube browse failed" },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/src/app/components/CatchUpPill.tsx
+++ b/apps/web/src/app/components/CatchUpPill.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { X } from "lucide-react";
+import { useCallback, useState } from "react";
+
+/**
+ * A quiet, dismissible chip for late joiners while the meeting assistant is
+ * live: one tap opens the transcript panel on the minutes tab, which already
+ * holds a self-updating summary of everything they missed.
+ *
+ * Deliberately gated so it never nags: it only exists when a transcript
+ * session is running (the assistant is strictly opt-in per meeting), only for
+ * people who joined meaningfully after it started, and once dismissed it stays
+ * gone for that session.
+ */
+
+const MIN_MISSED_MS = 2 * 60 * 1000;
+
+const dismissalKey = (sessionKey: string): string =>
+  `conclave.catchup.dismissed.${sessionKey}`;
+
+const readDismissed = (sessionKey: string): boolean => {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.sessionStorage.getItem(dismissalKey(sessionKey)) === "1";
+  } catch {
+    return false;
+  }
+};
+
+const writeDismissed = (sessionKey: string): void => {
+  try {
+    window.sessionStorage.setItem(dismissalKey(sessionKey), "1");
+  } catch {
+    // Storage unavailable; the in-memory state still hides the pill.
+  }
+};
+
+interface CatchUpPillProps {
+  /** When the live transcript session started (server clock, ms epoch). */
+  startedAt: number | null;
+  /** When this participant joined the call (local clock, ms epoch). */
+  joinedAt: number | null;
+  /** Stable key for this transcript session, used for the dismissal memory. */
+  sessionKey: string;
+  /** Opens the transcript panel on the minutes tab. */
+  onOpen: () => void;
+}
+
+export default function CatchUpPill({
+  startedAt,
+  joinedAt,
+  sessionKey,
+  onOpen,
+}: CatchUpPillProps) {
+  const [dismissed, setDismissed] = useState(() => readDismissed(sessionKey));
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+    writeDismissed(sessionKey);
+  }, [sessionKey]);
+
+  const open = useCallback(() => {
+    dismiss();
+    onOpen();
+  }, [dismiss, onOpen]);
+
+  if (dismissed || startedAt == null || joinedAt == null) return null;
+  const missedMs = joinedAt - startedAt;
+  if (missedMs < MIN_MISSED_MS) return null;
+
+  const missedMinutes = Math.max(2, Math.round(missedMs / 60_000));
+
+  return (
+    <div className="pointer-events-none absolute inset-x-0 top-4 z-40 flex justify-center px-4">
+      <div
+        className="pointer-events-auto flex max-w-[min(30rem,calc(100vw-2rem))] items-center gap-1 rounded-full border border-[#fafafa]/10 bg-[#0a0a0b]/85 p-1 shadow-[0_14px_42px_rgba(0,0,0,0.32)] backdrop-blur-md"
+        style={{ fontFamily: "'PolySans Trial', sans-serif" }}
+        role="status"
+      >
+        <button
+          type="button"
+          onClick={open}
+          className="flex min-w-0 items-center gap-2 rounded-full px-2.5 py-1.5 text-[12.5px] font-medium text-[#fafafa] transition-colors hover:bg-white/[0.06]"
+        >
+          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#F95F4A]" />
+          <span className="truncate">
+            Catch up on the last {missedMinutes} min
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Dismiss catch up"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[#fafafa]/55 transition-colors hover:bg-white/[0.06] hover:text-[#fafafa]"
+        >
+          <X size={13} strokeWidth={1.75} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -3,7 +3,7 @@
 import dynamic from "next/dynamic";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Dispatch, PointerEvent, SetStateAction } from "react";
-import { Home, LogOut, Plus, RefreshCw } from "lucide-react";
+import { Home, Loader2, LogOut, Plus, RefreshCw } from "lucide-react";
 import type { Socket } from "socket.io-client";
 import type { RoomInfo } from "@/lib/sfu-types";
 import ChatOverlay from "./ChatOverlay";
@@ -12,6 +12,7 @@ import ControlsBar from "./ControlsBar";
 import GridLayout from "./GridLayout";
 import ConnectionBanner from "./ConnectionBanner";
 import AdminNoticePill from "./AdminNoticePill";
+import CatchUpPill from "./CatchUpPill";
 import ParticipantsPanel from "./ParticipantsPanel";
 import MeetSettingsPanel from "./MeetSettingsPanel";
 import MeetViewPanel from "./MeetViewPanel";
@@ -21,6 +22,7 @@ import DevPlaygroundLayout from "./DevPlaygroundLayout";
 import ScreenShareAudioPlayers from "./ScreenShareAudioPlayers";
 import SystemAudioPlayers from "./SystemAudioPlayers";
 import WhiteboardLayout from "./WhiteboardLayout";
+import WatchLayout from "./WatchLayout";
 import ParticipantVideo from "./ParticipantVideo";
 import ToastQueue from "./ToastQueue";
 import TranscriptPanel from "./TranscriptPanel";
@@ -29,7 +31,11 @@ import type { BrowserState } from "../hooks/useSharedBrowser";
 import type {
   ConclaveAssistantApiKeyPromptState,
 } from "../hooks/useMeetChat";
-import type { ConclaveAssistantModel } from "../lib/conclave-assistant";
+import {
+  CONCLAVE_ASSISTANT_USER_ID,
+  type AssistantChatMessage,
+  type ConclaveAssistantModel,
+} from "../lib/conclave-assistant";
 import type {
   VideoEffectsDebugStats,
   VideoEffectsRuntimeStatus,
@@ -497,12 +503,15 @@ export default function MeetsMainContent({
   const isDevToolsEnabled = process.env.NODE_ENV === "development";
   const isDevPlaygroundEnabled = isDevToolsEnabled;
   const isWhiteboardActive = appsState.activeAppId === "whiteboard";
+  const isWatchActive = appsState.activeAppId === "watch";
   const isDevPlaygroundActive = appsState.activeAppId === "dev-playground";
   const handleOpenWhiteboard = useCallback(
     () => openApp("whiteboard"),
     [openApp],
   );
   const handleCloseWhiteboard = useCallback(() => closeApp(), [closeApp]);
+  const handleOpenWatch = useCallback(() => openApp("watch"), [openApp]);
+  const handleCloseWatch = useCallback(() => closeApp(), [closeApp]);
   const handleOpenDevPlayground = useCallback(
     () => openApp("dev-playground"),
     [openApp],
@@ -561,6 +570,17 @@ export default function MeetsMainContent({
   const [isVideoEffectsOpen, setIsVideoEffectsOpen] = useState(false);
   const [isViewPanelOpen, setIsViewPanelOpen] = useState(false);
   const [isTranscriptOpen, setIsTranscriptOpen] = useState(false);
+  // Which tab the transcript panel mounts on; the catch-up pill sets "minutes".
+  const [transcriptInitialTab, setTranscriptInitialTab] = useState<
+    "transcript" | "ask" | "minutes"
+  >("transcript");
+  // When this participant joined, for the late-join catch-up gate.
+  const [joinedAt, setJoinedAt] = useState<number | null>(null);
+  useEffect(() => {
+    if (isJoined && joinedAt == null) {
+      setJoinedAt(Date.now());
+    }
+  }, [isJoined, joinedAt]);
   const [canReserveDockedPanel, setCanReserveDockedPanel] = useState(false);
   const [viewportWidth, setViewportWidth] = useState(1280);
   const [gameDockWidth, setGameDockWidth] = useState(
@@ -1117,13 +1137,38 @@ export default function MeetsMainContent({
       setIsHostControlsOpen(false);
       setIsVideoEffectsOpen(false);
       setIsViewPanelOpen(false);
+    } else {
+      setTranscriptInitialTab("transcript");
     }
     setIsTranscriptOpen(opening);
   }, [isTranscriptOpen, setIsParticipantsOpen, toggleChat]);
 
   const handleCloseTranscript = useCallback(() => {
     setIsTranscriptOpen(false);
+    setTranscriptInitialTab("transcript");
   }, []);
+
+  // Catch-up moment for late joiners: while a transcript session is live and
+  // this participant joined well after it started, a quiet pill offers the
+  // live minutes. Opens the panel straight on the minutes tab.
+  const handleOpenCatchUp = useCallback(() => {
+    setTranscriptInitialTab("minutes");
+    if (!isTranscriptOpen) {
+      handleToggleTranscript();
+    }
+  }, [isTranscriptOpen, handleToggleTranscript]);
+
+  // Wrap-up moment: asks Conclave in the room chat for a recap, visible to
+  // everyone through the existing assistant relay. Only offered while the
+  // opt-in transcript session is running (the button lives in the minutes tab).
+  const canPostRecapToChat = !ghostEnabled && (!isChatLocked || isAdmin);
+  const handlePostRecap = useCallback((): boolean => {
+    if (!canPostRecapToChat) return false;
+    sendChat(
+      "@Conclave wrap up the meeting. Post a short recap: what we covered, decisions made, and action items with owners.",
+    );
+    return true;
+  }, [canPostRecapToChat, sendChat]);
 
   const handleToggleVideoFraming = useCallback(() => {
     if (!deferVideoEffectsPreload) {
@@ -1221,10 +1266,72 @@ export default function MeetsMainContent({
     [onPendingUserStale, setPendingUsers],
   );
 
-  const handleEndRoomForEveryone = useCallback(() => {
+  // The wrap-up intercept: when the host ends the call for everyone while the
+  // opt-in transcript is live and has content, offer to post a recap to chat
+  // first. "idle" ends immediately as before; "confirm" shows the choice;
+  // "posting" waits for the recap to land in chat, then ends.
+  const [endFlowState, setEndFlowState] = useState<
+    "idle" | "confirm" | "posting"
+  >("idle");
+  const recapRequestedAtRef = useRef(0);
+
+  const endRoomNow = useCallback(() => {
+    setEndFlowState("idle");
     if (!endRoomForEveryone) return;
     void endRoomForEveryone();
   }, [endRoomForEveryone]);
+
+  const handleEndRoomForEveryone = useCallback(() => {
+    if (!endRoomForEveryone) return;
+    const canOfferRecap =
+      canPostRecapToChat &&
+      transcript.isLive &&
+      transcript.allSegments.length > 0 &&
+      endFlowState === "idle";
+    if (canOfferRecap) {
+      setEndFlowState("confirm");
+      return;
+    }
+    void endRoomForEveryone();
+  }, [
+    endRoomForEveryone,
+    canPostRecapToChat,
+    transcript.isLive,
+    transcript.allSegments.length,
+    endFlowState,
+  ]);
+
+  const handlePostRecapAndEnd = useCallback(() => {
+    recapRequestedAtRef.current = Date.now();
+    if (!handlePostRecap()) {
+      endRoomNow();
+      return;
+    }
+    setEndFlowState("posting");
+  }, [endRoomNow, handlePostRecap]);
+
+  // End once the recap answer finishes streaming into chat (or errors), so the
+  // room actually sees it before the call closes.
+  useEffect(() => {
+    if (endFlowState !== "posting") return;
+    const requestedAt = recapRequestedAtRef.current;
+    const settled = chatMessages.some((message) => {
+      if (message.userId !== CONCLAVE_ASSISTANT_USER_ID) return false;
+      if (message.timestamp < requestedAt) return false;
+      const status = (message as AssistantChatMessage).assistantStatus;
+      return status === "done" || status === "error";
+    });
+    if (settled) {
+      endRoomNow();
+    }
+  }, [chatMessages, endFlowState, endRoomNow]);
+
+  // Safety cap so a stalled stream can never trap the host in the meeting.
+  useEffect(() => {
+    if (endFlowState !== "posting") return;
+    const timer = window.setTimeout(endRoomNow, 30_000);
+    return () => window.clearTimeout(timer);
+  }, [endFlowState, endRoomNow]);
 
   const hasBrowserAudio = useMemo(
     () =>
@@ -1429,6 +1536,83 @@ export default function MeetsMainContent({
         </div>
       )}
       {isJoined && <AdminNoticePill notice={adminNotice} />}
+      {isJoined && !isWebinarAttendee && !isTranscriptOpen && transcript.isLive ? (
+        <CatchUpPill
+          startedAt={transcript.session.startedAt}
+          joinedAt={joinedAt}
+          sessionKey={`${transcript.session.roomId}:${transcript.session.startedAt ?? 0}`}
+          onOpen={handleOpenCatchUp}
+        />
+      ) : null}
+      {endFlowState !== "idle" ? (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/55 px-4">
+          <div
+            className="w-full max-w-[22rem] rounded-2xl border border-white/10 bg-[#18181b] p-5"
+            style={{ fontFamily: "'PolySans Trial', sans-serif" }}
+            role="dialog"
+            aria-modal="true"
+            aria-label="End call for everyone"
+          >
+            {endFlowState === "confirm" ? (
+              <>
+                <h2 className="text-[15px] font-semibold text-[#fafafa]">
+                  End call for everyone?
+                </h2>
+                <p className="mt-1.5 text-[12.5px] leading-relaxed text-[#a1a1aa]">
+                  Conclave can post a recap of the meeting to chat before the
+                  call ends.
+                </p>
+                <div className="mt-4 flex flex-col gap-2">
+                  <button
+                    type="button"
+                    onClick={handlePostRecapAndEnd}
+                    className="w-full rounded-xl bg-[#F95F4A] px-3.5 py-2.5 text-[13px] font-medium text-white transition-opacity hover:opacity-90"
+                  >
+                    Post recap and end
+                  </button>
+                  <button
+                    type="button"
+                    onClick={endRoomNow}
+                    className="w-full rounded-xl border border-white/10 px-3.5 py-2.5 text-[13px] font-medium text-[#fafafa] transition-colors hover:bg-white/[0.06]"
+                  >
+                    End without recap
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEndFlowState("idle")}
+                    className="w-full rounded-xl px-3.5 py-2 text-[12.5px] font-medium text-[#a1a1aa] transition-colors hover:text-[#fafafa]"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <h2 className="text-[15px] font-semibold text-[#fafafa]">
+                  Posting recap
+                </h2>
+                <p className="mt-1.5 text-[12.5px] leading-relaxed text-[#a1a1aa]">
+                  Conclave is writing the recap in chat. The call ends for
+                  everyone once it lands.
+                </p>
+                <div className="mt-4 flex items-center justify-between gap-3">
+                  <span className="inline-flex items-center gap-2 text-[12px] text-[#a1a1aa]">
+                    <Loader2 size={13} className="animate-spin text-[#4F9CF9]" />
+                    Posting to chat
+                  </span>
+                  <button
+                    type="button"
+                    onClick={endRoomNow}
+                    className="rounded-xl border border-white/10 px-3 py-1.5 text-[12px] font-medium text-[#fafafa] transition-colors hover:bg-white/[0.06]"
+                  >
+                    End now
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      ) : null}
       <SystemAudioPlayers
         participants={participants}
         audioOutputDeviceId={audioOutputDeviceId}
@@ -1647,6 +1831,21 @@ export default function MeetsMainContent({
           audioOutputDeviceId={audioOutputDeviceId}
           getDisplayName={resolveDisplayName}
         />
+      ) : isWatchActive ? (
+        <WatchLayout
+          localStream={localStream}
+          isCameraOff={isCameraOff}
+          isMuted={isMuted}
+          isHandRaised={isHandRaised}
+          isGhost={ghostEnabled}
+          participants={participants}
+          userEmail={userEmail}
+          isMirrorCamera={mirrorLocalPreview}
+          activeSpeakerId={activeSpeakerId}
+          currentUserId={currentUserId}
+          audioOutputDeviceId={audioOutputDeviceId}
+          getDisplayName={resolveDisplayName}
+        />
       ) : isDevPlaygroundEnabled && isDevPlaygroundActive ? (
         <DevPlaygroundLayout
           localStream={localStream}
@@ -1836,6 +2035,9 @@ export default function MeetsMainContent({
                 isWhiteboardActive={isWhiteboardActive}
                 onOpenWhiteboard={isAdmin ? handleOpenWhiteboard : undefined}
                 onCloseWhiteboard={isAdmin ? handleCloseWhiteboard : undefined}
+                isWatchActive={isWatchActive}
+                onOpenWatch={isAdmin ? handleOpenWatch : undefined}
+                onCloseWatch={isAdmin ? handleCloseWatch : undefined}
                 isDevPlaygroundEnabled={isDevPlaygroundEnabled}
                 isDevPlaygroundActive={isDevPlaygroundActive}
                 onOpenDevPlayground={
@@ -1920,6 +2122,8 @@ export default function MeetsMainContent({
         <TranscriptPanel
           transcript={transcript}
           onClose={handleCloseTranscript}
+          initialTab={transcriptInitialTab}
+          onPostRecap={canPostRecapToChat ? handlePostRecap : undefined}
         />
       )}
 

--- a/apps/web/src/app/components/ScheduledMeetingLanding.tsx
+++ b/apps/web/src/app/components/ScheduledMeetingLanding.tsx
@@ -3,9 +3,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { CalendarClock, Copy, Loader2, PlayCircle } from "lucide-react";
 import type { PublicScheduledMeeting } from "@/lib/scheduled-meetings";
+import { buildMeetingPath, buildMeetingUrl } from "@/lib/meeting-links";
 
 type Props = {
   meeting: PublicScheduledMeeting;
+  clientId: string;
   viewerIsHost: boolean;
 };
 
@@ -40,6 +42,7 @@ const CTA_GHOST =
 
 export default function ScheduledMeetingLanding({
   meeting,
+  clientId,
   viewerIsHost,
 }: Props) {
   const [now, setNow] = useState<number>(() => Date.now());
@@ -61,8 +64,11 @@ export default function ScheduledMeetingLanding({
 
   const shareLink = useMemo(() => {
     if (typeof window === "undefined") return "";
-    return `${window.location.origin}/${meeting.roomCode}`;
-  }, [meeting.roomCode]);
+    return buildMeetingUrl(window.location.origin, {
+      roomCode: meeting.roomCode,
+      clientId,
+    });
+  }, [clientId, meeting.roomCode]);
 
   useEffect(() => {
     if (!isLive) return;
@@ -170,7 +176,10 @@ export default function ScheduledMeetingLanding({
           )}
           {isLive && (
             <a
-              href={`/${encodeURIComponent(meeting.roomCode)}`}
+              href={buildMeetingPath({
+                roomCode: meeting.roomCode,
+                clientId,
+              })}
               className={CTA_PRIMARY}
             >
               Open the meeting

--- a/apps/web/src/app/components/ScheduledMeetingsPanel.tsx
+++ b/apps/web/src/app/components/ScheduledMeetingsPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { ScheduledMeeting } from "@/lib/scheduled-meetings";
+import { buildMeetingPath, buildMeetingUrl } from "@/lib/meeting-links";
 
 type ScheduledMeetingsResponse = {
   scheduledMeetings?: ScheduledMeeting[];
@@ -56,9 +57,6 @@ const formatTime = (timestamp: number): string =>
     hour: "numeric",
     minute: "2-digit",
   });
-
-const getMeetingHref = (meeting: ScheduledMeeting): string =>
-  `/${encodeURIComponent(meeting.roomCode)}`;
 
 function ScheduledMeetingsPanel({ isSignedIn }: ScheduledMeetingsPanelProps) {
   const [meetings, setMeetings] = useState<ScheduledMeeting[]>([]);
@@ -193,7 +191,7 @@ function ScheduledMeetingsPanel({ isSignedIn }: ScheduledMeetingsPanelProps) {
       if (!response.ok) {
         throw new Error(await readError(response));
       }
-      window.location.href = getMeetingHref(meeting);
+      window.location.href = buildMeetingPath(meeting);
     } catch (startError) {
       setError((startError as Error).message || "Could not start meeting");
       setWorkingMeetingId(null);
@@ -235,7 +233,7 @@ function ScheduledMeetingsPanel({ isSignedIn }: ScheduledMeetingsPanelProps) {
     if (typeof window === "undefined") return;
     try {
       await navigator.clipboard.writeText(
-        `${window.location.origin}${getMeetingHref(meeting)}`,
+        buildMeetingUrl(window.location.origin, meeting),
       );
       setCopiedMeetingId(meeting.id);
       setTimeout(() => setCopiedMeetingId(null), 1600);
@@ -371,7 +369,7 @@ function ScheduledMeetingsPanel({ isSignedIn }: ScheduledMeetingsPanelProps) {
                 </div>
                 <div className="mt-3 flex flex-wrap gap-2">
                   {!isCancelled && (
-                    <a href={getMeetingHref(meeting)} className={ACTION}>
+                    <a href={buildMeetingPath(meeting)} className={ACTION}>
                       {isLive ? "Join" : "Open"}
                     </a>
                   )}

--- a/apps/web/src/app/components/TranscriptPanel.tsx
+++ b/apps/web/src/app/components/TranscriptPanel.tsx
@@ -17,11 +17,12 @@ import {
   Pause,
   Play,
   RefreshCw,
+  Send,
   Square,
   Tag,
   X,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import type {
   MeetingTranscriptController,
   TranscriptQaMessage,
@@ -69,6 +70,13 @@ import {
 interface TranscriptPanelProps {
   transcript: MeetingTranscriptController;
   onClose: () => void;
+  /** Which tab to show when the panel mounts, e.g. "minutes" from catch up. */
+  initialTab?: TranscriptTab;
+  /**
+   * Posts a meeting recap into the room chat through the assistant. Omit to
+   * hide the action (ghost mode, webinar attendees).
+   */
+  onPostRecap?: () => boolean;
 }
 
 type TranscriptTab = "transcript" | "ask" | "minutes";
@@ -181,7 +189,9 @@ function MinutesStatusBar({
         {isWorking ? (
           <>
             <Loader2 size={11} className="animate-spin text-[#4F9CF9]" />
-            <Shimmer className="text-[11.5px]">Updating minutes</Shimmer>
+            <Shimmer as="span" className="text-[11.5px]">
+              Updating minutes
+            </Shimmer>
           </>
         ) : (
           <span className="truncate">
@@ -607,7 +617,7 @@ function MinutesBuilding() {
       title={
         <span className="inline-flex items-center gap-2">
           <Loader2 size={13} className="animate-spin text-[#4F9CF9]" />
-          <Shimmer className="text-[14px] font-semibold">
+          <Shimmer as="span" className="text-[14px] font-semibold">
             Cooking up minutes
           </Shimmer>
         </span>
@@ -618,8 +628,25 @@ function MinutesBuilding() {
   );
 }
 
+/** A pause long enough that a quiet time marker helps you scan back later. */
+const TRANSCRIPT_PAUSE_MARKER_MS = 3 * 60 * 1000;
+
 function TranscriptView({ segments }: { segments: TranscriptSegment[] }) {
-  const groups = useMemo(() => groupSegments(segments), [segments]);
+  // Groups plus a "long pause before this group" flag, so lulls in the
+  // conversation become scannable time markers instead of invisible seams.
+  const rows = useMemo(() => {
+    const groups = groupSegments(segments);
+    let previousEndMs: number | null = null;
+    return groups.map((group) => {
+      const first = group.segments[0];
+      const last = group.segments[group.segments.length - 1];
+      const pauseBefore =
+        previousEndMs != null &&
+        first.startMs - previousEndMs >= TRANSCRIPT_PAUSE_MARKER_MS;
+      previousEndMs = last.endMs ?? last.updatedAt ?? last.startMs;
+      return { group, pauseBefore };
+    });
+  }, [segments]);
 
   if (segments.length === 0) {
     return <TranscriptFallback />;
@@ -628,39 +655,55 @@ function TranscriptView({ segments }: { segments: TranscriptSegment[] }) {
   return (
     <Conversation>
       <ConversationContent className="gap-4">
-        {groups.map((group) => {
+        {rows.map(({ group, pauseBefore }) => {
           const isLive = group.segments.some((segment) => !segment.isFinal);
           return (
-            <Message key={group.key} from="assistant" className="max-w-full gap-1.5">
-              <div className="flex w-full items-baseline justify-between gap-3">
-                <span className="truncate text-[12px] font-semibold text-[#fafafa]">
-                  {group.speakerDisplayName}
-                </span>
-                <span className="shrink-0 text-[10.5px] tabular-nums text-[#71717a]">
-                  {formatTranscriptTimestamp(group.segments[0].startMs)}
-                </span>
-              </div>
-              <MessageContent
-                className={[
-                  "w-full gap-1 transition-colors",
-                  isLive ? "border-[#4F9CF9]/35 bg-[#4F9CF9]/[0.06]" : "",
-                ].join(" ")}
+            <Fragment key={group.key}>
+              {pauseBefore ? (
+                <div className="flex items-center gap-3 px-1" aria-hidden="true">
+                  <span className="h-px flex-1 bg-white/[0.06]" />
+                  <span className="text-[10px] tabular-nums text-[#52525b]">
+                    {formatTranscriptTimestamp(group.segments[0].startMs)}
+                  </span>
+                  <span className="h-px flex-1 bg-white/[0.06]" />
+                </div>
+              ) : null}
+              {/* One-shot settle on mount so new speech eases in instead of
+                  popping. A single fade, never a loop. */}
+              <Message
+                from="assistant"
+                className="max-w-full animate-[acm-fade-in_220ms_ease-out] gap-1.5"
               >
-                {group.segments.map((segment) => (
-                  <p
-                    key={segment.itemId}
-                    className={
-                      segment.isFinal ? "text-[#e4e4e7]" : "text-[#a1a1aa]"
-                    }
-                  >
-                    {segment.text}
-                    {!segment.isFinal ? (
-                      <span className="ml-1 inline-block h-3 w-0.5 animate-pulse rounded-full bg-[#4F9CF9] align-middle" />
-                    ) : null}
-                  </p>
-                ))}
-              </MessageContent>
-            </Message>
+                <div className="flex w-full items-baseline justify-between gap-3">
+                  <span className="truncate text-[12px] font-semibold text-[#fafafa]">
+                    {group.speakerDisplayName}
+                  </span>
+                  <span className="shrink-0 text-[10.5px] tabular-nums text-[#52525b]">
+                    {formatTranscriptTimestamp(group.segments[0].startMs)}
+                  </span>
+                </div>
+                <MessageContent
+                  className={[
+                    "w-full gap-1 transition-colors duration-300",
+                    isLive ? "border-[#4F9CF9]/35 bg-[#4F9CF9]/[0.06]" : "",
+                  ].join(" ")}
+                >
+                  {group.segments.map((segment) => (
+                    <p
+                      key={segment.itemId}
+                      className={`leading-relaxed transition-colors duration-300 ${
+                        segment.isFinal ? "text-[#e4e4e7]" : "text-[#a1a1aa]"
+                      }`}
+                    >
+                      {segment.text}
+                      {!segment.isFinal ? (
+                        <span className="ml-1 inline-block h-3 w-[2px] rounded-full bg-[#4F9CF9]/80 align-middle" />
+                      ) : null}
+                    </p>
+                  ))}
+                </MessageContent>
+              </Message>
+            </Fragment>
           );
         })}
       </ConversationContent>
@@ -821,19 +864,30 @@ function MinutesTask({
 
 function MinutesView({
   transcript,
+  onPostRecap,
 }: {
   transcript: MeetingTranscriptController;
+  onPostRecap?: () => boolean;
 }) {
   const minutes = transcript.minutes;
   const hasMinutes = hasMinutesContent(minutes);
   const status = transcript.session.status;
   const isRunning = status === "live" || status === "paused";
+  const [recapPosted, setRecapPosted] = useState(false);
+
+  useEffect(() => {
+    if (!recapPosted) return;
+    const timer = window.setTimeout(() => setRecapPosted(false), 5_000);
+    return () => window.clearTimeout(timer);
+  }, [recapPosted]);
 
   if (!hasMinutes) {
     // While a session is live we're actively working toward minutes; only fall
     // back to the static "build as you talk" hint when nothing is running.
     return isRunning ? <MinutesBuilding /> : <MinutesFallback />;
   }
+
+  const canPostRecap = Boolean(onPostRecap) && !transcript.isViewOnly;
 
   return (
     <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4">
@@ -872,6 +926,40 @@ function MinutesView({
         icon={<ListChecks size={14} strokeWidth={1.8} />}
         items={minutes.followUps}
       />
+      {canPostRecap ? (
+        <div className="border-t border-white/[0.06] pt-3">
+          <button
+            type="button"
+            disabled={recapPosted}
+            onClick={() => {
+              if (recapPosted) return;
+              if (onPostRecap?.()) {
+                setRecapPosted(true);
+              }
+            }}
+            className={`flex w-full items-center justify-center gap-2 rounded-xl border px-3.5 py-2.5 text-[12.5px] font-medium transition-colors ${
+              recapPosted
+                ? "border-white/[0.06] bg-white/[0.02] text-[#a1a1aa]"
+                : "border-white/10 bg-white/[0.03] text-[#fafafa] hover:bg-white/[0.07]"
+            }`}
+          >
+            {recapPosted ? (
+              <>
+                <Check size={14} strokeWidth={1.8} className="text-[#22A578]" />
+                Recap posted to chat
+              </>
+            ) : (
+              <>
+                <Send size={13} strokeWidth={1.8} className="text-[#71717a]" />
+                Post recap to chat
+              </>
+            )}
+          </button>
+          <p className="mt-2 text-center text-[11px] leading-snug text-[#71717a]">
+            Conclave writes a short recap in the room chat for everyone.
+          </p>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -879,8 +967,12 @@ function MinutesView({
 export default function TranscriptPanel({
   transcript,
   onClose,
+  initialTab,
+  onPostRecap,
 }: TranscriptPanelProps) {
-  const [activeTab, setActiveTab] = useState<TranscriptTab>("transcript");
+  const [activeTab, setActiveTab] = useState<TranscriptTab>(
+    initialTab ?? "transcript",
+  );
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">(
     "idle",
   );
@@ -1096,7 +1188,7 @@ export default function TranscriptPanel({
             ) : activeTab === "ask" && !transcript.isViewOnly ? (
               <AskView messages={transcript.qaMessages} onAsk={transcript.ask} />
             ) : (
-              <MinutesView transcript={transcript} />
+              <MinutesView transcript={transcript} onPostRecap={onPostRecap} />
             )}
           </div>
 

--- a/apps/web/src/app/components/WatchLayout.tsx
+++ b/apps/web/src/app/components/WatchLayout.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { Hand } from "lucide-react";
+import { memo, useEffect, useRef } from "react";
+import { WatchWebApp } from "@conclave/apps-sdk/watch/web";
+import { Avatar } from "@conclave/ui-tokens/web";
+import { useSmartParticipantOrder } from "../hooks/useSmartParticipantOrder";
+import type { Participant } from "../lib/types";
+import { getSpeakerHighlightClasses, isSystemUserId } from "../lib/utils";
+import { isRemoteParticipantVisible } from "../lib/participant-visibility";
+import ParticipantVideo from "./ParticipantVideo";
+
+interface WatchLayoutProps {
+  localStream: MediaStream | null;
+  isCameraOff: boolean;
+  isMuted: boolean;
+  isHandRaised: boolean;
+  isGhost: boolean;
+  participants: Map<string, Participant>;
+  userEmail: string;
+  isMirrorCamera: boolean;
+  activeSpeakerId: string | null;
+  currentUserId: string;
+  audioOutputDeviceId?: string;
+  getDisplayName: (userId: string) => string;
+}
+
+function WatchLayout({
+  localStream,
+  isCameraOff,
+  isMuted,
+  isHandRaised,
+  isGhost,
+  participants,
+  userEmail,
+  isMirrorCamera,
+  activeSpeakerId,
+  currentUserId,
+  audioOutputDeviceId,
+  getDisplayName,
+}: WatchLayoutProps) {
+  const localVideoRef = useRef<HTMLVideoElement>(null);
+  const isLocalActiveSpeaker = activeSpeakerId === currentUserId;
+
+  useEffect(() => {
+    const video = localVideoRef.current;
+    if (!video) return;
+
+    if (!localStream) {
+      if (video.srcObject) {
+        video.srcObject = null;
+      }
+      return;
+    }
+
+    video.srcObject = localStream;
+    video.play().catch((err) => {
+      if (err.name !== "AbortError") {
+        console.error("[Meets] Watch local video play error:", err);
+      }
+    });
+
+    return () => {
+      if (video.srcObject === localStream) {
+        video.srcObject = null;
+      }
+    };
+  }, [localStream]);
+
+  const participantsList = useSmartParticipantOrder(
+    Array.from(participants.values()).filter(
+      (participant) =>
+        !isSystemUserId(participant.userId) &&
+        participant.userId !== currentUserId &&
+        isRemoteParticipantVisible(participant, isGhost, currentUserId),
+    ),
+    activeSpeakerId
+  );
+
+  return (
+    <div className="flex flex-1 min-h-0 min-w-0 gap-4 overflow-hidden mt-5">
+      <div className="flex-1 min-h-0 min-w-0 rounded-2xl border border-white/10 bg-[#0b0b0b] shadow-[0_20px_60px_rgba(0,0,0,0.4)] overflow-hidden">
+        <WatchWebApp />
+      </div>
+      <aside className="hidden lg:flex w-64 shrink-0 flex-col gap-3 overflow-y-auto overflow-x-visible px-1">
+        {!isGhost && (
+          <div
+            className={`relative bg-[#232327] border border-white/5 rounded-lg overflow-hidden h-36 shrink-0 transition-all duration-200 ${getSpeakerHighlightClasses(
+              isLocalActiveSpeaker
+            )}`}
+          >
+            <video
+              ref={localVideoRef}
+              autoPlay
+              muted
+              playsInline
+              className={`w-full h-full object-cover ${
+                isCameraOff ? "hidden" : ""
+              } ${isMirrorCamera ? "scale-x-[-1]" : ""}`}
+            />
+            {isCameraOff && (
+              <div className="absolute inset-0 flex items-center justify-center bg-[#18181b]">
+                <Avatar id={userEmail} name={userEmail} size={48} />
+              </div>
+            )}
+            {isHandRaised && (
+              <div
+                className="absolute top-3 left-3 p-1.5 rounded-full bg-amber-500/20 border border-amber-400/40 text-amber-300"
+                title="Hand raised"
+              >
+                <Hand className="w-3 h-3" />
+              </div>
+            )}
+            <div
+              className="absolute bottom-3 left-3 bg-black/70 backdrop-blur-sm border border-[#fafafa]/10 rounded-full px-3 py-1.5 flex items-center gap-2 text-[10px]"
+              style={{ fontFamily: "'PolySans Trial', sans-serif" }}
+            >
+              <span className="font-medium text-[#fafafa] uppercase tracking-wide">
+                You
+              </span>
+              {isMuted ? <span className="text-[#F95F4A]">Muted</span> : null}
+            </div>
+          </div>
+        )}
+
+        {participantsList.map((participant) => (
+          <ParticipantVideo
+            key={participant.userId}
+            participant={participant}
+            displayName={getDisplayName(participant.userId)}
+            isActiveSpeaker={activeSpeakerId === participant.userId}
+            compact
+            audioOutputDeviceId={audioOutputDeviceId}
+          />
+        ))}
+      </aside>
+    </div>
+  );
+}
+
+export default memo(WatchLayout);

--- a/apps/web/src/app/components/controls-config.ts
+++ b/apps/web/src/app/components/controls-config.ts
@@ -10,6 +10,7 @@ import {
   Mic,
   MicOff,
   Monitor,
+  MonitorPlay,
   PictureInPicture2,
   ScanFace,
   Shield,
@@ -107,6 +108,9 @@ export interface ControlsBarProps {
   isWhiteboardActive?: boolean;
   onOpenWhiteboard?: () => void;
   onCloseWhiteboard?: () => void;
+  isWatchActive?: boolean;
+  onOpenWatch?: () => void;
+  onCloseWatch?: () => void;
   isDevPlaygroundEnabled?: boolean;
   isDevPlaygroundActive?: boolean;
   onOpenDevPlayground?: () => void;
@@ -182,6 +186,9 @@ export const BROWSER_APPS: { id: string; name: string; description: string; url:
 
 export function canManageWhiteboard(p: ControlsBarProps): boolean {
   return Boolean(p.isAdmin && (p.onOpenWhiteboard || p.onCloseWhiteboard));
+}
+export function canManageWatch(p: ControlsBarProps): boolean {
+  return Boolean(p.isAdmin && (p.onOpenWatch || p.onCloseWatch));
 }
 export function canManageDevPlayground(p: ControlsBarProps): boolean {
   return Boolean(
@@ -404,6 +411,15 @@ export function buildControlsConfig(p: ControlsBarProps): ControlsConfig {
       label: p.isWhiteboardActive ? "Close whiteboard" : "Open whiteboard",
       active: p.isWhiteboardActive,
       onPress: () => (p.isWhiteboardActive ? p.onCloseWhiteboard?.() : p.onOpenWhiteboard?.()),
+    });
+  }
+  if (canManageWatch(p)) {
+    overflow.push({
+      id: "watch",
+      icon: MonitorPlay,
+      label: p.isWatchActive ? "Close watch together" : "Watch together",
+      active: p.isWatchActive,
+      onPress: () => (p.isWatchActive ? p.onCloseWatch?.() : p.onOpenWatch?.()),
     });
   }
   if (canManageDevPlayground(p)) {

--- a/apps/web/src/app/components/games/GamePanel.tsx
+++ b/apps/web/src/app/components/games/GamePanel.tsx
@@ -41,9 +41,10 @@ export function GamePanel({
   maxDockWidth?: number;
   onDockWidthChange?: (width: number) => void;
 }) {
-  const { publicState, view, isAdmin, isReadOnly, userId, move, endGame, startGame } =
+  const { publicState, view, isAdmin, isReadOnly, userId, move, endGame, startGame, joinGame } =
     useGame();
   const [rematchBusy, setRematchBusy] = useState(false);
+  const [joinBusy, setJoinBusy] = useState(false);
   if (!publicState) return null;
 
   const canControl = isAdmin && !isReadOnly;
@@ -63,6 +64,25 @@ export function GamePanel({
   const isPlayer = Boolean(
     userId && publicState.players.some((player) => player.id === userId),
   );
+  const isPendingJoiner = Boolean(
+    userId &&
+      publicState.pendingJoiners.some((player) => player.id === userId),
+  );
+  // Spectators receive a read-only projection for games that allow it; when
+  // the view is absent (imposter keeps secrets), fall back to the blocked copy.
+  const isSpectating = !isPlayer && view != null;
+  const canRequestSeat =
+    !isPlayer && !isReadOnly && !publicState.finished && publicState.canJoinLate;
+
+  const handleJoin = async () => {
+    if (joinBusy || isPendingJoiner) return;
+    setJoinBusy(true);
+    try {
+      await joinGame();
+    } finally {
+      setJoinBusy(false);
+    }
+  };
 
   return (
     <aside
@@ -108,14 +128,28 @@ export function GamePanel({
           <p style={{ fontSize: 13, color: color.textFaint }}>
             This game is not supported on web yet.
           </p>
-        ) : !isPlayer ? (
+        ) : !isPlayer && !isSpectating ? (
           <div style={{ padding: "18px 4px", textAlign: "center" }}>
             <p style={{ fontFamily: HEAD_FONT, fontSize: 17, color: color.text, margin: 0 }}>
               Game in progress
             </p>
             <p style={{ fontSize: 13, color: color.textMuted, lineHeight: 1.5, margin: "8px 0 0" }}>
-              This round started before you joined. You can watch the room and join the next game.
+              This game keeps its rounds private while running.
             </p>
+            {isPendingJoiner ? (
+              <p style={{ fontSize: 13, color: color.accent, margin: "14px 0 0" }}>
+                You will join at the next round
+              </p>
+            ) : canRequestSeat ? (
+              <button
+                type="button"
+                onClick={handleJoin}
+                disabled={joinBusy}
+                className="mt-4 inline-flex h-8 items-center justify-center rounded-lg border border-white/10 px-3 text-[12px] font-medium text-[#fafafa] transition-colors hover:bg-white/[0.06] disabled:opacity-60"
+              >
+                {joinBusy ? "Joining" : "Join next round"}
+              </button>
+            ) : null}
           </div>
         ) : view == null ? (
           <div style={{ padding: "18px 4px", textAlign: "center" }}>
@@ -128,12 +162,30 @@ export function GamePanel({
           </div>
         ) : (
           <>
+            {!isPlayer ? (
+              <div className="mb-3 flex items-center justify-between gap-2 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2">
+                <span style={{ fontSize: 12.5, color: color.textMuted }}>
+                  {isPendingJoiner ? "Joining at the next round" : "Watching"}
+                </span>
+                {!isPendingJoiner && canRequestSeat ? (
+                  <button
+                    type="button"
+                    onClick={handleJoin}
+                    disabled={joinBusy}
+                    style={{ backgroundColor: color.accent }}
+                    className="inline-flex h-7 shrink-0 items-center justify-center rounded-lg px-2.5 text-[12px] font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-60"
+                  >
+                    {joinBusy ? "Joining" : "Join next round"}
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
             <Game
               pub={publicState.view as never}
               me={view as never}
               players={publicState.players}
               isAdmin={isAdmin}
-              readOnly={isReadOnly}
+              readOnly={isReadOnly || !isPlayer}
               userId={userId}
               hostId={publicState.hostId}
               phase={publicState.phase}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -4,6 +4,9 @@
 /* Streamdown ships its own utility classes (used by the AI Elements Response
    component); let Tailwind scan them so markdown rendering is styled. */
 @source "../../../../node_modules/streamdown/dist/**/*.js";
+/* The apps SDK ships web components (whiteboard, watch together) styled with
+   Tailwind classes; it lives outside this app's auto-detected sources. */
+@source "../../../../packages/apps-sdk/src/**/*.{ts,tsx}";
 
 @font-face {
   font-family: "Virgil";
@@ -463,7 +466,7 @@ select:focus {
   border-radius: 16px;
   overflow: hidden;
   border: 1px solid rgba(250, 250, 250, 0.08);
-  /* The active-speaker ring is an INSET shadow, not a border-width change —
+  /* The active-speaker ring is an INSET shadow, not a border-width change;
      toggling 1px→2px border resized the video content box on every speaker
      change and read as jitter/flicker. The shadow keeps the box size constant. */
   transition: border-color 0.12s ease, box-shadow 0.12s ease;
@@ -857,7 +860,7 @@ select:focus {
 
 .mobile-sheet {
   background: var(--mobile-sheet-bg);
-  /* 1px border (incl. the top edge) gives the only separation from the stage —
+  /* 1px border (incl. the top edge) gives the only separation from the stage;
      no elevation glow. */
   border: 1px solid var(--mobile-sheet-border);
   border-bottom: 0;

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -16,6 +16,7 @@ import {
   registerApps,
 } from "@conclave/apps-sdk";
 import { devPlaygroundApp } from "@conclave/apps-sdk/dev-playground/web";
+import { watchApp } from "@conclave/apps-sdk/watch/web";
 import { whiteboardApp } from "@conclave/apps-sdk/whiteboard/web";
 import MeetsErrorBanner from "./components/MeetsErrorBanner";
 import MeetsHeader from "./components/MeetsHeader";
@@ -545,10 +546,10 @@ export default function MeetsClient({
 
   useEffect(() => {
     if (process.env.NODE_ENV === "development") {
-      registerApps([whiteboardApp, devPlaygroundApp]);
+      registerApps([whiteboardApp, watchApp, devPlaygroundApp]);
       return;
     }
-    registerApps([whiteboardApp]);
+    registerApps([whiteboardApp, watchApp]);
   }, []);
 
   const prewarm = usePrewarmSocket();

--- a/apps/web/src/app/schedule/schedule-client.tsx
+++ b/apps/web/src/app/schedule/schedule-client.tsx
@@ -22,6 +22,7 @@ import type {
   SchedulingEventType,
   WeeklyAvailability,
 } from "@/lib/scheduling";
+import { buildMeetingPath } from "@/lib/meeting-links";
 
 type Props = {
   user: {
@@ -32,6 +33,7 @@ type Props = {
 
 type Booking = {
   id: string;
+  clientId?: string;
   roomCode: string;
   title: string;
   attendeeName?: string | null;
@@ -627,7 +629,7 @@ export default function ScheduleClient({ user }: Props) {
                   {bookings.slice(0, 8).map((booking) => (
                     <a
                       key={booking.id}
-                      href={`/${encodeURIComponent(booking.roomCode)}`}
+                      href={buildMeetingPath(booking)}
                       className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/[0.02] p-3 transition-colors hover:bg-white/[0.05]"
                     >
                       <div className="min-w-0">

--- a/apps/web/src/lib/meeting-links.ts
+++ b/apps/web/src/lib/meeting-links.ts
@@ -1,0 +1,24 @@
+type MeetingLinkInput = {
+  roomCode: string;
+  clientId?: string | null;
+};
+
+const shouldIncludeClientId = (
+  clientId: string | null | undefined,
+): clientId is string => {
+  const normalized = clientId?.trim();
+  return Boolean(normalized && normalized !== "default");
+};
+
+export const buildMeetingPath = (meeting: MeetingLinkInput): string => {
+  const path = `/${encodeURIComponent(meeting.roomCode)}`;
+  if (!shouldIncludeClientId(meeting.clientId)) {
+    return path;
+  }
+  return `${path}?clientId=${encodeURIComponent(meeting.clientId.trim())}`;
+};
+
+export const buildMeetingUrl = (
+  origin: string,
+  meeting: MeetingLinkInput,
+): string => `${origin.replace(/\/$/, "")}${buildMeetingPath(meeting)}`;

--- a/apps/web/src/lib/scheduling.ts
+++ b/apps/web/src/lib/scheduling.ts
@@ -35,6 +35,7 @@ export type SchedulingDashboardResponse = {
 export type SchedulingBookingsResponse = {
   bookings?: Array<{
     id: string;
+    clientId: string;
     roomCode: string;
     title: string;
     hostName: string;

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -25,6 +25,24 @@
       "service": "conclave-web"
     }
   ],
+  "ratelimits": [
+    {
+      "name": "YOUTUBE_SEARCH_RATE_LIMITER",
+      "namespace_id": "2001",
+      "simple": {
+        "limit": 8,
+        "period": 60
+      }
+    },
+    {
+      "name": "YOUTUBE_TRENDING_RATE_LIMITER",
+      "namespace_id": "2002",
+      "simple": {
+        "limit": 30,
+        "period": 60
+      }
+    }
+  ],
   "r2_buckets": [
     {
       "binding": "NEXT_INC_CACHE_R2_BUCKET",

--- a/packages/apps-sdk/package.json
+++ b/packages/apps-sdk/package.json
@@ -14,12 +14,15 @@
     ".": "./src/index.ts",
     "./dev-playground/core": "./src/apps/dev-playground/core/index.ts",
     "./dev-playground/web": "./src/apps/dev-playground/web/index.ts",
+    "./watch/core": "./src/apps/watch/core/index.ts",
+    "./watch/web": "./src/apps/watch/web/index.ts",
     "./whiteboard/core": "./src/apps/whiteboard/core/index.ts",
     "./whiteboard/native": "./src/apps/whiteboard/native/index.ts",
     "./whiteboard/web": "./src/apps/whiteboard/web/index.ts"
   },
   "dependencies": {
     "lib0": "^0.2.117",
+    "react-player": "^3.4.0",
     "y-protocols": "^1.0.7",
     "yjs": "^13.6.31"
   },

--- a/packages/apps-sdk/src/apps/watch/core/doc/index.ts
+++ b/packages/apps-sdk/src/apps/watch/core/doc/index.ts
@@ -1,0 +1,365 @@
+import * as Y from "yjs";
+import {
+  createAppDoc,
+  ensureAppArray,
+  ensureAppMap,
+  getAppRoot,
+} from "../../../../sdk/doc/createAppDoc";
+import type {
+  PlaybackRecord,
+  PlaybackState,
+  QueueItem,
+  WriteContext,
+} from "../model/types";
+
+// The single Yjs root for the Watch together app. Everything the app needs to
+// converge on lives under this map: the current video, the playback record, and
+// the queue. Nobody streams video here; this doc syncs intent only and each
+// participant's own YouTube player fetches the media directly.
+const ROOT_KEY = "watch";
+const VIDEO_ID_KEY = "videoId";
+const VIDEO_TITLE_KEY = "videoTitle";
+const PLAYBACK_KEY = "playback";
+const QUEUE_KEY = "queue";
+const REQUEST_RESOLUTIONS_KEY = "requestResolutions";
+
+// Playback sub-map keys.
+const PB_STATE = "state";
+const PB_POSITION = "positionSeconds";
+const PB_UPDATED_AT = "updatedAt";
+const PB_RATE = "rate";
+
+const DEFAULT_RATE = 1;
+
+type WatchRoot = Y.Map<unknown>;
+type PlaybackMap = Y.Map<unknown>;
+type QueueArray = Y.Array<QueueItem>;
+
+const getRoot = (doc: Y.Doc): WatchRoot => getAppRoot(doc, ROOT_KEY);
+
+const getPlaybackMap = (doc: Y.Doc): PlaybackMap =>
+  ensureAppMap(getRoot(doc), PLAYBACK_KEY);
+
+const getQueueArray = (doc: Y.Doc): QueueArray =>
+  ensureAppArray(getRoot(doc), QUEUE_KEY) as QueueArray;
+
+const normalizeState = (value: unknown): PlaybackState =>
+  value === "playing" ? "playing" : "paused";
+
+const normalizePosition = (value: unknown): number =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+
+const normalizeRate = (value: unknown): number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_RATE;
+
+const normalizeUpdatedAt = (value: unknown): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : 0;
+
+/**
+ * Build the shared Watch doc with a deterministic schema:
+ * - `videoId`: the video everyone is watching, or null when idle.
+ * - `playback`: a map holding one playback record (state/position/updatedAt/rate).
+ * - `queue`: an array of up-next items.
+ */
+export const createWatchDoc = (): Y.Doc => {
+  return createAppDoc(ROOT_KEY, (root) => {
+    if (typeof root.get(VIDEO_ID_KEY) !== "string") {
+      root.set(VIDEO_ID_KEY, null);
+    }
+    ensureAppMap(root, PLAYBACK_KEY);
+    ensureAppArray(root, QUEUE_KEY);
+    ensureAppMap(root, REQUEST_RESOLUTIONS_KEY);
+  });
+};
+
+/* ---- Queue requests ------------------------------------------------------
+ * When the room is locked, non-admin doc writes are dropped server-side, so a
+ * request cannot ride the doc. Requests travel via awareness (exempt from the
+ * lock by design, and rightly ephemeral: leave the room, the request goes with
+ * you). Only the HOST'S DECISION touches the doc: accept enqueues the item,
+ * and either way a resolution marker is written here so the requester's client
+ * knows to clear its pending state.
+ * ------------------------------------------------------------------------ */
+
+export type WatchRequestResolution = "added" | "declined";
+
+const getResolutionsMap = (doc: Y.Doc): Y.Map<unknown> =>
+  ensureAppMap(getRoot(doc), REQUEST_RESOLUTIONS_KEY);
+
+/** Record the host's decision on a request (admin write). */
+export const resolveWatchRequest = (
+  doc: Y.Doc,
+  requestId: string,
+  resolution: WatchRequestResolution,
+): void => {
+  getResolutionsMap(doc).set(requestId, resolution);
+};
+
+/** Read the decision for a request id, if the host has made one. */
+export const getWatchRequestResolution = (
+  doc: Y.Doc,
+  requestId: string,
+): WatchRequestResolution | null => {
+  const value = getResolutionsMap(doc).get(requestId);
+  return value === "added" || value === "declined" ? value : null;
+};
+
+/** Expose the root map so the web layer never reaches into raw Yjs itself. */
+export const getWatchRoot = (doc: Y.Doc): WatchRoot => getRoot(doc);
+
+/** The video everyone is currently watching, or null when idle. */
+export const getVideoId = (doc: Y.Doc): string | null => {
+  const value = getRoot(doc).get(VIDEO_ID_KEY);
+  return typeof value === "string" && value.length > 0 ? value : null;
+};
+
+/** The current video's title (best effort, backfilled after start), or null. */
+export const getVideoTitle = (doc: Y.Doc): string | null => {
+  const value = getRoot(doc).get(VIDEO_TITLE_KEY);
+  return typeof value === "string" && value.length > 0 ? value : null;
+};
+
+/**
+ * Backfill the current video's title once metadata arrives. Guarded by video
+ * id so a slow fetch can never label a video that is no longer playing.
+ */
+export const setVideoTitle = (
+  doc: Y.Doc,
+  videoId: string,
+  title: string,
+): void => {
+  const root = getRoot(doc);
+  doc.transact(() => {
+    if (root.get(VIDEO_ID_KEY) !== videoId) return;
+    root.set(VIDEO_TITLE_KEY, title);
+  });
+};
+
+/** Backfill a queue item's title once metadata arrives. No-op if it is gone. */
+export const setQueueItemTitle = (
+  doc: Y.Doc,
+  itemId: string,
+  title: string,
+): void => {
+  const queue = getQueueArray(doc);
+  doc.transact(() => {
+    const list = queue.toArray();
+    const index = list.findIndex((item) => item?.id === itemId);
+    if (index === -1) return;
+    const current = list[index];
+    queue.delete(index, 1);
+    queue.insert(index, [{ ...current, title }]);
+  });
+};
+
+/**
+ * Read the current playback record. Returns a fully-normalized object so callers
+ * never have to defend against a partially-initialized Yjs map.
+ */
+export const getPlayback = (doc: Y.Doc): PlaybackRecord => {
+  const playback = getPlaybackMap(doc);
+  return {
+    state: normalizeState(playback.get(PB_STATE)),
+    positionSeconds: normalizePosition(playback.get(PB_POSITION)),
+    updatedAt: normalizeUpdatedAt(playback.get(PB_UPDATED_AT)),
+    rate: normalizeRate(playback.get(PB_RATE)),
+  };
+};
+
+/** The full up-next queue, normalized to typed items. */
+export const getQueue = (doc: Y.Doc): QueueItem[] => {
+  return getQueueArray(doc)
+    .toArray()
+    .filter(
+      (item): item is QueueItem =>
+        Boolean(item) &&
+        typeof item.id === "string" &&
+        typeof item.videoId === "string",
+    );
+};
+
+/**
+ * Write one playback record. This is the ONE write every acting client makes on
+ * play / pause / seek / rate change. `positionSeconds` must be the player
+ * position at the exact moment of the action, and `updatedAt` is stamped here so
+ * every other client can extrapolate the live position.
+ */
+export const writePlayback = (
+  doc: Y.Doc,
+  next: {
+    state: PlaybackState;
+    positionSeconds: number;
+    rate?: number;
+  },
+): void => {
+  const playback = getPlaybackMap(doc);
+  doc.transact(() => {
+    playback.set(PB_STATE, normalizeState(next.state));
+    playback.set(PB_POSITION, normalizePosition(next.positionSeconds));
+    playback.set(PB_RATE, normalizeRate(next.rate ?? DEFAULT_RATE));
+    playback.set(PB_UPDATED_AT, Date.now());
+  });
+};
+
+/**
+ * Point the room at a video. Used both when starting the very first video and
+ * when advancing to a queued item. Optionally seeds a fresh playback record so
+ * a new video starts cleanly from the given position.
+ */
+export const setVideo = (
+  doc: Y.Doc,
+  videoId: string,
+  options?: { play?: boolean; positionSeconds?: number; title?: string | null },
+): void => {
+  const root = getRoot(doc);
+  const playback = getPlaybackMap(doc);
+  doc.transact(() => {
+    root.set(VIDEO_ID_KEY, videoId);
+    root.set(VIDEO_TITLE_KEY, options?.title ?? null);
+    playback.set(PB_STATE, options?.play === false ? "paused" : "playing");
+    playback.set(PB_POSITION, normalizePosition(options?.positionSeconds ?? 0));
+    playback.set(PB_RATE, DEFAULT_RATE);
+    playback.set(PB_UPDATED_AT, Date.now());
+  });
+};
+
+/** Append an item to the up-next queue. */
+export const enqueue = (
+  doc: Y.Doc,
+  input: { videoId: string; title?: string | null },
+  ctx?: WriteContext,
+): QueueItem => {
+  const item: QueueItem = {
+    id: createQueueId(),
+    videoId: input.videoId,
+    title: input.title ?? null,
+    addedById: ctx?.userId ?? null,
+    addedByName: ctx?.userName ?? null,
+  };
+  getQueueArray(doc).push([item]);
+  return item;
+};
+
+/** Remove a queue item by its stable id. */
+export const removeQueueItem = (doc: Y.Doc, itemId: string): void => {
+  const queue = getQueueArray(doc);
+  const list = queue.toArray();
+  const index = list.findIndex((item) => item?.id === itemId);
+  if (index === -1) return;
+  queue.delete(index, 1);
+};
+
+/** Move a queue item one slot up or down. No-op at the edges or if gone. */
+export const moveQueueItem = (
+  doc: Y.Doc,
+  itemId: string,
+  direction: -1 | 1,
+): void => {
+  const queue = getQueueArray(doc);
+  doc.transact(() => {
+    const list = queue.toArray();
+    const index = list.findIndex((item) => item?.id === itemId);
+    if (index === -1) return;
+    const target = index + direction;
+    if (target < 0 || target >= list.length) return;
+    const item = list[index];
+    queue.delete(index, 1);
+    queue.insert(target, [item]);
+  });
+};
+
+/**
+ * Jump a queued item to the screen right now, atomically: it leaves the queue
+ * and becomes the current video with a fresh playing record in one transaction.
+ */
+export const playQueueItemNow = (doc: Y.Doc, itemId: string): void => {
+  const queue = getQueueArray(doc);
+  doc.transact(() => {
+    const list = queue.toArray();
+    const index = list.findIndex((item) => item?.id === itemId);
+    if (index === -1) return;
+    const item = list[index];
+    if (!item || typeof item.videoId !== "string") return;
+    queue.delete(index, 1);
+    const root = getRoot(doc);
+    const playback = getPlaybackMap(doc);
+    root.set(VIDEO_ID_KEY, item.videoId);
+    root.set(VIDEO_TITLE_KEY, item.title ?? null);
+    playback.set(PB_STATE, "playing");
+    playback.set(PB_POSITION, 0);
+    playback.set(PB_RATE, DEFAULT_RATE);
+    playback.set(PB_UPDATED_AT, Date.now());
+  });
+};
+
+/**
+ * Advance to the next queued video. Returns the video id that became active, or
+ * null if the queue was empty.
+ *
+ * DOUBLE-ADVANCE GUARD: the ENDED event fires on every client, so several may
+ * race to advance. `expectedCurrentVideoId` is the video that just ended; we
+ * only advance if the doc STILL points at it. The first writer flips `videoId`
+ * inside the transaction, so every later racer sees a mismatch and no-ops. This
+ * makes the queue head move exactly once per ended video.
+ */
+export const advanceQueue = (
+  doc: Y.Doc,
+  expectedCurrentVideoId: string | null,
+): string | null => {
+  let advancedTo: string | null = null;
+  doc.transact(() => {
+    if (getVideoId(doc) !== expectedCurrentVideoId) {
+      return;
+    }
+    const queue = getQueueArray(doc);
+    if (queue.length === 0) {
+      return;
+    }
+    const next = queue.get(0);
+    if (!next || typeof next.videoId !== "string") {
+      queue.delete(0, 1);
+      return;
+    }
+    queue.delete(0, 1);
+    const root = getRoot(doc);
+    const playback = getPlaybackMap(doc);
+    root.set(VIDEO_ID_KEY, next.videoId);
+    root.set(VIDEO_TITLE_KEY, next.title ?? null);
+    playback.set(PB_STATE, "playing");
+    playback.set(PB_POSITION, 0);
+    playback.set(PB_RATE, DEFAULT_RATE);
+    playback.set(PB_UPDATED_AT, Date.now());
+    advancedTo = next.videoId;
+  });
+  return advancedTo;
+};
+
+/**
+ * Compute where playback should be right now given a record and the current
+ * clock. This is the extrapolation at the heart of sync: while playing, the
+ * position advances in real time from `updatedAt`; while paused it is frozen.
+ * Author clocks differ slightly, which the drift threshold in the player hook
+ * absorbs, so no server-clock plumbing is needed.
+ */
+export const expectedPosition = (
+  playback: PlaybackRecord,
+  now: number = Date.now(),
+): number => {
+  if (playback.state !== "playing") {
+    return playback.positionSeconds;
+  }
+  const elapsedSeconds = Math.max(0, (now - playback.updatedAt) / 1000);
+  return playback.positionSeconds + elapsedSeconds * playback.rate;
+};
+
+const createQueueId = (): string => {
+  const hasRandomUUID =
+    typeof globalThis.crypto !== "undefined" &&
+    typeof globalThis.crypto.randomUUID === "function";
+  const random = hasRandomUUID
+    ? globalThis.crypto.randomUUID().replace(/-/g, "").slice(0, 12)
+    : Math.random().toString(36).slice(2, 14);
+  return `wt_${Date.now().toString(36)}_${random}`;
+};

--- a/packages/apps-sdk/src/apps/watch/core/index.ts
+++ b/packages/apps-sdk/src/apps/watch/core/index.ts
@@ -1,0 +1,3 @@
+export * from "./model/types";
+export * from "./doc/index";
+export * from "./youtube/id";

--- a/packages/apps-sdk/src/apps/watch/core/model/types.ts
+++ b/packages/apps-sdk/src/apps/watch/core/model/types.ts
@@ -1,0 +1,30 @@
+export type PlaybackState = "playing" | "paused";
+
+/**
+ * One playback record. Exactly one is held in the doc at a time. An acting
+ * client overwrites it on play / pause / seek / rate change.
+ */
+export type PlaybackRecord = {
+  state: PlaybackState;
+  /** Player position, in seconds, at the moment the record was written. */
+  positionSeconds: number;
+  /** ms epoch stamped by the author at the moment of the change. */
+  updatedAt: number;
+  /** Playback rate; default 1. */
+  rate: number;
+};
+
+/** An up-next queue entry. */
+export type QueueItem = {
+  id: string;
+  videoId: string;
+  title: string | null;
+  addedById: string | null;
+  addedByName: string | null;
+};
+
+/** Author identity attached to writes that record who acted. */
+export type WriteContext = {
+  userId?: string | null;
+  userName?: string | null;
+};

--- a/packages/apps-sdk/src/apps/watch/core/youtube/id.ts
+++ b/packages/apps-sdk/src/apps/watch/core/youtube/id.ts
@@ -1,0 +1,81 @@
+// YouTube video ids are exactly 11 chars from [A-Za-z0-9_-].
+const VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+
+/** True if the string is a bare, valid 11-char YouTube video id. */
+export const isValidVideoId = (value: string): boolean =>
+  VIDEO_ID_PATTERN.test(value);
+
+/**
+ * Extract an 11-char YouTube video id from user input. Accepts:
+ * - a bare id (`dQw4w9WgXcQ`)
+ * - `youtube.com/watch?v=<id>` (with any extra query params)
+ * - `youtu.be/<id>`
+ * - `youtube.com/shorts/<id>`
+ * - `youtube.com/embed/<id>` and `youtube.com/live/<id>`
+ * Returns null when nothing valid is found, so the caller can reject inline.
+ */
+export const parseVideoId = (raw: string): string | null => {
+  const input = raw.trim();
+  if (!input) return null;
+
+  // Bare id pasted directly.
+  if (isValidVideoId(input)) {
+    return input;
+  }
+
+  const url = safeParseUrl(input);
+  if (!url) {
+    // Not a URL and not a bare id: try a loose `v=` match as a last resort.
+    const looseMatch = input.match(/[?&]v=([A-Za-z0-9_-]{11})/);
+    return looseMatch ? looseMatch[1] : null;
+  }
+
+  const host = url.hostname.replace(/^www\./, "").toLowerCase();
+
+  // youtu.be/<id>
+  if (host === "youtu.be") {
+    const id = url.pathname.split("/").filter(Boolean)[0] ?? "";
+    return isValidVideoId(id) ? id : null;
+  }
+
+  const isYouTubeHost =
+    host === "youtube.com" ||
+    host === "m.youtube.com" ||
+    host === "music.youtube.com" ||
+    host.endsWith(".youtube.com");
+  if (!isYouTubeHost) {
+    return null;
+  }
+
+  // youtube.com/watch?v=<id>
+  const vParam = url.searchParams.get("v");
+  if (vParam && isValidVideoId(vParam)) {
+    return vParam;
+  }
+
+  // Path-based forms: /shorts/<id>, /embed/<id>, /live/<id>, /v/<id>.
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (segments.length >= 2) {
+    const [prefix, candidate] = segments;
+    if (
+      (prefix === "shorts" ||
+        prefix === "embed" ||
+        prefix === "live" ||
+        prefix === "v") &&
+      isValidVideoId(candidate)
+    ) {
+      return candidate;
+    }
+  }
+
+  return null;
+};
+
+const safeParseUrl = (value: string): URL | null => {
+  const withScheme = /^[a-z]+:\/\//i.test(value) ? value : `https://${value}`;
+  try {
+    return new URL(withScheme);
+  } catch {
+    return null;
+  }
+};

--- a/packages/apps-sdk/src/apps/watch/web/components/GestureOverlay.tsx
+++ b/packages/apps-sdk/src/apps/watch/web/components/GestureOverlay.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import type { GestureNeed } from "../hooks/useSyncedPlayback";
+import { thumbnailUrl } from "../youtubeMeta";
+
+type GestureOverlayProps = {
+  need: GestureNeed;
+  onResolve: () => void;
+  /** The current video, shown as a dimmed poster so the tap has context. */
+  videoId: string | null;
+  title: string | null;
+};
+
+/**
+ * Autoplay gesture overlay. Instead of a bare button in a void, the video's
+ * own thumbnail sits dimmed behind the prompt with its title, so joining
+ * reads as "join this". One solid coral pill, no animation.
+ */
+export function GestureOverlay({
+  need,
+  onResolve,
+  videoId,
+  title,
+}: GestureOverlayProps) {
+  if (need === "none") return null;
+  const label = need === "sound" ? "Join with sound" : "Tap to sync";
+  const sub =
+    need === "sound"
+      ? "You are watching muted until you join."
+      : "Your browser needs a tap before playback can start.";
+
+  return (
+    <div className="absolute inset-0 z-20 overflow-hidden">
+      {videoId ? (
+        <img
+          src={thumbnailUrl(videoId)}
+          alt=""
+          aria-hidden="true"
+          className="absolute inset-0 h-full w-full object-cover"
+          draggable={false}
+        />
+      ) : null}
+      <div
+        className="absolute inset-0"
+        style={{ backgroundColor: "rgba(0, 0, 0, 0.74)" }}
+      />
+
+      <div className="relative flex h-full w-full items-center justify-center p-6">
+        <div className="flex w-full max-w-sm flex-col items-center text-center">
+          <p className="flex items-center gap-1.5 text-[11px] font-medium text-[#a1a1aa]">
+            <span
+              className="h-1.5 w-1.5 rounded-full"
+              style={{ backgroundColor: "#F95F4A" }}
+            />
+            Playing for the room
+          </p>
+          {title ? (
+            <p
+              className="mt-2 text-[15px] font-medium leading-snug text-[#fafafa]"
+              style={{
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }}
+            >
+              {title}
+            </p>
+          ) : null}
+          <button
+            type="button"
+            onClick={onResolve}
+            className="mt-5 inline-flex h-11 cursor-pointer items-center gap-2.5 rounded-full px-6 text-[13.5px] font-medium text-white transition-opacity hover:opacity-90"
+            style={{ backgroundColor: "#F95F4A" }}
+          >
+            {need === "sound" ? (
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" fill="currentColor" stroke="none" />
+                <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+                <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+              </svg>
+            ) : (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <polygon points="6 4 20 12 6 20 6 4" />
+              </svg>
+            )}
+            {label}
+          </button>
+          <p className="mt-3 max-w-[16rem] text-[12px] leading-relaxed text-[#a1a1aa]">
+            {sub}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/apps-sdk/src/apps/watch/web/components/HostPill.tsx
+++ b/packages/apps-sdk/src/apps/watch/web/components/HostPill.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useRef, useState } from "react";
+
+type HostPillProps = {
+  /** Whether the room app lock is on (only admins may control playback). */
+  locked: boolean;
+  isAdmin: boolean;
+  /** Flip the room app lock. Only invoked for admins. */
+  onSetLocked: (locked: boolean) => void;
+};
+
+/**
+ * The playback permission surface, in context. The pill names the POLICY, not
+ * a person ("Host only" or "Everyone"), so it stays truthful with any number
+ * of co-hosts; every admin can open it and flip the switch, and the doc-level
+ * lock is the single source of truth underneath.
+ *
+ * The popover is fixed-positioned from the pill's rect so the rail's
+ * overflow-hidden (needed for the collapse animation) can never clip it.
+ */
+export function HostPill({ locked, isAdmin, onSetLocked }: HostPillProps) {
+  const [open, setOpen] = useState(false);
+  const [anchor, setAnchor] = useState<{ top: number; right: number } | null>(
+    null,
+  );
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (
+        !popoverRef.current?.contains(target) &&
+        !buttonRef.current?.contains(target)
+      ) {
+        setOpen(false);
+      }
+    };
+    const onScrollOrResize = () => setOpen(false);
+    document.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("resize", onScrollOrResize);
+    window.addEventListener("scroll", onScrollOrResize, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("resize", onScrollOrResize);
+      window.removeEventListener("scroll", onScrollOrResize, true);
+    };
+  }, [open]);
+
+  const label = locked ? "Host only" : "Everyone";
+
+  const glyph = locked ? (
+    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  ) : (
+    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 9.9-1" />
+    </svg>
+  );
+
+  if (!isAdmin) {
+    return (
+      <span
+        className="inline-flex h-7 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border border-white/10 px-2.5 text-[11px] font-medium text-[#a1a1aa]"
+        title={
+          locked
+            ? "Only the host can control playback and the queue"
+            : "Anyone can control playback and the queue"
+        }
+      >
+        {glyph}
+        {label}
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => {
+          const rect = buttonRef.current?.getBoundingClientRect();
+          if (rect) {
+            setAnchor({
+              top: rect.bottom + 8,
+              right: Math.max(8, window.innerWidth - rect.right),
+            });
+          }
+          setOpen((prev) => !prev);
+        }}
+        aria-expanded={open}
+        className="inline-flex h-7 shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-full border border-white/10 px-2.5 text-[11px] font-medium text-[#fafafa] transition-colors hover:bg-white/[0.06]"
+      >
+        {glyph}
+        {label}
+        <svg
+          width="9"
+          height="9"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+          style={{
+            transform: open ? "rotate(180deg)" : undefined,
+            transition: "transform 150ms ease",
+          }}
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {open && anchor ? (
+        <div
+          ref={popoverRef}
+          className="w-60 rounded-xl border border-white/10 p-3"
+          style={{
+            position: "fixed",
+            top: anchor.top,
+            right: anchor.right,
+            zIndex: 70,
+            backgroundColor: "#18181b",
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => onSetLocked(!locked)}
+            className="flex w-full cursor-pointer items-center justify-between gap-3 text-left"
+            role="switch"
+            aria-checked={!locked}
+          >
+            <span>
+              <span className="block text-[12.5px] font-medium text-[#fafafa]">
+                Everyone can control
+              </span>
+              <span className="mt-0.5 block text-[11px] leading-snug text-[#71717a]">
+                Playback, seeking, and the queue. Off means host only.
+              </span>
+            </span>
+            <span
+              className="relative h-5 w-9 shrink-0 rounded-full transition-colors"
+              style={{ backgroundColor: locked ? "#33333b" : "#F95F4A" }}
+            >
+              <span
+                className="absolute top-0.5 h-4 w-4 rounded-full bg-white transition-[left]"
+                style={{ left: locked ? 2 : 18 }}
+              />
+            </span>
+          </button>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/packages/apps-sdk/src/apps/watch/web/components/WatchControls.tsx
+++ b/packages/apps-sdk/src/apps/watch/web/components/WatchControls.tsx
@@ -1,0 +1,464 @@
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { PlaybackState } from "../../core/model/types";
+import type { WatchCaptionTrack } from "../hooks/useSyncedPlayback";
+import { formatTime } from "../format";
+
+type WatchControlsProps = {
+  playbackState: PlaybackState;
+  currentTime: number;
+  duration: number;
+  muted: boolean;
+  volume: number;
+  readOnly: boolean;
+  /** Cinema (expanded) view; a local preference, available to everyone. */
+  cinema: boolean;
+  onToggleCinema: () => void;
+  /** Closed captions; a local preference, available to everyone. */
+  captionsAvailable: boolean;
+  captionsOn: boolean;
+  captionTracks: WatchCaptionTrack[];
+  captionSizeAvailable: boolean;
+  captionFontSize: number;
+  onSetCaptionTrack: (language: string | null) => void;
+  onSetCaptionFontSize: (size: number) => void;
+  onPlay: () => void;
+  onPause: () => void;
+  onSeek: (seconds: number) => void;
+  onToggleMute: () => void;
+  onVolumeChange: (value: number) => void;
+};
+
+/**
+ * Slim control bar under the player. Custom flat chrome: a play/pause toggle, a
+ * flat seek bar, current/total time in tabular nums, and a LOCAL-ONLY mute and
+ * volume control (volume never syncs to the doc).
+ */
+export function WatchControls({
+  playbackState,
+  currentTime,
+  duration,
+  muted,
+  volume,
+  readOnly,
+  cinema,
+  onToggleCinema,
+  captionsAvailable,
+  captionsOn,
+  captionTracks,
+  captionSizeAvailable,
+  captionFontSize,
+  onSetCaptionTrack,
+  onSetCaptionFontSize,
+  onPlay,
+  onPause,
+  onSeek,
+  onToggleMute,
+  onVolumeChange,
+}: WatchControlsProps) {
+  // While dragging the seek bar, show the dragged value locally and only commit
+  // on release, so the reconcile tick does not fight the drag.
+  const [scrubValue, setScrubValue] = useState<number | null>(null);
+  const isPlaying = playbackState === "playing";
+  const max = duration > 0 ? duration : 0;
+  const displayTime = scrubValue ?? currentTime;
+  const clampedDisplay = max > 0 ? Math.min(displayTime, max) : displayTime;
+
+  return (
+    <div className="flex items-center gap-2.5 py-2 pl-2.5 pr-2">
+      <button
+        type="button"
+        onClick={isPlaying ? onPause : onPlay}
+        disabled={readOnly}
+        aria-label={isPlaying ? "Pause" : "Play"}
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-white transition-opacity hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+        style={{ backgroundColor: readOnly ? "#26262d" : "#F95F4A" }}
+      >
+        {isPlaying ? (
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <rect x="6" y="5" width="4" height="14" rx="1" />
+            <rect x="14" y="5" width="4" height="14" rx="1" />
+          </svg>
+        ) : (
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" style={{ marginLeft: 1.5 }}>
+            <polygon points="7 4 20 12 7 20 7 4" />
+          </svg>
+        )}
+      </button>
+
+      <span className="w-9 shrink-0 text-right text-[11px] tabular-nums text-[#e4e4e7]">
+        {formatTime(clampedDisplay)}
+      </span>
+
+      <Slider
+        className="min-w-0 flex-1"
+        value={max > 0 ? clampedDisplay : 0}
+        max={max || 100}
+        step={0.1}
+        disabled={readOnly || max <= 0}
+        dragging={scrubValue != null}
+        tone="accent"
+        ariaLabel="Seek"
+        onInput={(next) => setScrubValue(next)}
+        onCommit={(next) => {
+          setScrubValue(null);
+          onSeek(next);
+        }}
+      />
+
+      <span className="w-9 shrink-0 text-[11px] tabular-nums text-[#71717a]">
+        {formatTime(max)}
+      </span>
+
+      <div className="group/vol flex shrink-0 items-center">
+        <button
+          type="button"
+          onClick={onToggleMute}
+          aria-label={muted ? "Unmute" : "Mute"}
+          className="flex h-8 w-8 items-center justify-center rounded-full text-[#c4c4cc] transition-colors hover:text-white cursor-pointer"
+        >
+          {muted || volume === 0 ? (
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" fill="currentColor" stroke="none" />
+              <line x1="23" y1="9" x2="17" y2="15" />
+              <line x1="17" y1="9" x2="23" y2="15" />
+            </svg>
+          ) : (
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" fill="currentColor" stroke="none" />
+              <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+              <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+            </svg>
+          )}
+        </button>
+        {/* Volume rail tucks away and slides out on hover or keyboard focus,
+            so the seek bar stays the only accent line at rest. */}
+        <div className="hidden w-0 overflow-hidden transition-all duration-200 group-focus-within/vol:w-16 group-hover/vol:w-16 sm:block">
+          <Slider
+            className="w-16 pl-1 pr-1.5"
+            value={muted ? 0 : volume}
+            max={100}
+            step={1}
+            disabled={false}
+            dragging={false}
+            tone="neutral"
+            ariaLabel="Volume"
+            onInput={(next) => onVolumeChange(next)}
+            onCommit={(next) => onVolumeChange(next)}
+          />
+        </div>
+        {captionsAvailable ? (
+          <CaptionSettings
+            captionsOn={captionsOn}
+            tracks={captionTracks}
+            sizeAvailable={captionSizeAvailable}
+            fontSize={captionFontSize}
+            onSetTrack={onSetCaptionTrack}
+            onSetFontSize={onSetCaptionFontSize}
+          />
+        ) : null}
+        <button
+          type="button"
+          onClick={onToggleCinema}
+          aria-label={cinema ? "Exit cinema view" : "Cinema view"}
+          aria-pressed={cinema}
+          title={cinema ? "Exit cinema view" : "Cinema view"}
+          className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg text-[#c4c4cc] transition-colors hover:text-white"
+        >
+          {cinema ? (
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <polyline points="4 14 10 14 10 20" />
+              <polyline points="20 10 14 10 14 4" />
+              <line x1="14" y1="10" x2="21" y2="3" />
+              <line x1="3" y1="21" x2="10" y2="14" />
+            </svg>
+          ) : (
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <polyline points="15 3 21 3 21 9" />
+              <polyline points="9 21 3 21 3 15" />
+              <line x1="21" y1="3" x2="14" y2="10" />
+              <line x1="3" y1="21" x2="10" y2="14" />
+            </svg>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const CAPTION_SIZES: Array<{ label: string; value: number }> = [
+  { label: "Small", value: -1 },
+  { label: "Default", value: 0 },
+  { label: "Large", value: 2 },
+  { label: "Huge", value: 3 },
+];
+
+/**
+ * The one captions control: the CC button opens a small popover with Off, the
+ * language tracks, and size. Fixed-positioned from the button's rect (above
+ * the bar) so nothing can clip it, closing on outside click, scroll, or
+ * resize. All local.
+ */
+function CaptionSettings({
+  captionsOn,
+  tracks,
+  sizeAvailable,
+  fontSize,
+  onSetTrack,
+  onSetFontSize,
+}: {
+  captionsOn: boolean;
+  tracks: WatchCaptionTrack[];
+  sizeAvailable: boolean;
+  fontSize: number;
+  onSetTrack: (language: string | null) => void;
+  onSetFontSize: (size: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [anchor, setAnchor] = useState<{ bottom: number; right: number } | null>(
+    null,
+  );
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (
+        !popoverRef.current?.contains(target) &&
+        !buttonRef.current?.contains(target)
+      ) {
+        setOpen(false);
+      }
+    };
+    const onScrollOrResize = () => setOpen(false);
+    document.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("resize", onScrollOrResize);
+    window.addEventListener("scroll", onScrollOrResize, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("resize", onScrollOrResize);
+      window.removeEventListener("scroll", onScrollOrResize, true);
+    };
+  }, [open]);
+
+  const anyActive = tracks.some((track) => track.active);
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => {
+          const rect = buttonRef.current?.getBoundingClientRect();
+          if (rect) {
+            setAnchor({
+              bottom: window.innerHeight - rect.top + 8,
+              right: Math.max(8, window.innerWidth - rect.right),
+            });
+          }
+          setOpen((prev) => !prev);
+        }}
+        aria-label="Captions"
+        aria-expanded={open}
+        aria-pressed={captionsOn}
+        title="Captions"
+        className={`flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg transition-colors ${
+          captionsOn || open
+            ? "bg-white/[0.12] text-white"
+            : "text-[#c4c4cc] hover:text-white"
+        }`}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="3" y="5" width="18" height="14" rx="2.5" />
+          <path d="M10.5 10.2a2.2 2.2 0 0 0-3.6 1.8 2.2 2.2 0 0 0 3.6 1.8" />
+          <path d="M17 10.2a2.2 2.2 0 0 0-3.6 1.8 2.2 2.2 0 0 0 3.6 1.8" />
+        </svg>
+      </button>
+
+      {open && anchor
+        ? /* Portaled to body: the control bar's transform and backdrop-filter
+             make it the containing block for fixed descendants, which would
+             trap this popover inside the bar's overflow clipping. */
+          createPortal(
+        <div
+          ref={popoverRef}
+          className="w-44 rounded-xl border border-white/10 p-1"
+          style={{
+            position: "fixed",
+            bottom: anchor.bottom,
+            right: anchor.right,
+            zIndex: 70,
+            backgroundColor: "#18181b",
+            fontFamily: "'PolySans Trial', sans-serif",
+          }}
+        >
+          <p className="px-2 pb-0.5 pt-1 text-[10px] font-medium text-[#71717a]">
+            Captions
+          </p>
+          <SettingsRow
+            label="Off"
+            active={!anyActive}
+            onSelect={() => onSetTrack(null)}
+          />
+          {tracks.map((track) => (
+            <SettingsRow
+              key={track.language}
+              label={track.label}
+              active={track.active}
+              onSelect={() => onSetTrack(track.language)}
+            />
+          ))}
+          {sizeAvailable ? (
+            <>
+              <p className="px-2 pb-0.5 pt-1.5 text-[10px] font-medium text-[#71717a]">
+                Size
+              </p>
+              <div className="mx-1 mb-1 flex items-center rounded-lg border border-white/[0.08] p-0.5">
+                {CAPTION_SIZES.map((size) => (
+                  <button
+                    key={size.value}
+                    type="button"
+                    onClick={() => onSetFontSize(size.value)}
+                    aria-pressed={fontSize === size.value}
+                    className={`h-5.5 min-w-0 flex-1 cursor-pointer truncate rounded-md px-1 py-0.5 text-[10px] font-medium transition-colors ${
+                      fontSize === size.value
+                        ? "text-white"
+                        : "text-[#71717a] hover:text-[#fafafa]"
+                    }`}
+                    style={
+                      fontSize === size.value
+                        ? { backgroundColor: "#F95F4A" }
+                        : undefined
+                    }
+                  >
+                    {size.label}
+                  </button>
+                ))}
+              </div>
+            </>
+          ) : null}
+        </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}
+
+function SettingsRow({
+  label,
+  active,
+  onSelect,
+}: {
+  label: string;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg px-2 py-1 text-left text-[11.5px] transition-colors ${
+        active
+          ? "bg-white/[0.07] font-medium text-[#fafafa]"
+          : "text-[#a1a1aa] hover:bg-white/[0.04] hover:text-[#fafafa]"
+      }`}
+    >
+      <span className="truncate">{label}</span>
+      {active ? (
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#F95F4A" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="shrink-0">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : null}
+    </button>
+  );
+}
+
+type SliderProps = {
+  value: number;
+  max: number;
+  step: number;
+  disabled: boolean;
+  /** Keeps the thumb visible while the user is scrubbing. */
+  dragging: boolean;
+  /** Accent (coral) for the seek bar, neutral (white) for volume. */
+  tone: "accent" | "neutral";
+  ariaLabel: string;
+  className?: string;
+  onInput: (value: number) => void;
+  onCommit: (value: number) => void;
+};
+
+/**
+ * Flat slider: a hairline rail with a solid fill and a thumb that appears on
+ * hover or while dragging, driven by a transparent native range input on top
+ * for accessibility and pointer handling. No gradients: the fill is a
+ * plain-colored block sized by percentage.
+ */
+function Slider({
+  value,
+  max,
+  step,
+  disabled,
+  dragging,
+  tone,
+  ariaLabel,
+  className,
+  onInput,
+  onCommit,
+}: SliderProps) {
+  const pct = max > 0 ? Math.max(0, Math.min(100, (value / max) * 100)) : 0;
+  const fillColor = disabled
+    ? "#5a5a62"
+    : tone === "accent"
+      ? "#F95F4A"
+      : "#d4d4d8";
+
+  const commit = (event: React.SyntheticEvent<HTMLInputElement>) => {
+    onCommit(Number(event.currentTarget.value));
+  };
+
+  return (
+    <div className={`group relative flex h-4 items-center ${className ?? ""}`}>
+      {/* rail: hairline at rest, a touch taller under the pointer */}
+      <div
+        className="absolute left-0 right-0 h-[3px] rounded-full transition-all group-hover:h-1"
+        style={{ backgroundColor: "#33333b" }}
+      />
+      {/* fill (flat solid, sized by percentage) */}
+      <div
+        className="absolute left-0 h-[3px] rounded-full transition-all group-hover:h-1"
+        style={{ width: `${pct}%`, backgroundColor: fillColor }}
+      />
+      {/* thumb: revealed on hover or while scrubbing. Its travel is clamped
+          to the rail (0 to 100% minus its own width) so it never clips at
+          either end. */}
+      <div
+        className={`pointer-events-none absolute h-2.5 w-2.5 rounded-full transition-opacity ${
+          dragging ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+        }`}
+        style={{
+          left: `calc(${pct} * (100% - 10px) / 100)`,
+          backgroundColor: disabled ? "#6b6b72" : "#ffffff",
+        }}
+      />
+      {/* transparent native input drives interaction + a11y */}
+      <input
+        type="range"
+        min={0}
+        max={max}
+        step={step}
+        value={value}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        onChange={(event) => onInput(Number(event.currentTarget.value))}
+        onMouseUp={commit}
+        onTouchEnd={commit}
+        onKeyUp={commit}
+        className="absolute inset-0 m-0 w-full cursor-pointer appearance-none bg-transparent opacity-0 disabled:cursor-not-allowed"
+      />
+    </div>
+  );
+}

--- a/packages/apps-sdk/src/apps/watch/web/components/WatchEmptyState.tsx
+++ b/packages/apps-sdk/src/apps/watch/web/components/WatchEmptyState.tsx
@@ -1,0 +1,422 @@
+import React, { useEffect, useRef, useState } from "react";
+import { parseVideoId } from "../../core/youtube/id";
+import {
+  fetchTrending,
+  fetchVideoTitle,
+  formatAge,
+  formatDuration,
+  formatViews,
+  searchVideos,
+  thumbnailUrl,
+  type WatchSearchResult,
+} from "../youtubeMeta";
+
+type WatchEmptyStateProps = {
+  onStart: (videoId: string, title?: string | null) => void;
+  readOnly: boolean;
+  /**
+   * What picking a video does: start playback for the room (idle state), add
+   * to the queue (browsing with control), or request it (browsing without).
+   */
+  mode?: "start" | "add" | "request";
+};
+
+const PICK_LABEL: Record<"start" | "add" | "request", string> = {
+  start: "Play",
+  add: "Add",
+  request: "Request",
+};
+
+const PREVIEW_HINT: Record<"start" | "add" | "request", string> = {
+  start: "Starts in sync for everyone in the room",
+  add: "Adds to the room queue",
+  request: "Sends a request for the host to approve",
+};
+
+/**
+ * The idle browse surface. One pill input takes either a YouTube link (instant
+ * live preview of exactly what will play) or a search query (results on
+ * submit, quota-friendly). Trending fills the grid until there is a query, so
+ * the app opens with something to tap instead of an empty form.
+ */
+export function WatchEmptyState({
+  onStart,
+  readOnly,
+  mode = "start",
+}: WatchEmptyStateProps) {
+  const [value, setValue] = useState("");
+  const [previewTitle, setPreviewTitle] = useState<string | null>(null);
+  const [trending, setTrending] = useState<WatchSearchResult[]>([]);
+  const [trendingToken, setTrendingToken] = useState<string | null>(null);
+  const [results, setResults] = useState<WatchSearchResult[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [searchedFor, setSearchedFor] = useState<string | null>(null);
+  const requestRef = useRef(0);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const loadingMoreRef = useRef(false);
+
+  const previewId = parseVideoId(value);
+
+  useEffect(() => {
+    if (readOnly) return;
+    let cancelled = false;
+    void fetchTrending().then((page) => {
+      if (cancelled) return;
+      setTrending(page.items);
+      setTrendingToken(page.nextPageToken);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [readOnly]);
+
+  // Infinite scroll for trending: a sentinel below the grid pulls the next
+  // page (deduped) as it nears the viewport. Search results stay single-page.
+  useEffect(() => {
+    if (readOnly || !trendingToken) return;
+    const sentinel = sentinelRef.current;
+    const root = scrollRef.current;
+    if (!sentinel || !root) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        if (loadingMoreRef.current) return;
+        loadingMoreRef.current = true;
+        void fetchTrending(trendingToken).then((page) => {
+          loadingMoreRef.current = false;
+          setTrendingToken(page.nextPageToken);
+          if (page.items.length === 0) return;
+          setTrending((previous) => {
+            const seen = new Set(previous.map((item) => item.videoId));
+            return [
+              ...previous,
+              ...page.items.filter((item) => !seen.has(item.videoId)),
+            ];
+          });
+        });
+      },
+      { root, rootMargin: "600px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+    // results/previewId swap the grid in and out; rebind to the fresh sentinel.
+  }, [readOnly, trendingToken, results, previewId]);
+
+  // Live title for a pasted link, race-guarded.
+  useEffect(() => {
+    if (!previewId) {
+      setPreviewTitle(null);
+      return;
+    }
+    const requestId = ++requestRef.current;
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      void fetchVideoTitle(previewId).then((title) => {
+        if (cancelled || requestRef.current !== requestId) return;
+        setPreviewTitle(title);
+      });
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [previewId]);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (readOnly) return;
+    if (previewId) {
+      onStart(previewId, previewTitle);
+      return;
+    }
+    const query = value.trim();
+    if (!query) return;
+    const requestId = ++requestRef.current;
+    setSearching(true);
+    setSearchedFor(query);
+    void searchVideos(query).then((items) => {
+      if (requestRef.current !== requestId) return;
+      setResults(items);
+      setSearching(false);
+    });
+  };
+
+  if (readOnly) {
+    return (
+      <div className="flex h-full w-full items-center justify-center p-6">
+        <div className="w-full max-w-sm">
+          <div
+            aria-hidden="true"
+            className="mx-auto flex aspect-video w-full items-center justify-center rounded-2xl border border-white/10"
+            style={{ backgroundColor: "#101014" }}
+          >
+            <span
+              className="flex h-12 w-12 items-center justify-center rounded-full"
+              style={{ backgroundColor: "#F95F4A" }}
+            >
+              <PlayGlyph />
+            </span>
+          </div>
+          <p className="mt-5 text-center text-[13px] leading-relaxed text-[#a1a1aa]">
+            Waiting for the host to start something. Playback stays in sync for
+            everyone.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const showResults = results !== null || searching;
+  const gridItems = showResults ? (results ?? []) : trending;
+
+  return (
+    <div ref={scrollRef} className="h-full w-full overflow-y-auto">
+      <div className="mx-auto w-full max-w-6xl px-6 pb-8 pt-7">
+        {/* Centered pill search: one box for links and searches alike. */}
+        <form
+          onSubmit={handleSubmit}
+          className="relative mx-auto w-full max-w-xl"
+        >
+          <input
+            type="text"
+            value={value}
+            autoFocus
+            onChange={(event) => setValue(event.target.value)}
+            placeholder="Search YouTube or paste a link"
+            className="h-11 w-full rounded-full border border-white/10 bg-white/[0.04] pl-4 pr-24 text-sm text-[#fafafa] outline-none transition-colors placeholder:text-[#71717a] focus:border-[#F95F4A]/50"
+          />
+          <button
+            type="submit"
+            disabled={!value.trim()}
+            aria-label={previewId ? "Play for everyone" : "Search"}
+            className="absolute right-1.5 top-1/2 flex h-8 -translate-y-1/2 cursor-pointer items-center justify-center gap-1.5 rounded-full px-3 text-[12.5px] font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+            style={{ backgroundColor: "#F95F4A" }}
+          >
+            {previewId ? (
+              <>
+                {mode === "start" ? <PlayGlyph size={11} /> : <PlusGlyph size={12} />}
+                {PICK_LABEL[mode]}
+              </>
+            ) : (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <circle cx="11" cy="11" r="7" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              </svg>
+            )}
+          </button>
+        </form>
+
+        {previewId ? (
+          /* A pasted link becomes a live preview card: what you see is exactly
+             what plays for the room when you tap it. */
+          <button
+            type="button"
+            onClick={() => onStart(previewId, previewTitle)}
+            className="group mx-auto mt-8 block w-full max-w-md cursor-pointer text-left"
+          >
+            <div
+              className="relative aspect-video w-full overflow-hidden rounded-2xl border border-white/10 transition-colors group-hover:border-white/25"
+              style={{ backgroundColor: "#101014" }}
+            >
+              <img
+                src={thumbnailUrl(previewId)}
+                alt=""
+                className="h-full w-full object-cover"
+                draggable={false}
+              />
+              <div
+                className="absolute inset-0"
+                style={{ backgroundColor: "rgba(0, 0, 0, 0.35)" }}
+              />
+              <span
+                className="absolute left-1/2 top-1/2 flex h-12 w-12 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full"
+                style={{ backgroundColor: "#F95F4A" }}
+              >
+                <PlayGlyph />
+              </span>
+            </div>
+            <p className="mt-2.5 text-center text-[13px] font-medium text-[#fafafa]">
+              {previewTitle ??
+                (mode === "start"
+                  ? "Tap to play this link for the room"
+                  : "Tap to pick this link")}
+            </p>
+            <p className="mt-1 text-center text-[11.5px] text-[#71717a]">
+              {PREVIEW_HINT[mode]}
+            </p>
+          </button>
+        ) : (
+          <>
+            <div className="mt-8 flex items-center gap-2">
+              {showResults ? (
+                <>
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#F95F4A" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <circle cx="11" cy="11" r="7" />
+                    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                  </svg>
+                  <h3 className="text-[13px] font-medium text-[#fafafa]">
+                    {searching
+                      ? "Searching"
+                      : `Results for "${searchedFor ?? ""}"`}
+                  </h3>
+                  {!searching ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setResults(null);
+                        setSearchedFor(null);
+                        setValue("");
+                      }}
+                      className="ml-1 cursor-pointer text-[11.5px] text-[#71717a] transition-colors hover:text-[#fafafa]"
+                    >
+                      Clear
+                    </button>
+                  ) : null}
+                </>
+              ) : trending.length > 0 ? (
+                <>
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#F95F4A" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z" />
+                  </svg>
+                  <h3 className="text-[13px] font-medium text-[#fafafa]">
+                    Trending
+                  </h3>
+                </>
+              ) : null}
+            </div>
+
+            {showResults && !searching && gridItems.length === 0 ? (
+              <p className="mt-3 text-[12.5px] text-[#71717a]">
+                Nothing found. Try a different search or paste a link.
+              </p>
+            ) : null}
+
+            <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-6 md:grid-cols-3 xl:grid-cols-4">
+              {searching
+                ? Array.from({ length: 8 }).map((_, index) => (
+                    <div key={index} aria-hidden="true">
+                      <div
+                        className="aspect-video w-full rounded-xl border border-white/[0.06]"
+                        style={{ backgroundColor: "#101014" }}
+                      />
+                      <div
+                        className="mt-2 h-3 w-4/5 rounded"
+                        style={{ backgroundColor: "#17171c" }}
+                      />
+                      <div
+                        className="mt-1.5 h-2.5 w-2/5 rounded"
+                        style={{ backgroundColor: "#131318" }}
+                      />
+                    </div>
+                  ))
+                : gridItems.map((item) => {
+                    const duration = formatDuration(item.durationSeconds);
+                    const views = formatViews(item.views);
+                    const age = formatAge(item.publishedAt);
+                    const meta = [views, age].filter(Boolean).join(" · ");
+                    return (
+                      <button
+                        key={item.videoId}
+                        type="button"
+                        onClick={() => onStart(item.videoId, item.title)}
+                        className="group cursor-pointer text-left"
+                      >
+                        <div
+                          className="relative aspect-video w-full overflow-hidden rounded-xl border border-white/[0.08] transition-colors group-hover:border-white/25"
+                          style={{ backgroundColor: "#101014" }}
+                        >
+                          <img
+                            src={item.thumbnail ?? thumbnailUrl(item.videoId)}
+                            alt=""
+                            className="h-full w-full object-cover"
+                            loading="lazy"
+                            draggable={false}
+                          />
+                          {duration ? (
+                            <span
+                              className="absolute bottom-1.5 right-1.5 rounded-md px-1.5 py-0.5 text-[10.5px] font-medium tabular-nums text-white"
+                              style={{ backgroundColor: "rgba(0, 0, 0, 0.85)" }}
+                            >
+                              {duration}
+                            </span>
+                          ) : null}
+                          <span
+                            className="absolute left-1/2 top-1/2 flex h-9 w-9 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full opacity-0 transition-opacity group-hover:opacity-100"
+                            style={{ backgroundColor: "#F95F4A" }}
+                          >
+                            {mode === "start" ? (
+                              <PlayGlyph size={12} />
+                            ) : (
+                              <PlusGlyph size={14} />
+                            )}
+                          </span>
+                        </div>
+                        <p
+                          className="mt-2 text-[13px] font-medium leading-snug text-[#f4f4f5]"
+                          style={{
+                            display: "-webkit-box",
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: "vertical",
+                            overflow: "hidden",
+                          }}
+                        >
+                          {item.title}
+                        </p>
+                        {item.channel ? (
+                          <p className="mt-1 truncate text-[11.5px] text-[#a1a1aa]">
+                            {item.channel}
+                          </p>
+                        ) : null}
+                        {meta ? (
+                          <p className="mt-0.5 truncate text-[11px] text-[#71717a]">
+                            {meta}
+                          </p>
+                        ) : null}
+                      </button>
+                    );
+                  })}
+            </div>
+            {!showResults && trendingToken ? (
+              <div ref={sentinelRef} aria-hidden="true" className="h-px" />
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PlayGlyph({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="#ffffff"
+      aria-hidden="true"
+      style={{ marginLeft: 2 }}
+    >
+      <polygon points="6 4 20 12 6 20 6 4" />
+    </svg>
+  );
+}
+
+function PlusGlyph({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="#ffffff"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}

--- a/packages/apps-sdk/src/apps/watch/web/components/WatchQueue.tsx
+++ b/packages/apps-sdk/src/apps/watch/web/components/WatchQueue.tsx
@@ -1,0 +1,316 @@
+import React, { useRef, useState } from "react";
+import type { QueueItem } from "../../core/model/types";
+import { parseVideoId } from "../../core/youtube/id";
+import {
+  searchVideos,
+  thumbnailUrl,
+  type WatchSearchResult,
+} from "../youtubeMeta";
+
+type NowPlaying = {
+  videoId: string;
+  title: string | null;
+};
+
+type WatchQueueProps = {
+  items: QueueItem[];
+  nowPlaying: NowPlaying | null;
+  readOnly: boolean;
+  onAdd: (videoId: string, title?: string | null) => void;
+  onRemove: (itemId: string) => void;
+  /** Jump this item to the screen right now. */
+  onPlayNow: (itemId: string) => void;
+  /** Move this item one slot up (-1) or down (1). */
+  onMove: (itemId: string, direction: -1 | 1) => void;
+  /** Right side of the header row (host pill, collapse control). */
+  headerAccessory?: React.ReactNode;
+  /** Pending queue requests, rendered between the header and the add box. */
+  requestsSection?: React.ReactNode;
+};
+
+/**
+ * The side rail: a Now playing card, the up-next list with real thumbnails, and
+ * an add-to-queue input. Titles are backfilled from metadata when available and
+ * fall back to the video id.
+ */
+/**
+ * The rail's add box: a link enqueues immediately; anything else searches on
+ * submit and shows a compact result list to tap into the queue.
+ */
+function QueueAddBox({
+  onAdd,
+}: {
+  onAdd: (videoId: string, title?: string | null) => void;
+}) {
+  const [value, setValue] = useState("");
+  const [results, setResults] = useState<WatchSearchResult[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const requestRef = useRef(0);
+
+  const reset = () => {
+    setValue("");
+    setResults(null);
+    setSearching(false);
+    requestRef.current += 1;
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const raw = value.trim();
+    if (!raw) return;
+    const id = parseVideoId(raw);
+    if (id) {
+      onAdd(id);
+      reset();
+      return;
+    }
+    const requestId = ++requestRef.current;
+    setSearching(true);
+    void searchVideos(raw).then((items) => {
+      if (requestRef.current !== requestId) return;
+      setResults(items.slice(0, 5));
+      setSearching(false);
+    });
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit} className="flex items-stretch gap-1.5">
+        <input
+          type="text"
+          value={value}
+          onChange={(event) => {
+            setValue(event.target.value);
+            if (results) setResults(null);
+          }}
+          placeholder="Search or paste a link"
+          className="h-9 min-w-0 flex-1 rounded-lg border border-white/10 bg-white/[0.04] px-3 text-[12.5px] text-[#fafafa] outline-none transition-colors placeholder:text-[#71717a] focus:border-[#F95F4A]/50"
+        />
+        <button
+          type="submit"
+          disabled={!value.trim() || searching}
+          className="h-9 shrink-0 cursor-pointer rounded-lg px-3 text-[12.5px] font-medium transition-opacity hover:opacity-90 disabled:cursor-not-allowed"
+          style={
+            !value.trim() || searching
+              ? { backgroundColor: "#26262d", color: "#71717a" }
+              : { backgroundColor: "#F95F4A", color: "#ffffff" }
+          }
+        >
+          Add
+        </button>
+      </form>
+      {searching ? (
+        <p className="mt-2 text-[11.5px] text-[#71717a]">Searching</p>
+      ) : null}
+      {results !== null && !searching ? (
+        results.length === 0 ? (
+          <p className="mt-2 text-[11.5px] text-[#71717a]">
+            Nothing found. Try a different search.
+          </p>
+        ) : (
+          <ul className="mt-2 flex flex-col gap-0.5 rounded-lg border border-white/[0.06] p-1" style={{ backgroundColor: "#0c0c10" }}>
+            {results.map((item) => (
+              <li key={item.videoId}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onAdd(item.videoId, item.title);
+                    reset();
+                  }}
+                  className="flex w-full cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-white/[0.06]"
+                >
+                  <div
+                    className="h-8 w-14 shrink-0 overflow-hidden rounded border border-white/[0.06]"
+                    style={{ backgroundColor: "#0a0a0b" }}
+                  >
+                    <img
+                      src={item.thumbnail ?? thumbnailUrl(item.videoId)}
+                      alt=""
+                      className="h-full w-full object-cover"
+                      loading="lazy"
+                      draggable={false}
+                    />
+                  </div>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[11.5px] font-medium text-[#e4e4e7]">
+                      {item.title}
+                    </span>
+                    {item.channel ? (
+                      <span className="block truncate text-[10px] text-[#71717a]">
+                        {item.channel}
+                      </span>
+                    ) : null}
+                  </span>
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#71717a" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="shrink-0">
+                    <line x1="12" y1="5" x2="12" y2="19" />
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                  </svg>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+export function WatchQueue({
+  items,
+  nowPlaying,
+  readOnly,
+  onAdd,
+  onRemove,
+  onPlayNow,
+  onMove,
+  headerAccessory,
+  requestsSection,
+}: WatchQueueProps) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {nowPlaying ? (
+        <div className="border-b border-white/[0.06] px-3 pb-3 pt-3">
+          <div
+            className="overflow-hidden rounded-lg border border-white/10"
+            style={{ backgroundColor: "#0a0a0b" }}
+          >
+            <img
+              src={thumbnailUrl(nowPlaying.videoId)}
+              alt=""
+              className="aspect-video w-full object-cover"
+              draggable={false}
+            />
+          </div>
+          <p
+            className="mt-2 text-[12.5px] font-medium leading-snug text-[#fafafa]"
+            style={{
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+            }}
+          >
+            {nowPlaying.title ?? nowPlaying.videoId}
+          </p>
+        </div>
+      ) : null}
+
+      <div className="flex items-center justify-between gap-2 px-3 pb-2 pt-3">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <h3 className="whitespace-nowrap text-[12px] font-medium text-[#fafafa]">
+            Up next
+          </h3>
+          {items.length > 0 ? (
+            <span className="rounded-full border border-white/10 px-1.5 py-0.5 text-[10px] tabular-nums text-[#a1a1aa]">
+              {items.length}
+            </span>
+          ) : null}
+        </div>
+        {headerAccessory ? (
+          <div className="flex shrink-0 items-center gap-1">{headerAccessory}</div>
+        ) : null}
+      </div>
+
+      {requestsSection}
+
+      {!readOnly ? (
+        <div className="px-3 pb-2.5">
+          <QueueAddBox onAdd={onAdd} />
+        </div>
+      ) : null}
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-2">
+        {items.length === 0 ? (
+          <p className="px-2 py-3 text-[12px] leading-relaxed text-[#71717a]">
+            {readOnly
+              ? "Nothing queued yet."
+              : "Add links to build a queue. When a video ends, the next one plays for everyone."}
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-0.5">
+            {items.map((item, index) => (
+              <li
+                key={item.id}
+                className="group flex items-center gap-2.5 rounded-lg px-1.5 py-1.5 transition-colors hover:bg-white/[0.05]"
+              >
+                <div
+                  className="relative h-10 w-[71px] shrink-0 overflow-hidden rounded-md border border-white/[0.06]"
+                  style={{ backgroundColor: "#0a0a0b" }}
+                >
+                  <img
+                    src={thumbnailUrl(item.videoId)}
+                    alt=""
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                    draggable={false}
+                  />
+                  {!readOnly ? (
+                    <button
+                      type="button"
+                      onClick={() => onPlayNow(item.id)}
+                      aria-label="Play now"
+                      title="Play now"
+                      className="absolute inset-0 flex cursor-pointer items-center justify-center opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
+                      style={{ backgroundColor: "rgba(0, 0, 0, 0.55)" }}
+                    >
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="#ffffff" aria-hidden="true">
+                        <polygon points="6 4 20 12 6 20 6 4" />
+                      </svg>
+                    </button>
+                  ) : null}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-[12px] font-medium text-[#e4e4e7]">
+                    {item.title ?? item.videoId}
+                  </p>
+                  {item.addedByName ? (
+                    <p className="mt-0.5 truncate text-[10.5px] text-[#71717a]">
+                      {item.addedByName}
+                    </p>
+                  ) : null}
+                </div>
+                {!readOnly ? (
+                  <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+                    <button
+                      type="button"
+                      onClick={() => onMove(item.id, -1)}
+                      disabled={index === 0}
+                      aria-label="Move up"
+                      className="flex h-6 w-5 cursor-pointer items-center justify-center rounded-md text-[#71717a] transition-colors hover:bg-white/[0.06] hover:text-[#fafafa] disabled:cursor-default disabled:opacity-30"
+                    >
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                        <polyline points="18 15 12 9 6 15" />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onMove(item.id, 1)}
+                      disabled={index === items.length - 1}
+                      aria-label="Move down"
+                      className="flex h-6 w-5 cursor-pointer items-center justify-center rounded-md text-[#71717a] transition-colors hover:bg-white/[0.06] hover:text-[#fafafa] disabled:cursor-default disabled:opacity-30"
+                    >
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                        <polyline points="6 9 12 15 18 9" />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onRemove(item.id)}
+                      aria-label="Remove from queue"
+                      className="flex h-6 w-5 cursor-pointer items-center justify-center rounded-md text-[#71717a] transition-colors hover:bg-white/[0.06] hover:text-[#fafafa]"
+                    >
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                        <line x1="18" y1="6" x2="6" y2="18" />
+                        <line x1="6" y1="6" x2="18" y2="18" />
+                      </svg>
+                    </button>
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/apps-sdk/src/apps/watch/web/components/WatchWebApp.tsx
+++ b/packages/apps-sdk/src/apps/watch/web/components/WatchWebApp.tsx
@@ -1,0 +1,683 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import ReactPlayer from "react-player";
+import { useApps } from "../../../../sdk/hooks/useApps";
+import { useAppDoc } from "../../../../sdk/hooks/useAppDoc";
+import {
+  advanceQueue,
+  enqueue,
+  getVideoId,
+  getWatchRequestResolution,
+  moveQueueItem,
+  playQueueItemNow,
+  removeQueueItem,
+  resolveWatchRequest,
+  setQueueItemTitle,
+  setVideo,
+  setVideoTitle,
+} from "../../core/doc/index";
+import { useSyncedPlayback } from "../hooks/useSyncedPlayback";
+import { useWatchDocState } from "../hooks/useWatchDocState";
+import {
+  useWatchRequests,
+  type WatchRequest,
+} from "../hooks/useWatchRequests";
+import { fetchVideoTitle, thumbnailUrl } from "../youtubeMeta";
+import { GestureOverlay } from "./GestureOverlay";
+import { HostPill } from "./HostPill";
+import { WatchControls } from "./WatchControls";
+import { WatchEmptyState } from "./WatchEmptyState";
+import { WatchQueue } from "./WatchQueue";
+
+// Hide the floating controls after this much pointer idle while playing.
+const CONTROLS_IDLE_MS = 2600;
+
+/**
+ * Watch together: synced YouTube playback on the Conclave apps SDK. Nobody
+ * streams video to anyone. YouTube serves each participant directly and the
+ * shared Yjs doc syncs intent only.
+ *
+ * The player is react-player v3 with native controls OFF and a click shield
+ * over the iframe, so ALL playback intent flows through our custom UI, which
+ * writes the doc first; the player follows declaratively. This removes the
+ * whole class of native-control/echo bugs by construction.
+ */
+export function WatchWebApp() {
+  const { user, isAdmin, isReadOnly: appReadOnly, setLocked } = useApps();
+  const { doc, locked, awareness } = useAppDoc("watch");
+  // Read-only when the app itself is read-only (observer) or the room is locked
+  // and the user is not an admin. Playback still follows the doc either way.
+  const isReadOnly = Boolean(appReadOnly) || (locked && !isAdmin);
+  // Locked non-admins cannot edit, but they CAN ask: their picks become queue
+  // requests the host approves. True observers get neither.
+  const canRequest = !appReadOnly && locked && !isAdmin;
+
+  const watchRequests = useWatchRequests({
+    doc,
+    awareness,
+    self: { id: user?.id ?? null, name: user?.name ?? null },
+  });
+
+  const { videoId, videoTitle, queue } = useWatchDocState(doc);
+
+  const player = useSyncedPlayback({ doc, videoId, readOnly: isReadOnly });
+
+  // Start a video: play immediately when idle, append to the queue otherwise.
+  // Playback starts instantly with no title; the title backfills into the doc
+  // a moment later (best effort, guarded so a slow fetch cannot mislabel).
+  const handleAdd = useCallback(
+    (nextVideoId: string, knownTitle?: string | null) => {
+      if (isReadOnly) return;
+      const current = getVideoId(doc);
+      if (!current) {
+        setVideo(doc, nextVideoId, {
+          play: true,
+          positionSeconds: 0,
+          title: knownTitle ?? null,
+        });
+        if (!knownTitle) {
+          void fetchVideoTitle(nextVideoId).then((title) => {
+            if (title) setVideoTitle(doc, nextVideoId, title);
+          });
+        }
+        return;
+      }
+      const item = enqueue(
+        doc,
+        { videoId: nextVideoId, title: knownTitle ?? null },
+        { userId: user?.id ?? null, userName: user?.name ?? null },
+      );
+      if (!knownTitle) {
+        void fetchVideoTitle(nextVideoId).then((title) => {
+          if (title) setQueueItemTitle(doc, item.id, title);
+        });
+      }
+    },
+    [doc, isReadOnly, user?.id, user?.name],
+  );
+
+  // The empty-state browse surface always starts playback (it only renders
+  // when idle).
+  const handleStart = useCallback(
+    (nextVideoId: string, knownTitle?: string | null) => {
+      if (isReadOnly) return;
+      // Guard against a race where a video appeared between render and submit.
+      if (getVideoId(doc)) {
+        handleAdd(nextVideoId, knownTitle);
+        return;
+      }
+      setVideo(doc, nextVideoId, {
+        play: true,
+        positionSeconds: 0,
+        title: knownTitle ?? null,
+      });
+      if (!knownTitle) {
+        void fetchVideoTitle(nextVideoId).then((title) => {
+          if (title) setVideoTitle(doc, nextVideoId, title);
+        });
+      }
+    },
+    [doc, handleAdd, isReadOnly],
+  );
+
+  const handleRemove = useCallback(
+    (itemId: string) => {
+      if (isReadOnly) return;
+      removeQueueItem(doc, itemId);
+    },
+    [doc, isReadOnly],
+  );
+
+  const handlePlayNow = useCallback(
+    (itemId: string) => {
+      if (isReadOnly) return;
+      const item = queue.find((entry) => entry.id === itemId);
+      playQueueItemNow(doc, itemId);
+      if (item && !item.title) {
+        void fetchVideoTitle(item.videoId).then((title) => {
+          if (title) setVideoTitle(doc, item.videoId, title);
+        });
+      }
+    },
+    [doc, isReadOnly, queue],
+  );
+
+  const handleMove = useCallback(
+    (itemId: string, direction: -1 | 1) => {
+      if (isReadOnly) return;
+      moveQueueItem(doc, itemId, direction);
+    },
+    [doc, isReadOnly],
+  );
+
+  const handleSetLocked = useCallback(
+    (nextLocked: boolean) => {
+      void setLocked(nextLocked);
+    },
+    [setLocked],
+  );
+
+  // The queue rail collapses to give the video the whole app; a chip brings it
+  // back. A local preference, never synced, and it doubles as theater view.
+  const [railOpen, setRailOpen] = useState(true);
+  const handleToggleRail = useCallback(() => {
+    setRailOpen((prev) => !prev);
+  }, []);
+
+  // Personal browse mode over the running video: playback (and audio) carry on
+  // underneath while you shop trending or search for the queue.
+  const [browsing, setBrowsing] = useState(false);
+  const handleBrowsePick = useCallback(
+    (pickedId: string, pickedTitle?: string | null) => {
+      if (appReadOnly) return;
+      if (canRequest) {
+        watchRequests.submitRequest(pickedId, pickedTitle);
+        // Close so the requester lands on their pending row in the rail.
+        setBrowsing(false);
+        setRailOpen(true);
+        return;
+      }
+      // Editors stay in browse to add several in a row; items appear in the
+      // rail as they land.
+      handleAdd(pickedId, pickedTitle);
+    },
+    [appReadOnly, canRequest, handleAdd, watchRequests],
+  );
+
+  const acceptRequest = useCallback(
+    (request: WatchRequest) => {
+      // With co-hosts, two admins can race on the same request; the first
+      // resolution wins and later clicks become no-ops instead of duplicates.
+      if (getWatchRequestResolution(doc, request.id)) return;
+      resolveWatchRequest(doc, request.id, "added");
+      const item = enqueue(
+        doc,
+        { videoId: request.videoId, title: request.title },
+        { userId: request.byId, userName: request.byName },
+      );
+      if (!request.title) {
+        void fetchVideoTitle(request.videoId).then((title) => {
+          if (title) setQueueItemTitle(doc, item.id, title);
+        });
+      }
+    },
+    [doc],
+  );
+
+  const declineRequest = useCallback(
+    (request: WatchRequest) => {
+      if (getWatchRequestResolution(doc, request.id)) return;
+      resolveWatchRequest(doc, request.id, "declined");
+    },
+    [doc],
+  );
+
+  const hasVideo = Boolean(videoId);
+  const isPlaying = player.playbackState === "playing";
+  // A video that ended into an EMPTY queue parks paused at its final frame,
+  // and the ENDED event that normally advances has already fired. So when
+  // something lands in the queue afterwards (an add, another client, an
+  // accepted request), any client with edit rights advances; advanceQueue's
+  // compare-and-swap lets exactly one writer win across the room.
+  const videoOver =
+    hasVideo &&
+    !isPlaying &&
+    player.duration > 0 &&
+    player.currentTime >= player.duration - 1.5;
+  useEffect(() => {
+    if (isReadOnly || !videoOver || queue.length === 0 || !videoId) return;
+    advanceQueue(doc, videoId);
+  }, [doc, isReadOnly, queue.length, videoId, videoOver]);
+
+  const endedIdle = videoOver && queue.length === 0;
+
+  // Pending queue requests, shown to everyone; the host gets the verdict
+  // buttons, the requester gets a cancel, and a decline leaves a short note.
+  const requestsSection =
+    watchRequests.requests.length > 0 || watchRequests.declined ? (
+      <div className="border-b border-white/[0.06] px-3 pb-2.5">
+        {watchRequests.requests.length > 0 ? (
+          <p className="pb-1.5 text-[11px] font-medium text-[#a1a1aa]">
+            Requests
+          </p>
+        ) : null}
+        <ul className="flex flex-col gap-1">
+          {watchRequests.requests.map((request) => {
+            const mine = watchRequests.myRequest?.id === request.id;
+            return (
+              <li
+                key={request.id}
+                className="flex items-center gap-2 rounded-lg border border-white/[0.06] px-2 py-1.5"
+                style={{ backgroundColor: "#101014" }}
+              >
+                <div
+                  className="h-8 w-14 shrink-0 overflow-hidden rounded border border-white/[0.06]"
+                  style={{ backgroundColor: "#0a0a0b" }}
+                >
+                  <img
+                    src={thumbnailUrl(request.videoId)}
+                    alt=""
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                    draggable={false}
+                  />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-[11.5px] font-medium text-[#e4e4e7]">
+                    {request.title ?? request.videoId}
+                  </p>
+                  <p className="mt-0.5 truncate text-[10px] text-[#71717a]">
+                    {mine ? "Your request" : (request.byName ?? "Someone")}
+                  </p>
+                </div>
+                {isAdmin && !appReadOnly ? (
+                  <div className="flex shrink-0 items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => acceptRequest(request)}
+                      aria-label="Add to queue"
+                      title="Add to queue"
+                      className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-full text-white transition-opacity hover:opacity-90"
+                      style={{ backgroundColor: "#22A578" }}
+                    >
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => declineRequest(request)}
+                      aria-label="Decline request"
+                      title="Decline"
+                      className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-full border border-white/10 text-[#a1a1aa] transition-colors hover:bg-white/[0.06] hover:text-[#fafafa]"
+                    >
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                        <line x1="18" y1="6" x2="6" y2="18" />
+                        <line x1="6" y1="6" x2="18" y2="18" />
+                      </svg>
+                    </button>
+                  </div>
+                ) : mine ? (
+                  <button
+                    type="button"
+                    onClick={watchRequests.cancelRequest}
+                    aria-label="Cancel request"
+                    className="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-full text-[#71717a] transition-colors hover:bg-white/[0.06] hover:text-[#fafafa]"
+                  >
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                      <line x1="18" y1="6" x2="6" y2="18" />
+                      <line x1="6" y1="6" x2="18" y2="18" />
+                    </svg>
+                  </button>
+                ) : (
+                  <span className="shrink-0 text-[10px] text-[#71717a]">
+                    Pending
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+        {watchRequests.declined ? (
+          <p className="pt-1.5 text-[11px] text-[#71717a]">
+            Your request was declined
+          </p>
+        ) : null}
+      </div>
+    ) : null;
+
+  const railContent = (
+    <WatchQueue
+      items={queue}
+      nowPlaying={videoId ? { videoId, title: videoTitle } : null}
+      readOnly={isReadOnly}
+      onAdd={handleAdd}
+      onRemove={handleRemove}
+      onPlayNow={handlePlayNow}
+      onMove={handleMove}
+      requestsSection={requestsSection}
+      headerAccessory={
+        <>
+          {!appReadOnly ? (
+            <button
+              type="button"
+              onClick={() => setBrowsing((prev) => !prev)}
+              aria-label={browsing ? "Back to video" : "Browse videos"}
+              aria-pressed={browsing}
+              title={browsing ? "Back to video" : "Browse videos"}
+              className={`flex h-7 w-7 cursor-pointer items-center justify-center rounded-md transition-colors ${
+                browsing
+                  ? "bg-white/[0.1] text-[#fafafa]"
+                  : "text-[#71717a] hover:bg-white/[0.06] hover:text-[#fafafa]"
+              }`}
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect x="3" y="3" width="7" height="7" rx="1.5" />
+                <rect x="14" y="3" width="7" height="7" rx="1.5" />
+                <rect x="3" y="14" width="7" height="7" rx="1.5" />
+                <rect x="14" y="14" width="7" height="7" rx="1.5" />
+              </svg>
+            </button>
+          ) : null}
+          <HostPill
+            locked={locked}
+            isAdmin={Boolean(isAdmin)}
+            onSetLocked={handleSetLocked}
+          />
+        </>
+      }
+    />
+  );
+
+  // Floating controls visibility: always there while paused, prompting, or
+  // errored; while playing they fade after a short pointer idle and any pointer
+  // movement brings them back. A single opacity transition, no loops.
+  const [pointerFresh, setPointerFresh] = useState(true);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pokeControls = useCallback(() => {
+    setPointerFresh(true);
+    if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+    idleTimerRef.current = setTimeout(() => {
+      setPointerFresh(false);
+    }, CONTROLS_IDLE_MS);
+  }, []);
+  useEffect(() => {
+    pokeControls();
+    return () => {
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+    };
+  }, [pokeControls, isPlaying]);
+  const controlsVisible =
+    pointerFresh ||
+    !isPlaying ||
+    player.gestureNeed !== "none" ||
+    Boolean(player.error);
+
+  const handleShieldClick = useCallback(() => {
+    // In mini form the whole tile is the "go back" affordance.
+    if (browsing) {
+      setBrowsing(false);
+      return;
+    }
+    pokeControls();
+    if (isReadOnly) return;
+    if (isPlaying) {
+      player.pause();
+    } else {
+      player.play();
+    }
+  }, [browsing, isPlaying, isReadOnly, player, pokeControls]);
+
+  return (
+    <div
+      className="flex h-full w-full flex-col overflow-hidden lg:flex-row"
+      style={{
+        backgroundColor: "#0d0d10",
+        fontFamily: "'PolySans Trial', sans-serif",
+      }}
+    >
+      {/* Player column */}
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <div
+          className="relative min-h-0 flex-1 overflow-hidden bg-black"
+          onPointerMove={pokeControls}
+          onPointerDown={pokeControls}
+        >
+          {hasVideo ? (
+            /* Hard clipping container: the youtube-video custom element sizes
+               itself by its intrinsic 16:9 ratio when left in normal flow,
+               overflowing the stage. Pinning it inside an absolute box and
+               forcing block 100% sizing keeps the video exactly in its frame.
+               While browsing, this same box shrinks into a floating mini
+               player (the ONE iframe simply moves), so playback stays visible
+               and tapping it returns to the full view. */
+            <div
+              className={
+                browsing
+                  ? "group/mini absolute bottom-4 right-4 z-40 aspect-video w-64 overflow-hidden rounded-xl border border-white/10 shadow-[0_16px_48px_rgba(0,0,0,0.5)] md:w-72"
+                  : "absolute inset-0 overflow-hidden"
+              }
+            >
+              <ReactPlayer
+                ref={player.attachPlayer}
+                src={`https://www.youtube.com/watch?v=${videoId}`}
+                playing={player.playing}
+                muted={player.mutedProp}
+                volume={player.volumeProp}
+                playbackRate={player.rate}
+                controls={false}
+                playsInline
+                width="100%"
+                height="100%"
+                style={{
+                  display: "block",
+                  width: "100%",
+                  height: "100%",
+                  backgroundColor: "#000",
+                }}
+                onReady={player.onReady}
+                onTimeUpdate={player.onTimeUpdate}
+                onDurationChange={player.onDurationChange}
+                onPlaying={player.onPlaying}
+                onEnded={player.onEnded}
+                onError={player.onError}
+                fallback={
+                  <div
+                    className="absolute inset-0"
+                    style={{ backgroundColor: "#000" }}
+                  />
+                }
+              />
+              {/* Click shield: the iframe never receives input, so the hidden
+                  native UI can never inject intent. Tapping toggles play/pause,
+                  or returns from browse when in mini form. */}
+              <button
+                type="button"
+                aria-label={
+                  browsing ? "Back to video" : isPlaying ? "Pause" : "Play"
+                }
+                onClick={handleShieldClick}
+                className="absolute inset-0 m-0 cursor-pointer border-0 p-0"
+                style={{ backgroundColor: "transparent" }}
+              />
+              {browsing ? (
+                <span
+                  aria-hidden="true"
+                  className="pointer-events-none absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full border border-white/10 opacity-0 transition-opacity group-hover/mini:opacity-100"
+                  style={{ backgroundColor: "rgba(10, 10, 11, 0.85)" }}
+                >
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#fafafa" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="15 3 21 3 21 9" />
+                    <polyline points="9 21 3 21 3 15" />
+                    <line x1="21" y1="3" x2="14" y2="10" />
+                    <line x1="3" y1="21" x2="10" y2="14" />
+                  </svg>
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+
+          {!hasVideo ? (
+            <div className="absolute inset-0" style={{ backgroundColor: "#0d0d10" }}>
+              <WatchEmptyState onStart={handleStart} readOnly={isReadOnly} />
+            </div>
+          ) : null}
+
+          {hasVideo && player.error ? (
+            <div className="pointer-events-none absolute inset-x-0 top-3 flex justify-center px-4">
+              <div
+                className="rounded-full border border-white/10 px-3.5 py-2 text-[12.5px] font-medium text-[#fafafa]"
+                style={{ backgroundColor: "rgba(10, 10, 11, 0.85)" }}
+                role="status"
+              >
+                {player.error}
+              </div>
+            </div>
+          ) : null}
+
+          {hasVideo ? (
+            <GestureOverlay
+              need={player.gestureNeed}
+              onResolve={player.resolveGesture}
+              videoId={videoId}
+              title={videoTitle}
+            />
+          ) : null}
+
+          {/* The video finished with nothing queued: offer the way back to
+              browsing without hunting for the rail button. */}
+          {endedIdle && !browsing && !appReadOnly ? (
+            <div className="absolute inset-0 z-10 flex items-center justify-center">
+              <button
+                type="button"
+                onClick={() => setBrowsing(true)}
+                className="inline-flex h-10 cursor-pointer items-center gap-2 rounded-full border border-white/10 px-4 text-[13px] font-medium text-[#fafafa] transition-colors hover:bg-white/[0.06]"
+                style={{
+                  backgroundColor: "rgba(10, 10, 11, 0.85)",
+                  backdropFilter: "blur(8px)",
+                }}
+              >
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#F95F4A" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <circle cx="11" cy="11" r="7" />
+                  <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                </svg>
+                Browse more videos
+              </button>
+            </div>
+          ) : null}
+
+          {/* Personal browse mode: an opaque layer over the (still running)
+              player. Your playback keeps going; you are just shopping. */}
+          {hasVideo && browsing ? (
+            <div
+              className="absolute inset-0 z-30 flex flex-col"
+              style={{ backgroundColor: "#0d0d10" }}
+            >
+              <div className="flex shrink-0 items-center justify-between px-4 pt-3">
+                <button
+                  type="button"
+                  onClick={() => setBrowsing(false)}
+                  className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-full border border-white/10 px-3 text-[12px] font-medium text-[#fafafa] transition-colors hover:bg-white/[0.06]"
+                >
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <polyline points="15 18 9 12 15 6" />
+                  </svg>
+                  Back to video
+                </button>
+                {canRequest ? (
+                  <span className="text-[11px] text-[#71717a]">
+                    Picks are sent to the host to approve
+                  </span>
+                ) : null}
+              </div>
+              <div className="min-h-0 flex-1">
+                <WatchEmptyState
+                  mode={canRequest ? "request" : "add"}
+                  readOnly={false}
+                  onStart={handleBrowsePick}
+                />
+              </div>
+            </div>
+          ) : null}
+
+          {/* The queue rail handle: a slim tab at the vertical center of the
+              stage's right edge, pointing the way it will move the rail. */}
+          {hasVideo && !browsing ? (
+            <button
+              type="button"
+              onClick={handleToggleRail}
+              aria-label={railOpen ? "Hide the queue" : "Show the queue"}
+              title={railOpen ? "Hide the queue" : "Show the queue"}
+              className="absolute right-0 top-1/2 z-20 flex h-14 w-6 -translate-y-1/2 cursor-pointer items-center justify-center rounded-l-lg border border-r-0 border-white/10 text-[#71717a] transition-colors hover:bg-white/[0.06] hover:text-[#fafafa]"
+              style={{
+                backgroundColor: "rgba(10, 10, 11, 0.85)",
+                backdropFilter: "blur(8px)",
+              }}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                {railOpen ? (
+                  <polyline points="9 18 15 12 9 6" />
+                ) : (
+                  <polyline points="15 18 9 12 15 6" />
+                )}
+              </svg>
+            </button>
+          ) : null}
+
+          {/* Floating custom controls: the only playback UI there is. */}
+          {hasVideo ? (
+            <div
+              className={`absolute bottom-5 left-1/2 z-10 w-[min(34rem,calc(100%-1.5rem))] -translate-x-1/2 overflow-hidden rounded-2xl border border-white/10 transition-opacity duration-200 ${
+                controlsVisible ? "opacity-100" : "pointer-events-none opacity-0"
+              }`}
+              style={{
+                backgroundColor: "rgba(10, 10, 11, 0.88)",
+                backdropFilter: "blur(8px)",
+              }}
+            >
+              <WatchControls
+                playbackState={player.playbackState}
+                currentTime={player.currentTime}
+                duration={player.duration}
+                muted={player.muted}
+                volume={player.volume}
+                readOnly={isReadOnly}
+                cinema={!railOpen}
+                onToggleCinema={() => {
+                  handleToggleRail();
+                  pokeControls();
+                }}
+                captionsAvailable={player.captionsAvailable}
+                captionsOn={player.captionsOn}
+                captionTracks={player.captionTracks}
+                captionSizeAvailable={player.captionSizeAvailable}
+                captionFontSize={player.captionFontSize}
+                onSetCaptionTrack={(language) => {
+                  player.setCaptionTrack(language);
+                  pokeControls();
+                }}
+                onSetCaptionFontSize={(size) => {
+                  player.setCaptionFontSize(size);
+                  pokeControls();
+                }}
+                onPlay={player.play}
+                onPause={player.pause}
+                onSeek={player.seek}
+                onToggleMute={player.toggleMute}
+                onVolumeChange={player.setVolume}
+              />
+              {isReadOnly ? (
+                <div className="flex items-center gap-1.5 border-t border-white/[0.06] px-3 py-1.5 text-[11px] text-[#8b8b93]">
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                  </svg>
+                  Host has locked controls
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Queue column, only once something is playing. On narrow layouts it
+          sits under the player with a capped height; on wide layouts it is a
+          fixed side rail. Collapsing animates the width (or height) shut while
+          the fixed-width inner keeps the content from reflowing mid-slide. */}
+      {hasVideo ? (
+        <aside
+          className={`flex min-h-0 shrink-0 flex-col overflow-hidden border-white/10 transition-all duration-300 ease-out lg:max-h-none ${
+            railOpen
+              ? "max-h-[38%] border-t lg:w-72 lg:border-l lg:border-t-0"
+              : "max-h-0 lg:w-0"
+          }`}
+          style={{ backgroundColor: "#0f0f13" }}
+          aria-hidden={!railOpen}
+        >
+          <div className="flex h-full min-h-0 w-full flex-col lg:w-72">
+            {railContent}
+          </div>
+        </aside>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/apps-sdk/src/apps/watch/web/format.ts
+++ b/packages/apps-sdk/src/apps/watch/web/format.ts
@@ -1,0 +1,15 @@
+/** Format seconds as m:ss or h:mm:ss. Meant for tabular-nums display. */
+export const formatTime = (totalSeconds: number): string => {
+  if (!Number.isFinite(totalSeconds) || totalSeconds < 0) {
+    return "0:00";
+  }
+  const seconds = Math.floor(totalSeconds % 60);
+  const minutes = Math.floor((totalSeconds / 60) % 60);
+  const hours = Math.floor(totalSeconds / 3600);
+  const ss = seconds.toString().padStart(2, "0");
+  if (hours > 0) {
+    const mm = minutes.toString().padStart(2, "0");
+    return `${hours}:${mm}:${ss}`;
+  }
+  return `${minutes}:${ss}`;
+};

--- a/packages/apps-sdk/src/apps/watch/web/hooks/useSyncedPlayback.ts
+++ b/packages/apps-sdk/src/apps/watch/web/hooks/useSyncedPlayback.ts
@@ -1,0 +1,623 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type * as Y from "yjs";
+import {
+  advanceQueue,
+  expectedPosition,
+  getPlayback,
+  getQueue,
+  writePlayback,
+} from "../../core/doc/index";
+import type { PlaybackRecord, PlaybackState } from "../../core/model/types";
+
+// If the local player drifts more than this from the extrapolated doc position,
+// we seek. 1.5s comfortably absorbs author clock skew and buffering jitter while
+// still keeping everyone visibly in sync.
+const DRIFT_THRESHOLD_SECONDS = 1.5;
+
+// How long after asking for playback we wait before deciding the browser
+// blocked autoplay and a user gesture is required.
+const AUTOPLAY_PROBE_MS = 1200;
+
+export type GestureNeed = "none" | "sound" | "sync";
+
+/**
+ * The media element react-player v3 renders (youtube-video-element) implements
+ * the HTMLMediaElement interface: `currentTime` is readable AND assignable
+ * (assigning seeks), `play`/`pause` are promises, `paused`/`muted`/`duration`
+ * read live state. That is the whole surface this hook needs.
+ */
+export type WatchMediaElement = Pick<
+  HTMLVideoElement,
+  "currentTime" | "duration" | "paused" | "muted" | "play" | "pause" | "textTracks"
+>;
+
+type MediaEvent = React.SyntheticEvent<HTMLVideoElement>;
+
+export type SyncedPlaybackHandle = {
+  /** Callback ref for `<ReactPlayer ref>`; captures the media element. */
+  attachPlayer: (element: WatchMediaElement | null) => void;
+
+  /* ---- Declarative props for <ReactPlayer>. The player FOLLOWS the doc; it
+     never leads. All intent enters through the actions below, which write the
+     doc first, so there is no echo problem by construction. ---- */
+  playing: boolean;
+  mutedProp: boolean;
+  /** 0..1 for the media element (the UI works in 0..100). */
+  volumeProp: number;
+  rate: number;
+
+  /* ---- Media event handlers to spread onto <ReactPlayer>. ---- */
+  onReady: () => void;
+  onTimeUpdate: (event: MediaEvent) => void;
+  onDurationChange: (event: MediaEvent) => void;
+  onPlaying: () => void;
+  onEnded: () => void;
+  onError: (event: MediaEvent) => void;
+
+  /* ---- UI state. ---- */
+  ready: boolean;
+  error: string | null;
+  gestureNeed: GestureNeed;
+  muted: boolean;
+  /** Local volume 0..100 (never synced). */
+  volume: number;
+  currentTime: number;
+  duration: number;
+  playbackState: PlaybackState;
+  /** Whether this video has caption tracks at all. */
+  captionsAvailable: boolean;
+  /** Whether a caption track is currently showing (local only). */
+  captionsOn: boolean;
+  /** The video's caption tracks, with the active one flagged. */
+  captionTracks: WatchCaptionTrack[];
+  /** Whether the player exposes caption font sizing. */
+  captionSizeAvailable: boolean;
+  /** Current caption size step (-1 small, 0 default, 2 large, 3 huge). */
+  captionFontSize: number;
+
+  /* ---- Actions (the ONLY sources of playback intent). ---- */
+  play: () => void;
+  pause: () => void;
+  seek: (seconds: number) => void;
+  toggleMute: () => void;
+  setVolume: (value: number) => void;
+  toggleCaptions: () => void;
+  /** Show captions in this language, or turn them off with null. */
+  setCaptionTrack: (language: string | null) => void;
+  setCaptionFontSize: (size: number) => void;
+  resolveGesture: () => void;
+};
+
+export type WatchCaptionTrack = {
+  language: string;
+  label: string;
+  active: boolean;
+};
+
+/**
+ * Best-effort handle on the element's underlying YT player for the captions
+ * module options (font size). Internal to youtube-video-element, so it is
+ * feature-detected and every call is guarded; if a future version hides it,
+ * the size control simply disappears.
+ */
+type CaptionsApi = {
+  setOption?: (module: string, option: string, value: unknown) => void;
+};
+
+const captionsApiOf = (
+  element: WatchMediaElement | null,
+): CaptionsApi | null => {
+  const api = (element as unknown as { api?: CaptionsApi } | null)?.api;
+  return api && typeof api.setOption === "function" ? api : null;
+};
+
+type UseSyncedPlaybackArgs = {
+  doc: Y.Doc;
+  videoId: string | null;
+  /** When true, actions author nothing; the player still follows the doc. */
+  readOnly: boolean;
+};
+
+/**
+ * The sync engine for Watch together, built on one rule: the shared doc is the
+ * single source of playback intent. Our custom controls write the doc; the
+ * player follows it declaratively via the `playing` prop plus drift-corrected
+ * seeks. Native player controls are hidden and the iframe is click-shielded by
+ * the component, so no player event is ever ambiguous user intent, which is
+ * what previously forced echo-guard heuristics (and their failure modes).
+ */
+export function useSyncedPlayback({
+  doc,
+  videoId,
+  readOnly,
+}: UseSyncedPlaybackArgs): SyncedPlaybackHandle {
+  const elementRef = useRef<WatchMediaElement | null>(null);
+  const readOnlyRef = useRef(readOnly);
+  readOnlyRef.current = readOnly;
+  const videoIdRef = useRef<string | null>(videoId);
+  videoIdRef.current = videoId;
+  // The last video this client advanced away from, so a duplicate ENDED event
+  // cannot make the same client advance the queue twice.
+  const advancedFromRef = useRef<string | null>(null);
+
+  const [record, setRecord] = useState<PlaybackRecord>(() => getPlayback(doc));
+  const recordRef = useRef(record);
+  recordRef.current = record;
+
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [gestureNeed, setGestureNeed] = useState<GestureNeed>("none");
+  // Start muted so the initial autoplay satisfies browser policy; the gesture
+  // overlay lifts the mute on a real click. Volume and mute never sync.
+  const [muted, setMuted] = useState(true);
+  const mutedRef = useRef(muted);
+  mutedRef.current = muted;
+  const [volume, setVolumeState] = useState(100);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [captionsAvailable, setCaptionsAvailable] = useState(false);
+  const [captionsOn, setCaptionsOn] = useState(false);
+  const [captionTracks, setCaptionTracks] = useState<WatchCaptionTrack[]>([]);
+  const [captionSizeAvailable, setCaptionSizeAvailable] = useState(false);
+  const [captionFontSize, setCaptionFontSizeState] = useState(0);
+  const captionFontSizeRef = useRef(0);
+  captionFontSizeRef.current = captionFontSize;
+  // The embed must load YouTube's captions module (cc_load_policy 1, the
+  // element's default) or the tracklist never appears and the CC control has
+  // nothing to show. That default also force-displays captions, so each new
+  // video gets one initialization pass applying the user's sticky session
+  // preference, which starts as off.
+  const captionsPreferredRef = useRef(false);
+  const captionsInitializedForRef = useRef<string | null>(null);
+  // Declared before syncCaptionState (which runs it), assigned after the
+  // callback below is created.
+  const applyCaptionFontSizeRef = useRef<(() => void) | null>(null);
+
+  // Read caption state straight off the element's textTracks. The element
+  // rebuilds the list on every source change, so this is re-read on the safety
+  // tick rather than holding a subscription to a stale list.
+  const syncCaptionState = useCallback(() => {
+    const element = elementRef.current;
+    const tracks = element?.textTracks;
+    if (!tracks) {
+      setCaptionsAvailable(false);
+      setCaptionsOn(false);
+      setCaptionTracks([]);
+      return;
+    }
+    const list = Array.from(tracks);
+
+    // One-time per video: apply the sticky caption preference. The captions
+    // module starts force-displaying (its load policy), so default-off means
+    // disabling every track once the tracklist materializes.
+    const currentVideo = videoIdRef.current;
+    if (
+      list.length > 0 &&
+      currentVideo &&
+      captionsInitializedForRef.current !== currentVideo
+    ) {
+      captionsInitializedForRef.current = currentVideo;
+      if (captionsPreferredRef.current) {
+        const preferred =
+          typeof navigator !== "undefined" && navigator.language
+            ? navigator.language.slice(0, 2).toLowerCase()
+            : "en";
+        const pick =
+          list.find((track) =>
+            track.language?.toLowerCase().startsWith(preferred),
+          ) ?? list[0];
+        for (const track of list) {
+          track.mode = track === pick ? "showing" : "disabled";
+        }
+        applyCaptionFontSizeRef.current?.();
+      } else {
+        for (const track of list) {
+          track.mode = "disabled";
+        }
+      }
+    }
+
+    setCaptionsAvailable(list.length > 0);
+    setCaptionsOn(list.some((track) => track.mode === "showing"));
+    setCaptionSizeAvailable(captionsApiOf(element) !== null);
+    setCaptionTracks((previous) => {
+      const next: WatchCaptionTrack[] = list.map((track) => ({
+        language: track.language,
+        label: track.label || track.language,
+        active: track.mode === "showing",
+      }));
+      // Keep the reference stable when nothing changed, so consumers do not
+      // re-render once a second.
+      const same =
+        previous.length === next.length &&
+        previous.every(
+          (track, index) =>
+            track.language === next[index].language &&
+            track.label === next[index].label &&
+            track.active === next[index].active,
+        );
+      return same ? previous : next;
+    });
+  }, []);
+
+  // The captions module forgets styling between videos; reapply the chosen
+  // size whenever a track goes live.
+  const applyCaptionFontSize = useCallback(() => {
+    const size = captionFontSizeRef.current;
+    if (size === 0) return;
+    try {
+      captionsApiOf(elementRef.current)?.setOption?.(
+        "captions",
+        "fontSize",
+        size,
+      );
+    } catch {
+      /* styling is best effort */
+    }
+  }, []);
+  applyCaptionFontSizeRef.current = applyCaptionFontSize;
+
+  // Seek the local player toward the doc when it has drifted too far.
+  const correctDrift = useCallback((target: PlaybackRecord) => {
+    const element = elementRef.current;
+    if (!element) return;
+    const expected = expectedPosition(target);
+    if (!Number.isFinite(expected)) return;
+    let current = 0;
+    try {
+      current = element.currentTime ?? 0;
+    } catch {
+      return;
+    }
+    if (Math.abs(current - expected) > DRIFT_THRESHOLD_SECONDS) {
+      try {
+        element.currentTime = Math.max(0, expected);
+      } catch {
+        /* element not ready to seek yet */
+      }
+    }
+  }, []);
+
+  // Follow the doc: mirror the record into state (which drives the `playing`
+  // prop) and correct position drift on every remote change.
+  useEffect(() => {
+    const sync = () => {
+      const next = getPlayback(doc);
+      setRecord(next);
+      correctDrift(next);
+    };
+    doc.on("update", sync);
+    sync();
+    return () => {
+      doc.off("update", sync);
+    };
+  }, [correctDrift, doc]);
+
+  // A gentle safety tick: keeps the time display fresh when timeupdate is
+  // throttled (hidden tabs) and re-checks drift while paused.
+  useEffect(() => {
+    if (!ready) return;
+    const interval = setInterval(() => {
+      const element = elementRef.current;
+      if (!element) return;
+      try {
+        setCurrentTime(element.currentTime ?? 0);
+      } catch {
+        /* ignore */
+      }
+      correctDrift(recordRef.current);
+      syncCaptionState();
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [correctDrift, ready, syncCaptionState]);
+
+  // A new video started: allow it to advance the queue when it ends, and clear
+  // any stale error from the previous one.
+  useEffect(() => {
+    if (!videoId) return;
+    if (advancedFromRef.current !== videoId) {
+      advancedFromRef.current = null;
+    }
+    setError(null);
+  }, [videoId]);
+
+  // Probe for blocked autoplay: if the room wants playback but the element is
+  // still paused shortly after, a gesture is needed to start at all ("sync").
+  // If it plays but only because we are muted, a gesture buys sound ("sound").
+  useEffect(() => {
+    if (!ready || record.state !== "playing") return;
+    const timer = setTimeout(() => {
+      const element = elementRef.current;
+      if (!element) return;
+      if (element.paused) {
+        setGestureNeed((prev) => (prev === "none" ? "sync" : prev));
+      } else if (mutedRef.current) {
+        setGestureNeed((prev) => (prev === "none" ? "sound" : prev));
+      }
+    }, AUTOPLAY_PROBE_MS);
+    return () => clearTimeout(timer);
+  }, [ready, record.state, videoId]);
+
+  /* ---- Media event handlers. None of these author intent; with the iframe
+     shielded, player events can only be consequences of the doc. ---- */
+
+  const onReady = useCallback(() => {
+    setReady(true);
+    setError(null);
+    correctDrift(recordRef.current);
+  }, [correctDrift]);
+
+  const onTimeUpdate = useCallback(
+    (event: MediaEvent) => {
+      const element = event.currentTarget;
+      setCurrentTime(element.currentTime ?? 0);
+      if (recordRef.current.state === "playing") {
+        correctDrift(recordRef.current);
+      }
+    },
+    [correctDrift],
+  );
+
+  const onDurationChange = useCallback((event: MediaEvent) => {
+    const value = event.currentTarget.duration;
+    setDuration(typeof value === "number" && Number.isFinite(value) ? value : 0);
+  }, []);
+
+  const onPlaying = useCallback(() => {
+    // Playback genuinely running: downgrade or clear the gesture prompt.
+    setGestureNeed((prev) => {
+      if (prev === "none") return prev;
+      return mutedRef.current ? "sound" : "none";
+    });
+  }, []);
+
+  const onEnded = useCallback(() => {
+    const ended = videoIdRef.current;
+    if (readOnlyRef.current || !ended) return;
+    if (advancedFromRef.current === ended) return;
+    const queue = getQueue(doc);
+    if (queue.length > 0) {
+      advancedFromRef.current = ended;
+      advanceQueue(doc, ended);
+      return;
+    }
+    // Nothing queued: park the doc at the end so late joiners do not see the
+    // position extrapolate past the duration forever.
+    const element = elementRef.current;
+    let position = 0;
+    try {
+      position = element?.duration ?? element?.currentTime ?? 0;
+    } catch {
+      position = 0;
+    }
+    writePlayback(doc, { state: "paused", positionSeconds: position, rate: 1 });
+  }, [doc]);
+
+  const onError = useCallback((event: MediaEvent) => {
+    const mediaError = event.currentTarget?.error;
+    const message =
+      mediaError && typeof mediaError.message === "string" && mediaError.message.trim()
+        ? mediaError.message.trim()
+        : "This video failed to play. It may not allow embedding.";
+    setError(message);
+  }, []);
+
+  /* ---- Actions: write the doc first, the player follows. ---- */
+
+  const readElementTime = useCallback((): number => {
+    const element = elementRef.current;
+    if (!element) return recordRef.current.positionSeconds;
+    try {
+      const value = element.currentTime;
+      return typeof value === "number" && Number.isFinite(value) ? value : 0;
+    } catch {
+      return recordRef.current.positionSeconds;
+    }
+  }, []);
+
+  const play = useCallback(() => {
+    if (readOnlyRef.current) return;
+    writePlayback(doc, {
+      state: "playing",
+      positionSeconds: readElementTime(),
+      rate: recordRef.current.rate,
+    });
+  }, [doc, readElementTime]);
+
+  const pause = useCallback(() => {
+    if (readOnlyRef.current) return;
+    writePlayback(doc, {
+      state: "paused",
+      positionSeconds: readElementTime(),
+      rate: recordRef.current.rate,
+    });
+  }, [doc, readElementTime]);
+
+  const seek = useCallback(
+    (seconds: number) => {
+      if (readOnlyRef.current) return;
+      const target = Math.max(0, seconds);
+      const element = elementRef.current;
+      if (element) {
+        try {
+          element.currentTime = target;
+        } catch {
+          /* ignore */
+        }
+      }
+      setCurrentTime(target);
+      writePlayback(doc, {
+        state: recordRef.current.state,
+        positionSeconds: target,
+        rate: recordRef.current.rate,
+      });
+    },
+    [doc],
+  );
+
+  /* ---- Local mute / volume (never synced). ---- */
+
+  const toggleMute = useCallback(() => {
+    setMuted((prev) => {
+      const next = !prev;
+      const element = elementRef.current;
+      if (element) {
+        try {
+          // Assign directly as well as via the prop, so an unmute stays inside
+          // the user's click for browser gesture rules.
+          element.muted = next;
+        } catch {
+          /* ignore */
+        }
+      }
+      if (!next) {
+        setGestureNeed((prev2) => (prev2 === "sound" ? "none" : prev2));
+      }
+      return next;
+    });
+  }, []);
+
+  const setVolume = useCallback((value: number) => {
+    const clamped = Math.max(0, Math.min(100, Math.round(value)));
+    setVolumeState(clamped);
+    if (clamped > 0) {
+      setMuted((prev) => {
+        if (!prev) return prev;
+        const element = elementRef.current;
+        if (element) {
+          try {
+            element.muted = false;
+          } catch {
+            /* ignore */
+          }
+        }
+        return false;
+      });
+    }
+  }, []);
+
+  // Toggle closed captions on the local player only (never synced). The
+  // element mirrors YouTube's caption list into standard textTracks: showing a
+  // track turns YT captions on for that language, no showing track turns them
+  // off. Preference order when enabling: the browser language, then the first.
+  const toggleCaptions = useCallback(() => {
+    const tracks = elementRef.current?.textTracks;
+    if (!tracks) return;
+    const list = Array.from(tracks);
+    if (list.length === 0) return;
+    const anyShowing = list.some((track) => track.mode === "showing");
+    if (anyShowing) {
+      for (const track of list) {
+        if (track.mode === "showing") track.mode = "disabled";
+      }
+      captionsPreferredRef.current = false;
+      setCaptionsOn(false);
+      return;
+    }
+    captionsPreferredRef.current = true;
+    const preferred =
+      typeof navigator !== "undefined" && navigator.language
+        ? navigator.language.slice(0, 2).toLowerCase()
+        : "en";
+    const pick =
+      list.find((track) =>
+        track.language?.toLowerCase().startsWith(preferred),
+      ) ?? list[0];
+    pick.mode = "showing";
+    setCaptionsOn(true);
+    applyCaptionFontSize();
+  }, [applyCaptionFontSize]);
+
+  const setCaptionTrack = useCallback(
+    (language: string | null) => {
+      const tracks = elementRef.current?.textTracks;
+      if (!tracks) return;
+      for (const track of Array.from(tracks)) {
+        const shouldShow = language !== null && track.language === language;
+        track.mode = shouldShow ? "showing" : "disabled";
+      }
+      captionsPreferredRef.current = language !== null;
+      setCaptionsOn(language !== null);
+      if (language !== null) applyCaptionFontSize();
+      syncCaptionState();
+    },
+    [applyCaptionFontSize, syncCaptionState],
+  );
+
+  const setCaptionFontSize = useCallback(
+    (size: number) => {
+      setCaptionFontSizeState(size);
+      captionFontSizeRef.current = size;
+      try {
+        captionsApiOf(elementRef.current)?.setOption?.(
+          "captions",
+          "fontSize",
+          size,
+        );
+      } catch {
+        /* styling is best effort */
+      }
+    },
+    [],
+  );
+
+  // Resolve the gesture overlay with a real click: unmute synchronously (so the
+  // gesture context applies) and kick playback if the room wants it running.
+  const resolveGesture = useCallback(() => {
+    setGestureNeed("none");
+    setMuted(false);
+    const element = elementRef.current;
+    if (!element) return;
+    try {
+      element.muted = false;
+      if (recordRef.current.state === "playing" && element.paused) {
+        void element.play()?.catch?.(() => {
+          /* the reconcile props keep trying */
+        });
+      }
+    } catch {
+      /* ignore */
+    }
+    correctDrift(recordRef.current);
+  }, [correctDrift]);
+
+  const attachPlayer = useCallback((element: WatchMediaElement | null) => {
+    elementRef.current = element;
+  }, []);
+
+  return {
+    attachPlayer,
+    playing: Boolean(videoId) && record.state === "playing",
+    mutedProp: muted,
+    volumeProp: volume / 100,
+    rate: record.rate,
+    onReady,
+    onTimeUpdate,
+    onDurationChange,
+    onPlaying,
+    onEnded,
+    onError,
+    ready,
+    error,
+    gestureNeed,
+    muted,
+    volume,
+    currentTime,
+    duration,
+    playbackState: record.state,
+    captionsAvailable,
+    captionsOn,
+    captionTracks,
+    captionSizeAvailable,
+    captionFontSize,
+    play,
+    pause,
+    seek,
+    toggleMute,
+    setVolume,
+    toggleCaptions,
+    setCaptionTrack,
+    setCaptionFontSize,
+    resolveGesture,
+  };
+}

--- a/packages/apps-sdk/src/apps/watch/web/hooks/useWatchDocState.ts
+++ b/packages/apps-sdk/src/apps/watch/web/hooks/useWatchDocState.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import type * as Y from "yjs";
+import { getQueue, getVideoId, getVideoTitle } from "../../core/doc/index";
+import type { QueueItem } from "../../core/model/types";
+
+type WatchDocState = {
+  videoId: string | null;
+  videoTitle: string | null;
+  queue: QueueItem[];
+};
+
+/**
+ * Reactively read the durable Watch doc fields the React tree renders: the
+ * current video (id + title) and the queue. Playback timing lives in
+ * useSyncedPlayback; this hook only tracks the content that changes the layout.
+ */
+export function useWatchDocState(doc: Y.Doc): WatchDocState {
+  const [state, setState] = useState<WatchDocState>(() => ({
+    videoId: getVideoId(doc),
+    videoTitle: getVideoTitle(doc),
+    queue: getQueue(doc),
+  }));
+
+  useEffect(() => {
+    const sync = () => {
+      setState({
+        videoId: getVideoId(doc),
+        videoTitle: getVideoTitle(doc),
+        queue: getQueue(doc),
+      });
+    };
+    sync();
+    doc.on("update", sync);
+    return () => {
+      doc.off("update", sync);
+    };
+  }, [doc]);
+
+  return state;
+}

--- a/packages/apps-sdk/src/apps/watch/web/hooks/useWatchRequests.ts
+++ b/packages/apps-sdk/src/apps/watch/web/hooks/useWatchRequests.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Awareness } from "y-protocols/awareness";
+import type * as Y from "yjs";
+import { getWatchRequestResolution } from "../../core/doc/index";
+
+const AWARENESS_FIELD = "watchRequest";
+const DECLINED_NOTE_MS = 4_000;
+
+export type WatchRequest = {
+  id: string;
+  videoId: string;
+  title: string | null;
+  byId: string | null;
+  byName: string | null;
+};
+
+type UseWatchRequestsArgs = {
+  doc: Y.Doc;
+  awareness: Awareness;
+  self: { id: string | null; name: string | null };
+};
+
+const parseRequest = (value: unknown): WatchRequest | null => {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.id !== "string" || typeof record.videoId !== "string") {
+    return null;
+  }
+  return {
+    id: record.id,
+    videoId: record.videoId,
+    title: typeof record.title === "string" ? record.title : null,
+    byId: typeof record.byId === "string" ? record.byId : null,
+    byName: typeof record.byName === "string" ? record.byName : null,
+  };
+};
+
+/**
+ * Queue requests for participants without control permission. The pending
+ * request rides the requester's AWARENESS state (which the room lock does not
+ * block, and which naturally disappears with them), while the host's decision
+ * arrives back through the doc's resolution markers. This hook serves both
+ * roles: everyone reads the live request list; a requester submits, cancels,
+ * and auto-clears when resolved.
+ */
+export function useWatchRequests({ doc, awareness, self }: UseWatchRequestsArgs) {
+  const [requests, setRequests] = useState<WatchRequest[]>([]);
+  const [myRequest, setMyRequest] = useState<WatchRequest | null>(null);
+  const [declined, setDeclined] = useState(false);
+  const myRequestRef = useRef<WatchRequest | null>(null);
+  myRequestRef.current = myRequest;
+
+  // Live request list from every participant's awareness state.
+  useEffect(() => {
+    const snapshot = () => {
+      const next: WatchRequest[] = [];
+      for (const state of awareness.getStates().values()) {
+        const request = parseRequest(
+          (state as Record<string, unknown> | null)?.[AWARENESS_FIELD],
+        );
+        if (request) next.push(request);
+      }
+      next.sort((a, b) => a.id.localeCompare(b.id));
+      setRequests(next);
+    };
+    snapshot();
+    awareness.on("change", snapshot);
+    return () => {
+      awareness.off("change", snapshot);
+    };
+  }, [awareness]);
+
+  // When the host resolves my request, clear the pending state; a decline gets
+  // a short-lived note so the requester is not left guessing.
+  useEffect(() => {
+    const check = () => {
+      const mine = myRequestRef.current;
+      if (!mine) return;
+      const resolution = getWatchRequestResolution(doc, mine.id);
+      if (!resolution) return;
+      awareness.setLocalStateField(AWARENESS_FIELD, null);
+      setMyRequest(null);
+      if (resolution === "declined") {
+        setDeclined(true);
+      }
+    };
+    check();
+    doc.on("update", check);
+    return () => {
+      doc.off("update", check);
+    };
+  }, [awareness, doc]);
+
+  useEffect(() => {
+    if (!declined) return;
+    const timer = setTimeout(() => setDeclined(false), DECLINED_NOTE_MS);
+    return () => clearTimeout(timer);
+  }, [declined]);
+
+  // Leaving the app withdraws any pending request.
+  useEffect(() => {
+    return () => {
+      awareness.setLocalStateField(AWARENESS_FIELD, null);
+    };
+  }, [awareness]);
+
+  const submitRequest = useCallback(
+    (videoId: string, title?: string | null) => {
+      const request: WatchRequest = {
+        id: `wr_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+        videoId,
+        title: title ?? null,
+        byId: self.id,
+        byName: self.name,
+      };
+      awareness.setLocalStateField(AWARENESS_FIELD, request);
+      setMyRequest(request);
+      setDeclined(false);
+    },
+    [awareness, self.id, self.name],
+  );
+
+  const cancelRequest = useCallback(() => {
+    awareness.setLocalStateField(AWARENESS_FIELD, null);
+    setMyRequest(null);
+  }, [awareness]);
+
+  return { requests, myRequest, declined, submitRequest, cancelRequest };
+}

--- a/packages/apps-sdk/src/apps/watch/web/index.ts
+++ b/packages/apps-sdk/src/apps/watch/web/index.ts
@@ -1,0 +1,13 @@
+import { createWatchDoc } from "../core/doc/index";
+import { defineApp } from "../../../sdk/registry/index";
+import { WatchWebApp } from "./components/WatchWebApp";
+
+export const watchApp = defineApp({
+  id: "watch",
+  name: "Watch together",
+  description: "Synced YouTube playback",
+  createDoc: createWatchDoc,
+  web: WatchWebApp,
+});
+
+export { WatchWebApp };

--- a/packages/apps-sdk/src/apps/watch/web/youtubeMeta.ts
+++ b/packages/apps-sdk/src/apps/watch/web/youtubeMeta.ts
@@ -1,0 +1,149 @@
+// Best-effort YouTube metadata for the UI. Thumbnails come straight from the
+// predictable ytimg CDN (no key, always available). Titles come from the public
+// oEmbed endpoint and are strictly optional: any failure resolves to null and
+// the UI falls back to the video id.
+
+const TITLE_FETCH_TIMEOUT_MS = 2_500;
+
+/** Medium-quality 16:9 thumbnail for a video id. */
+export const thumbnailUrl = (videoId: string): string =>
+  `https://i.ytimg.com/vi/${videoId}/mqdefault.jpg`;
+
+export type WatchSearchResult = {
+  videoId: string;
+  title: string;
+  channel: string;
+  thumbnail: string | null;
+  durationSeconds: number | null;
+  views: number | null;
+  publishedAt: string | null;
+};
+
+/** 3661 -> "1:01:01", 754 -> "12:34". Null in, null out. */
+export const formatDuration = (seconds: number | null): string | null => {
+  if (seconds == null || !Number.isFinite(seconds) || seconds < 0) return null;
+  const whole = Math.round(seconds);
+  const h = Math.floor(whole / 3600);
+  const m = Math.floor((whole % 3600) / 60);
+  const s = whole % 60;
+  const mm = h > 0 ? String(m).padStart(2, "0") : String(m);
+  const ss = String(s).padStart(2, "0");
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+};
+
+/** 2712345 -> "2.7M views", 857000 -> "857K views". Null in, null out. */
+export const formatViews = (views: number | null): string | null => {
+  if (views == null || !Number.isFinite(views) || views < 0) return null;
+  if (views >= 1_000_000_000)
+    return `${(views / 1_000_000_000).toFixed(1).replace(/\.0$/, "")}B views`;
+  if (views >= 1_000_000)
+    return `${(views / 1_000_000).toFixed(1).replace(/\.0$/, "")}M views`;
+  if (views >= 1_000) return `${Math.round(views / 1_000)}K views`;
+  return `${views} views`;
+};
+
+/** ISO date -> "13 hours ago", "2 days ago", "3 months ago". */
+export const formatAge = (publishedAt: string | null): string | null => {
+  if (!publishedAt) return null;
+  const then = Date.parse(publishedAt);
+  if (!Number.isFinite(then)) return null;
+  const diffMs = Date.now() - then;
+  if (diffMs < 0) return null;
+  const minutes = Math.floor(diffMs / 60_000);
+  const plural = (n: number, unit: string) =>
+    `${n} ${unit}${n === 1 ? "" : "s"} ago`;
+  if (minutes < 60) return plural(Math.max(1, minutes), "minute");
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return plural(hours, "hour");
+  const days = Math.floor(hours / 24);
+  if (days < 7) return plural(days, "day");
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return plural(weeks, "week");
+  const months = Math.floor(days / 30);
+  if (months < 12) return plural(Math.max(1, months), "month");
+  return plural(Math.floor(days / 365), "year");
+};
+
+const parseSearchItems = (payload: unknown): WatchSearchResult[] => {
+  const items = (payload as { items?: unknown })?.items;
+  if (!Array.isArray(items)) return [];
+  return items.filter(
+    (item): item is WatchSearchResult =>
+      Boolean(item) &&
+      typeof item.videoId === "string" &&
+      typeof item.title === "string",
+  );
+};
+
+/**
+ * Search YouTube through the host's server proxy (the API key stays server
+ * side). Fails soft to an empty list; callers show their own empty copy.
+ */
+export const searchVideos = async (
+  query: string,
+): Promise<WatchSearchResult[]> => {
+  if (typeof fetch !== "function" || !query.trim()) return [];
+  try {
+    const response = await fetch(
+      `/api/youtube/search?q=${encodeURIComponent(query.trim())}`,
+    );
+    if (!response.ok) return [];
+    return parseSearchItems(await response.json());
+  } catch {
+    return [];
+  }
+};
+
+export type TrendingPage = {
+  items: WatchSearchResult[];
+  nextPageToken: string | null;
+};
+
+/** A page of trending videos for the browse surface. Fails soft to empty. */
+export const fetchTrending = async (
+  pageToken?: string | null,
+): Promise<TrendingPage> => {
+  if (typeof fetch !== "function") return { items: [], nextPageToken: null };
+  try {
+    const url = pageToken
+      ? `/api/youtube/trending?pageToken=${encodeURIComponent(pageToken)}`
+      : "/api/youtube/trending";
+    const response = await fetch(url);
+    if (!response.ok) return { items: [], nextPageToken: null };
+    const payload = (await response.json()) as { nextPageToken?: unknown };
+    return {
+      items: parseSearchItems(payload),
+      nextPageToken:
+        typeof payload.nextPageToken === "string"
+          ? payload.nextPageToken
+          : null,
+    };
+  } catch {
+    return { items: [], nextPageToken: null };
+  }
+};
+
+/** Fetch a video's title via oEmbed. Never throws; null on any failure. */
+export const fetchVideoTitle = async (
+  videoId: string,
+): Promise<string | null> => {
+  if (typeof fetch !== "function") return null;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TITLE_FETCH_TIMEOUT_MS);
+    const response = await fetch(
+      `https://www.youtube.com/oembed?url=${encodeURIComponent(
+        `https://www.youtube.com/watch?v=${videoId}`,
+      )}&format=json`,
+      { signal: controller.signal },
+    );
+    clearTimeout(timer);
+    if (!response.ok) return null;
+    const payload = (await response.json()) as { title?: unknown };
+    return typeof payload.title === "string" && payload.title.trim()
+      ? payload.title.trim()
+      : null;
+  } catch {
+    return null;
+  }
+};

--- a/packages/apps-sdk/src/games/GameProvider.tsx
+++ b/packages/apps-sdk/src/games/GameProvider.tsx
@@ -208,6 +208,19 @@ export function GameProvider({
     );
   }, [socket, isReadOnly]);
 
+  const joinGame = useCallback(async (): Promise<GameMoveResult> => {
+    if (isReadOnly) {
+      return { success: false, error: "Observer mode is read-only" };
+    }
+    if (!socket) return { success: false, error: "Not connected" };
+    return emitWithAck<GameMoveResult>(
+      socket,
+      "game:join",
+      undefined,
+      { success: false, error: "Timed out" },
+    );
+  }, [socket, isReadOnly]);
+
   const move = useCallback(
     async (type: string, payload?: unknown): Promise<GameMoveResult> => {
       if (isReadOnly) {
@@ -283,6 +296,7 @@ export function GameProvider({
       userId,
       startGame,
       endGame,
+      joinGame,
       move,
       openVote,
       castVote,
@@ -299,6 +313,7 @@ export function GameProvider({
       userId,
       startGame,
       endGame,
+      joinGame,
       move,
       openVote,
       castVote,

--- a/packages/apps-sdk/src/games/types.ts
+++ b/packages/apps-sdk/src/games/types.ts
@@ -61,6 +61,10 @@ export type GamePublicState = {
   hasLeaderboard: boolean;
   /** Public-safe rematch settings. Text options are omitted. */
   config: GameConfig;
+  /** Room members queued to be seated at the next round boundary. */
+  pendingJoiners: GamePlayer[];
+  /** Whether a spectator can currently request a seat for the next round. */
+  canJoinLate: boolean;
 };
 
 export type GameMoveResult = {
@@ -96,6 +100,8 @@ export type GameContextValue = {
   userId: string | null;
   startGame: (gameId: string, options?: GameConfig) => Promise<GameMoveResult>;
   endGame: () => Promise<GameMoveResult>;
+  /** Ask for a seat in the running game; granted at the next round boundary. */
+  joinGame: () => Promise<GameMoveResult>;
   move: (type: string, payload?: unknown) => Promise<GameMoveResult>;
   openVote: (candidateIds?: string[]) => Promise<GameMoveResult>;
   castVote: (gameId: string) => Promise<GameMoveResult>;

--- a/packages/apps-sdk/src/index.ts
+++ b/packages/apps-sdk/src/index.ts
@@ -11,3 +11,4 @@ export * from "./sdk/assets/createAssetUploadHandler";
 export * from "./games/index";
 
 export * as WhiteboardCore from "./apps/whiteboard/core/index";
+export * as WatchCore from "./apps/watch/core/index";

--- a/packages/sfu/server/games/engine.ts
+++ b/packages/sfu/server/games/engine.ts
@@ -30,6 +30,8 @@ export class GameSession {
   private readonly content: unknown | null;
   private state: unknown;
   private finished = false;
+  /** Room members waiting for a seat at the next round boundary. */
+  private pendingJoiners: GamePlayer[] = [];
 
   constructor(options: {
     module: GameModule;
@@ -77,7 +79,12 @@ export class GameSession {
     players: GamePlayer[];
     adminIds: Iterable<string>;
   }): void {
-    this.activePlayers = dedupePlayers(options.players).filter((player) =>
+    const roomPlayers = dedupePlayers(options.players);
+    const roomPlayerIds = new Set(roomPlayers.map((player) => player.id));
+    this.pendingJoiners = this.pendingJoiners.filter((player) =>
+      roomPlayerIds.has(player.id),
+    );
+    this.activePlayers = roomPlayers.filter((player) =>
       this.playerIds.has(player.id),
     );
     this.adminIds = new Set(options.adminIds);
@@ -93,6 +100,75 @@ export class GameSession {
       now,
       isAdmin: (playerId: string) => this.adminIds.has(playerId),
     };
+  }
+
+  /** Whether non-players may receive a projected view of this game. */
+  get spectatable(): boolean {
+    return this.module.spectatable !== false;
+  }
+
+  hasPendingPlayer(playerId: string): boolean {
+    return this.pendingJoiners.some((player) => player.id === playerId);
+  }
+
+  private getLateJoinPhases(now: number = Date.now()): string[] {
+    const phases = this.module.lateJoinPhases;
+    if (!phases) return [];
+    if (typeof phases === "function") {
+      return phases(this.state, this.context(now));
+    }
+    return phases;
+  }
+
+  /**
+   * Queue a room member for a seat at the next round boundary. The seat is
+   * granted when the game transitions into one of the module's declared
+   * `lateJoinPhases`, so a joiner never lands mid-round with impossible state.
+   */
+  requestSeat(
+    player: GamePlayer,
+  ): { ok: true } | { ok: false; error: string } {
+    if (this.finished) {
+      return { ok: false, error: "Game has ended" };
+    }
+    if (this.hasPlayer(player.id)) {
+      return { ok: false, error: "You are already in this game" };
+    }
+    if (this.hasPendingPlayer(player.id)) {
+      return { ok: true };
+    }
+    if (this.getLateJoinPhases().length === 0) {
+      return { ok: false, error: "This game does not support joining mid-game" };
+    }
+    if (
+      this.players.length + this.pendingJoiners.length >=
+      this.module.maxPlayers
+    ) {
+      return { ok: false, error: "Game is full" };
+    }
+    this.pendingJoiners.push({ id: player.id, name: player.name });
+    return { ok: true };
+  }
+
+  /**
+   * Seat queued joiners when the phase just transitioned into a declared
+   * late-join phase (a fresh round). Round state in the modules is keyed by
+   * player id with absent-means-not-acted semantics, so a newly seated player
+   * simply participates from this round on; scores default to zero.
+   */
+  private seatPendingIfBoundary(previousPhase: string): void {
+    if (this.pendingJoiners.length === 0 || this.finished) return;
+    const phases = this.getLateJoinPhases();
+    if (phases.length === 0) return;
+    const phase = this.module.getPhase(this.state);
+    if (phase === previousPhase || !phases.includes(phase)) return;
+    for (const joiner of this.pendingJoiners) {
+      if (this.playerIds.has(joiner.id)) continue;
+      this.playerIds.add(joiner.id);
+      this.players.push({ id: joiner.id, name: joiner.name });
+      this.activePlayers.push({ id: joiner.id, name: joiner.name });
+    }
+    this.pendingJoiners = [];
   }
 
   /**
@@ -111,6 +187,7 @@ export class GameSession {
     if (!this.hasPlayer(playerId)) {
       return { ok: false, error: "You are not a player in this game" };
     }
+    const previousPhase = this.module.getPhase(this.state);
     try {
       const next = this.module.onMove(
         this.state,
@@ -119,6 +196,7 @@ export class GameSession {
       );
       this.state = next;
       this.finished = this.module.isFinished?.(next) ?? false;
+      this.seatPendingIfBoundary(previousPhase);
       return { ok: true };
     } catch (error) {
       if (error instanceof GameMoveError) {
@@ -131,15 +209,18 @@ export class GameSession {
   /** Advance time-driven state. Returns true if the projection changed. */
   tick(now: number = Date.now()): boolean {
     if (this.finished || !this.module.onTick) return false;
+    const previousPhase = this.module.getPhase(this.state);
     const next = this.module.onTick(this.state, this.context(now));
     if (next === this.state) return false;
     this.state = next;
     this.finished = this.module.isFinished?.(next) ?? false;
+    this.seatPendingIfBoundary(previousPhase);
     return true;
   }
 
   getPublicState(now: number = Date.now()): GamePublicState {
     const ctx = this.context(now);
+    const lateJoinPhases = this.getLateJoinPhases(now);
     return {
       gameId: this.module.id,
       name: this.module.name,
@@ -150,6 +231,12 @@ export class GameSession {
       finished: this.finished,
       hasLeaderboard: Boolean(this.module.hasLeaderboard),
       config: publicRematchConfig(this.module.options, this.config),
+      pendingJoiners: this.pendingJoiners.slice(),
+      canJoinLate:
+        !this.finished &&
+        lateJoinPhases.length > 0 &&
+        this.players.length + this.pendingJoiners.length <
+          this.module.maxPlayers,
     };
   }
 

--- a/packages/sfu/server/games/modules/bluff.ts
+++ b/packages/sfu/server/games/modules/bluff.ts
@@ -262,6 +262,7 @@ export const bluffModule: GameModule<BluffState> = {
   description: "Fool the room, find the truth",
   minPlayers: 2,
   maxPlayers: 16,
+  lateJoinPhases: ["write"],
   tickMs: 500,
   hasLeaderboard: true,
   options: [

--- a/packages/sfu/server/games/modules/imposter.ts
+++ b/packages/sfu/server/games/modules/imposter.ts
@@ -160,6 +160,9 @@ export const imposterModule: GameModule<ImposterState> = {
   description: "Spot the faker in the room",
   minPlayers: 3,
   maxPlayers: 12,
+  // Roles are fixed at setup and the crew view carries the secret word, so
+  // this game supports neither mid-game seating nor spectating.
+  spectatable: false,
   tickMs: 500,
   options: [
     GAME_CONTENT_TOPIC_OPTION,

--- a/packages/sfu/server/games/modules/mostLikelyTo.ts
+++ b/packages/sfu/server/games/modules/mostLikelyTo.ts
@@ -161,6 +161,7 @@ export const mostLikelyToModule: GameModule<MltState> = {
   description: "Vote who the room picks",
   minPlayers: 3,
   maxPlayers: 50,
+  lateJoinPhases: ["vote"],
   tickMs: 500,
   options: [
     GAME_CONTENT_TOPIC_OPTION,

--- a/packages/sfu/server/games/modules/mostLikelyTo.ts
+++ b/packages/sfu/server/games/modules/mostLikelyTo.ts
@@ -276,6 +276,9 @@ export const mostLikelyToModule: GameModule<MltState> = {
       prompt: state.phase === "lobby" ? null : (state.prompts[state.index] ?? null),
       players: ctx.players.map((player) => ({ id: player.id, name: player.name })),
       counts,
+      // Who has locked in a vote (never for whom), so tiles can show a check.
+      votedPlayerIds:
+        state.phase === "vote" || reveal ? Object.keys(state.votes) : [],
       answeredCount: Object.keys(state.votes).length,
       totalPlayers: ctx.activePlayers.length,
       winnerId: reveal ? winnerId : null,

--- a/packages/sfu/server/games/modules/reaction.ts
+++ b/packages/sfu/server/games/modules/reaction.ts
@@ -89,6 +89,7 @@ export const reactionModule: GameModule<ReactionState> = {
   description: "Tap the instant it turns green",
   minPlayers: 1,
   maxPlayers: 50,
+  lateJoinPhases: ["arming"],
   tickMs: 120,
   hasLeaderboard: true,
   options: [

--- a/packages/sfu/server/games/modules/trivia.ts
+++ b/packages/sfu/server/games/modules/trivia.ts
@@ -194,6 +194,7 @@ export const triviaModule: GameModule<TriviaState> = {
   description: "Quick-fire quiz",
   minPlayers: 1,
   maxPlayers: 24,
+  lateJoinPhases: ["question"],
   tickMs: 500,
   hasLeaderboard: true,
   options: [

--- a/packages/sfu/server/games/modules/wordle.ts
+++ b/packages/sfu/server/games/modules/wordle.ts
@@ -265,6 +265,8 @@ export const wordleModule: GameModule<WordleState> = {
   description: "Guess a hidden five-letter word",
   minPlayers: 1,
   maxPlayers: 32,
+  lateJoinPhases: (state) =>
+    state.wordSource === "setter" ? ["set-word"] : [],
   tickMs: 500,
   options: [
     {

--- a/packages/sfu/server/games/modules/wouldYouRather.ts
+++ b/packages/sfu/server/games/modules/wouldYouRather.ts
@@ -198,6 +198,7 @@ export const wouldYouRatherModule: GameModule<WyrState> = {
   description: "Pick a side, no wrong answers",
   minPlayers: 1,
   maxPlayers: 50,
+  lateJoinPhases: ["choose"],
   tickMs: 500,
   options: [
     GAME_CONTENT_TOPIC_OPTION,

--- a/packages/sfu/server/games/types.ts
+++ b/packages/sfu/server/games/types.ts
@@ -91,6 +91,10 @@ export type GameMove = {
   payload: unknown;
 };
 
+type LateJoinPhasesResolver<S> = {
+  bivarianceHack(state: S, ctx: GameContext): string[];
+}["bivarianceHack"];
+
 /**
  * A game module is the authoritative definition of one game. It is pure with
  * respect to its own state: every method takes the current state and returns
@@ -109,6 +113,18 @@ export type GameModule<S = unknown> = {
   /** When true, the dock shows a live leaderboard (the publicView must expose a
    *  `scoreboard` array of `{ id, name, score }`). */
   hasLeaderboard?: boolean;
+  /**
+   * Phases whose ENTRY is a safe round boundary for seating queued late
+   * joiners (e.g. trivia's "question"). Omit, leave empty, or return an empty
+   * list when mid-game joining does not fit the current state/config.
+   */
+  lateJoinPhases?: string[] | LateJoinPhasesResolver<S>;
+  /**
+   * Whether non-players may receive this game's `playerView` as a read-only
+   * spectator projection. Defaults to true; set false when the view for an
+   * arbitrary id would leak a secret (imposter's crew view reveals the word).
+   */
+  spectatable?: boolean;
 
   /** Optional async content loader, used before setup for AI-backed prompts. */
   generateContent?(ctx: GameContentContext): Promise<unknown | null>;
@@ -172,6 +188,11 @@ export type GameEndResponse = {
   error?: string;
 };
 
+export type GameJoinResponse = {
+  success: boolean;
+  error?: string;
+};
+
 /** Broadcast to the whole room on every state change. */
 export type GamePublicState = {
   gameId: string;
@@ -182,6 +203,10 @@ export type GamePublicState = {
   view: unknown;
   finished: boolean;
   hasLeaderboard: boolean;
+  /** Room members queued to be seated at the next round boundary. */
+  pendingJoiners: GamePlayer[];
+  /** Whether a spectator can currently request a seat for the next round. */
+  canJoinLate: boolean;
   /** Public-safe rematch settings. Text options are omitted. */
   config: GameConfig;
 };

--- a/packages/sfu/server/socket/handlers/adminHandlers.ts
+++ b/packages/sfu/server/socket/handlers/adminHandlers.ts
@@ -1532,15 +1532,17 @@ export const registerAdminHandlers = (
       });
     }
 
-    if (delayMs > 0) {
-      setTimeout(() => {
+    // Give the roomEnded broadcast and the admin ack a moment to flush before
+    // the hard disconnect. Closing on the very next tick races the network
+    // write, and a client that loses that race sees a raw socket drop (the
+    // "connection interrupted" reconnect banner) instead of the ended screen.
+    const ROOM_END_FLUSH_GRACE_MS = 400;
+    setTimeout(
+      () => {
         scheduleRoomClosure(roomChannelId, pendingSockets);
-      }, delayMs);
-    } else {
-      setTimeout(() => {
-        scheduleRoomClosure(roomChannelId, pendingSockets);
-      }, 0);
-    }
+      },
+      Math.max(delayMs, ROOM_END_FLUSH_GRACE_MS),
+    );
 
     respond(cb, {
       success: true,

--- a/packages/sfu/server/socket/handlers/gameHandlers.ts
+++ b/packages/sfu/server/socket/handlers/gameHandlers.ts
@@ -7,6 +7,7 @@ import { getGameCatalog, getGameModule } from "../../games/registry.js";
 import type {
   GameCatalogEntry,
   GameEndResponse,
+  GameJoinResponse,
   GameMoveData,
   GameMoveResponse,
   GamePlayer,
@@ -185,6 +186,18 @@ const broadcastGame = (io: SocketIOServer, room: Room): void => {
       view: session.getPlayerView(player.id, now),
     });
   }
+  // Spectators (room members without a seat) get a read-only projection so
+  // they can watch the round while waiting to join. Gated per module: games
+  // whose per-player view would leak a secret opt out via `spectatable`.
+  if (session.spectatable) {
+    for (const client of room.clients.values()) {
+      if (session.hasPlayer(client.id)) continue;
+      client.socket.emit("game:view", {
+        gameId: session.gameId,
+        view: session.getPlayerView(client.id, now),
+      });
+    }
+  }
 };
 
 const buildVoteState = (room: Room): GameVoteState | null => {
@@ -246,7 +259,7 @@ export const buildGameStateResponse = (
     vote,
     selfId,
   };
-  if (playerId && session.hasPlayer(playerId)) {
+  if (playerId && (session.hasPlayer(playerId) || session.spectatable)) {
     response.view = session.getPlayerView(playerId, now);
   }
   return response;
@@ -638,6 +651,40 @@ export const registerGameHandlers = (context: ConnectionContext): void => {
       respond(callback, { success: true });
     },
   );
+
+  // A spectator asks for a seat. The seat is granted at the next round
+  // boundary (the module's `lateJoinPhases`), never mid-round.
+  socket.on("game:join", (callback: (response: GameJoinResponse) => void) => {
+    if (!context.currentRoom || !context.currentClient) {
+      respond(callback, { success: false, error: "Not in a room" });
+      return;
+    }
+    if (context.currentClient.isObserver) {
+      respond(callback, { success: false, error: "Observers cannot join games" });
+      return;
+    }
+    if (!takeToken(socket, "game:join", RATE_LIMITS.gameControl)) {
+      respond(callback, { success: false, error: "Slow down" });
+      return;
+    }
+    const room = context.currentRoom;
+    const session = room.gameSession;
+    if (!session || session.isFinished()) {
+      respond(callback, { success: false, error: "No game to join" });
+      return;
+    }
+    const playerId = context.currentClient.id;
+    const result = session.requestSeat({
+      id: playerId,
+      name: room.getDisplayNameForUser(playerId) ?? "Guest",
+    });
+    if (!result.ok) {
+      respond(callback, { success: false, error: result.error });
+      return;
+    }
+    broadcastGame(io, room);
+    respond(callback, { success: true });
+  });
 
   socket.on("game:end", (callback: (response: GameEndResponse) => void) => {
     if (!context.currentRoom || !context.currentClient) {

--- a/packages/sfu/test/late-join.test.ts
+++ b/packages/sfu/test/late-join.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { GameSession } from "../server/games/engine.js";
+import { triviaModule } from "../server/games/modules/trivia.js";
+import { imposterModule } from "../server/games/modules/imposter.js";
+import { wordleModule } from "../server/games/modules/wordle.js";
+import type { GamePlayer } from "../server/games/types.js";
+
+const players: GamePlayer[] = [
+  { id: "host", name: "Host" },
+  { id: "p2", name: "Player Two" },
+];
+
+const startedTriviaSession = (): GameSession => {
+  const session = new GameSession({
+    module: triviaModule,
+    players,
+    adminIds: ["host"],
+    hostId: "host",
+    config: { questions: 3, pace: "normal" },
+    seed: 7,
+  });
+  expect(session.applyMove("host", "start", undefined)).toEqual({ ok: true });
+  return session;
+};
+
+/**
+ * Drive every seated player through an answer, then tick through the reveal
+ * into the next question. `applyMove` stamps deadlines with the real clock, so
+ * the ticks ride real-time offsets rather than synthetic timestamps.
+ */
+const advanceToNextQuestion = (session: GameSession): void => {
+  for (const player of session.getPublicState().players) {
+    const result = session.applyMove(player.id, "answer", { choice: 0 });
+    expect(result.ok).toBe(true);
+  }
+  // Everyone answered, so the question deadline collapsed to now; tick into
+  // reveal, then tick far past the reveal deadline into the next question.
+  session.tick(Date.now() + 1_000);
+  session.tick(Date.now() + 60_000);
+};
+
+describe("late-join seats", () => {
+  it("queues a joiner and seats them when the next question starts", () => {
+    const session = startedTriviaSession();
+
+    const result = session.requestSeat({ id: "late", name: "Late Joiner" });
+    expect(result).toEqual({ ok: true });
+    expect(session.hasPlayer("late")).toBe(false);
+    expect(session.hasPendingPlayer("late")).toBe(true);
+
+    const before = session.getPublicState(0);
+    expect(before.pendingJoiners.map((p) => p.id)).toEqual(["late"]);
+    expect(before.players.map((p) => p.id)).toEqual(["host", "p2"]);
+
+    advanceToNextQuestion(session);
+
+    const after = session.getPublicState(0);
+    expect(after.phase).toBe("question");
+    expect(after.pendingJoiners).toEqual([]);
+    expect(after.players.map((p) => p.id)).toEqual(["host", "p2", "late"]);
+    expect(session.hasPlayer("late")).toBe(true);
+
+    // The new seat plays this round like anyone else.
+    expect(session.applyMove("late", "answer", { choice: 1 }).ok).toBe(true);
+  });
+
+  it("does not seat a joiner mid-round", () => {
+    const session = startedTriviaSession();
+    session.requestSeat({ id: "late", name: "Late Joiner" });
+
+    // A single answer does not end the round, so no boundary is crossed.
+    expect(session.applyMove("host", "answer", { choice: 0 }).ok).toBe(true);
+    expect(session.hasPlayer("late")).toBe(false);
+    expect(session.getPublicState(0).pendingJoiners.length).toBe(1);
+  });
+
+  it("rejects seats beyond maxPlayers, counting pending joiners", () => {
+    const bigRoster: GamePlayer[] = Array.from(
+      { length: triviaModule.maxPlayers },
+      (_, index) => ({ id: `p${index}`, name: `Player ${index}` }),
+    );
+    const session = new GameSession({
+      module: triviaModule,
+      players: bigRoster,
+      adminIds: ["p0"],
+      hostId: "p0",
+      config: { questions: 3, pace: "normal" },
+      seed: 7,
+    });
+    const result = session.requestSeat({ id: "overflow", name: "Overflow" });
+    expect(result).toEqual({ ok: false, error: "Game is full" });
+  });
+
+  it("is idempotent for a joiner who asks twice", () => {
+    const session = startedTriviaSession();
+    expect(session.requestSeat({ id: "late", name: "Late" })).toEqual({ ok: true });
+    expect(session.requestSeat({ id: "late", name: "Late" })).toEqual({ ok: true });
+    expect(session.getPublicState(0).pendingJoiners.length).toBe(1);
+  });
+
+  it("drops pending joiners who leave before the next boundary", () => {
+    const session = startedTriviaSession();
+
+    expect(session.requestSeat({ id: "late", name: "Late Joiner" })).toEqual({
+      ok: true,
+    });
+    session.updateRoomMembership({ players, adminIds: ["host"] });
+
+    expect(session.hasPendingPlayer("late")).toBe(false);
+    expect(session.getPublicState(0).pendingJoiners).toEqual([]);
+
+    advanceToNextQuestion(session);
+
+    expect(session.hasPlayer("late")).toBe(false);
+    expect(session.getPublicState(0).players.map((p) => p.id)).toEqual([
+      "host",
+      "p2",
+    ]);
+  });
+
+  it("rejects joining games without late-join support", () => {
+    const session = new GameSession({
+      module: imposterModule,
+      players: [
+        { id: "host", name: "Host" },
+        { id: "p2", name: "P2" },
+        { id: "p3", name: "P3" },
+      ],
+      adminIds: ["host"],
+      hostId: "host",
+      config: {},
+      seed: 7,
+    });
+    const result = session.requestSeat({ id: "late", name: "Late" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("exposes canJoinLate on the public state", () => {
+    const session = startedTriviaSession();
+    expect(session.getPublicState(0).canJoinLate).toBe(true);
+  });
+
+  it("does not advertise late join for random Wordle rounds", () => {
+    const session = new GameSession({
+      module: wordleModule,
+      players,
+      adminIds: ["host"],
+      hostId: "host",
+      config: { wordSource: "random", rounds: 2, timeLimitMinutes: 1 },
+      seed: 7,
+    });
+
+    expect(session.applyMove("host", "start", undefined)).toEqual({ ok: true });
+    expect(session.getPublicState(0).canJoinLate).toBe(false);
+    expect(session.requestSeat({ id: "late", name: "Late" })).toEqual({
+      ok: false,
+      error: "This game does not support joining mid-game",
+    });
+  });
+});
+
+describe("spectating", () => {
+  it("gives spectators a neutral trivia view with no secrets", () => {
+    const session = startedTriviaSession();
+    expect(session.spectatable).toBe(true);
+    const view = session.getPlayerView("stranger", 0) as {
+      answered: boolean;
+      choice: number | null;
+      score: number;
+    };
+    expect(view.answered).toBe(false);
+    expect(view.choice).toBeNull();
+    expect(view.score).toBe(0);
+  });
+
+  it("marks imposter as not spectatable", () => {
+    expect(imposterModule.spectatable).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,7 +167,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@10.2.2)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
       wrangler:
         specifier: ^4.105.0
         version: 4.105.0(@cloudflare/workers-types@4.20260628.1)
@@ -189,6 +189,9 @@ importers:
       react-native-svg:
         specifier: '*'
         version: 15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2))(react@19.2.7)
+      react-player:
+        specifier: ^3.4.0
+        version: 3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       socket.io-client:
         specifier: '*'
         version: 4.8.3(supports-color@10.2.2)
@@ -220,7 +223,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@10.2.2)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
 
   packages/sfu:
     dependencies:
@@ -271,7 +274,7 @@ importers:
         version: 6.0.1
       socket.io:
         specifier: ^4.8.3
-        version: 4.8.3
+        version: 4.8.3(supports-color@10.2.2)
       y-protocols:
         specifier: ^1.0.7
         version: 1.0.7(yjs@13.6.31)
@@ -305,7 +308,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@10.2.2)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
 
   packages/shared-browser:
     dependencies:
@@ -320,7 +323,7 @@ importers:
         version: 5.2.1(supports-color@10.2.2)
       socket.io:
         specifier: ^4.8.3
-        version: 4.8.3
+        version: 4.8.3(supports-color@10.2.2)
     devDependencies:
       '@types/cors':
         specifier: ^2.8.19
@@ -351,10 +354,10 @@ importers:
         version: 0.548.0(react@19.2.7)
       lucide-react-native:
         specifier: '*'
-        version: 1.16.0(react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+        version: 1.16.0(react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2))(react@19.2.7)
       react-native:
         specifier: '*'
-        version: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)
+        version: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2)
     devDependencies:
       '@types/react':
         specifier: ^19.2.17
@@ -1459,6 +1462,31 @@ packages:
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
+  '@mux/mux-data-google-ima@0.3.17':
+    resolution: {integrity: sha512-4wpH6dYybyZhqLn9qGn/+67Z8MZnQRAdqTFEEZw2bx61M9q01uPYYHxd8qwOnYtUGEeafsdTwVHVxKHGD3oc1A==}
+
+  '@mux/mux-player-react@3.13.0':
+    resolution: {integrity: sha512-7IkImo1H3rUYeuWHI/L0L7sGUqBvZCvptx3+4igc+P/V3WgqNFjOyQlcyxzxgXNtNNhGmkn5NaF3TU9DPbOmAQ==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0
+      '@types/react-dom': '*'
+      react: ^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0
+      react-dom: ^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@mux/mux-player@3.13.0':
+    resolution: {integrity: sha512-vh4CIMahUa29gys+mlfsOFKYKAKXxE07jSWk9WZxkdpGBW1fKfCQXlNxBoAIQlPa9Uk4MZuM3HVgqdW6aTuaZg==}
+
+  '@mux/mux-video@0.31.0':
+    resolution: {integrity: sha512-DvO2GynIJhPDc0LMuWvC144lCF+E07NI+chrg/vcRQlCf2fPdNNqCSMoaRdWu2S2v/Orsc85giT9K6GRbjbzgA==}
+
+  '@mux/playback-core@0.35.0':
+    resolution: {integrity: sha512-7Zi1EJ9sQNIUlQVBjJCXV0CB+rUVEsU3vNRElRV4xnD7dbpoioIAhe1SjZNBifjnK5aBKLDwQHypbnL3Cw3a5A==}
+
   '@next/env@16.2.9':
     resolution: {integrity: sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==}
 
@@ -2259,6 +2287,68 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@svta/cml-608@1.0.2':
+    resolution: {integrity: sha512-ZEJ68330gcLKfvVv6Qifr1HR7+GldDUxzkjqSbqRK7jHtHSLSV1JAyDwlYe8+C7ABuY1bp8MpgJ4/Gg+jl+pLQ==}
+    engines: {node: '>=20'}
+
+  '@svta/cml-cmcd@2.3.2':
+    resolution: {integrity: sha512-SKBBjLmci0WK8HMjuv+36tVIMktonoOoxsXblOFZmB+ePPV2zjRMTD+2ZmE/1VEPJkKHENyhSjSHgJyeOlvZ1A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-structured-field-values': 1.1.3
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-cmsd@1.0.6':
+    resolution: {integrity: sha512-LUORV6bb0TbU4rSC2HoPqUCix1igLrXkRQXWiIyJo2OMzb14kAK/1jsW0mzY6up6w1GrjKQcjc6OwqJdo/zd/g==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-cta': 1.0.6
+      '@svta/cml-structured-field-values': 1.1.3
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-cta@1.0.6':
+    resolution: {integrity: sha512-l13/4myTX1EbRd38nY8J1umVY5UdR/nZO6CeKqVLXnMMIayg7/fu0TueZckjTA9Loal55MGK1xbHnXVjz7OUUw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-structured-field-values': 1.1.3
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-dash@1.0.6':
+    resolution: {integrity: sha512-4XtHYlPrzL/dRe/8XmRQoLnTo9S86tISgrl67eUqKl5MtNTpZBYTncuPrspslPZPZROBBWNrBuepYfYUtU9CKA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-id3@1.0.6':
+    resolution: {integrity: sha512-63j8gkAnPOmOBWlp0hIZPvsIioZttdbg6/TgwITqMYbSLYVJ+6QGa/UtIP0I84NsfstANw6QdCn7i8SS08kn1A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-request@1.0.12':
+    resolution: {integrity: sha512-4sJvnnoNpq58j2mCGP8k+MF6wVy/qa4gbt6kfT1dPIKmn3mPxw+JVfilhcWsUi+peK2yCZxOJJYyHj1cAcQE1w==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-cmcd': 2.3.2
+      '@svta/cml-utils': 1.5.0
+      '@svta/cml-xml': 1.1.4
+
+  '@svta/cml-structured-field-values@1.1.3':
+    resolution: {integrity: sha512-XqLzQOTznz6kh/nsSh8dy1kV7GQjL4csG+2U5EvLGhAqNuNUczbVg5EAsDobKDVg8xhdthdXx2UuwM+ZHQCxSg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-utils@1.5.0':
+    resolution: {integrity: sha512-JMqclD7Akd+GSJiuaYNUHOP2wNtf/nauKeszlYeivSHfi0Lp3pmSW5PXDvJ2dO4aPmmSOQbF0ztTsW9Vcs2Whw==}
+    engines: {node: '>=20'}
+
+  '@svta/cml-xml@1.1.4':
+    resolution: {integrity: sha512-jbixqjiJIc16SGxylHwiOzO+DuhkGfuP+fJ9AHeVJKdFDKnabgfCDpnp6dvZpZnjMj4nHvzVtuUV7RISPIwYXw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@svta/cml-utils': 1.5.0
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -2647,6 +2737,9 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vimeo/player@2.29.0':
+    resolution: {integrity: sha512-9JjvjeqUndb9otCCFd0/+2ESsLk7VkDE6sxOBy9iy2ukezuQbplVRi+g9g59yAurKofbmTi/KcKxBGO/22zWRw==}
+
   '@vitest/expect@3.2.6':
     resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
 
@@ -2865,6 +2958,9 @@ packages:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
 
+  bcp-47-match@2.0.3:
+    resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
+
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
@@ -3015,8 +3111,16 @@ packages:
   canvaskit-wasm@0.41.0:
     resolution: {integrity: sha512-cnbL02NFB3yOYMF/MtxViZHgD1vh55Pvy+zR8q4JuFvyCPejZP3eClkt2GuZ0S7jOmGMCJXaHBasbMChbR9JZg==}
 
+  castable-video@1.1.16:
+    resolution: {integrity: sha512-wBhe2dZu2afhewL3EaGgVYTyDsa9HvNhY98clMZkNzDrLelOValSrTaoMos9YX7PPBCrgpd1j6YmNyyI2Vbq3w==}
+
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  ce-la-react@0.3.2:
+    resolution: {integrity: sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA==}
+    peerDependencies:
+      react: '>=17.0.0'
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -3095,6 +3199,9 @@ packages:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
 
+  cloudflare-video-element@1.3.5:
+    resolution: {integrity: sha512-zj9gjJa6xW8MNrfc4oKuwgGS0njRLpOlQjdifbuNxvy8k4Y3pKCyKCMG2XIsjd2iQGhgjS57b1P5VWdJlxcXBw==}
+
   cloudflare@4.5.0:
     resolution: {integrity: sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ==}
 
@@ -3105,6 +3212,9 @@ packages:
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
+
+  codem-isoboxer@0.3.10:
+    resolution: {integrity: sha512-eNk3TRV+xQMJ1PEj0FQGY8KD4m0GPxT487XJ+Iftm7mVa9WpPFDMWqPt+46buiP5j5Wzqe5oMIhqBcAeKfygSA==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3220,6 +3330,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  custom-media-element@1.4.6:
+    resolution: {integrity: sha512-/HRYqJOa1ob5ik4q7FIJVYxTJCFs/FL3+cQPAJjUf2uiqrDEzbTgB315gQ2rG8oK3w094W9m5tcB8S5Qah+caA==}
 
   cytoscape-cose-bilkent@4.1.0:
     resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
@@ -3376,6 +3489,13 @@ packages:
 
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  dash-video-element@0.3.2:
+    resolution: {integrity: sha512-eN1IqgtTAbq4zVkbt82BDwQtybQ6WOXyQU5HbftUSnqo+SHAPbZCif1Y7uViAhgvuEPvZtbiXDiacvvTeGxc/g==}
+
+  dashjs@5.2.0:
+    resolution: {integrity: sha512-2W2KHFN53Sk7+rtdnIfSUK/3Oov+hraMTeVZwDOTSCNKM1cQtFiJdblNzRMnl59a/QDseG7JW+PC9mh/B+CMcg==}
+    engines: {node: '>=20'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -4029,6 +4149,15 @@ packages:
   hermes-parser@0.35.0:
     resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
 
+  hls-video-element@1.5.11:
+    resolution: {integrity: sha512-tJJ65/52CDxj8XFyIve6zT9nVVdUIc6mqvKR25X0ycPKHk07rpjp4xxVteeCefDUBSf/tFLhlICFmn3KWj37xA==}
+
+  hls.js@1.6.16:
+    resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
+
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -4081,8 +4210,14 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  imsc@1.1.5:
+    resolution: {integrity: sha512-V8je+CGkcvGhgl2C1GlhqFFiUOIEdwXbXLiu1Fcubvvbo+g9inauqT3l0pNYXGoLPBj3jxtZz9t+wCopMkwadQ==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -4293,6 +4428,9 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
 
@@ -4369,6 +4507,9 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
+
+  localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -4531,6 +4672,15 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  media-chrome@4.19.2:
+    resolution: {integrity: sha512-4ai1ITN8wBhwugQcRgqe3tN0z6OSKGOXqHLNrS04MgKFfsLqu6Dm8MPq02pI9Y9ZKoXtFjIl85jOryIW9es3BA==}
+
+  media-played-ranges-mixin@0.1.0:
+    resolution: {integrity: sha512-zTsvkleu5sAyTsPVxDI+KUbCwy/lXwHgOPi3ER9S3lhtAWhGTQH6qxvfrVMym1cvoLU36SPbVr6Qe8Zxyc0WpA==}
+
+  media-tracks@0.3.5:
+    resolution: {integrity: sha512-l54rkKXlLBt3ob3zOLWHcnjvwUmX5bNEZ70igyapOZZC9imzqBmq1oz8p2roiV04KhjblFIi2hetLPF1oYVLRA==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -4800,6 +4950,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mux-embed@5.18.1:
+    resolution: {integrity: sha512-ePsHjiEKY+FgrSBiMmaF+LOtTQSSBWv/1zqpREQFN96JE93xlsArT/MEi30yKOE06MgjOlL70YI750molu3y7g==}
+
   nan@2.27.0:
     resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
 
@@ -4811,6 +4964,9 @@ packages:
   nanostores@1.4.0:
     resolution: {integrity: sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  native-promise-only@0.8.1:
+    resolution: {integrity: sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -5016,6 +5172,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
@@ -5068,6 +5227,9 @@ packages:
   picospinner@3.0.0:
     resolution: {integrity: sha512-lGA1TNsmy2bxvRsTI2cV01kfTwKzZjnZSDmF9llYNyMHMrU4sP87lQ5taiIKm88L3cbswjl008nwyGc3WpNvzg==}
     engines: {node: '>=18.0.0'}
+
+  player.style@0.3.4:
+    resolution: {integrity: sha512-5O9bkbq0APQIkhptyZwp0gUgheCeImGPFo4hvPF2M5xBmgsUYzsUPHCfMye2xyeRE1zvQBKtziaC3jPgnHE1tw==}
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -5125,6 +5287,9 @@ packages:
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
@@ -5189,6 +5354,9 @@ packages:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -5223,6 +5391,13 @@ packages:
         optional: true
       '@types/react':
         optional: true
+
+  react-player@3.4.0:
+    resolution: {integrity: sha512-QpQSHXtnMBKjQVNeaCYMtTVcynWQ0DDDhz/FJu1OR9PHLC1Aih94UqNstywzSHbJ6Oc7lI8/7kDDqcIvyTI6zQ==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18 || ^19
+      react: ^17.0.2 || ^18 || ^19
+      react-dom: ^17.0.2 || ^18 || ^19
 
   react-reconciler@0.31.0:
     resolution: {integrity: sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==}
@@ -5341,6 +5516,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.2.1:
+    resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
 
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
@@ -5488,6 +5666,9 @@ packages:
   split-ca@1.0.1:
     resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
 
+  spotify-audio-element@1.0.4:
+    resolution: {integrity: sha512-QdKrJPkYCzaNwwz2vN2eDGyoW0KmQFmnwVprB41mpMzj4qujbqr6pegEchQeTn0b5PceKiLoVu0pp2QDpTcWnw==}
+
   ssh2@1.17.0:
     resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
     engines: {node: '>=10.16.0'}
@@ -5583,6 +5764,9 @@ packages:
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
+  super-media-element@1.4.2:
+    resolution: {integrity: sha512-9pP/CVNp4NF2MNlRzLwQkjiTgKKe9WYXrLh9+8QokWmMxz+zt2mf1utkWLco26IuA3AfVcTb//qtlTIjY3VHxA==}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -5647,6 +5831,9 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  tiktok-video-element@0.1.2:
+    resolution: {integrity: sha512-w6TboLm236XJKKiIXIhCbYCnUxbixBbaAoty0etaEAZ/2kHkVIdfZdv2oouMU/HGMsWCHI/VjQ3wU3MJ+s192Q==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -5730,6 +5917,9 @@ packages:
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  twitch-video-element@0.1.6:
+    resolution: {integrity: sha512-X7l8gy+DEFKJ/EztUwaVnAYwQN9fUJxPkOVJj2sE62sGvGU4DNLyvmOsmVulM+8Plc5dMg6hYIMNRAPaH+39Uw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -5876,6 +6066,9 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vimeo-video-element@1.7.2:
+    resolution: {integrity: sha512-7QM7fvSZvTTSq4igxBuO6Gc+0u3Exgk4IaLNixVzilCPzHEf7SN8b6YLXSM5QCs0ineTJI4XjiUCSoIbabHvwg==}
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -5955,6 +6148,10 @@ packages:
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
+  weakmap-polyfill@2.0.4:
+    resolution: {integrity: sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw==}
+    engines: {node: '>=8.10.0'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -5995,6 +6192,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wistia-video-element@1.4.0:
+    resolution: {integrity: sha512-udI8/yiMZ+KIGwYK1qNOFiXl+s/wffiY+XkwTXlBFICZylFalOS0QYEQqYOmuBsm3jNfGUS4O50tLuN7Ejqm3A==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -6116,6 +6316,9 @@ packages:
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  youtube-video-element@1.9.0:
+    resolution: {integrity: sha512-Hh0dbQM+FVlUaYUbpYkZNUvdKxTNcSNvTGzkQKYShltnX+LRHEp2eYvC2Zm43eU8Np+CBZuoNR2i+seCYzzAyg==}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -7360,6 +7563,43 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
+  '@mux/mux-data-google-ima@0.3.17':
+    dependencies:
+      mux-embed: 5.18.1
+
+  '@mux/mux-player-react@3.13.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@mux/mux-player': 3.13.0(react@19.2.7)
+      '@mux/playback-core': 0.35.0
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@mux/mux-player@3.13.0(react@19.2.7)':
+    dependencies:
+      '@mux/mux-video': 0.31.0
+      '@mux/playback-core': 0.35.0
+      media-chrome: 4.19.2(react@19.2.7)
+      player.style: 0.3.4(react@19.2.7)
+    transitivePeerDependencies:
+      - react
+
+  '@mux/mux-video@0.31.0':
+    dependencies:
+      '@mux/mux-data-google-ima': 0.3.17
+      '@mux/playback-core': 0.35.0
+      castable-video: 1.1.16
+      custom-media-element: 1.4.6
+      media-tracks: 0.3.5
+
+  '@mux/playback-core@0.35.0':
+    dependencies:
+      hls.js: 1.6.16
+      mux-embed: 5.18.1
+
   '@next/env@16.2.9':
     optional: true
 
@@ -7758,15 +7998,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@react-native/virtualized-lists@0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-
   '@redis/bloom@6.0.1(@redis/client@6.0.1)':
     dependencies:
       '@redis/client': 6.0.1
@@ -8091,6 +8322,48 @@ snapshots:
   '@speed-highlight/core@1.2.17': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@svta/cml-608@1.0.2': {}
+
+  '@svta/cml-cmcd@2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-structured-field-values': 1.1.3(@svta/cml-utils@1.5.0)
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-cmsd@1.0.6(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-cta': 1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      '@svta/cml-structured-field-values': 1.1.3(@svta/cml-utils@1.5.0)
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-structured-field-values': 1.1.3(@svta/cml-utils@1.5.0)
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-dash@1.0.6(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-id3@1.0.6(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-request@1.0.12(@svta/cml-cmcd@2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@svta/cml-xml@1.1.4(@svta/cml-utils@1.5.0))':
+    dependencies:
+      '@svta/cml-cmcd': 2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      '@svta/cml-utils': 1.5.0
+      '@svta/cml-xml': 1.1.4(@svta/cml-utils@1.5.0)
+
+  '@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
+
+  '@svta/cml-utils@1.5.0': {}
+
+  '@svta/cml-xml@1.1.4(@svta/cml-utils@1.5.0)':
+    dependencies:
+      '@svta/cml-utils': 1.5.0
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -8523,6 +8796,11 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vimeo/player@2.29.0':
+    dependencies:
+      native-promise-only: 0.8.1
+      weakmap-polyfill: 2.0.4
+
   '@vitest/expect@3.2.6':
     dependencies:
       '@types/chai': 5.2.3
@@ -8725,6 +9003,8 @@ snapshots:
 
   basic-ftp@5.3.1: {}
 
+  bcp-47-match@2.0.3: {}
+
   bcrypt-pbkdf@1.0.2:
     dependencies:
       tweetnacl: 0.14.5
@@ -8752,7 +9032,7 @@ snapshots:
       next: 16.3.0-preview.5(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      vitest: 3.2.6(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@10.2.2)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
+      vitest: 3.2.6(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -8852,7 +9132,15 @@ snapshots:
     dependencies:
       '@webgpu/types': 0.1.21
 
+  castable-video@1.1.16:
+    dependencies:
+      custom-media-element: 1.4.6
+
   ccount@2.0.1: {}
+
+  ce-la-react@0.3.2(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   chai@5.3.3:
     dependencies:
@@ -8934,6 +9222,8 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  cloudflare-video-element@1.3.5: {}
+
   cloudflare@4.5.0:
     dependencies:
       '@types/node': 18.19.130
@@ -8949,6 +9239,8 @@ snapshots:
   clsx@2.1.1: {}
 
   cluster-key-slot@1.1.2: {}
+
+  codem-isoboxer@0.3.10: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -9062,6 +9354,8 @@ snapshots:
   css-what@6.2.2: {}
 
   csstype@3.2.3: {}
+
+  custom-media-element@1.4.6: {}
 
   cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
     dependencies:
@@ -9247,6 +9541,37 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  dash-video-element@0.3.2(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0):
+    dependencies:
+      custom-media-element: 1.4.6
+      dashjs: 5.2.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      media-tracks: 0.3.5
+    transitivePeerDependencies:
+      - '@svta/cml-cta'
+      - '@svta/cml-structured-field-values'
+      - '@svta/cml-utils'
+
+  dashjs@5.2.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0):
+    dependencies:
+      '@svta/cml-608': 1.0.2
+      '@svta/cml-cmcd': 2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      '@svta/cml-cmsd': 1.0.6(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      '@svta/cml-dash': 1.0.6(@svta/cml-utils@1.5.0)
+      '@svta/cml-id3': 1.0.6(@svta/cml-utils@1.5.0)
+      '@svta/cml-request': 1.0.12(@svta/cml-cmcd@2.3.2(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@svta/cml-xml@1.1.4(@svta/cml-utils@1.5.0))
+      '@svta/cml-xml': 1.1.4(@svta/cml-utils@1.5.0)
+      bcp-47-match: 2.0.3
+      codem-isoboxer: 0.3.10
+      fast-deep-equal: 3.1.3
+      html-entities: 2.6.0
+      imsc: 1.1.5
+      localforage: 1.10.0
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - '@svta/cml-cta'
+      - '@svta/cml-structured-field-values'
+      - '@svta/cml-utils'
+
   data-uri-to-buffer@4.0.1: {}
 
   data-uri-to-buffer@6.0.2: {}
@@ -9412,7 +9737,7 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@6.6.9:
+  engine.io@6.6.9(supports-color@10.2.2):
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 20.19.43
@@ -10048,6 +10373,16 @@ snapshots:
     dependencies:
       hermes-estree: 0.35.0
 
+  hls-video-element@1.5.11:
+    dependencies:
+      custom-media-element: 1.4.6
+      hls.js: 1.6.16
+      media-tracks: 0.3.5
+
+  hls.js@1.6.16: {}
+
+  html-entities@2.6.0: {}
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -10111,7 +10446,13 @@ snapshots:
     dependencies:
       queue: 6.0.2
 
+  immediate@3.0.6: {}
+
   import-meta-resolve@4.2.0: {}
+
+  imsc@1.1.5:
+    dependencies:
+      sax: 1.2.1
 
   imurmurhash@0.1.4: {}
 
@@ -10286,6 +10627,10 @@ snapshots:
     dependencies:
       isomorphic.js: 0.2.5
 
+  lie@3.1.1:
+    dependencies:
+      immediate: 3.0.6
+
   lighthouse-logger@1.4.2:
     dependencies:
       debug: 2.6.9
@@ -10341,6 +10686,10 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  localforage@1.10.0:
+    dependencies:
+      lie: 3.1.1
 
   locate-path@6.0.0:
     dependencies:
@@ -10398,12 +10747,6 @@ snapshots:
       react: 19.2.7
       react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2)
       react-native-svg: 15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2))(react@19.2.7)
-
-  lucide-react-native@1.16.0(react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)
-      react-native-svg: 15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
 
   lucide-react@0.548.0(react@19.2.7):
     dependencies:
@@ -10585,6 +10928,16 @@ snapshots:
   mdn-data@2.0.14: {}
 
   mdn-data@2.27.1: {}
+
+  media-chrome@4.19.2(react@19.2.7):
+    dependencies:
+      ce-la-react: 0.3.2(react@19.2.7)
+    transitivePeerDependencies:
+      - react
+
+  media-played-ranges-mixin@0.1.0: {}
+
+  media-tracks@0.3.5: {}
 
   media-typer@1.1.0: {}
 
@@ -11085,12 +11438,16 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mux-embed@5.18.1: {}
+
   nan@2.27.0:
     optional: true
 
   nanoid@3.3.15: {}
 
   nanostores@1.4.0: {}
+
+  native-promise-only@0.8.1: {}
 
   natural-compare@1.4.0: {}
 
@@ -11290,6 +11647,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-browserify@1.0.1: {}
+
   path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
@@ -11325,6 +11684,12 @@ snapshots:
   picomatch@4.0.4: {}
 
   picospinner@3.0.0: {}
+
+  player.style@0.3.4(react@19.2.7):
+    dependencies:
+      media-chrome: 4.19.2(react@19.2.7)
+    transitivePeerDependencies:
+      - react
 
   points-on-curve@0.2.0: {}
 
@@ -11384,6 +11749,12 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
 
   property-information@7.2.0: {}
 
@@ -11489,13 +11860,15 @@ snapshots:
       prompts: 2.4.2
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      socket.io: 4.8.3
+      socket.io: 4.8.3(supports-color@10.2.2)
       tailwindcss: 4.3.1
       tsconfig-paths: 4.2.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  react-is@16.13.1: {}
 
   react-is@18.3.1: {}
 
@@ -11513,58 +11886,6 @@ snapshots:
       css-tree: 1.1.3
       react: 19.2.7
       react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2)
-
-  react-native-svg@15.15.5(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
-    dependencies:
-      css-select: 5.2.2
-      css-tree: 1.1.3
-      react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)
-
-  react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      '@react-native/assets-registry': 0.85.3
-      '@react-native/codegen': 0.85.3(@babel/core@7.29.7)
-      '@react-native/community-cli-plugin': 0.85.3(supports-color@10.2.2)
-      '@react-native/gradle-plugin': 0.85.3
-      '@react-native/js-polyfills': 0.85.3
-      '@react-native/normalize-colors': 0.85.3
-      '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      babel-plugin-syntax-hermes-parser: 0.33.3
-      base64-js: 1.5.1
-      commander: 12.1.0
-      flow-enums-runtime: 0.0.6
-      hermes-compiler: 250829098.0.10
-      invariant: 2.2.4
-      memoize-one: 5.2.1
-      metro-runtime: 0.84.4
-      metro-source-map: 0.84.4(supports-color@10.2.2)
-      nullthrows: 1.1.1
-      pretty-format: 29.7.0
-      promise: 8.3.0
-      react: 19.2.7
-      react-devtools-core: 6.1.5
-      react-refresh: 0.14.2
-      regenerator-runtime: 0.13.11
-      scheduler: 0.27.0
-      semver: 7.8.0
-      stacktrace-parser: 0.1.11
-      tinyglobby: 0.2.16
-      whatwg-fetch: 3.6.20
-      ws: 7.5.11
-      yargs: 17.7.2
-    optionalDependencies:
-      '@types/react': 19.2.17
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@react-native-community/cli'
-      - '@react-native/metro-config'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2):
     dependencies:
@@ -11610,6 +11931,27 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  react-player@3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@mux/mux-player-react': 3.13.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react': 19.2.17
+      cloudflare-video-element: 1.3.5
+      dash-video-element: 0.3.2(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      hls-video-element: 1.5.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      spotify-audio-element: 1.0.4
+      tiktok-video-element: 0.1.2
+      twitch-video-element: 0.1.6
+      vimeo-video-element: 1.7.2
+      wistia-video-element: 1.4.0
+      youtube-video-element: 1.9.0
+    transitivePeerDependencies:
+      - '@svta/cml-cta'
+      - '@svta/cml-structured-field-values'
+      - '@svta/cml-utils'
+      - '@types/react-dom'
 
   react-reconciler@0.31.0(react@19.2.7):
     dependencies:
@@ -11781,6 +12123,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sax@1.2.1: {}
+
   scheduler@0.25.0: {}
 
   scheduler@0.27.0: {}
@@ -11946,28 +12290,28 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@10.2.2)
       engine.io-client: 6.6.6(supports-color@10.2.2)
-      socket.io-parser: 4.2.6
+      socket.io-parser: 4.2.6(supports-color@10.2.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6:
+  socket.io-parser@4.2.6(supports-color@10.2.2):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@4.8.3:
+  socket.io@4.8.3(supports-color@10.2.2):
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.6
       debug: 4.4.3(supports-color@10.2.2)
-      engine.io: 6.6.9
+      engine.io: 6.6.9(supports-color@10.2.2)
       socket.io-adapter: 2.5.8
-      socket.io-parser: 4.2.6
+      socket.io-parser: 4.2.6(supports-color@10.2.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -12000,6 +12344,8 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   split-ca@1.0.1: {}
+
+  spotify-audio-element@1.0.4: {}
 
   ssh2@1.17.0:
     dependencies:
@@ -12115,6 +12461,8 @@ snapshots:
 
   stylis@4.4.0: {}
 
+  super-media-element@1.4.2: {}
+
   supports-color@10.2.2: {}
 
   supports-color@7.2.0:
@@ -12210,6 +12558,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  tiktok-video-element@0.1.2: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -12275,6 +12625,8 @@ snapshots:
       fsevents: 2.3.3
 
   tweetnacl@0.14.5: {}
+
+  twitch-video-element@0.1.6: {}
 
   type-check@0.4.0:
     dependencies:
@@ -12420,7 +12772,12 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@10.2.2)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3):
+  vimeo-video-element@1.7.2:
+    dependencies:
+      '@vimeo/player': 2.29.0
+      media-played-ranges-mixin: 0.1.0
+
+  vite-node@3.2.4(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@10.2.2)
@@ -12441,7 +12798,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@10.2.2)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@10.2.2)
@@ -12496,7 +12853,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.8.3
 
-  vitest@3.2.6(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@10.2.2)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3):
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -12519,7 +12876,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@10.2.2)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13
@@ -12538,7 +12895,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.6(@types/debug@4.1.13)(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3):
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@10.2.2)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -12561,7 +12918,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.3.5(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@10.2.2)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13
@@ -12585,6 +12942,8 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  weakmap-polyfill@2.0.4: {}
 
   web-namespaces@2.0.1: {}
 
@@ -12617,6 +12976,10 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wistia-video-element@1.4.0:
+    dependencies:
+      super-media-element: 1.4.2
 
   word-wrap@1.2.5: {}
 
@@ -12736,6 +13099,10 @@ snapshots:
       '@speed-highlight/core': 1.2.17
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  youtube-video-element@1.9.0:
+    dependencies:
+      media-played-ranges-mixin: 0.1.0
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds a late-join/spectator system to the game engine, `votedPlayerIds` tracking to the Most Likely To module, and a new Watch/YouTube co-watching SDK — though the commit message only mentions the `votedPlayerIds` change.

- **Late-join infrastructure**: `GameSession` gains a `pendingJoiners` queue; `requestSeat` validates capacity and game support, `seatPendingIfBoundary` promotes joiners atomically at declared phase boundaries. Each game module opts in via `lateJoinPhases` (static or dynamic); imposter opts out of both late-joining and spectating via `spectatable: false`.
- **Spectator broadcast**: `broadcastGame` now emits `game:view` to non-players for spectatable sessions; `buildGameStateResponse` likewise widens view delivery. A new `game:join` socket handler lets room members request a seat with observer/rate-limit guards.
- **SDK & UI**: `GameProvider` adds `joinGame`; `GamePanel` surfaces \"Join next round\" and \"Watching\" banners; a comprehensive test suite covers all new edge cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all new game-engine paths are gated by validation and covered by the new test suite.

The late-join/spectator logic is well-isolated in GameSession, transport-agnostic, and directly tested by late-join.test.ts which covers queue, seat, mid-round guard, max-player overflow, disconnect pruning, idempotency, and spectator projection. The socket handler changes add proper observer and rate-limit guards. The only open question is a UX design choice in mostLikelyTo around whether a late joiner should immediately be a vote target.

No files require special attention, though mostLikelyTo.ts is worth a second look to confirm that seating a player at the vote boundary (making them an immediate vote candidate) is the intended experience.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/sfu/server/games/engine.ts | Adds pendingJoiners queue, requestSeat, seatPendingIfBoundary, and spectatable getter; logic is clean and well-guarded with idempotency, max-player checks, and room-membership pruning. |
| packages/sfu/server/socket/handlers/gameHandlers.ts | Adds game:join handler with observer/rate-limit/session guards, and extends broadcastGame to push spectator views for spectatable sessions. The buildGameStateResponse condition update correctly widens view delivery to spectators. |
| packages/sfu/server/games/types.ts | Adds lateJoinPhases, spectatable, pendingJoiners, canJoinLate, and GameJoinResponse types. The bivariance-hack pattern for LateJoinPhasesResolver is a recognised TypeScript workaround and is applied correctly. |
| packages/sfu/server/games/modules/mostLikelyTo.ts | Adds votedPlayerIds to the public view (keyed by voter, not target) and sets lateJoinPhases: ["vote"]; late joiners become vote candidates for the current prompt immediately on seating, which may be unexpected. |
| packages/sfu/server/games/modules/imposter.ts | Correctly marks spectatable: false with an explanatory comment; no lateJoinPhases set, so mid-game seating is correctly rejected by requestSeat. |
| packages/sfu/test/late-join.test.ts | New test suite covering queue/seat, mid-round guard, maxPlayers counting, idempotency, disconnect pruning, non-supporting games, canJoinLate, Wordle random mode, and spectator projection — comprehensive coverage of the new behaviour. |
| packages/apps-sdk/src/games/GameProvider.tsx | Adds joinGame callback wired to game:join socket event with read-only guard; cleanly follows the existing startGame/endGame pattern. |
| apps/web/src/app/components/games/GamePanel.tsx | Adds spectator/pending-joiner UI states and Join next round button; correctly passes readOnly={isReadOnly || !isPlayer} to the Game component for spectators. |
| packages/sfu/server/socket/handlers/adminHandlers.ts | Simplifies the room-closure timeout to always apply a minimum 400 ms flush grace, fixing a subtle race where a zero-delay closure could drop the roomEnded broadcast before clients received it. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Room member connects] --> B{Is a game player?}
    B -- Yes --> C[Receives game:view per tick]
    B -- No --> D{session.spectatable?}
    D -- No --> E[No view delivered\neg. Imposter]
    D -- Yes --> F[Receives spectator game:view per tick]
    F --> G{Wants to join?}
    G -- game:join event --> H{Validations\nfinished? / maxPlayers?\nlateJoinPhases?}
    H -- Rejected --> I[Error response]
    H -- Accepted --> J[Added to pendingJoiners\nstill spectating]
    J --> K{Phase boundary\nseatPendingIfBoundary}
    K -- Phase unchanged\nor not in lateJoinPhases --> J
    K -- Entered lateJoinPhase --> L[Promoted to full player\nreceives per-player view]
    L --> C
    J --> M{updateRoomMembership\ncalled}
    M -- Player left room --> N[Removed from pendingJoiners]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Room member connects] --> B{Is a game player?}
    B -- Yes --> C[Receives game:view per tick]
    B -- No --> D{session.spectatable?}
    D -- No --> E[No view delivered\neg. Imposter]
    D -- Yes --> F[Receives spectator game:view per tick]
    F --> G{Wants to join?}
    G -- game:join event --> H{Validations\nfinished? / maxPlayers?\nlateJoinPhases?}
    H -- Rejected --> I[Error response]
    H -- Accepted --> J[Added to pendingJoiners\nstill spectating]
    J --> K{Phase boundary\nseatPendingIfBoundary}
    K -- Phase unchanged\nor not in lateJoinPhases --> J
    K -- Entered lateJoinPhase --> L[Promoted to full player\nreceives per-player view]
    L --> C
    J --> M{updateRoomMembership\ncalled}
    M -- Player left room --> N[Removed from pendingJoiners]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["feat(game): add spectator support and ga..."](https://github.com/acm-vit/conclave/commit/f9f59012e306dd4f7b8a460532a3b87c0ba99d63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41242684)</sub>

**Context used:**

- Context used - Encourage people to write better commit messages ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->