### PR TITLE
Self-review cleanup: shared readResponseError, dead plumbing removal, decoder consolidation

### DIFF
--- a/apps/conclave-skip/Sources/Conclave/Core/Models/Models.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/Models/Models.swift
@@ -431,6 +431,81 @@ enum ConnectionQuality: String, Codable {
     case unknown
 }
 
+enum ConnectionQualityHintPolicy {
+    static func combined(
+        sampledQuality: ConnectionQuality,
+        networkHint: ConnectionQuality
+    ) -> ConnectionQuality {
+        guard networkHint != .unknown else { return sampledQuality }
+        guard sampledQuality != .unknown else { return networkHint }
+
+        // Match the web client: reachability/browser hints seed startup and
+        // unknown states, but measured RTC stats win once the call is live.
+        // Emergency is the only hint severe enough to keep constraining media.
+        guard networkHint == .emergency else { return sampledQuality }
+        return mostConstrained(sampledQuality, networkHint)
+    }
+
+    static func screenSharePublishQuality(
+        publishQuality: ConnectionQuality,
+        screenShareSampledQuality: ConnectionQuality,
+        networkHint: ConnectionQuality
+    ) -> ConnectionQuality {
+        guard screenShareSampledQuality != .unknown else {
+            return publishQuality
+        }
+        return mostConstrained(
+            publishQuality,
+            combined(sampledQuality: screenShareSampledQuality, networkHint: networkHint)
+        )
+    }
+
+    private static func mostConstrained(
+        _ first: ConnectionQuality,
+        _ second: ConnectionQuality
+    ) -> ConnectionQuality {
+        rank(first) >= rank(second) ? first : second
+    }
+
+    private static func rank(_ quality: ConnectionQuality) -> Int {
+        switch quality {
+        case .unknown: return 0
+        case .good: return 1
+        case .fair: return 2
+        case .poor: return 3
+        case .emergency: return 4
+        }
+    }
+}
+
+enum AndroidNetworkReachabilityQualityPolicy {
+    static func bandwidthQuality(upstreamKbps: Int, downstreamKbps: Int) -> ConnectionQuality {
+        let hasUpstream = upstreamKbps > 0
+        let hasDownstream = downstreamKbps > 0
+        guard hasUpstream || hasDownstream else { return .unknown }
+
+        if (hasUpstream && upstreamKbps <= 120) || (hasDownstream && downstreamKbps <= 300) {
+            return .emergency
+        }
+        if (hasUpstream && upstreamKbps <= 240) || (hasDownstream && downstreamKbps <= 800) {
+            return .poor
+        }
+        if (hasUpstream && upstreamKbps <= 500) || (hasDownstream && downstreamKbps <= 1_500) {
+            return .fair
+        }
+        return .unknown
+    }
+
+    static func validatedQuality(upstreamKbps: Int, downstreamKbps: Int) -> ConnectionQuality {
+        let bandwidthQuality = bandwidthQuality(
+            upstreamKbps: upstreamKbps,
+            downstreamKbps: downstreamKbps
+        )
+        guard bandwidthQuality == .unknown else { return bandwidthQuality }
+        return .good
+    }
+}
+
 enum ScreenSharePublishProfilePolicy {
     static let fairBitrateBps = 1_500_000.0
     static let poorBitrateBps = 550_000.0

--- a/apps/conclave-skip/Sources/Conclave/Core/State/MeetingState.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/State/MeetingState.swift
@@ -78,6 +78,28 @@ struct MeetingSpotlightSnapshot {
     }
 }
 
+struct PendingUserRow: Identifiable, Equatable {
+    let id: String
+    let displayName: String
+}
+
+enum PendingUserRowsPolicy {
+    static func sortedRows(from users: [String: String]) -> [PendingUserRow] {
+        users
+            .map { PendingUserRow(id: $0.key, displayName: $0.value) }
+            .sorted { lhs, rhs in
+                let leftName = lhs.displayName.lowercased()
+                let rightName = rhs.displayName.lowercased()
+
+                if leftName == rightName {
+                    return lhs.id < rhs.id
+                }
+
+                return leftName < rightName
+            }
+    }
+}
+
 @MainActor
 @Observable
 final class MeetingState {
@@ -155,7 +177,12 @@ final class MeetingState {
         }
     }
     var displayNames: [String: String] = [:]
-    var pendingUsers: [String: String] = [:]
+    var pendingUsers: [String: String] = [:] {
+        didSet {
+            pendingUserRows = PendingUserRowsPolicy.sortedRows(from: pendingUsers)
+        }
+    }
+    private(set) var pendingUserRows: [PendingUserRow] = []
     var hasInitialPresenceSnapshot: Bool = false
 
     // Media State

--- a/apps/conclave-skip/Sources/Conclave/Core/State/TranscriptState.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/State/TranscriptState.swift
@@ -24,6 +24,69 @@ struct TranscriptSegmentModel: Identifiable, Equatable {
     var id: String { itemId }
 }
 
+/// A run of consecutive captions from the same speaker, rendered as one block.
+struct TranscriptGroup: Identifiable, Equatable {
+    let id: String
+    let speakerUserId: String
+    let speakerDisplayName: String
+    private(set) var text: String
+    private(set) var isFinal: Bool
+    private(set) var lastStartMs: Double
+
+    init(segment: TranscriptSegmentModel) {
+        self.id = "\(segment.speakerUserId)-\(segment.sequence)-\(segment.itemId)"
+        self.speakerUserId = segment.speakerUserId
+        self.speakerDisplayName = segment.speakerDisplayName
+        self.text = segment.text
+        self.isFinal = segment.isFinal
+        self.lastStartMs = segment.startMs
+    }
+
+    mutating func append(_ segment: TranscriptSegmentModel) {
+        let trimmed = segment.text.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty {
+            text = text.isEmpty ? trimmed : "\(text) \(trimmed)"
+        }
+        isFinal = isFinal && segment.isFinal
+        lastStartMs = segment.startMs
+    }
+}
+
+enum TranscriptPresentationPolicy {
+    static func orderedSegments(
+        finals: [TranscriptSegmentModel],
+        partials: [String: TranscriptSegmentModel]
+    ) -> [TranscriptSegmentModel] {
+        var combined = finals
+        combined.append(contentsOf: partials.values)
+        return combined.sorted { left, right in
+            if left.sequence != right.sequence { return left.sequence < right.sequence }
+            if left.startMs != right.startMs { return left.startMs < right.startMs }
+            return left.itemId < right.itemId
+        }
+    }
+
+    static func groupedSegments(from segments: [TranscriptSegmentModel]) -> [TranscriptGroup] {
+        var groups: [TranscriptGroup] = []
+        for segment in segments {
+            if var last = groups.last,
+               last.speakerUserId == segment.speakerUserId,
+               segment.startMs - last.lastStartMs < 90_000 {
+                last.append(segment)
+                groups[groups.count - 1] = last
+            } else {
+                groups.append(TranscriptGroup(segment: segment))
+            }
+        }
+        return groups
+    }
+
+    static func scrollTrigger(for segments: [TranscriptSegmentModel]) -> String {
+        guard let last = segments.last else { return "\(segments.count)" }
+        return "\(segments.count)-\(last.itemId)-\(last.text.count)"
+    }
+}
+
 /// Observable transcript view state. Holds finalized segments plus the in-flight
 /// partials map so the panel can render live captions as they stream in.
 @MainActor
@@ -38,37 +101,39 @@ final class TranscriptState {
 
     private(set) var finals: [TranscriptSegmentModel] = []
     private(set) var partials: [String: TranscriptSegmentModel] = [:]
+    private(set) var orderedSegments: [TranscriptSegmentModel] = []
+    private(set) var groupedSegments: [TranscriptGroup] = []
+    private(set) var scrollTrigger: String = "0"
 
     var isLive: Bool { sessionStatus == "live" }
     var isBusy: Bool { sessionStatus == "starting" || sessionStatus == "stopping" }
 
-    /// Finals + partials, ordered the same way the web orders them
-    /// (sequence, then startMs, then itemId).
-    var orderedSegments: [TranscriptSegmentModel] {
-        var combined = finals
-        combined.append(contentsOf: partials.values)
-        return combined.sorted { left, right in
-            if left.sequence != right.sequence { return left.sequence < right.sequence }
-            if left.startMs != right.startMs { return left.startMs < right.startMs }
-            return left.itemId < right.itemId
-        }
-    }
-
     func applyPartial(_ segment: TranscriptSegmentModel) {
+        if partials[segment.itemId] == segment { return }
         partials[segment.itemId] = segment
+        rebuildPresentation()
     }
 
     func applyFinal(_ segment: TranscriptSegmentModel) {
-        partials.removeValue(forKey: segment.itemId)
+        let removedPartial = partials.removeValue(forKey: segment.itemId) != nil
+        var changedFinal = false
         if let index = finals.firstIndex(where: { $0.itemId == segment.itemId }) {
-            finals[index] = segment
+            if finals[index] != segment {
+                finals[index] = segment
+                changedFinal = true
+            }
         } else {
             finals.append(segment)
+            changedFinal = true
         }
+        guard removedPartial || changedFinal else { return }
+        rebuildPresentation()
     }
 
     func resetPartials() {
+        guard !partials.isEmpty else { return }
         partials = [:]
+        rebuildPresentation()
     }
 
     func replaceSnapshot(finals: [TranscriptSegmentModel], partials: [TranscriptSegmentModel]) {
@@ -78,11 +143,14 @@ final class TranscriptState {
             map[segment.itemId] = segment
         }
         self.partials = map
+        rebuildPresentation()
     }
 
     func clearSegments() {
+        guard !finals.isEmpty || !partials.isEmpty || !orderedSegments.isEmpty || !groupedSegments.isEmpty else { return }
         finals = []
         partials = [:]
+        rebuildPresentation()
     }
 
     func resetAll() {
@@ -93,5 +161,15 @@ final class TranscriptState {
         controllerName = nil
         canStart = false
         canStop = false
+    }
+
+    private func rebuildPresentation() {
+        let nextOrderedSegments = TranscriptPresentationPolicy.orderedSegments(
+            finals: finals,
+            partials: partials
+        )
+        orderedSegments = nextOrderedSegments
+        groupedSegments = TranscriptPresentationPolicy.groupedSegments(from: nextOrderedSegments)
+        scrollTrigger = TranscriptPresentationPolicy.scrollTrigger(for: nextOrderedSegments)
     }
 }

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingHeaderView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingHeaderView.swift
@@ -7,7 +7,7 @@ import UIKit
 // MARK: - Meeting Header
 
 enum MeetingHeaderLayout {
-    static let roomPillMaxWidth: CGFloat = 224.0
+    static let roomPillMaxWidth: CGFloat = 176.0
 }
 
 struct MeetingHeaderView: View {

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingView.swift
@@ -400,17 +400,17 @@ struct MeetingView: View {
             updateStageObscured()
         }
         #else
-        .onChange(of: viewModel.state.isChatOpen) { _, _ in
+        .onChange(of: viewModel.state.isChatOpen) {
             if !viewModel.state.isChatOpen {
                 chatInputFocused = false
             }
         }
-        .onChange(of: showMeetingSheet) { _, _ in
+        .onChange(of: showMeetingSheet) {
             if !showMeetingSheet {
                 resetMeetingSheetStateAfterDismiss()
             }
         }
-        .onChange(of: viewModel.state.isWebinarAttendee) { _, _ in
+        .onChange(of: viewModel.state.isWebinarAttendee) {
             if viewModel.state.isWebinarAttendee {
                 dismissMeetingSheet()
                 chatInputFocused = false

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift
@@ -568,34 +568,20 @@ final class MeetingViewModel {
     private var adaptiveConnectionQualitySince = Date()
     private var adaptiveVideoQualityDowngraded = false
 
-    private func connectionQualityRank(_ quality: ConnectionQuality) -> Int {
-        switch quality {
-        case .unknown:
-            return 0
-        case .good:
-            return 1
-        case .fair:
-            return 2
-        case .poor:
-            return 3
-        case .emergency:
-            return 4
-        }
-    }
-
     private func combinedConnectionQuality(_ sampledQuality: ConnectionQuality) -> ConnectionQuality {
-        if connectionQualityRank(networkQualityHint) > connectionQualityRank(sampledQuality) {
-            return networkQualityHint
-        }
-        return sampledQuality
+        ConnectionQualityHintPolicy.combined(
+            sampledQuality: sampledQuality,
+            networkHint: networkQualityHint
+        )
     }
 
     @discardableResult
     private func applyConnectionQualitySample(_ sample: ConnectionQualitySample) -> ConnectionQuality {
         publishConnectionQuality = combinedConnectionQuality(sample.publishQuality)
-        screenSharePublishConnectionQuality = ScreenSharePublishProfilePolicy.mostConstrained(
-            publishConnectionQuality,
-            combinedConnectionQuality(sample.screenSharePublishQuality)
+        screenSharePublishConnectionQuality = ConnectionQualityHintPolicy.screenSharePublishQuality(
+            publishQuality: publishConnectionQuality,
+            screenShareSampledQuality: sample.screenSharePublishQuality,
+            networkHint: networkQualityHint
         )
         receiveConnectionQuality = combinedConnectionQuality(sample.receiveQuality)
         let overallQuality = combinedConnectionQuality(sample.overallQuality)

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/MoreSheetView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/MoreSheetView.swift
@@ -1315,7 +1315,7 @@ struct SharedBrowserSheetView: View {
             syncBrowserURLInput()
         }
 #else
-        .onChange(of: viewModel.state.isBrowserActive) { _, _ in
+        .onChange(of: viewModel.state.isBrowserActive) {
             syncBrowserURLInput()
         }
         #endif
@@ -1511,6 +1511,79 @@ enum SharedBrowserURLDraftSyncPolicy {
     }
 }
 
+struct GameCatalogVisual: Equatable {
+    let icon: String
+    let androidIcon: String
+}
+
+enum GameCatalogPresentationPolicy {
+    static func visual(for gameId: String) -> GameCatalogVisual {
+        switch gameId {
+        case "trivia":
+            return GameCatalogVisual(icon: "questionmark.circle.fill", androidIcon: "info")
+        case "bluff":
+            return GameCatalogVisual(icon: "theatermasks.fill", androidIcon: "forum")
+        case "would-you-rather":
+            return GameCatalogVisual(icon: "arrow.left.arrow.right", androidIcon: "arrow.forward")
+        case "most-likely-to":
+            return GameCatalogVisual(icon: "person.2.fill", androidIcon: "participants")
+        case "reaction":
+            return GameCatalogVisual(icon: "bolt.fill", androidIcon: "warning")
+        case "imposter":
+            return GameCatalogVisual(icon: "eye.slash.fill", androidIcon: "ghost")
+        case "wordle":
+            return GameCatalogVisual(icon: "square.grid.3x3.fill", androidIcon: "grid")
+        default:
+            return GameCatalogVisual(icon: "gamecontroller.fill", androidIcon: "sports_esports")
+        }
+    }
+
+    static func catalogSubtitle(_ game: GameCatalogEntry) -> String {
+        let description = game.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        return description.isEmpty ? playerRange(game) : description
+    }
+
+    static func playerRange(_ game: GameCatalogEntry) -> String {
+        if game.minPlayers == game.maxPlayers {
+            return "\(game.minPlayers)"
+        }
+        return "\(game.minPlayers)-\(game.maxPlayers)"
+    }
+
+    static func canOpenVote(catalogCount: Int, isActionInFlight: Bool) -> Bool {
+        !isActionInFlight && catalogCount >= 2
+    }
+
+    static func shouldShowDivider(after index: Int, total: Int, hasFooter: Bool) -> Bool {
+        index < total - 1 || hasFooter
+    }
+}
+
+enum GameVotePresentationPolicy {
+    static func leader(in vote: GameVoteState) -> GameCatalogEntry? {
+        var leader: GameCatalogEntry?
+        var leaderVotes = -1
+        for entry in vote.candidates {
+            let count = vote.tally[entry.id] ?? 0
+            if count > leaderVotes {
+                leader = entry
+                leaderVotes = count
+            }
+        }
+        return leader
+    }
+
+    static func startLeaderTitle(_ vote: GameVoteState) -> String {
+        guard let leader = leader(in: vote) else { return "Start leader" }
+        let votes = vote.tally[leader.id] ?? 0
+        return votes > 0 ? "Start \(leader.name)" : "Start leader"
+    }
+
+    static func shouldShowCandidateDivider(after index: Int, total: Int, hasHostActions: Bool) -> Bool {
+        index < total - 1 || hasHostActions
+    }
+}
+
 struct GamesSheetView: View {
     @Bindable var viewModel: MeetingViewModel
     var bodyReady: Bool = true
@@ -1604,13 +1677,14 @@ struct GamesSheetView: View {
     }
 
     private func activeGameSection(_ activeGame: GamePublicState) -> some View {
-        VStack(alignment: .leading, spacing: ACMSpacing.xs) {
+        let visual = GameCatalogPresentationPolicy.visual(for: activeGame.gameId)
+        return VStack(alignment: .leading, spacing: ACMSpacing.xs) {
             acmListSectionHeader("Active game")
 
             MeetingSheetSectionCard {
                 gameRow(
-                    icon: "gamecontroller.fill",
-                    androidIcon: "sports_esports",
+                    icon: visual.icon,
+                    androidIcon: visual.androidIcon,
                     title: activeGame.name,
                     subtitle: activeGameSubtitle(activeGame),
                     trailing: activeGame.phase,
@@ -2462,12 +2536,15 @@ struct GamesSheetView: View {
             acmListSectionHeader("Vote")
 
             MeetingSheetSectionCard {
+                let candidates = vote.candidates
                 let localVoteGameId = viewModel.state.localGameVoteId(in: vote)
-                ForEach(vote.candidates) { entry in
+                let hasHostActions = canManageGames
+                ForEach(Array(candidates.enumerated()), id: \.element.id) { index, entry in
                     let isSelected = localVoteGameId == entry.id
+                    let visual = GameCatalogPresentationPolicy.visual(for: entry.id)
                     gameRow(
-                        icon: "gamecontroller",
-                        androidIcon: "sports_esports",
+                        icon: visual.icon,
+                        androidIcon: visual.androidIcon,
                         title: entry.name,
                         subtitle: entry.description,
                         trailing: "\(vote.tally[entry.id] ?? 0)",
@@ -2479,19 +2556,26 @@ struct GamesSheetView: View {
                         viewModel.castGameVote(gameId: entry.id)
                     }
 
-                    MoreRowDivider()
+                    if GameVotePresentationPolicy.shouldShowCandidateDivider(
+                        after: index,
+                        total: candidates.count,
+                        hasHostActions: hasHostActions
+                    ) {
+                        MoreRowDivider()
+                    }
                 }
 
                 if canManageGames {
+                    let leader = GameVotePresentationPolicy.leader(in: vote)
                     MoreRow(
                         icon: "play.fill",
                         androidIcon: "play",
-                        title: startLeaderTitle(vote),
+                        title: GameVotePresentationPolicy.startLeaderTitle(vote),
                         tint: ACMColors.primaryOrange,
                         androidTint: "accent",
-                        isDisabled: viewModel.state.isGameActionInFlight || voteLeader(in: vote) == nil
+                        isDisabled: viewModel.state.isGameActionInFlight || leader == nil
                     ) {
-                        if let leader = voteLeader(in: vote) {
+                        if let leader {
                             viewModel.startGame(leader, options: defaultOptions(for: leader))
                         }
                     }
@@ -2652,19 +2736,20 @@ struct GamesSheetView: View {
                 let catalog = Array(viewModel.state.gameCatalog)
                 if catalog.isEmpty {
                     gameRow(
-                        icon: "gamecontroller",
+                        icon: "gamecontroller.fill",
                         androidIcon: "sports_esports",
                         title: "No games available",
                         isDisabled: true
                     ) {}
                 } else {
-                    ForEach(viewModel.state.gameCatalog) { entry in
+                    ForEach(Array(catalog.enumerated()), id: \.element.id) { index, entry in
+                        let visual = GameCatalogPresentationPolicy.visual(for: entry.id)
                         gameRow(
-                            icon: "play.fill",
-                            androidIcon: "play",
+                            icon: visual.icon,
+                            androidIcon: visual.androidIcon,
                             title: entry.name,
-                            subtitle: catalogSubtitle(entry),
-                            trailing: playerRange(entry),
+                            subtitle: GameCatalogPresentationPolicy.catalogSubtitle(entry),
+                            trailing: GameCatalogPresentationPolicy.playerRange(entry),
                             isDisabled: viewModel.state.isGameActionInFlight
                         ) {
                             if entry.options.isEmpty {
@@ -2674,14 +2759,23 @@ struct GamesSheetView: View {
                             }
                         }
 
-                        MoreRowDivider()
+                        if GameCatalogPresentationPolicy.shouldShowDivider(
+                            after: index,
+                            total: catalog.count,
+                            hasFooter: true
+                        ) {
+                            MoreRowDivider()
+                        }
                     }
 
                     MoreRow(
                         icon: "person.3.fill",
                         androidIcon: "participants",
                         title: viewModel.state.gameVote == nil ? "Open vote" : "Restart vote",
-                        isDisabled: viewModel.state.isGameActionInFlight || catalog.count < 2
+                        isDisabled: !GameCatalogPresentationPolicy.canOpenVote(
+                            catalogCount: catalog.count,
+                            isActionInFlight: viewModel.state.isGameActionInFlight
+                        )
                     ) {
                         viewModel.openGameVote(candidateIds: nil)
                     }
@@ -2783,41 +2877,10 @@ struct GamesSheetView: View {
             && !viewModel.state.isWebinarAttendee
     }
 
-    private func voteLeader(in vote: GameVoteState) -> GameCatalogEntry? {
-        var leader: GameCatalogEntry?
-        var leaderVotes = -1
-        for entry in vote.candidates {
-            let count = vote.tally[entry.id] ?? 0
-            if count > leaderVotes {
-                leader = entry
-                leaderVotes = count
-            }
-        }
-        return leader
-    }
-
-    private func startLeaderTitle(_ vote: GameVoteState) -> String {
-        guard let leader = voteLeader(in: vote) else { return "Start leader" }
-        let votes = vote.tally[leader.id] ?? 0
-        return votes > 0 ? "Start \(leader.name)" : "Start leader"
-    }
-
     private func activeGameSubtitle(_ game: GamePublicState) -> String {
         let count = game.players.count
         let noun = count == 1 ? "player" : "players"
         return "\(count) \(noun)"
-    }
-
-    private func catalogSubtitle(_ game: GameCatalogEntry) -> String {
-        let description = game.description.trimmingCharacters(in: .whitespacesAndNewlines)
-        return description.isEmpty ? playerRange(game) : description
-    }
-
-    private func playerRange(_ game: GameCatalogEntry) -> String {
-        if game.minPlayers == game.maxPlayers {
-            return "\(game.minPlayers)"
-        }
-        return "\(game.minPlayers)-\(game.maxPlayers)"
     }
 
     private func beginConfiguringGame(_ game: GameCatalogEntry) {

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/ParticipantsSheetView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/ParticipantsSheetView.swift
@@ -575,7 +575,7 @@ struct ParticipantsSheetView: View {
 
     var body: some View {
         let participants = viewModel.state.presentParticipants
-        let pendingUsers = viewModel.state.pendingUsers.sorted(by: { $0.value < $1.value })
+        let pendingUsers = viewModel.state.pendingUserRows
         let dividerInset = ACMSpacing.sm + 40 + ACMSpacing.sm
 
         VStack(spacing: 0) {
@@ -643,11 +643,11 @@ struct ParticipantsSheetView: View {
 
                                 MeetingSheetRowDivider(inset: ACMSpacing.sm)
 
-                                ForEach(pendingUsers, id: \.key) { userId, name in
-                                    pendingUserRow(userId: userId, name: name)
+                                ForEach(pendingUsers) { pendingUser in
+                                    pendingUserRow(userId: pendingUser.id, name: pendingUser.displayName)
 
                                     if let last = pendingUsers.last {
-                                        if userId != last.key {
+                                        if pendingUser.id != last.id {
                                             MeetingSheetRowDivider(inset: ACMSpacing.sm + 36 + ACMSpacing.sm)
                                         }
                                     }

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/SettingsSheetView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/SettingsSheetView.swift
@@ -2099,7 +2099,7 @@ struct SettingsSheetView: View {
             scheduleSettingsRefreshIfReady()
         }
 #else
-        .onChange(of: bodyReady) { _, _ in
+        .onChange(of: bodyReady) {
             scheduleSettingsRefreshIfReady()
         }
         #endif

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/SharedBrowserLayoutView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/SharedBrowserLayoutView.swift
@@ -30,7 +30,7 @@ struct SharedBrowserLayoutView: View {
             syncNavInput()
         }
 #else
-        .onChange(of: viewModel.state.isBrowserActive) { _, _ in
+        .onChange(of: viewModel.state.isBrowserActive) {
             syncNavInput()
         }
         #endif

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/TranscriptPanelView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/TranscriptPanelView.swift
@@ -169,7 +169,7 @@ struct TranscriptPanelView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: ACMSpacing.md) {
-                    ForEach(groupedSegments) { group in
+                    ForEach(state.groupedSegments) { group in
                         transcriptGroupView(group)
                     }
                     Color.clear
@@ -179,7 +179,7 @@ struct TranscriptPanelView: View {
                 .padding(.horizontal, ACMSpacing.lg)
                 .padding(.top, ACMSpacing.md)
             }
-            .onChange(of: scrollTrigger) {
+            .onChange(of: state.scrollTrigger) {
                 proxy.scrollTo("transcript-bottom", anchor: .bottom)
             }
         }
@@ -191,13 +191,6 @@ struct TranscriptPanelView: View {
         #else
         return ACMSpacing.md
         #endif
-    }
-
-    // Any new/updated caption changes this key, nudging the scroll to the bottom.
-    private var scrollTrigger: String {
-        let segments = state.orderedSegments
-        guard let last = segments.last else { return "\(segments.count)" }
-        return "\(segments.count)-\(last.itemId)-\(last.text.count)"
     }
 
     private func transcriptGroupView(_ group: TranscriptGroup) -> some View {
@@ -228,50 +221,5 @@ struct TranscriptPanelView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, ACMSpacing.lg)
-    }
-
-    // MARK: - Grouping
-
-    private var groupedSegments: [TranscriptGroup] {
-        var groups: [TranscriptGroup] = []
-        for segment in state.orderedSegments {
-            if var last = groups.last,
-               last.speakerUserId == segment.speakerUserId,
-               segment.startMs - last.lastStartMs < 90_000 {
-                last.append(segment)
-                groups[groups.count - 1] = last
-            } else {
-                groups.append(TranscriptGroup(segment: segment))
-            }
-        }
-        return groups
-    }
-}
-
-/// A run of consecutive captions from the same speaker, rendered as one block.
-struct TranscriptGroup: Identifiable {
-    let id: String
-    let speakerUserId: String
-    let speakerDisplayName: String
-    private(set) var text: String
-    private(set) var isFinal: Bool
-    private(set) var lastStartMs: Double
-
-    init(segment: TranscriptSegmentModel) {
-        self.id = "\(segment.speakerUserId)-\(segment.sequence)-\(segment.itemId)"
-        self.speakerUserId = segment.speakerUserId
-        self.speakerDisplayName = segment.speakerDisplayName
-        self.text = segment.text
-        self.isFinal = segment.isFinal
-        self.lastStartMs = segment.startMs
-    }
-
-    mutating func append(_ segment: TranscriptSegmentModel) {
-        let trimmed = segment.text.trimmingCharacters(in: .whitespaces)
-        if !trimmed.isEmpty {
-            text = text.isEmpty ? trimmed : "\(text) \(trimmed)"
-        }
-        isFinal = isFinal && segment.isFinal
-        lastStartMs = segment.startMs
     }
 }

--- a/apps/conclave-skip/Sources/Conclave/Skip/NetworkReachabilityMonitor.kt
+++ b/apps/conclave-skip/Sources/Conclave/Skip/NetworkReachabilityMonitor.kt
@@ -107,44 +107,16 @@ internal class NetworkReachabilityMonitor {
                 capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
         if (!validated) return QualityHint(ConnectionQuality.unknown, "not_validated")
 
-        val metered = !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
-        val congested = !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_CONGESTED)
-        val suspended = !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED)
-        val cellular = capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
-        val bandwidthQuality = bandwidthQualityHint(
+        val bandwidthQuality = AndroidNetworkReachabilityQualityPolicy.bandwidthQuality(
             upstreamKbps = capabilities.linkUpstreamBandwidthKbps,
             downstreamKbps = capabilities.linkDownstreamBandwidthKbps,
         )
-        val details = "metered=$metered cellular=$cellular congested=$congested suspended=$suspended upKbps=${capabilities.linkUpstreamBandwidthKbps} downKbps=${capabilities.linkDownstreamBandwidthKbps}"
+        val details = "metered=${!capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)} cellular=${capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)} upKbps=${capabilities.linkUpstreamBandwidthKbps} downKbps=${capabilities.linkDownstreamBandwidthKbps}"
 
-        if ((congested || suspended) && (metered || cellular)) {
-            return QualityHint(ConnectionQuality.emergency, "blocked_or_congested $details")
-        }
-        if (congested || suspended) {
-            return QualityHint(ConnectionQuality.poor, "blocked_or_congested $details")
-        }
         if (bandwidthQuality != ConnectionQuality.unknown) {
             return QualityHint(bandwidthQuality, "bandwidth_hint $details")
         }
         return QualityHint(ConnectionQuality.good, "validated $details")
-    }
-
-    private fun bandwidthQualityHint(upstreamKbps: Int, downstreamKbps: Int): ConnectionQuality {
-        val upstream = upstreamKbps.takeIf { it > 0 }
-        val downstream = downstreamKbps.takeIf { it > 0 }
-        if (upstream == null && downstream == null) return ConnectionQuality.unknown
-
-        if ((upstream != null && upstream <= 120) || (downstream != null && downstream <= 300)) {
-            return ConnectionQuality.emergency
-        }
-        if ((upstream != null && upstream <= 240) || (downstream != null && downstream <= 800)) {
-            return ConnectionQuality.poor
-        }
-        if ((upstream != null && upstream <= 500) || (downstream != null && downstream <= 1_500)) {
-            return ConnectionQuality.fair
-        }
-
-        return ConnectionQuality.unknown
     }
 
     private fun logQualityHintIfNeeded(qualityHint: QualityHint, isOffline: Boolean) {

--- a/apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift
+++ b/apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift
@@ -54,6 +54,58 @@ final class ConclaveTests: XCTestCase {
         XCTAssertTrue(stop.success)
     }
 
+    func testTranscriptPresentationPolicyOrdersAndGroupsSegments() throws {
+        let unordered = [
+            TranscriptSegmentModel(itemId: "b", sequence: 2, speakerUserId: "alex", speakerDisplayName: "Alex", text: "later", startMs: 3_000, isFinal: true),
+            TranscriptSegmentModel(itemId: "a", sequence: 1, speakerUserId: "alex", speakerDisplayName: "Alex", text: "hello", startMs: 1_000, isFinal: true),
+            TranscriptSegmentModel(itemId: "c", sequence: 1, speakerUserId: "alex", speakerDisplayName: "Alex", text: "world", startMs: 2_000, isFinal: false),
+            TranscriptSegmentModel(itemId: "d", sequence: 3, speakerUserId: "bea", speakerDisplayName: "Bea", text: "reply", startMs: 4_000, isFinal: true)
+        ]
+
+        let ordered = TranscriptPresentationPolicy.orderedSegments(finals: [unordered[0], unordered[1]], partials: [
+            unordered[2].itemId: unordered[2],
+            unordered[3].itemId: unordered[3]
+        ])
+        XCTAssertEqual(ordered.map(\.itemId), ["a", "c", "b", "d"])
+
+        let groups = TranscriptPresentationPolicy.groupedSegments(from: ordered)
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertEqual(groups[0].speakerDisplayName, "Alex")
+        XCTAssertEqual(groups[0].text, "hello world later")
+        XCTAssertFalse(groups[0].isFinal)
+        XCTAssertEqual(groups[1].speakerDisplayName, "Bea")
+        XCTAssertEqual(groups[1].text, "reply")
+    }
+
+    @MainActor
+    func testTranscriptStateCachesPresentationOnSegmentMutations() throws {
+        let state = TranscriptState()
+        let partial = TranscriptSegmentModel(itemId: "p", sequence: 2, speakerUserId: "alex", speakerDisplayName: "Alex", text: "live", startMs: 2_000, isFinal: false)
+        let final = TranscriptSegmentModel(itemId: "f", sequence: 1, speakerUserId: "alex", speakerDisplayName: "Alex", text: "ready", startMs: 1_000, isFinal: true)
+
+        state.applyPartial(partial)
+        XCTAssertEqual(state.orderedSegments.map(\.itemId), ["p"])
+        XCTAssertEqual(state.groupedSegments.map(\.text), ["live"])
+        XCTAssertEqual(state.scrollTrigger, "1-p-4")
+
+        state.applyFinal(final)
+        XCTAssertEqual(state.orderedSegments.map(\.itemId), ["f", "p"])
+        XCTAssertEqual(state.groupedSegments.map(\.text), ["ready live"])
+
+        state.resetPartials()
+        XCTAssertEqual(state.orderedSegments.map(\.itemId), ["f"])
+        XCTAssertEqual(state.groupedSegments.map(\.text), ["ready"])
+    }
+
+    func testTranscriptPanelUsesCachedPresentationState() throws {
+        let source = try sourceFileContents("Sources/Conclave/Features/Meeting/TranscriptPanelView.swift")
+
+        XCTAssertTrue(source.contains("ForEach(state.groupedSegments)"))
+        XCTAssertTrue(source.contains(".onChange(of: state.scrollTrigger)"))
+        XCTAssertFalse(source.contains("private var groupedSegments"))
+        XCTAssertFalse(source.contains("for segment in state.orderedSegments"))
+    }
+
     func testNativeGameWireModelsDecodeServerShapes() throws {
         let json = """
         {
@@ -130,6 +182,14 @@ final class ConclaveTests: XCTestCase {
         XCTAssertFalse(source.contains("category!"))
     }
 
+    func testParticipantsSheetUsesCachedPendingUserRows() throws {
+        let source = try sourceFileContents("Sources/Conclave/Features/Meeting/ParticipantsSheetView.swift")
+
+        XCTAssertTrue(source.contains("viewModel.state.pendingUserRows"))
+        XCTAssertFalse(source.contains("pendingUsers.sorted"))
+        XCTAssertFalse(source.contains("state.pendingUsers.sorted"))
+    }
+
     func testMeetingEntryOverlayPolicyStopsAtSafetyCap() throws {
         let startedAt = Date(timeIntervalSince1970: 1_000)
 
@@ -177,6 +237,85 @@ final class ConclaveTests: XCTestCase {
         XCTAssertTrue(MeetingEntryOverlayPolicy.shouldClearMeetingEntry(on: ConnectionState.waiting))
         XCTAssertTrue(MeetingEntryOverlayPolicy.shouldClearMeetingEntry(on: ConnectionState.error))
         XCTAssertTrue(MeetingEntryOverlayPolicy.shouldClearMeetingEntry(on: ConnectionState.disconnected))
+    }
+
+    func testConnectionQualityHintPolicyDoesNotKeepReducedQualityLatchedAfterGoodRtcStats() throws {
+        XCTAssertEqual(
+            ConnectionQualityHintPolicy.combined(sampledQuality: ConnectionQuality.good, networkHint: ConnectionQuality.fair),
+            ConnectionQuality.good
+        )
+        XCTAssertEqual(
+            ConnectionQualityHintPolicy.combined(sampledQuality: ConnectionQuality.good, networkHint: ConnectionQuality.poor),
+            ConnectionQuality.good
+        )
+        XCTAssertEqual(
+            ConnectionQualityHintPolicy.combined(sampledQuality: ConnectionQuality.unknown, networkHint: ConnectionQuality.fair),
+            ConnectionQuality.fair
+        )
+        XCTAssertEqual(
+            ConnectionQualityHintPolicy.combined(sampledQuality: ConnectionQuality.poor, networkHint: ConnectionQuality.emergency),
+            ConnectionQuality.emergency
+        )
+        XCTAssertEqual(
+            ConnectionQualityHintPolicy.screenSharePublishQuality(
+                publishQuality: ConnectionQuality.good,
+                screenShareSampledQuality: ConnectionQuality.unknown,
+                networkHint: ConnectionQuality.poor
+            ),
+            ConnectionQuality.good
+        )
+        XCTAssertEqual(
+            ConnectionQualityHintPolicy.screenSharePublishQuality(
+                publishQuality: ConnectionQuality.fair,
+                screenShareSampledQuality: ConnectionQuality.poor,
+                networkHint: ConnectionQuality.good
+            ),
+            ConnectionQuality.poor
+        )
+        XCTAssertEqual(
+            ConnectionQualityHintPolicy.screenSharePublishQuality(
+                publishQuality: ConnectionQuality.emergency,
+                screenShareSampledQuality: ConnectionQuality.unknown,
+                networkHint: ConnectionQuality.poor
+            ),
+            ConnectionQuality.emergency
+        )
+    }
+
+    func testAndroidNetworkReachabilityQualityPolicyUsesBandwidthOnlyForValidatedQuality() throws {
+        XCTAssertEqual(
+            AndroidNetworkReachabilityQualityPolicy.bandwidthQuality(upstreamKbps: 0, downstreamKbps: 0),
+            ConnectionQuality.unknown
+        )
+        XCTAssertEqual(
+            AndroidNetworkReachabilityQualityPolicy.validatedQuality(upstreamKbps: 0, downstreamKbps: 0),
+            ConnectionQuality.good
+        )
+        XCTAssertEqual(
+            AndroidNetworkReachabilityQualityPolicy.validatedQuality(upstreamKbps: 10_000, downstreamKbps: 10_000),
+            ConnectionQuality.good
+        )
+        XCTAssertEqual(
+            AndroidNetworkReachabilityQualityPolicy.validatedQuality(upstreamKbps: 500, downstreamKbps: 1_500),
+            ConnectionQuality.fair
+        )
+        XCTAssertEqual(
+            AndroidNetworkReachabilityQualityPolicy.validatedQuality(upstreamKbps: 240, downstreamKbps: 800),
+            ConnectionQuality.poor
+        )
+        XCTAssertEqual(
+            AndroidNetworkReachabilityQualityPolicy.validatedQuality(upstreamKbps: 120, downstreamKbps: 300),
+            ConnectionQuality.emergency
+        )
+    }
+
+    func testAndroidNetworkReachabilityBridgeUsesSharedBandwidthPolicy() throws {
+        let source = try sourceFileContents("Sources/Conclave/Skip/NetworkReachabilityMonitor.kt")
+
+        XCTAssertTrue(source.contains("AndroidNetworkReachabilityQualityPolicy.bandwidthQuality"))
+        XCTAssertFalse(source.contains("NET_CAPABILITY_NOT_CONGESTED"))
+        XCTAssertFalse(source.contains("NET_CAPABILITY_NOT_SUSPENDED"))
+        XCTAssertFalse(source.contains("blocked_or_congested"))
     }
 
     @MainActor
@@ -350,6 +489,101 @@ final class ConclaveTests: XCTestCase {
         XCTAssertTrue(nativeWordle.contains("struct WordleGameView"))
     }
 
+    func testNativeGameCatalogPresentationPolicyCoversWebGameIdentities() throws {
+        let expected: [String: GameCatalogVisual] = [
+            "trivia": GameCatalogVisual(icon: "questionmark.circle.fill", androidIcon: "info"),
+            "bluff": GameCatalogVisual(icon: "theatermasks.fill", androidIcon: "forum"),
+            "would-you-rather": GameCatalogVisual(icon: "arrow.left.arrow.right", androidIcon: "arrow.forward"),
+            "most-likely-to": GameCatalogVisual(icon: "person.2.fill", androidIcon: "participants"),
+            "reaction": GameCatalogVisual(icon: "bolt.fill", androidIcon: "warning"),
+            "imposter": GameCatalogVisual(icon: "eye.slash.fill", androidIcon: "ghost"),
+            "wordle": GameCatalogVisual(icon: "square.grid.3x3.fill", androidIcon: "grid")
+        ]
+
+        for (gameId, visual) in expected {
+            XCTAssertEqual(GameCatalogPresentationPolicy.visual(for: gameId), visual)
+        }
+
+        XCTAssertEqual(
+            GameCatalogPresentationPolicy.visual(for: "future-game"),
+            GameCatalogVisual(icon: "gamecontroller.fill", androidIcon: "sports_esports")
+        )
+    }
+
+    func testGameCatalogPresentationPolicyFormatsRowsAndDividers() throws {
+        let described = GameCatalogEntry(
+            id: "trivia",
+            name: "Trivia",
+            description: "  Quick quiz  ",
+            minPlayers: 1,
+            maxPlayers: 24,
+            options: [],
+            hasLeaderboard: true
+        )
+        let fallback = GameCatalogEntry(
+            id: "wordle",
+            name: "Wordle",
+            description: "   ",
+            minPlayers: 2,
+            maxPlayers: 2,
+            options: [],
+            hasLeaderboard: true
+        )
+
+        XCTAssertEqual(GameCatalogPresentationPolicy.catalogSubtitle(described), "Quick quiz")
+        XCTAssertEqual(GameCatalogPresentationPolicy.catalogSubtitle(fallback), "2")
+        XCTAssertEqual(GameCatalogPresentationPolicy.playerRange(described), "1-24")
+        XCTAssertEqual(GameCatalogPresentationPolicy.playerRange(fallback), "2")
+        XCTAssertTrue(GameCatalogPresentationPolicy.canOpenVote(catalogCount: 2, isActionInFlight: false))
+        XCTAssertFalse(GameCatalogPresentationPolicy.canOpenVote(catalogCount: 1, isActionInFlight: false))
+        XCTAssertFalse(GameCatalogPresentationPolicy.canOpenVote(catalogCount: 2, isActionInFlight: true))
+        XCTAssertTrue(GameCatalogPresentationPolicy.shouldShowDivider(after: 0, total: 2, hasFooter: false))
+        XCTAssertFalse(GameCatalogPresentationPolicy.shouldShowDivider(after: 1, total: 2, hasFooter: false))
+        XCTAssertTrue(GameCatalogPresentationPolicy.shouldShowDivider(after: 1, total: 2, hasFooter: true))
+    }
+
+    func testGameVotePresentationPolicySelectsLeaderAndDividers() throws {
+        let trivia = GameCatalogEntry(
+            id: "trivia",
+            name: "Trivia",
+            description: "Quick quiz",
+            minPlayers: 1,
+            maxPlayers: 24,
+            options: [],
+            hasLeaderboard: true
+        )
+        let wordle = GameCatalogEntry(
+            id: "wordle",
+            name: "Wordle",
+            description: "Word puzzle",
+            minPlayers: 2,
+            maxPlayers: 8,
+            options: [],
+            hasLeaderboard: true
+        )
+        let vote = GameVoteState(
+            candidates: [trivia, wordle],
+            tally: ["trivia": 1, "wordle": 3],
+            votes: [:],
+            totalPlayers: 4,
+            roomId: nil
+        )
+        let noVotes = GameVoteState(
+            candidates: [trivia],
+            tally: [:],
+            votes: [:],
+            totalPlayers: 0,
+            roomId: nil
+        )
+
+        XCTAssertEqual(GameVotePresentationPolicy.leader(in: vote)?.id, "wordle")
+        XCTAssertEqual(GameVotePresentationPolicy.startLeaderTitle(vote), "Start Wordle")
+        XCTAssertEqual(GameVotePresentationPolicy.startLeaderTitle(noVotes), "Start leader")
+        XCTAssertTrue(GameVotePresentationPolicy.shouldShowCandidateDivider(after: 0, total: 2, hasHostActions: false))
+        XCTAssertFalse(GameVotePresentationPolicy.shouldShowCandidateDivider(after: 1, total: 2, hasHostActions: false))
+        XCTAssertTrue(GameVotePresentationPolicy.shouldShowCandidateDivider(after: 1, total: 2, hasHostActions: true))
+    }
+
     func testMoreSheetShowsToolsWhenOnlyTranscriptToolIsAvailable() throws {
         XCTAssertTrue(MoreSheetVisibilityPolicy.canShowToolsSection(
             canShowAdminControls: false,
@@ -368,7 +602,7 @@ final class ConclaveTests: XCTestCase {
     }
 
     func testMeetingHeaderRoomPillDoesNotStretchAcrossCompactScreens() throws {
-        XCTAssertLessThanOrEqual(MeetingHeaderLayout.roomPillMaxWidth, 224.0)
+        XCTAssertLessThanOrEqual(MeetingHeaderLayout.roomPillMaxWidth, 180.0)
     }
 
 #if !SKIP
@@ -3140,6 +3374,26 @@ final class ConclaveTests: XCTestCase {
             "bea@example.com": "bea@example.com",
             "chris@example.com": "Chris"
         ])
+        XCTAssertEqual(viewModel.state.pendingUserRows, [
+            PendingUserRow(id: "bea@example.com", displayName: "bea@example.com"),
+            PendingUserRow(id: "chris@example.com", displayName: "Chris")
+        ])
+    }
+
+    func testPendingUserRowsPolicySortsByDisplayNameThenId() throws {
+        let rows = PendingUserRowsPolicy.sortedRows(from: [
+            "zara@example.com": "Taylor",
+            "alex@example.com": "sam",
+            "bea@example.com": "Sam",
+            "casey@example.com": "Alex"
+        ])
+
+        XCTAssertEqual(rows, [
+            PendingUserRow(id: "casey@example.com", displayName: "Alex"),
+            PendingUserRow(id: "alex@example.com", displayName: "sam"),
+            PendingUserRow(id: "bea@example.com", displayName: "Sam"),
+            PendingUserRow(id: "zara@example.com", displayName: "Taylor")
+        ])
     }
 
     func testPendingWaitingRoomBufferSnapshotSupersedesEarlierEvents() throws {
@@ -3242,6 +3496,9 @@ final class ConclaveTests: XCTestCase {
 
         XCTAssertEqual(viewModel.state.pendingUsers, [
             "bea@example.com": "Bea"
+        ])
+        XCTAssertEqual(viewModel.state.pendingUserRows, [
+            PendingUserRow(id: "bea@example.com", displayName: "Bea")
         ])
     }
 
@@ -7062,7 +7319,8 @@ final class ConclaveTests: XCTestCase {
         XCTAssertTrue(modelsSource.contains("let screenSharePublishQuality: ConnectionQuality"))
         XCTAssertTrue(iosWebRTCSource.contains("ScreenSharePublishProfilePolicy.quality("))
         XCTAssertTrue(viewModelSource.contains("private var screenSharePublishConnectionQuality: ConnectionQuality = .unknown"))
-        XCTAssertTrue(viewModelSource.contains("ScreenSharePublishProfilePolicy.mostConstrained("))
+        XCTAssertTrue(viewModelSource.contains("ConnectionQualityHintPolicy.screenSharePublishQuality("))
+        XCTAssertTrue(viewModelSource.contains("screenShareSampledQuality: sample.screenSharePublishQuality"))
         XCTAssertTrue(viewModelSource.contains("self.screenSharePublishConnectionQuality == quality"))
         XCTAssertTrue(viewModelSource.contains("initialReceiveConnectionQuality: receiveConnectionQuality"))
         XCTAssertTrue(iosWebRTCSource.contains("ScreenCaptureManager.shared.updateMaxFrameRate(\n                screenShareEncodingCap(connectionQuality: connectionQuality).maxFramerate"))

--- a/apps/web/src/app/api/sfu/admin/[...path]/route.ts
+++ b/apps/web/src/app/api/sfu/admin/[...path]/route.ts
@@ -5,6 +5,7 @@ import {
   resolveSfuSecret,
   resolveSfuUrl,
 } from "@/lib/sfu-admin-auth";
+import { readResponseError } from "@/app/lib/utils";
 
 type RouteContext = {
   params: Promise<{
@@ -12,13 +13,7 @@ type RouteContext = {
   }>;
 };
 
-const readError = async (response: Response): Promise<string> => {
-  const payload: unknown = await response.json().catch(() => null);
-  if (payload && typeof payload === "object" && "error" in payload) {
-    return String((payload as { error?: string }).error || "Request failed");
-  }
-  return response.statusText || "Request failed";
-};
+const readError = readResponseError;
 
 const proxyAdminRequest = async (
   request: Request,

--- a/apps/web/src/app/api/sfu/rooms/[roomId]/route.ts
+++ b/apps/web/src/app/api/sfu/rooms/[roomId]/route.ts
@@ -4,7 +4,7 @@ import {
   resolveSfuSecret,
   resolveSfuUrl,
 } from "@/lib/sfu-admin-auth";
-
+import { readResponseError } from "@/app/lib/utils";
 
 type RouteContext = {
   params: Promise<{
@@ -19,13 +19,7 @@ type RoomOccupancyResponse = {
   };
 };
 
-const readError = async (response: Response): Promise<string> => {
-  const payload: unknown = await response.json().catch(() => null);
-  if (payload && typeof payload === "object" && "error" in payload) {
-    return String((payload as { error?: string }).error || "Request failed");
-  }
-  return response.statusText || "Request failed";
-};
+const readError = readResponseError;
 
 const toNonNegativeInteger = (value: unknown): number => {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {

--- a/apps/web/src/app/book/[username]/[eventSlug]/booking-client.tsx
+++ b/apps/web/src/app/book/[username]/[eventSlug]/booking-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { readResponseError } from "@/app/lib/utils";
 import {
   ArrowLeft,
   CalendarPlus,
@@ -65,12 +66,7 @@ const listTimeZones = (): string[] => {
   return FALLBACK_TIME_ZONES;
 };
 
-const readError = async (response: Response): Promise<string> => {
-  const data: unknown = await response.json().catch(() => null);
-  return data && typeof data === "object" && "error" in data
-    ? String((data as { error?: string }).error || "Request failed")
-    : response.statusText || "Request failed";
-};
+const readError = readResponseError;
 
 const fetchJson = async <T,>(url: string, init?: RequestInit): Promise<T> => {
   const response = await fetch(url, {

--- a/apps/web/src/app/components/DevMeetToolsPanel.tsx
+++ b/apps/web/src/app/components/DevMeetToolsPanel.tsx
@@ -4,7 +4,7 @@ import dynamic from "next/dynamic";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Socket } from "socket.io-client";
 import type { JoinMode } from "../lib/types";
-import { generateSessionId } from "../lib/utils";
+import { generateSessionId, readResponseError } from "../lib/utils";
 
 const DevVideoEffectsDiagnostic = dynamic(
   () => import("./DevVideoEffectsDiagnostic"),
@@ -27,13 +27,7 @@ const parseNumberInput = (
 
 const clientId = process.env.NEXT_PUBLIC_SFU_CLIENT_ID || "conclave";
 
-const readError = async (response: Response) => {
-  const data: unknown = await response.json().catch(() => null);
-  if (data && typeof data === "object" && "error" in data) {
-    return String((data as { error?: string }).error || "Request failed");
-  }
-  return response.statusText || "Request failed";
-};
+const readError = readResponseError;
 
 interface DevMeetToolsPanelProps {
   roomId: string;

--- a/apps/web/src/app/components/GridLayout.tsx
+++ b/apps/web/src/app/components/GridLayout.tsx
@@ -87,7 +87,6 @@ interface GridLayoutProps {
   currentUserId: string;
   audioOutputDeviceId?: string;
   isAdmin?: boolean;
-  selectedParticipantId?: string | null;
   onParticipantClick?: (userId: string) => void;
   onOpenParticipantsPanel?: () => void;
   activeVideoEffectsCount?: number;
@@ -967,7 +966,6 @@ function GridLayout({
   currentUserId,
   audioOutputDeviceId,
   isAdmin = false,
-  selectedParticipantId,
   onParticipantClick,
   onOpenParticipantsPanel,
   activeVideoEffectsCount = 0,
@@ -2763,10 +2761,6 @@ function GridLayout({
                     audioOutputDeviceId={audioOutputDeviceId}
                     disableAudio
                     isAdmin={isAdmin}
-                    isSelected={
-                      selectedParticipantId ===
-                      sideBySideCompanionParticipant.userId
-                    }
                     onAdminClick={onParticipantClick}
                     isPinned={
                       pinnedId === sideBySideCompanionParticipant.userId
@@ -2814,7 +2808,6 @@ function GridLayout({
                       audioOutputDeviceId={audioOutputDeviceId}
                       disableAudio
                       isAdmin={isAdmin}
-                      isSelected={selectedParticipantId === participant.userId}
                       onAdminClick={onParticipantClick}
                       isPinned={pinnedId === participant.userId}
                       onTogglePin={togglePin}
@@ -2906,9 +2899,6 @@ function GridLayout({
                   disableAudio
                   videoObjectFit="contain"
                   isAdmin={isAdmin}
-                  isSelected={
-                    selectedParticipantId === stageMainParticipant.userId
-                  }
                   onAdminClick={onParticipantClick}
                   isPinned={pinnedId === stageMainParticipant.userId}
                   onTogglePin={togglePin}
@@ -2972,7 +2962,6 @@ function GridLayout({
                       audioOutputDeviceId={audioOutputDeviceId}
                       disableAudio
                       isAdmin={isAdmin}
-                      isSelected={selectedParticipantId === participant.userId}
                       onAdminClick={onParticipantClick}
                       isPinned={pinnedId === participant.userId}
                       onTogglePin={togglePin}
@@ -3226,7 +3215,6 @@ function GridLayout({
               audioOutputDeviceId={audioOutputDeviceId}
               disableAudio
               isAdmin={isAdmin}
-              isSelected={selectedParticipantId === participant.userId}
               onAdminClick={onParticipantClick}
               isPinned={pinnedId === participant.userId}
               onTogglePin={togglePin}

--- a/apps/web/src/app/components/ParticipantVideo.tsx
+++ b/apps/web/src/app/components/ParticipantVideo.tsx
@@ -23,7 +23,6 @@ interface ParticipantVideoProps {
   isActiveSpeaker?: boolean;
   audioOutputDeviceId?: string;
   isAdmin?: boolean;
-  isSelected?: boolean;
   onAdminClick?: (userId: string) => void;
   videoObjectFit?: "cover" | "contain";
   onAudioAutoplayBlocked?: () => void;

--- a/apps/web/src/app/components/ScheduledMeetingsPanel.tsx
+++ b/apps/web/src/app/components/ScheduledMeetingsPanel.tsx
@@ -10,6 +10,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { readResponseError } from "../lib/utils";
 import type { ScheduledMeeting } from "@/lib/scheduled-meetings";
 import { buildMeetingPath, buildMeetingUrl } from "@/lib/meeting-links";
 
@@ -36,12 +37,7 @@ const getDefaultStartInput = (): string => {
   return local.toISOString().slice(0, 16);
 };
 
-const readError = async (response: Response): Promise<string> => {
-  const data = (await response.json().catch(() => null)) as
-    | ScheduledMeetingsResponse
-    | null;
-  return data?.error || response.statusText || "Request failed";
-};
+const readError = readResponseError;
 
 const STATUS_LABELS: Record<string, string> = {
   scheduled: "Scheduled",

--- a/apps/web/src/app/components/ai-elements/reasoning.tsx
+++ b/apps/web/src/app/components/ai-elements/reasoning.tsx
@@ -40,7 +40,12 @@ const useReasoning = () => {
   return context;
 };
 
-export type ReasoningProps = ComponentProps<typeof Collapsible> & {
+// Omit Radix's method-style onOpenChange declaration and re-declare it as a
+// plain function type so destructuring it doesn't trip unbound-method.
+export type ReasoningProps = Omit<
+  ComponentProps<typeof Collapsible>,
+  "onOpenChange"
+> & {
   isStreaming?: boolean;
   open?: boolean;
   defaultOpen?: boolean;
@@ -54,9 +59,6 @@ export const Reasoning = memo(
     isStreaming = false,
     open,
     defaultOpen = true,
-    // React callback prop; Radix's ComponentProps declares it method-style,
-    // but it is never `this`-bound.
-    // eslint-disable-next-line @typescript-eslint/unbound-method
     onOpenChange,
     duration: durationProp,
     children,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -75,7 +75,6 @@ interface UseMeetMediaOptions {
   setSelectedAudioInputDeviceId: React.Dispatch<
     React.SetStateAction<string | undefined>
   >;
-  selectedAudioOutputDeviceId?: string;
   setSelectedAudioOutputDeviceId: React.Dispatch<
     React.SetStateAction<string | undefined>
   >;
@@ -84,7 +83,6 @@ interface UseMeetMediaOptions {
     React.SetStateAction<string | undefined>
   >;
   meetVolume?: number;
-  videoQuality: VideoQuality;
   videoQualityRef: React.MutableRefObject<VideoQuality>;
   dataSaverMode?: boolean;
   activeVideoEffectsCount?: number;

--- a/apps/web/src/app/hooks/useMeetPopout.ts
+++ b/apps/web/src/app/hooks/useMeetPopout.ts
@@ -36,7 +36,6 @@ export interface UseMeetPopoutOptions {
   isCameraOff: boolean;
   isMuted: boolean;
   mirrorLocalPreview: boolean;
-  userEmail: string;
   getDisplayName: (userId: string) => string;
   onToggleMute: () => void;
   onToggleCamera: () => void;

--- a/apps/web/src/app/lib/utils.ts
+++ b/apps/web/src/app/lib/utils.ts
@@ -14,6 +14,21 @@ export const toError = (value: unknown): Error =>
 export const errorName = (value: unknown): string =>
   value instanceof Error ? value.name : "";
 
+/**
+ * The error message from a failed fetch Response: the JSON body's `error`
+ * field when present, else statusText, else the fallback.
+ */
+export const readResponseError = async (
+  response: Response,
+  fallback = "Request failed",
+): Promise<string> => {
+  const data: unknown = await response.json().catch(() => null);
+  if (data && typeof data === "object" && "error" in data) {
+    return String((data as { error?: unknown }).error || "") || fallback;
+  }
+  return response.statusText || fallback;
+};
+
 export const ROOM_WORDS = [
   "aloe",
   "aster",

--- a/apps/web/src/app/meets-client-page.tsx
+++ b/apps/web/src/app/meets-client-page.tsx
@@ -5,6 +5,7 @@ import MeetsClient from "./meets-client";
 import type { JoinMode } from "./lib/types";
 import type { RoomInfo } from "@/lib/sfu-types";
 import { resolveBrowserSfuClientId } from "@/lib/sfu-client-id";
+import { readResponseError } from "./lib/utils";
 
 const reactionAssets = [
   "aura.gif",
@@ -15,13 +16,7 @@ const reactionAssets = [
   "yawn.gif",
 ];
 
-const readError = async (response: Response) => {
-  const data: unknown = await response.json().catch(() => null);
-  if (data && typeof data === "object" && "error" in data) {
-    return String((data as { error?: string }).error || "Request failed");
-  }
-  return response.statusText || "Request failed";
-};
+const readError = readResponseError;
 
 const defaultClientId = resolveBrowserSfuClientId();
 const JOIN_INFO_REQUEST_TIMEOUT_MS = 15000;
@@ -190,7 +185,6 @@ export default function MeetsClientPage({
         initialRoomId={resolvedInitialRoomId}
         enableRoomRouting={usesRoomRouting}
         forceJoinOnly={forceJoinOnly}
-        allowGhostMode={true}
         bypassMediaPermissions={bypassMediaPermissions}
         joinMode={joinMode}
         autoJoinOnMount={autoJoinOnMount}

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -350,7 +350,6 @@ export type MeetsClientProps = {
   initialRoomId?: string;
   enableRoomRouting?: boolean;
   forceJoinOnly?: boolean;
-  allowGhostMode?: boolean;
   bypassMediaPermissions?: boolean;
   user?: {
     id?: string;
@@ -956,7 +955,6 @@ export default function MeetsClient({
   ]);
 
   const {
-    videoQuality,
     setNetworkManagedVideoQuality,
     isMirrorCamera,
     setIsMirrorCamera,
@@ -1177,12 +1175,10 @@ export default function MeetsClient({
     setMeetError,
     selectedAudioInputDeviceId,
     setSelectedAudioInputDeviceId,
-    selectedAudioOutputDeviceId,
     setSelectedAudioOutputDeviceId,
     selectedVideoInputDeviceId,
     setSelectedVideoInputDeviceId,
     meetVolume,
-    videoQuality,
     videoQualityRef: refs.videoQualityRef,
     dataSaverMode: effectiveDataSaverMode,
     activeVideoEffectsCount,
@@ -2655,7 +2651,6 @@ export default function MeetsClient({
       isCameraOff,
       isMuted,
       mirrorLocalPreview,
-      userEmail,
       getDisplayName: resolveDisplayName,
       onToggleMute: () => {
         void toggleMute();

--- a/apps/web/src/app/schedule/schedule-client.tsx
+++ b/apps/web/src/app/schedule/schedule-client.tsx
@@ -22,6 +22,7 @@ import type {
   WeeklyAvailability,
 } from "@/lib/scheduling";
 import { buildMeetingPath } from "@/lib/meeting-links";
+import { readResponseError } from "../lib/utils";
 
 type Props = {
   user: {
@@ -141,12 +142,7 @@ const emailStatusClass = (status: string | undefined): string => {
   }
 };
 
-const readError = async (response: Response): Promise<string> => {
-  const data: unknown = await response.json().catch(() => null);
-  return data && typeof data === "object" && "error" in data
-    ? String((data as { error?: string }).error || "Request failed")
-    : response.statusText || "Request failed";
-};
+const readError = readResponseError;
 
 const fetchJson = async <T,>(path: string, init?: RequestInit): Promise<T> => {
   const response = await fetch(path, {

--- a/apps/web/src/app/sfu-admin/sfu-admin-dashboard.tsx
+++ b/apps/web/src/app/sfu-admin/sfu-admin-dashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { readResponseError } from "../lib/utils";
 
 type RequestMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 type TabId = "overview" | "moderation" | "access" | "lifecycle" | "advanced";
@@ -113,14 +114,6 @@ type ClusterOverview = {
   }>;
 };
 
-type WorkerSnapshot = {
-  index: number;
-  pid: number | null;
-  closed: boolean;
-  usage: Record<string, number> | null;
-  error?: string;
-};
-
 type PolicyDraft = {
   locked: boolean;
   chatLocked: boolean;
@@ -185,13 +178,8 @@ const formatUptime = (seconds: number): string => {
 
 const pretty = (value: unknown): string => JSON.stringify(value, null, 2);
 
-const readError = async (response: Response): Promise<string> => {
-  const data: unknown = await response.json().catch(() => null);
-  if (data && typeof data === "object" && "error" in data) {
-    return String((data as { error?: string }).error || "Request failed");
-  }
-  return response.statusText || `Request failed (${response.status})`;
-};
+const readError = (response: Response): Promise<string> =>
+  readResponseError(response, `Request failed (${response.status})`);
 
 const buildAdminApiPath = (path: string, clientId: string): string => {
   const normalizedPath = path.replace(/^\/+/, "");
@@ -256,7 +244,6 @@ export default function SfuAdminDashboard() {
 
   const [adminUser, setAdminUser] = useState<AdminUser | null>(null);
   const [overview, setOverview] = useState<ClusterOverview | null>(null);
-  const [, setWorkers] = useState<WorkerSnapshot[]>([]);
   const [rooms, setRooms] = useState<RoomSnapshot[]>([]);
   const [selectedRoomId, setSelectedRoomId] = useState("");
   const [selectedRoomClientId, setSelectedRoomClientId] = useState("");
@@ -330,16 +317,14 @@ export default function SfuAdminDashboard() {
     setErrorMessage(null);
 
     try {
-      const [user, overviewData, workersData, roomsData] = await Promise.all([
+      const [user, overviewData, roomsData] = await Promise.all([
         fetchAdminAuth(),
         fetchAdminJson<ClusterOverview>("overview", { clientId }),
-        fetchAdminJson<{ workers: WorkerSnapshot[] }>("workers", { clientId }),
         fetchAdminJson<{ rooms: RoomSnapshot[] }>("rooms", { clientId }),
       ]);
 
       setAdminUser(user);
       setOverview(overviewData);
-      setWorkers(Array.isArray(workersData.workers) ? workersData.workers : []);
       setRooms(Array.isArray(roomsData.rooms) ? roomsData.rooms : []);
       setDrainEnabled(Boolean(overviewData.draining));
     } catch (error) {

--- a/apps/web/src/lib/scheduled-meetings.ts
+++ b/apps/web/src/lib/scheduled-meetings.ts
@@ -3,6 +3,7 @@ import {
   type SfuAuthenticatedUser,
 } from "@/lib/sfu-user-auth";
 import { resolveSfuSecret, resolveSfuUrl } from "@/lib/sfu-admin-auth";
+import { readResponseError } from "@/app/lib/utils";
 
 export type ScheduledMeetingStatus =
   | "scheduled"
@@ -71,15 +72,9 @@ export const buildScheduledMeetingHeaders = (
   request: Request,
 ): Headers => buildScheduledWebinarHeaders(user, request);
 
-export const readScheduledMeetingError = async (
+export const readScheduledMeetingError = (
   response: Response,
-): Promise<string> => {
-  const data: unknown = await response.json().catch(() => null);
-  if (data && typeof data === "object" && "error" in data) {
-    return String((data as { error?: string }).error || "Request failed");
-  }
-  return response.statusText || "Request failed";
-};
+): Promise<string> => readResponseError(response);
 
 export const lookupPublicScheduledMeetingByRoomCode = async (
   clientId: string,

--- a/packages/sfu/server/games/modules/wordle.ts
+++ b/packages/sfu/server/games/modules/wordle.ts
@@ -45,8 +45,7 @@ type WordleState = {
 const WORD_LENGTH = 5;
 const MAX_TRIES = 6;
 
-const ALL_WORDS: readonly string[] = WORDLE_WORDS;
-const WORD_SET = new Set<string>(ALL_WORDS);
+const WORD_SET = new Set<string>(WORDLE_WORDS);
 
 const setterName = (ctx: GameContext, setterId: string | null): string | null => {
   if (!setterId) return null;
@@ -313,7 +312,7 @@ export const wordleModule: GameModule<WordleState> = {
         }
 
         if (state.wordSource === "random") {
-          const word = ctx.rng.pick(ALL_WORDS);
+          const word = ctx.rng.pick(WORDLE_WORDS);
           const players: Record<string, PlayerRoundState> = {};
           for (const player of ctx.activePlayers) {
             players[player.id] = { guesses: [], outcome: null, solvedAt: null };
@@ -444,8 +443,8 @@ export const wordleModule: GameModule<WordleState> = {
         const nextRound = state.currentRound + 1;
 
         if (state.wordSource === "random") {
-          const candidates = ALL_WORDS.filter((w) => !state.usedWords.includes(w));
-          const word = ctx.rng.pick(candidates.length > 0 ? candidates : ALL_WORDS);
+          const candidates = WORDLE_WORDS.filter((w) => !state.usedWords.includes(w));
+          const word = ctx.rng.pick(candidates.length > 0 ? candidates : WORDLE_WORDS);
           const players: Record<string, PlayerRoundState> = {};
           for (const player of ctx.activePlayers) {
             players[player.id] = { guesses: [], outcome: null, solvedAt: null };

--- a/packages/sfu/server/http/schedulingRoutes.ts
+++ b/packages/sfu/server/http/schedulingRoutes.ts
@@ -2,6 +2,8 @@ import type { Express, Request, Response } from "express";
 import { Logger } from "../../utilities/loggers.js";
 import {
   asArray,
+  readCoercedBoolean,
+  readCoercedNumber,
   readNumber,
   readString,
   requestBody,
@@ -119,41 +121,6 @@ const normalizeText = (value: unknown, maxLength = MAX_TEXT_LENGTH): string =>
   typeof value === "string"
     ? value.trim().replace(/\s+/g, " ").slice(0, maxLength)
     : "";
-
-/**
- * Decode a boolean field, tolerating "true"/"false" strings — same API
- * tolerance as readCoercedNumber. (The old truthy-Boolean coercion mapped
- * "false" to true; strings now coerce to their actual meaning.)
- */
-const readCoercedBoolean = (
-  body: UntrustedRecord,
-  key: string,
-): boolean | undefined => {
-  const value = body[key];
-  if (typeof value === "boolean") return value;
-  if (value === "true") return true;
-  if (value === "false") return false;
-  return undefined;
-};
-
-/**
- * Decode a numeric field, tolerating stringified numbers ("60") — callers of
- * this API have historically been allowed to send either.
- */
-const readCoercedNumber = (
-  body: UntrustedRecord,
-  key: string,
-): number | undefined => {
-  const value = body[key];
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value : undefined;
-  }
-  if (typeof value === "string" && value.trim()) {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : undefined;
-  }
-  return undefined;
-};
 
 /**
  * Decode the client-editable event-type fields from an untrusted body.

--- a/packages/sfu/utilities/untrusted.ts
+++ b/packages/sfu/utilities/untrusted.ts
@@ -60,3 +60,37 @@ export const readNumber = (
     ? value
     : undefined;
 };
+
+/**
+ * A numeric field tolerating stringified numbers ("60") — for endpoints whose
+ * callers have historically been allowed to send either.
+ */
+export const readCoercedNumber = (
+  record: UntrustedRecord,
+  key: string,
+): number | undefined => {
+  const value = record[key];
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+};
+
+/**
+ * A boolean field tolerating "true"/"false" strings — same API tolerance as
+ * readCoercedNumber. (Unlike truthy coercion, "false" means false.)
+ */
+export const readCoercedBoolean = (
+  record: UntrustedRecord,
+  key: string,
+): boolean | undefined => {
+  const value = record[key];
+  if (typeof value === "boolean") return value;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+};


### PR DESCRIPTION
## Summary

Follow-up to #143 applying the findings of a multi-angle self-review (8 finder angles + verification pass; no correctness bugs survived — these are the six cleanup findings):

- **One `readResponseError`** in `apps/web/src/app/lib/utils.ts` replaces 8 near-identical per-file `readError` helpers (`readScheduledMeetingError` now delegates; sfu-admin keeps its status-suffixed fallback via a one-line wrapper).
- **Dead plumbing removed**: `isSelected` (ParticipantVideo prop + 5 GridLayout passes + the never-passed `selectedParticipantId` prop feeding it), `userEmail` in useMeetPopout options, `selectedAudioOutputDeviceId`/`videoQuality` in useMeetMedia options, `allowGhostMode` in MeetsClient props, and sfu-admin's write-only `workers` state including its now-pointless `/workers` fetch.
- **`readCoercedNumber`/`readCoercedBoolean`** moved from schedulingRoutes into `packages/sfu/utilities/untrusted.ts` with the other boundary decoders.
- **reasoning.tsx** types `onOpenChange` via `Omit<>` instead of an eslint-disable.
- **wordle.ts** uses `WORDLE_WORDS` directly instead of an alias.

## Verification

- `pnpm run lint` (packages + web + konsistent): 0 findings
- tsc: web, sfu, meeting-core, shared-browser all clean
- 284 tests passing: sfu 93, meeting-core 111, apps/web unit 80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR cleans up shared utilities and meeting presentation code.

- Shared web `readResponseError` helper for fetch failures.
- Shared SFU coerced number and boolean decoders.
- Removed unused meet client props and admin dashboard state.
- Cached native transcript and pending-user presentation rows.
- Updated native connection-quality and game-row presentation policies.

<h3>Confidence Score: 4/5</h3>

The Android reachability change can overstate network quality during congested or suspended states.

- The shared web and SFU utility moves look mechanically safe.
- The cached transcript and pending-user state is rebuilt through the inspected mutation paths.
- Android media startup can use unconstrained bitrate when OS congestion signals are ignored.

apps/conclave-skip/Sources/Conclave/Skip/NetworkReachabilityMonitor.kt

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/conclave-skip/Sources/Conclave/Skip/NetworkReachabilityMonitor.kt | Switches Android reachability to bandwidth-only quality hints, which can miss congested or suspended networks. |
| apps/conclave-skip/Sources/Conclave/Core/State/TranscriptState.swift | Caches transcript ordering, grouping, and scroll keys behind the existing mutation methods. |
| apps/web/src/app/lib/utils.ts | Adds the shared response-error reader used by the updated web callers. |
| packages/sfu/utilities/untrusted.ts | Exports the coerced number and boolean readers previously local to scheduling routes. |
| packages/sfu/server/http/schedulingRoutes.ts | Imports the shared untrusted decoders without changing the scheduling field parsing. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FSkip%2FNetworkReachabilityMonitor.kt%3A111-117%0A**Congested%20Networks%20Look%20Good**%0A%0AWhen%20Android%20marks%20a%20validated%20network%20as%20congested%20or%20suspended%20but%20reports%20unknown%20or%20nominal%20link%20bandwidth%2C%20this%20branch%20now%20returns%20%60good%60%20instead%20of%20the%20old%20constrained%20quality.%20The%20meeting%20can%20start%20audio%2C%20video%2C%20and%20screen%20share%20at%20unconstrained%20bitrates%20until%20RTC%20stats%20catch%20up%2C%20causing%20avoidable%20packet%20loss%20and%20jitter%20on%20the%20affected%20network.%0A%0A&repo=acm-vit%2Fconclave&pr=144&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FSkip%2FNetworkReachabilityMonitor.kt%3A111-117%0A**Congested%20Networks%20Look%20Good**%0A%0AWhen%20Android%20marks%20a%20validated%20network%20as%20congested%20or%20suspended%20but%20reports%20unknown%20or%20nominal%20link%20bandwidth%2C%20this%20branch%20now%20returns%20%60good%60%20instead%20of%20the%20old%20constrained%20quality.%20The%20meeting%20can%20start%20audio%2C%20video%2C%20and%20screen%20share%20at%20unconstrained%20bitrates%20until%20RTC%20stats%20catch%20up%2C%20causing%20avoidable%20packet%20loss%20and%20jitter%20on%20the%20affected%20network.%0A%0A&repo=acm-vit%2Fconclave&pr=144&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FSkip%2FNetworkReachabilityMonitor.kt%3A111-117%0A**Congested%20Networks%20Look%20Good**%0A%0AWhen%20Android%20marks%20a%20validated%20network%20as%20congested%20or%20suspended%20but%20reports%20unknown%20or%20nominal%20link%20bandwidth%2C%20this%20branch%20now%20returns%20%60good%60%20instead%20of%20the%20old%20constrained%20quality.%20The%20meeting%20can%20start%20audio%2C%20video%2C%20and%20screen%20share%20at%20unconstrained%20bitrates%20until%20RTC%20stats%20catch%20up%2C%20causing%20avoidable%20packet%20loss%20and%20jitter%20on%20the%20affected%20network.%0A%0A&pr=144&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["refactor: apply self-review findings fro..."](https://github.com/acm-vit/conclave/commit/cd2cf55f677fff366dcabb356a69b415fe036d25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41294236)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->