### PR TITLE
fix

### DIFF
--- a/apps/web/src/app/components/DevPlaygroundLayout.tsx
+++ b/apps/web/src/app/components/DevPlaygroundLayout.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import { errorName } from "../lib/utils";
-import { Hand } from "lucide-react";
-import { memo, useEffect, useRef } from "react";
+import { memo } from "react";
 import { DevPlaygroundWebApp } from "@conclave/apps-sdk/dev-playground/web";
-import { Avatar } from "@conclave/ui-tokens/web";
 import { useSmartParticipantOrder } from "../hooks/useSmartParticipantOrder";
 import type { Participant } from "../lib/types";
-import { getSpeakerHighlightClasses, isSystemUserId } from "../lib/utils";
+import { isSystemUserId } from "../lib/utils";
 import { isRemoteParticipantVisible } from "../lib/participant-visibility";
 import ParticipantVideo from "./ParticipantVideo";
+import RailLocalTile from "./RailLocalTile";
 
 interface DevPlaygroundLayoutProps {
   localStream: MediaStream | null;
@@ -40,33 +38,7 @@ function DevPlaygroundLayout({
   audioOutputDeviceId,
   getDisplayName,
 }: DevPlaygroundLayoutProps) {
-  const localVideoRef = useRef<HTMLVideoElement>(null);
   const isLocalActiveSpeaker = activeSpeakerId === currentUserId;
-
-  useEffect(() => {
-    const video = localVideoRef.current;
-    if (!video) return;
-
-    if (!localStream) {
-      if (video.srcObject) {
-        video.srcObject = null;
-      }
-      return;
-    }
-
-    video.srcObject = localStream;
-    video.play().catch((err) => {
-      if (errorName(err) !== "AbortError") {
-        console.error("[Meets] Dev playground local video play error:", err);
-      }
-    });
-
-    return () => {
-      if (video.srcObject === localStream) {
-        video.srcObject = null;
-      }
-    };
-  }, [localStream]);
 
   const participantsList = useSmartParticipantOrder(
     Array.from(participants.values()).filter(
@@ -85,43 +57,16 @@ function DevPlaygroundLayout({
       </div>
       <aside className="hidden lg:flex w-64 shrink-0 flex-col gap-3 overflow-y-auto overflow-x-visible px-1">
         {!isGhost && (
-          <div
-            className={`relative bg-[#232327] border border-white/5 rounded-lg overflow-hidden h-36 shrink-0 transition-all duration-200 ${getSpeakerHighlightClasses(
-              isLocalActiveSpeaker
-            )}`}
-          >
-            <video
-              ref={localVideoRef}
-              autoPlay
-              muted
-              playsInline
-              className={`w-full h-full object-cover ${
-                isCameraOff ? "hidden" : ""
-              } ${isMirrorCamera ? "scale-x-[-1]" : ""}`}
-            />
-            {isCameraOff && (
-              <div className="absolute inset-0 flex items-center justify-center bg-[#18181b]">
-                <Avatar id={userEmail} name={userEmail} size={48} />
-              </div>
-            )}
-            {isHandRaised && (
-              <div
-                className="absolute top-3 left-3 p-1.5 rounded-full bg-amber-500/20 border border-amber-400/40 text-amber-300"
-                title="Hand raised"
-              >
-                <Hand className="w-3 h-3" />
-              </div>
-            )}
-            <div
-              className="absolute bottom-3 left-3 bg-black/70 backdrop-blur-sm border border-[#fafafa]/10 rounded-full px-3 py-1.5 flex items-center gap-2 text-[10px]"
-              style={{ fontFamily: "'PolySans Trial', sans-serif" }}
-            >
-              <span className="font-medium text-[#fafafa] uppercase tracking-wide">
-                You
-              </span>
-              {isMuted ? <span className="text-[#F95F4A]">Muted</span> : null}
-            </div>
-          </div>
+          <RailLocalTile
+            stream={localStream}
+            isCameraOff={isCameraOff}
+            isMuted={isMuted}
+            isHandRaised={isHandRaised}
+            isMirrorCamera={isMirrorCamera}
+            isActiveSpeaker={isLocalActiveSpeaker}
+            displayName={getDisplayName(currentUserId)}
+            userEmail={userEmail}
+          />
         )}
 
         {participantsList.map((participant) => (

--- a/apps/web/src/app/components/RailLocalTile.tsx
+++ b/apps/web/src/app/components/RailLocalTile.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Hand, MicOff } from "lucide-react";
+import { memo, useEffect, useRef } from "react";
+import { Avatar } from "@conclave/ui-tokens/web";
+import { truncateDisplayName } from "../lib/utils";
+import GameTileOverlay from "./games/GameTileOverlay";
+
+interface RailLocalTileProps {
+  stream: MediaStream | null;
+  isCameraOff: boolean;
+  isMuted: boolean;
+  isHandRaised: boolean;
+  isMirrorCamera: boolean;
+  isActiveSpeaker: boolean;
+  displayName: string;
+  userEmail: string;
+}
+
+/**
+ * The local participant's tile for app side rails (watch, whiteboard), styled
+ * identically to the compact ParticipantVideo tiles it sits beside: same tile
+ * chrome and speaking treatment, same name pill with the coral You tag, the
+ * voice activity waves, and the mute icon.
+ */
+function RailLocalTile({
+  stream,
+  isCameraOff,
+  isMuted,
+  isHandRaised,
+  isMirrorCamera,
+  isActiveSpeaker,
+  displayName,
+  userEmail,
+}: RailLocalTileProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    if (!stream || isCameraOff) {
+      if (video.srcObject) {
+        video.srcObject = null;
+      }
+      return;
+    }
+
+    if (video.srcObject !== stream) {
+      video.srcObject = stream;
+    }
+    video.play().catch(() => {});
+
+    return () => {
+      if (video.srcObject === stream) {
+        video.srcObject = null;
+      }
+    };
+  }, [stream, isCameraOff]);
+
+  return (
+    <div
+      className={`acm-video-tile group relative h-36 w-48 shrink-0 sm:w-auto ${
+        isActiveSpeaker ? "speaking" : ""
+      } ${isHandRaised ? "!border-amber-400/60" : ""}`}
+      style={{ fontFamily: "'PolySans Trial', sans-serif" }}
+    >
+      <video
+        ref={videoRef}
+        autoPlay
+        muted
+        playsInline
+        className={`h-full w-full object-cover ${isCameraOff ? "hidden" : ""} ${
+          isMirrorCamera ? "scale-x-[-1]" : ""
+        }`}
+      />
+      {isCameraOff && (
+        <div className="absolute inset-0 flex items-center justify-center bg-[#18181b]">
+          <Avatar
+            className="text-lg"
+            id={userEmail}
+            name={displayName || userEmail}
+            size={48}
+          />
+        </div>
+      )}
+      {isHandRaised && (
+        <div
+          className="absolute left-3 top-3 rounded-full border border-amber-400/40 bg-amber-500/20 p-1.5 text-amber-300"
+          title="Hand raised"
+        >
+          <Hand className="h-3 w-3" />
+        </div>
+      )}
+      <div className="absolute bottom-3 left-3 flex max-w-[85%] items-center gap-2 rounded-full border border-[#fafafa]/10 bg-black/70 px-3 py-1.5 text-[10px]">
+        <span className="truncate font-medium text-[#fafafa]" title={displayName}>
+          {truncateDisplayName(displayName, 12)}
+        </span>
+        <span className="shrink-0 font-medium text-[#F95F4A]">You</span>
+        {isActiveSpeaker && !isMuted && (
+          <span className="acm-voice-activity" aria-label="Speaking">
+            <span />
+            <span />
+            <span />
+          </span>
+        )}
+        {isMuted && <MicOff className="h-3 w-3 shrink-0 text-[#F95F4A]" />}
+      </div>
+      <GameTileOverlay compact />
+    </div>
+  );
+}
+
+export default memo(RailLocalTile);

--- a/apps/web/src/app/components/WatchLayout.tsx
+++ b/apps/web/src/app/components/WatchLayout.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import { errorName } from "../lib/utils";
-import { Hand } from "lucide-react";
-import { memo, useEffect, useRef } from "react";
+import { memo } from "react";
 import { WatchWebApp } from "@conclave/apps-sdk/watch/web";
-import { Avatar } from "@conclave/ui-tokens/web";
 import { useSmartParticipantOrder } from "../hooks/useSmartParticipantOrder";
 import type { Participant } from "../lib/types";
-import { getSpeakerHighlightClasses, isSystemUserId } from "../lib/utils";
+import { isSystemUserId } from "../lib/utils";
 import { isRemoteParticipantVisible } from "../lib/participant-visibility";
 import ParticipantVideo from "./ParticipantVideo";
+import RailLocalTile from "./RailLocalTile";
 
 interface WatchLayoutProps {
   localStream: MediaStream | null;
@@ -40,33 +38,7 @@ function WatchLayout({
   audioOutputDeviceId,
   getDisplayName,
 }: WatchLayoutProps) {
-  const localVideoRef = useRef<HTMLVideoElement>(null);
   const isLocalActiveSpeaker = activeSpeakerId === currentUserId;
-
-  useEffect(() => {
-    const video = localVideoRef.current;
-    if (!video) return;
-
-    if (!localStream) {
-      if (video.srcObject) {
-        video.srcObject = null;
-      }
-      return;
-    }
-
-    video.srcObject = localStream;
-    video.play().catch((err) => {
-      if (errorName(err) !== "AbortError") {
-        console.error("[Meets] Watch local video play error:", err);
-      }
-    });
-
-    return () => {
-      if (video.srcObject === localStream) {
-        video.srcObject = null;
-      }
-    };
-  }, [localStream]);
 
   const participantsList = useSmartParticipantOrder(
     Array.from(participants.values()).filter(
@@ -85,43 +57,16 @@ function WatchLayout({
       </div>
       <aside className="hidden lg:flex w-64 shrink-0 flex-col gap-3 overflow-y-auto overflow-x-visible px-1">
         {!isGhost && (
-          <div
-            className={`relative bg-[#232327] border border-white/5 rounded-lg overflow-hidden h-36 shrink-0 transition-all duration-200 ${getSpeakerHighlightClasses(
-              isLocalActiveSpeaker
-            )}`}
-          >
-            <video
-              ref={localVideoRef}
-              autoPlay
-              muted
-              playsInline
-              className={`w-full h-full object-cover ${
-                isCameraOff ? "hidden" : ""
-              } ${isMirrorCamera ? "scale-x-[-1]" : ""}`}
-            />
-            {isCameraOff && (
-              <div className="absolute inset-0 flex items-center justify-center bg-[#18181b]">
-                <Avatar id={userEmail} name={userEmail} size={48} />
-              </div>
-            )}
-            {isHandRaised && (
-              <div
-                className="absolute top-3 left-3 p-1.5 rounded-full bg-amber-500/20 border border-amber-400/40 text-amber-300"
-                title="Hand raised"
-              >
-                <Hand className="w-3 h-3" />
-              </div>
-            )}
-            <div
-              className="absolute bottom-3 left-3 bg-black/70 backdrop-blur-sm border border-[#fafafa]/10 rounded-full px-3 py-1.5 flex items-center gap-2 text-[10px]"
-              style={{ fontFamily: "'PolySans Trial', sans-serif" }}
-            >
-              <span className="font-medium text-[#fafafa] uppercase tracking-wide">
-                You
-              </span>
-              {isMuted ? <span className="text-[#F95F4A]">Muted</span> : null}
-            </div>
-          </div>
+          <RailLocalTile
+            stream={localStream}
+            isCameraOff={isCameraOff}
+            isMuted={isMuted}
+            isHandRaised={isHandRaised}
+            isMirrorCamera={isMirrorCamera}
+            isActiveSpeaker={isLocalActiveSpeaker}
+            displayName={getDisplayName(currentUserId)}
+            userEmail={userEmail}
+          />
         )}
 
         {participantsList.map((participant) => (

--- a/apps/web/src/app/components/WhiteboardLayout.tsx
+++ b/apps/web/src/app/components/WhiteboardLayout.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import { errorName } from "../lib/utils";
-import { Hand } from "lucide-react";
-import { memo, useEffect, useRef } from "react";
+import { memo } from "react";
 import { WhiteboardWebApp } from "@conclave/apps-sdk/whiteboard/web";
-import { Avatar } from "@conclave/ui-tokens/web";
 import { useSmartParticipantOrder } from "../hooks/useSmartParticipantOrder";
 import type { Participant } from "../lib/types";
-import { getSpeakerHighlightClasses, isSystemUserId } from "../lib/utils";
+import { isSystemUserId } from "../lib/utils";
 import { isRemoteParticipantVisible } from "../lib/participant-visibility";
 import ParticipantVideo from "./ParticipantVideo";
+import RailLocalTile from "./RailLocalTile";
 
 interface WhiteboardLayoutProps {
   localStream: MediaStream | null;
@@ -40,33 +38,7 @@ function WhiteboardLayout({
   audioOutputDeviceId,
   getDisplayName,
 }: WhiteboardLayoutProps) {
-  const localVideoRef = useRef<HTMLVideoElement>(null);
   const isLocalActiveSpeaker = activeSpeakerId === currentUserId;
-
-  useEffect(() => {
-    const video = localVideoRef.current;
-    if (!video) return;
-
-    if (!localStream) {
-      if (video.srcObject) {
-        video.srcObject = null;
-      }
-      return;
-    }
-
-    video.srcObject = localStream;
-    video.play().catch((err) => {
-      if (errorName(err) !== "AbortError") {
-        console.error("[Meets] Whiteboard local video play error:", err);
-      }
-    });
-
-    return () => {
-      if (video.srcObject === localStream) {
-        video.srcObject = null;
-      }
-    };
-  }, [localStream]);
 
   const participantsList = useSmartParticipantOrder(
     Array.from(participants.values()).filter(
@@ -85,43 +57,16 @@ function WhiteboardLayout({
       </div>
       <aside className="hidden lg:flex w-64 shrink-0 flex-col gap-3 overflow-y-auto overflow-x-visible px-1">
         {!isGhost && (
-          <div
-            className={`relative bg-[#232327] border border-white/5 rounded-lg overflow-hidden h-36 shrink-0 transition-all duration-200 ${getSpeakerHighlightClasses(
-              isLocalActiveSpeaker
-            )}`}
-          >
-            <video
-              ref={localVideoRef}
-              autoPlay
-              muted
-              playsInline
-              className={`w-full h-full object-cover ${
-                isCameraOff ? "hidden" : ""
-              } ${isMirrorCamera ? "scale-x-[-1]" : ""}`}
-            />
-            {isCameraOff && (
-              <div className="absolute inset-0 flex items-center justify-center bg-[#18181b]">
-                <Avatar id={userEmail} name={userEmail} size={48} />
-              </div>
-            )}
-            {isHandRaised && (
-              <div
-                className="absolute top-3 left-3 p-1.5 rounded-full bg-amber-500/20 border border-amber-400/40 text-amber-300"
-                title="Hand raised"
-              >
-                <Hand className="w-3 h-3" />
-              </div>
-            )}
-            <div
-              className="absolute bottom-3 left-3 bg-black/70 backdrop-blur-sm border border-[#fafafa]/10 rounded-full px-3 py-1.5 flex items-center gap-2 text-[10px]"
-              style={{ fontFamily: "'PolySans Trial', sans-serif" }}
-            >
-              <span className="font-medium text-[#fafafa] uppercase tracking-wide">
-                You
-              </span>
-              {isMuted ? <span className="text-[#F95F4A]">Muted</span> : null}
-            </div>
-          </div>
+          <RailLocalTile
+            stream={localStream}
+            isCameraOff={isCameraOff}
+            isMuted={isMuted}
+            isHandRaised={isHandRaised}
+            isMirrorCamera={isMirrorCamera}
+            isActiveSpeaker={isLocalActiveSpeaker}
+            displayName={getDisplayName(currentUserId)}
+            userEmail={userEmail}
+          />
         )}
 
         {participantsList.map((participant) => (

--- a/apps/web/src/app/components/games/WordleGame.tsx
+++ b/apps/web/src/app/components/games/WordleGame.tsx
@@ -52,6 +52,12 @@ type WordleMe = {
   myGuesses: Array<{ word: string; feedback: TileState[]; at: number }>;
   myOutcome: PlayerOutcome | null;
   mySolvedAt: number | null;
+  /** Setter only: every contestant's live board, letters included. */
+  boards: Array<{
+    playerId: string;
+    guesses: Array<{ word: string; feedback: TileState[]; at: number }>;
+    outcome: PlayerOutcome | null;
+  }> | null;
 };
 
 const WORDLE_GREEN = "#538d4e";
@@ -203,6 +209,134 @@ function Tile({
   );
 }
 
+function SetterBoards({
+  boards,
+  standings,
+  wordLength,
+  maxTries,
+}: {
+  boards: NonNullable<WordleMe["boards"]>;
+  standings: WordlePublic["standings"];
+  wordLength: number;
+  maxTries: number;
+}) {
+  const nameById = new Map(
+    standings.map((entry) => [entry.playerId, entry.playerName]),
+  );
+  const rankById = new Map(
+    standings.map((entry, index) => [entry.playerId, index]),
+  );
+  const ordered = [...boards].sort(
+    (a, b) =>
+      (rankById.get(a.playerId) ?? Number.MAX_SAFE_INTEGER) -
+      (rankById.get(b.playerId) ?? Number.MAX_SAFE_INTEGER),
+  );
+
+  return (
+    <div>
+      <p style={{ fontSize: 11, color: color.textFaint, fontFamily: HEAD_FONT, margin: "0 0 8px" }}>
+        Live boards
+      </p>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(118px, 1fr))",
+          gap: 10,
+        }}
+      >
+        {ordered.map((board) => {
+          const solved = board.outcome === "win";
+          return (
+            <div
+              key={board.playerId}
+              style={{
+                padding: 8,
+                borderRadius: radius.md,
+                border: `1px solid ${solved ? `${WORDLE_GREEN}66` : color.border}`,
+                background: solved ? `${WORDLE_GREEN}14` : color.surfaceRaised,
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+                <span
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    fontSize: 11.5,
+                    color: color.text,
+                    fontFamily: HEAD_FONT,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {nameById.get(board.playerId) ?? "Player"}
+                </span>
+                <span
+                  style={{
+                    fontSize: 10,
+                    fontFamily: HEAD_FONT,
+                    color:
+                      board.outcome === "win"
+                        ? WORDLE_GREEN
+                        : board.outcome
+                          ? color.textMuted
+                          : color.textFaint,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {board.outcome
+                    ? statusText(board.outcome)
+                    : `${board.guesses.length}/${maxTries}`}
+                </span>
+              </div>
+              <div style={{ display: "grid", gap: 2 }}>
+                {Array.from({ length: maxTries }, (_, rowIndex) => {
+                  const guess = board.guesses[rowIndex];
+                  return (
+                    <div
+                      key={rowIndex}
+                      style={{
+                        display: "grid",
+                        gridTemplateColumns: `repeat(${wordLength}, 1fr)`,
+                        gap: 2,
+                      }}
+                    >
+                      {Array.from({ length: wordLength }, (_, colIndex) => (
+                        <div
+                          key={colIndex}
+                          style={{
+                            aspectRatio: "1",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            fontFamily: HEAD_FONT,
+                            fontSize: 9,
+                            fontWeight: 700,
+                            color: "#ffffff",
+                            borderRadius: 2,
+                            border: guess
+                              ? "1px solid transparent"
+                              : `1px solid ${color.border}`,
+                            background: guess
+                              ? letterBg(guess.feedback[colIndex])
+                              : "transparent",
+                          }}
+                        >
+                          {guess ? guess.word[colIndex] : ""}
+                        </div>
+                      ))}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export default function WordleGame({
   pub,
   me,
@@ -219,10 +353,30 @@ export default function WordleGame({
   const prevGuessCountRef = useRef(me.myGuesses.length);
   const animateRow = useRef(-1);
 
+  // A new round resets the server-side board but not this component, so clear
+  // every piece of local round state here (render-phase reset, per React's
+  // derived-state pattern). Without this, a half-typed draft pre-fills the new
+  // board and the stale animateRow leaves a row stuck on the flip animation's
+  // transparent back face, which reads as a missing row.
+  const [lastRoundKey, setLastRoundKey] = useState(pub.currentRound);
+  if (lastRoundKey !== pub.currentRound) {
+    setLastRoundKey(pub.currentRound);
+    setSecretDraft("");
+    setGuessDraft("");
+    setError(null);
+    prevGuessCountRef.current = 0;
+    animateRow.current = -1;
+  }
+
   const currentCount = me.myGuesses.length;
   if (currentCount > prevGuessCountRef.current) {
     animateRow.current = currentCount - 1;
     prevGuessCountRef.current = currentCount;
+  } else if (currentCount < prevGuessCountRef.current) {
+    // The board shrank outside a round change (view re-projection); never
+    // leave the reveal animation pointing at a row that no longer exists.
+    prevGuessCountRef.current = currentCount;
+    animateRow.current = -1;
   }
 
   const remainingMs = useRemaining(pub.deadline, pub.serverNow);
@@ -676,22 +830,32 @@ export default function WordleGame({
           ) : null}
         </>
       ) : pub.phase !== "set-word" ? (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 9,
-            padding: "13px 16px",
-            borderRadius: radius.pill,
-            background: color.surfaceRaised,
-            border: `1px solid ${color.border}`,
-          }}
-        >
-          <span style={{ width: 7, height: 7, borderRadius: radius.pill, background: wordleAccent }} />
-          <span style={{ fontSize: 13, color: color.text }}>You set the word</span>
-          <span style={{ fontSize: 13, color: color.textMuted }}>· watching players guess</span>
-        </div>
+        <>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 9,
+              padding: "13px 16px",
+              borderRadius: radius.pill,
+              background: color.surfaceRaised,
+              border: `1px solid ${color.border}`,
+            }}
+          >
+            <span style={{ width: 7, height: 7, borderRadius: radius.pill, background: wordleAccent }} />
+            <span style={{ fontSize: 13, color: color.text }}>You set the word</span>
+            <span style={{ fontSize: 13, color: color.textMuted }}>· watching players guess</span>
+          </div>
+          {me.boards && me.boards.length > 0 ? (
+            <SetterBoards
+              boards={me.boards}
+              standings={pub.standings}
+              wordLength={pub.wordLength}
+              maxTries={pub.maxTries}
+            />
+          ) : null}
+        </>
       ) : null}
 
       {pub.standings.length > 0 && pub.phase === "playing" ? (

--- a/apps/web/src/app/lib/utils.ts
+++ b/apps/web/src/app/lib/utils.ts
@@ -356,15 +356,6 @@ export function isValidAssetPath(value: string): boolean {
   return value.startsWith("/reactions/") && !value.includes("..");
 }
 
-export function getSpeakerHighlightClasses(isActive: boolean): string {
-  // Design law: active speaker = flat 2px solid brand-orange ring — no glow /
-  // drop-shadow halo, and orange (not emerald). Uses an INSET ring (box-shadow),
-  // NOT a border-width change: toggling 1px→2px border resized the tile's
-  // content box and read as jitter/flicker on every speaker change. The ring
-  // keeps the box size constant. Matches the grid's `.acm-video-tile.speaking`.
-  return isActive ? "ring-2 ring-inset ring-[#F95F4A]" : "";
-}
-
 export function prioritizeActiveSpeaker<T extends { userId: string }>(
   participants: readonly T[],
   activeSpeakerId: string | null

--- a/packages/meeting-core/src/participant-reducer.ts
+++ b/packages/meeting-core/src/participant-reducer.ts
@@ -48,6 +48,11 @@ export type ParticipantAction =
     }
   | { type: "CLEAR_ALL" };
 
+// A brand-new entry has no producers, so it cannot be sending media: it starts
+// muted and camera-off. Anything else lies in the UI for participants who
+// joined with media off, since they never produce and so no later event
+// corrects the flag. Attaching a stream (UPDATE_STREAM) and the producer sync
+// paths flip these to on as soon as media actually flows.
 const createEmptyParticipant = (
   userId: string,
   isGhost = false
@@ -61,8 +66,8 @@ const createEmptyParticipant = (
   videoProducerId: null,
   screenShareProducerId: null,
   screenShareAudioProducerId: null,
-  isMuted: false,
-  isCameraOff: false,
+  isMuted: true,
+  isCameraOff: true,
   isVideoAdaptivelyPaused: false,
   isHandRaised: false,
   isGhost,

--- a/packages/meeting-core/test/participant-reducer.test.ts
+++ b/packages/meeting-core/test/participant-reducer.test.ts
@@ -37,16 +37,18 @@ const videoAction = (
 });
 
 describe("participantReducer — ADD_PARTICIPANT (join)", () => {
-  it("adds a brand-new participant with default flags", () => {
+  it("adds a brand-new participant as muted and camera-off until media flows", () => {
     const next = participantReducer(empty(), {
       type: "ADD_PARTICIPANT",
       userId: "a",
     });
     const p = next.get("a")!;
+    // No producers means no media: a joiner who never turns their camera on
+    // never produces, so nothing would ever correct an optimistic "on" flag.
     expect(p).toMatchObject({
       userId: "a",
-      isMuted: false,
-      isCameraOff: false,
+      isMuted: true,
+      isCameraOff: true,
       isVideoAdaptivelyPaused: false,
       isHandRaised: false,
       isGhost: false,

--- a/packages/sfu/server/games/modules/wordle.ts
+++ b/packages/sfu/server/games/modules/wordle.ts
@@ -608,6 +608,16 @@ export const wordleModule: GameModule<WordleState> = {
       myGuesses: progress?.guesses ?? [],
       myOutcome: progress?.outcome ?? null,
       mySolvedAt: progress?.solvedAt ?? null,
+      // The setter already knows the word, so their private view carries every
+      // contestant's live board (letters included) to spectate while waiting.
+      // Contestants never receive each other's boards; letters would leak.
+      boards: isSetter
+        ? Object.entries(state.players).map(([contestantId, contestant]) => ({
+            playerId: contestantId,
+            guesses: contestant.guesses,
+            outcome: contestant.outcome,
+          }))
+        : null,
     };
   },
 


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR cleans up rail tiles and extends Wordle setter views. The main changes are:

- Replaces repeated local rail tile markup with `RailLocalTile`.
- Adds live contestant boards for the Wordle setter.
- Clears Wordle local draft and animation state on round changes.
- Starts new meeting participants muted and camera-off until media arrives.

<h3>Confidence Score: 4/5</h3>

The Wordle setter board view needs a round-sync guard before merging.

- Public round state and private board state can be rendered together even when they come from different rounds.
- That can briefly expose previous-round contestant guess letters to the current setter.
- The rail tile and participant default changes look consistent with their callers.

apps/web/src/app/components/games/WordleGame.tsx

<details open><summary><h3>Security Review</h3></summary>

The Wordle setter view now carries contestant guess letters. The server gates the field to the setter, but the client can render stale private board data across a round transition if public and private updates arrive separately.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/components/RailLocalTile.tsx | Adds a shared compact local tile for side rails, including local video binding, avatar fallback, hand raise, mute, speaking, and game overlay UI. |
| apps/web/src/app/components/DevPlaygroundLayout.tsx | Switches the local side-rail tile to the shared `RailLocalTile` component. |
| apps/web/src/app/components/WatchLayout.tsx | Switches the local side-rail tile to the shared `RailLocalTile` component. |
| apps/web/src/app/components/WhiteboardLayout.tsx | Switches the local side-rail tile to the shared `RailLocalTile` component. |
| apps/web/src/app/components/games/WordleGame.tsx | Adds setter board rendering and local round-state resets; stale private board data can be shown during round transitions. |
| packages/sfu/server/games/modules/wordle.ts | Adds setter-only private board data containing contestant guesses. |
| packages/meeting-core/src/participant-reducer.ts | Changes empty participant defaults to muted and camera-off until stream or producer updates correct them. |
| packages/meeting-core/test/participant-reducer.test.ts | Updates reducer tests for the new participant default flags. |
| apps/web/src/app/lib/utils.ts | Removes the unused speaker highlight helper. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2Fgames%2FWordleGame.tsx%3A850-856%0A**Round-Mismatched%20Boards%20Render**%0A%0AWhen%20%60pub.currentRound%60%20advances%20before%20the%20matching%20private%20view%20arrives%2C%20this%20renders%20the%20old%20%60me.boards%60%20beside%20the%20new%20round%20UI.%20For%20a%20newly%20selected%20setter%2C%20that%20can%20briefly%20show%20previous-round%20contestant%20guess%20letters%20until%20the%20private%20view%20catches%20up%2C%20so%20the%20board%20payload%20should%20be%20tied%20to%20the%20same%20round%20or%20hidden%20while%20the%20public%20and%20private%20views%20are%20out%20of%20sync.%0A%0A&repo=acm-vit%2Fconclave&pr=146&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2Fgames%2FWordleGame.tsx%3A850-856%0A**Round-Mismatched%20Boards%20Render**%0A%0AWhen%20%60pub.currentRound%60%20advances%20before%20the%20matching%20private%20view%20arrives%2C%20this%20renders%20the%20old%20%60me.boards%60%20beside%20the%20new%20round%20UI.%20For%20a%20newly%20selected%20setter%2C%20that%20can%20briefly%20show%20previous-round%20contestant%20guess%20letters%20until%20the%20private%20view%20catches%20up%2C%20so%20the%20board%20payload%20should%20be%20tied%20to%20the%20same%20round%20or%20hidden%20while%20the%20public%20and%20private%20views%20are%20out%20of%20sync.%0A%0A&repo=acm-vit%2Fconclave&pr=146&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2Fgames%2FWordleGame.tsx%3A850-856%0A**Round-Mismatched%20Boards%20Render**%0A%0AWhen%20%60pub.currentRound%60%20advances%20before%20the%20matching%20private%20view%20arrives%2C%20this%20renders%20the%20old%20%60me.boards%60%20beside%20the%20new%20round%20UI.%20For%20a%20newly%20selected%20setter%2C%20that%20can%20briefly%20show%20previous-round%20contestant%20guess%20letters%20until%20the%20private%20view%20catches%20up%2C%20so%20the%20board%20payload%20should%20be%20tied%20to%20the%20same%20round%20or%20hidden%20while%20the%20public%20and%20private%20views%20are%20out%20of%20sync.%0A%0A&pr=146&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix wordle"](https://github.com/acm-vit/conclave/commit/ad9d7ae84962b3d1779616072d0802f3b5b9e265) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41312083)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->