### PR TITLE
feat(native): move games into meeting stage

### DIFF
--- a/apps/conclave-skip/AGENTS.md
+++ b/apps/conclave-skip/AGENTS.md
@@ -1,0 +1,337 @@
+# Conclave Skip Native Agent Notes
+
+This directory is the active native app. Do not make new changes in
+`apps/mobile`; it is deprecated for this workstream.
+
+`apps/conclave-skip` is a Skip app: Swift is the source of truth, iOS compiles
+the Swift directly, and Android is generated/transpiled to Kotlin/Jetpack
+Compose with a few hand-written Kotlin bridges in `Sources/Conclave/Skip`.
+Every change must be judged on both platforms.
+
+## Current Priorities
+
+The native app was improved specifically around meeting entry, Lottie,
+bottom sheets, games, and responsiveness. Continue from those assumptions:
+
+- Native should feel instant. Avoid broad recomposition and heavy view trees.
+- Android sheets must use the native `FlexibleBottomSheet` bridge, not a custom
+  fake sheet.
+- Android Lottie must use LottieFiles `dotlottie-android`, not Airbnb
+  `lottie-compose` for `.lottie` playback.
+- iOS must stay green with `swift build` and `swift test`.
+- No gradients anywhere. Use dark flat surfaces, 1 px borders, and the coral
+  accent only.
+- Do not re-enable R8/minification. Release builds are intentionally
+  un-minified because R8 has broken SkipUI runtime behavior.
+
+## Build And Verification Commands
+
+Run these from `/Users/ishaan/Projects/conclave` unless noted.
+
+```bash
+cd apps/conclave-skip
+swift build
+swift test
+```
+
+Android uses the system Gradle binary, not a wrapper:
+
+```bash
+cd apps/conclave-skip/Android
+/opt/homebrew/bin/gradle :Conclave:compileDebugKotlin --console=plain
+ALLOW_DEBUG_RELEASE_SIGNING=true /opt/homebrew/bin/gradle :app:assembleRelease --console=plain
+```
+
+The local release APK is written to:
+
+```text
+apps/conclave-skip/.build/Android/app/outputs/apk/release/app-release.apk
+```
+
+For iOS simulator builds, the Skip project may need plugin validation skipped
+and Skip actions disabled during Xcode build:
+
+```bash
+xcodebuild \
+  -project apps/conclave-skip/Darwin/Conclave.xcodeproj \
+  -scheme "Conclave App" \
+  -configuration Debug \
+  -destination 'id=<SIMULATOR_UDID>' \
+  -derivedDataPath /tmp/conclave-ios-dd \
+  -skipPackagePluginValidation \
+  -skipMacroValidation \
+  build SKIP_ZERO=1 SKIP_ACTION=none
+```
+
+Install and open with `agent-device` when a simulator is available:
+
+```bash
+agent-device install com.acmvit.conclave /tmp/conclave-ios-dd/Build/Products/Debug-iphonesimulator/Conclave.app --platform ios --udid <SIMULATOR_UDID>
+agent-device open com.acmvit.conclave --platform ios --udid <SIMULATOR_UDID>
+```
+
+Real Android proof still matters for completion:
+
+```bash
+adb devices -l
+adb install -r apps/conclave-skip/.build/Android/app/outputs/apk/release/app-release.apk
+adb shell uiautomator dump /sdcard/ui.xml
+adb pull /sdcard/ui.xml /tmp/conclave-ui.xml
+```
+
+Do not use `uiautomator dump /dev/tty`; it can collide with stale
+UiAutomation sessions. Dump to a file and pull it.
+
+## Performance Learnings
+
+The app felt sluggish mostly because of over-broad recomposition, not because
+of a single expensive CPU task. SkipUI maps SwiftUI view bodies into Compose
+functions. If a large body reads `MeetingViewModel.shared` or many fields from
+`MeetingState`, unrelated state changes can rebuild large subtrees.
+
+The important fixes and patterns:
+
+- Split large views into narrow leaf views.
+- Pass primitives into controls and rows where possible instead of the whole
+  view model.
+- Keep high-frequency state isolated: active speaker, audio levels,
+  connection quality, reactions, and stats should be read only by tiny views.
+- Stop or throttle high-frequency updates when the stage is obscured by chat,
+  transcript, sheets, or overlays.
+- Avoid sorting, filtering, formatting, JSON parsing, or large allocations in
+  `body`.
+- Use cached presentation policies for derived lists, scores, game rows,
+  pending users, and transcript groups.
+- Avoid broad `.animation(value:)` on large containers. Scope animation to the
+  small layer that actually moves or fades.
+- Keep stable identities in `ForEach`; do not use indices for dynamic lists.
+- Prefer `LazyVStack`/lazy content for sheets and long panels.
+- On Android, confirm idle draw cadence is quiet. Watch `ConclavePerf` logs and
+  `View: setRequestedFrameRate` spam in logcat.
+
+Useful Android performance signals:
+
+```bash
+PID=$(adb shell pidof com.acmvit.conclave)
+adb logcat -d | grep " $PID "
+adb logcat -d | grep ConclavePerf
+adb logcat -d | grep setRequestedFrameRate
+```
+
+The expected idle state in a meeting is not constant 60 fps redraws. Lottie
+will animate during entry, but it must be removed after reveal.
+
+## Entry Overlay
+
+The meeting-entry overlay is there to hide connection/setup churn. It should
+start immediately on New/Join, play the lock sound once, show the branded
+Lottie, then fade once the meeting is actually settled.
+
+The robust model is:
+
+- `MeetingState.isEnteringMeeting` records entry intent.
+- `MeetingState.meetingEntryStartedAt` provides a hard deadline.
+- `MeetingEntryOverlayPolicy.shouldShow(...)` is the source of truth for
+  visibility.
+- The view model may schedule a nice reveal after `.joined`, but the overlay
+  must also have a hard ceiling so a cancelled task cannot leave a black screen.
+- Clear entry state on terminal paths: joined after settle, waiting room,
+  error, disconnected, and intentional leave.
+
+Do not make the overlay depend only on a fire-and-forget task. View churn can
+cancel tasks silently; the policy and observable timestamp are the fallback.
+
+## Lottie On Android And iOS
+
+Android uses the LottieFiles dotLottie player in:
+
+```text
+Sources/Conclave/Skip/ConclaveLottie.kt
+```
+
+The dependency is declared in:
+
+```text
+Sources/Conclave/Skip/skip.yml
+```
+
+The Android runtime asset must exist at:
+
+```text
+Android/app/src/main/assets/conclave-animation.lottie
+```
+
+iOS uses `lottie-ios` from:
+
+```text
+Sources/Conclave/Features/Meeting/ConclaveLottieView.swift
+Sources/Conclave/Resources/conclave-animation.lottie
+```
+
+Important Lottie rules:
+
+- Gate iOS-only Lottie imports with `#if os(iOS)`, not `canImport(Lottie)`.
+  `canImport` can be true on the macOS transpile host even when the framework
+  is not linked for that target.
+- Keep the Android dotLottie player in a small `ComposeView` bridge.
+- Use `DotLottieSource.Asset("conclave-animation.lottie")` for the app asset.
+- Prewarm native dotLottie libraries from Android diagnostics so first entry
+  does not pay the full native load cost.
+- Log load, first frame, first render, and load/runtime errors under
+  `ConclavePerf` while diagnosing.
+- Confirm the APK contains both the asset and native libraries:
+
+```bash
+unzip -l apps/conclave-skip/.build/Android/app/outputs/apk/release/app-release.apk | rg "conclave-animation|dotlottie|dlplayer|lottie"
+```
+
+## Bottom Sheets
+
+Android meeting sheets are bridged through:
+
+```text
+Sources/Conclave/Skip/FlexibleMeetingSheetHost.kt
+Sources/Conclave/Features/Meeting/MeetingSheetView.swift
+```
+
+Use Skydoves `FlexibleBottomSheet` for native movement, nested scrolling, and
+modal behavior. Do not rebuild the old custom sheet.
+
+Sheet rules:
+
+- Let `FlexibleBottomSheet` own show/hide animation on Android.
+- Use `allowNestedScroll = true`.
+- Keep `windowInsets = WindowInsets(0, 0, 0, 0)` only if the Swift content
+  already handles bottom spacing; otherwise verify there is no black bottom
+  obstruction.
+- The sheet must have a native drag handle, icon rows, and enough bottom
+  padding to reveal the end of transcript/game/settings content.
+- Do not present a new Skip sheet from a dismissing Skip sheet. On Android,
+  close the current sheet first and then open transcript or another panel.
+- Use lazy sheet content and avoid recomputing game/catalog rows every frame.
+
+For iOS, keep the standard SwiftUI sheet path. Do not force Android sheet
+bridges into iOS.
+
+## Android `onChange` Crash Pattern
+
+SkipUI can crash on Android when the two-parameter `.onChange` form restores a
+null old value during high-churn recomposition:
+
+```text
+java.lang.NullPointerException: Parameter specified as non-null is null
+```
+
+For Android hot paths, prefer the zero-parameter overload whenever the closure
+does not truly need old/new values:
+
+```swift
+#if SKIP
+.onChange(of: someValueKey) {
+    updateFromCurrentState()
+}
+#else
+.onChange(of: someValue) { _, newValue in
+    update(newValue)
+}
+#endif
+```
+
+This matters especially in:
+
+- `ContentView`
+- `MeetingView`
+- `ChatViews`
+- `ControlsBarView`
+- `SettingsSheetView`
+- `MeetingBannerOverlay`
+
+Do not casually reintroduce `{ _, _ in }` under `#if SKIP` on entry, sheet,
+chat, transcript, or meeting-state paths.
+
+## Native Games Parity
+
+The games sheet should support the whole web-style catalog and the common
+server projection shapes:
+
+- Trivia
+- Bluff
+- Would You Rather
+- Most Likely To
+- Reaction
+- Imposter
+- Wordle
+- Open vote
+
+Native game detail views should handle lobby, question, reveal, results,
+scoreboard, counts, vote splits, per-round points, and read-only spectator
+views when the server sends a public view. Keep presentation parsing in testable
+policy helpers rather than inline in `body`.
+
+Tests that protect this area live in:
+
+```text
+Tests/ConclaveTests/ConclaveTests.swift
+```
+
+## SwiftUI And iOS Guidance
+
+For iOS, keep the SwiftUI code idiomatic:
+
+- Prefer `@Observable` and `@State` for owned state in new code.
+- Keep `@State` private.
+- Use `foregroundStyle`, `clipShape`, and `NavigationStack` patterns when
+  adding new views.
+- Keep `body` pure and small.
+- Avoid `UIScreen.main.bounds`.
+- Avoid deep `GeometryReader` dependency when a fixed layout policy is enough.
+- Use stable IDs in lists.
+- Keep button/icon accessibility labels in place.
+- Use the normal SwiftUI `.sheet` path on iOS unless an Android-only bridge is
+  explicitly required under `#if SKIP`.
+
+## Design Rules
+
+The native app should match the web app's quiet dark meeting surface:
+
+- No gradients.
+- No decorative blobs or atmospheric backgrounds.
+- Flat solid surfaces.
+- 1 px borders.
+- Coral accent for primary action.
+- Compact meeting header and room pill.
+- Dense but readable controls.
+- Real icons in rows and buttons.
+- Cards only for repeated items or framed tools, not nested decorative panels.
+- Text must fit on compact phones.
+
+Use this scan before declaring UI work done:
+
+```bash
+rg -n "Gradient|LinearGradient|RadialGradient|AngularGradient|ACMGradients|gradient" apps/conclave-skip/Sources/Conclave apps/conclave-skip/Android
+```
+
+## Device Verification Checklist
+
+Do not mark the handoff goal complete without concrete runtime proof:
+
+- Cold start renders JoinView, not a black screen.
+- New meeting as guest starts joining.
+- Entry overlay shows visible Lottie and plays sound once.
+- Overlay reveals a settled meeting within roughly 2 seconds of ready.
+- No black screen remains past the safety cap.
+- Join by code works.
+- Bad code returns to setup with a branded error path.
+- Locked room shows waiting-room behavior.
+- Chat opens/closes without Android NPE.
+- More sheet opens with native animation, scrolls, and has no bottom obstruction.
+- Transcript opens and its last content is visible above bottom safe area.
+- Settings and participants sheets open and scroll.
+- Invite/share sheet opens without SkipUI preference crashes.
+- Idle meeting draw cadence is quiet.
+- No gradients.
+- `swift build`, `swift test`, Android Kotlin compile, and release assemble pass.
+
+Be precise in final reports: say what was verified on Android real device,
+iOS simulator, iOS real device, or only by build/test. Do not turn a simulator
+smoke test into a claim of Android device proof.

--- a/apps/conclave-skip/CLAUDE.md
+++ b/apps/conclave-skip/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/conclave-skip/Sources/Conclave/Core/Models/SocketMessages.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/Models/SocketMessages.swift
@@ -485,6 +485,12 @@ struct GamePublicState: Codable {
     let finished: Bool
     let hasLeaderboard: Bool
     let roomId: String?
+    // Server also sends the sanitized start config (for rematch), players who
+    // asked for a seat at the next round boundary, and whether late join is
+    // currently possible. Optional so older SFU payloads still decode.
+    let config: [String: GameConfigValue]?
+    let pendingJoiners: [GamePlayer]?
+    let canJoinLate: Bool?
 }
 
 struct GamePlayerViewNotification: Codable {

--- a/apps/conclave-skip/Sources/Conclave/Core/Networking/SfuEvents.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/Networking/SfuEvents.swift
@@ -80,6 +80,7 @@ enum SfuClientEvent: String {
     case gameMove = "game:move"
     case gameEnd = "game:end"
     case gameGetState = "game:getState"
+    case gameJoin = "game:join"
     case gameVoteOpen = "game:vote:open"
     case gameVoteCast = "game:vote:cast"
     case gameVoteCancel = "game:vote:cancel"

--- a/apps/conclave-skip/Sources/Conclave/Core/Networking/SocketIOManager+Android.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/Networking/SocketIOManager+Android.swift
@@ -176,6 +176,7 @@ final class SocketIOManager {
     func getGameState() async throws -> GameStateResponse { fatalError() }
     func startGame(gameId: String, options: [String: GameConfigValue]? = nil) async throws -> GameActionResponse { fatalError() }
     func endGame() async throws -> GameActionResponse { fatalError() }
+    func joinGame() async throws -> GameActionResponse { fatalError() }
     func sendGameMove(gameId: String, type: String, payload: GameJSONValue? = nil) async throws -> GameMoveResponse { fatalError() }
     func openGameVote(candidateIds: [String]? = nil) async throws -> GameActionResponse { fatalError() }
     func castGameVote(gameId: String) async throws -> GameActionResponse { fatalError() }

--- a/apps/conclave-skip/Sources/Conclave/Core/Networking/SocketIOManager+macOS.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/Networking/SocketIOManager+macOS.swift
@@ -260,6 +260,9 @@ final class SocketIOManager {
     func endGame() async throws -> GameActionResponse {
         GameActionResponse(success: true, gameId: nil, error: nil)
     }
+    func joinGame() async throws -> GameActionResponse {
+        GameActionResponse(success: true, gameId: nil, error: nil)
+    }
     func sendGameMove(gameId: String, type: String, payload: GameJSONValue? = nil) async throws -> GameMoveResponse {
         GameMoveResponse(success: true, error: nil)
     }

--- a/apps/conclave-skip/Sources/Conclave/Core/Networking/SocketIOManager.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/Networking/SocketIOManager.swift
@@ -114,6 +114,7 @@ private enum SocketEvent {
     static let gameMove = SfuClientEvent.gameMove.rawValue
     static let gameEnd = SfuClientEvent.gameEnd.rawValue
     static let gameGetState = SfuClientEvent.gameGetState.rawValue
+    static let gameJoin = SfuClientEvent.gameJoin.rawValue
     static let gameVoteOpen = SfuClientEvent.gameVoteOpen.rawValue
     static let gameVoteCast = SfuClientEvent.gameVoteCast.rawValue
     static let gameVoteCancel = SfuClientEvent.gameVoteCancel.rawValue
@@ -1071,6 +1072,11 @@ final class SocketIOManager {
 
     func endGame() async throws -> GameActionResponse {
         let data = try await emitAckOnly(event: SocketEvent.gameEnd)
+        return try JSONDecoder().decode(GameActionResponse.self, from: data)
+    }
+
+    func joinGame() async throws -> GameActionResponse {
+        let data = try await emitAckOnly(event: SocketEvent.gameJoin)
         return try JSONDecoder().decode(GameActionResponse.self, from: data)
     }
 

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/ChatViews.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/ChatViews.swift
@@ -311,7 +311,7 @@ struct ChatOverlayView: View {
                     )
                 }
 
-                HStack(spacing: 10) {
+                HStack(alignment: .bottom, spacing: 10) {
                     Button {
                         isInputFocused = false
                         showGifPicker = true
@@ -330,18 +330,15 @@ struct ChatOverlayView: View {
                     .disabled(isChatDisabled)
                     .accessibilityLabel("Add a GIF")
 
+                    #if SKIP
                     TextField(placeholder, text: messageTextBinding)
                         .textFieldStyle(.plain)
                         .font(ACMFont.trial(14))
                         .foregroundStyle(ACMColors.text)
                         .tint(ACMColors.primaryOrange)
                         .padding(.horizontal, inputHorizontalPadding)
-                        #if SKIP
                         .padding(.vertical, inputVerticalPadding)
                         .frame(height: inputHeight, alignment: .center)
-                        #else
-                        .frame(height: inputHeight)
-                        #endif
                         .acmColorBackground(ACMColors.bgAlt)
                         .overlay {
                             Capsule().strokeBorder(lineWidth: 1).foregroundStyle(ACMColors.border)
@@ -357,6 +354,32 @@ struct ChatOverlayView: View {
                             sendMessage()
                         }
                         .disabled(isChatDisabled)
+                    #else
+                    // Grows to a few lines on iOS; SkipUI has no vertical-axis
+                    // TextField, so Android stays single line above.
+                    TextField(placeholder, text: messageTextBinding, axis: .vertical)
+                        .textFieldStyle(.plain)
+                        .font(ACMFont.trial(14))
+                        .foregroundStyle(ACMColors.text)
+                        .tint(ACMColors.primaryOrange)
+                        .padding(.horizontal, inputHorizontalPadding)
+                        .padding(.vertical, 10)
+                        .frame(minHeight: inputHeight)
+                        .acmColorBackground(ACMColors.bgAlt)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                                .strokeBorder(lineWidth: 1)
+                                .foregroundStyle(ACMColors.border)
+                        }
+                        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                        .focused($isInputFocused)
+                        .lineLimit(1...4)
+                        .submitLabel(SubmitLabel.send)
+                        .onSubmit {
+                            sendMessage()
+                        }
+                        .disabled(isChatDisabled)
+                    #endif
 
                     Button {
                         sendMessage()
@@ -374,7 +397,9 @@ struct ChatOverlayView: View {
                         #endif
                         .disabled(!canSendMessage)
                 }
+                #if SKIP
                 .frame(height: inputHeight)
+                #endif
                 .onTapGesture {
                     markComposerActive()
                 }
@@ -420,6 +445,7 @@ struct ChatOverlayView: View {
         guard !isChatDisabled else { return }
         let activeReply = replyTarget
         replyTarget = nil
+        HapticManager.shared.trigger(.light)
         viewModel.sendChatGif(gif, replyTo: activeReply)
     }
 
@@ -431,6 +457,7 @@ struct ChatOverlayView: View {
         if ChatSubmitReplyPolicy.shouldClearReplyAfterSubmit(trimmed, isDmEnabled: viewModel.state.isDmEnabled) {
             replyTarget = nil
         }
+        HapticManager.shared.trigger(.light)
         viewModel.sendChatMessage(trimmed, replyTo: activeReply)
         if shouldClearDraft {
             messageText = ""
@@ -510,6 +537,19 @@ struct ChatOverlayView: View {
     }
 }
 
+/// Only pull the list down for a new entry when the reader is already at the
+/// bottom or the entry is their own; otherwise they are reading history and
+/// yanking the scroll position is hostile.
+enum ChatAutoScrollPolicy {
+    static func shouldAutoScroll(isAtBottom: Bool, latestIsFromLocalUser: Bool) -> Bool {
+        isAtBottom || latestIsFromLocalUser
+    }
+
+    static func unseenCount(previous: Int, appending: Bool) -> Int {
+        appending ? previous + 1 : 0
+    }
+}
+
 private struct ChatTimelineView: View, Equatable {
     let chatMessages: [ChatMessage]
     let systemMessages: [SystemMessage]
@@ -522,6 +562,9 @@ private struct ChatTimelineView: View, Equatable {
     let onReply: (ChatMessage) -> Void
     @State private var delayedScrollTask: Task<Void, Never>?
     @State private var observedLatestEntryId: String?
+    @State private var isAtBottom = true
+    @State private var unseenCount = 0
+    @State private var actionMessageId: String?
 
     private var timeline: [ChatTimelineEntry] {
         (chatMessages.map { ChatTimelineEntry.message($0) }
@@ -539,9 +582,20 @@ private struct ChatTimelineView: View, Equatable {
             lhs.commandSuggestionsCount == rhs.commandSuggestionsCount
     }
 
+    private func latestEntryIsFromLocalUser(_ entries: [ChatTimelineEntry]) -> Bool {
+        guard let last = entries.last else { return false }
+        switch last {
+        case .message(let message):
+            return isCurrentUser(message.userId)
+        case .system:
+            // System rows are feedback for something this user just did.
+            return true
+        }
+    }
+
     var body: some View {
         let _ = PerformanceDiagnostics.render("ChatTimelineView") {
-            "chat=\(chatMessages.count) system=\(systemMessages.count) focused=\(isInputFocused)"
+            "chat=\(chatMessages.count) system=\(systemMessages.count) focused=\(isInputFocused) atBottom=\(isAtBottom)"
         }
         let entries = timeline
         let latestEntryId = entries.last?.id
@@ -558,9 +612,31 @@ private struct ChatTimelineView: View, Equatable {
                             )
                             .id(entry.id)
                         }
+
+                        // Bottom sentinel: while it is composed the reader is
+                        // effectively at the end of the timeline.
+                        Color.clear
+                            .frame(height: 1)
+                            .onAppear {
+                                isAtBottom = true
+                                unseenCount = 0
+                            }
+                            .onDisappear {
+                                isAtBottom = false
+                            }
                     }
                     .padding(.horizontal, 14)
                     .padding(.vertical, 12)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if unseenCount > 0 && !isAtBottom {
+                    ChatNewMessagesPill(count: unseenCount) {
+                        unseenCount = 0
+                        scrollToLatestMessage(in: entries, proxy: proxy)
+                        scheduleDelayedScroll(in: entries, proxy: proxy)
+                    }
+                    .padding(.bottom, 10)
                 }
             }
 #if SKIP
@@ -573,8 +649,7 @@ private struct ChatTimelineView: View, Equatable {
                 guard change.shouldScroll else {
                     return
                 }
-                scrollToLatestMessage(in: entries, proxy: proxy)
-                scheduleDelayedScroll(in: entries, proxy: proxy)
+                handleNewLatestEntry(entries: entries, proxy: proxy)
             }
 #else
             .onChange(of: latestEntryId) { previousEntryId, currentEntryId in
@@ -584,8 +659,7 @@ private struct ChatTimelineView: View, Equatable {
                 ) else {
                     return
                 }
-                scrollToLatestMessage(in: entries, proxy: proxy)
-                scheduleDelayedScroll(in: entries, proxy: proxy)
+                handleNewLatestEntry(entries: entries, proxy: proxy)
             }
 #endif
             .onAppear {
@@ -620,6 +694,19 @@ private struct ChatTimelineView: View, Equatable {
         }
     }
 
+    private func handleNewLatestEntry(entries: [ChatTimelineEntry], proxy: ScrollViewProxy) {
+        if ChatAutoScrollPolicy.shouldAutoScroll(
+            isAtBottom: isAtBottom,
+            latestIsFromLocalUser: latestEntryIsFromLocalUser(entries)
+        ) {
+            unseenCount = 0
+            scrollToLatestMessage(in: entries, proxy: proxy)
+            scheduleDelayedScroll(in: entries, proxy: proxy)
+        } else {
+            unseenCount = ChatAutoScrollPolicy.unseenCount(previous: unseenCount, appending: true)
+        }
+    }
+
     private func messageValue(_ entry: ChatTimelineEntry) -> ChatMessage? {
         switch entry {
         case .message(let message):
@@ -628,6 +715,15 @@ private struct ChatTimelineView: View, Equatable {
             return ChatMessagePresentation.actionText(from: message.content) == nil ? message : nil
         case .system:
             return nil
+        }
+    }
+
+    private func toggleActions(for message: ChatMessage) {
+        if actionMessageId == message.id {
+            actionMessageId = nil
+        } else {
+            HapticManager.shared.trigger(.light)
+            actionMessageId = message.id
         }
     }
 
@@ -645,7 +741,14 @@ private struct ChatTimelineView: View, Equatable {
                     message: message,
                     isFromCurrentUser: isFromCurrentUser,
                     isReplyFromCurrentUser: isReplyFromCurrentUser,
-                    onReply: onReply,
+                    isActionActive: actionMessageId == message.id,
+                    onReply: { replyTarget in
+                        actionMessageId = nil
+                        onReply(replyTarget)
+                    },
+                    onToggleActions: { target in
+                        toggleActions(for: target)
+                    },
                     actionText: actionText
                 )
                 .padding(.top, grouped ? 2.0 : 10.0)
@@ -655,7 +758,14 @@ private struct ChatTimelineView: View, Equatable {
                     isFromCurrentUser: isFromCurrentUser,
                     isReplyFromCurrentUser: isReplyFromCurrentUser,
                     isGroupedWithPrevious: grouped,
-                    onReply: onReply
+                    isActionActive: actionMessageId == message.id,
+                    onReply: { replyTarget in
+                        actionMessageId = nil
+                        onReply(replyTarget)
+                    },
+                    onToggleActions: { target in
+                        toggleActions(for: target)
+                    }
                 )
                 .padding(.top, grouped ? 2.0 : 10.0)
             }
@@ -698,6 +808,31 @@ private struct ChatTimelineView: View, Equatable {
         withAnimation(Animation.easeOut(duration: 0.12)) {
             proxy.scrollTo(last.id, anchor: .bottom)
         }
+    }
+}
+
+/// Floating jump-to-latest chip shown while the reader is scrolled up and new
+/// messages arrive underneath.
+private struct ChatNewMessagesPill: View {
+    let count: Int
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                ACMSystemIcon.icon("arrow.down", android: "arrow.down", size: 11)
+                    .foregroundStyle(Color.white)
+                Text(count == 1 ? "1 new message" : "\(count) new messages")
+                    .font(ACMFont.trial(12, weight: .semibold))
+                    .foregroundStyle(Color.white)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 14)
+            .frame(height: 32)
+            .background(ACMColors.primaryOrange, in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Jump to newest messages")
     }
 }
 
@@ -1092,7 +1227,9 @@ struct ChatActionMessageRow: View {
     let message: ChatMessage
     let isFromCurrentUser: Bool
     let isReplyFromCurrentUser: Bool
+    let isActionActive: Bool
     let onReply: (ChatMessage) -> Void
+    let onToggleActions: (ChatMessage) -> Void
     let actionText: String
 
     private var directMessageLabel: String? {
@@ -1115,19 +1252,43 @@ struct ChatActionMessageRow: View {
                 )
             }
 
-            HStack(spacing: 6) {
-                Text(actionLine)
-                    .font(ACMFont.trial(12))
-                    .foregroundStyle(ACMColors.textMuted)
-                    .multilineTextAlignment(.center)
+            Text(actionLine)
+                .font(ACMFont.trial(12))
+                .foregroundStyle(ACMColors.textMuted)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity, alignment: .center)
 
-                ChatReplyButton {
-                    onReply(message)
-                }
+            #if SKIP
+            if isActionActive {
+                ChatMessageActionStrip(
+                    onReply: { onReply(message) },
+                    onCopy: { copyChatMessageText(message) },
+                    onDismiss: { onToggleActions(message) }
+                )
+                .padding(.top, 2)
             }
-            .frame(maxWidth: .infinity, alignment: .center)
+            #endif
         }
         .padding(.vertical, 2)
+        #if SKIP
+        .onLongPressGesture {
+            onToggleActions(message)
+        }
+        #else
+        .contentShape(Rectangle())
+        .contextMenu {
+            Button {
+                onReply(message)
+            } label: {
+                Label("Reply", systemImage: "arrowshape.turn.up.left")
+            }
+            Button {
+                copyChatMessageText(message)
+            } label: {
+                Label("Copy", systemImage: "doc.on.doc")
+            }
+        }
+        #endif
     }
 
     private var actionLine: String {
@@ -1153,13 +1314,16 @@ enum ChatGroupingPolicy {
 
 /// Flat, left-aligned message row (Meet / Discord / web-chat style): avatar +
 /// name + time header on the first message of a sender run, plain-text body,
-/// no bubbles or right/left split.
+/// no bubbles or right/left split. Actions live behind a long press (context
+/// menu on iOS, an inline strip on Android) so rows stay clean.
 struct ChatMessageRow: View {
     let message: ChatMessage
     let isFromCurrentUser: Bool
     let isReplyFromCurrentUser: Bool
     let isGroupedWithPrevious: Bool
+    let isActionActive: Bool
     let onReply: (ChatMessage) -> Void
+    let onToggleActions: (ChatMessage) -> Void
 
     private var senderName: String {
         ChatMessagePresentation.displayName(for: message, isFromCurrentUser: false)
@@ -1189,14 +1353,40 @@ struct ChatMessageRow: View {
                 }
 
                 messageContent
+
+                #if SKIP
+                if isActionActive {
+                    ChatMessageActionStrip(
+                        onReply: { onReply(message) },
+                        onCopy: { copyChatMessageText(message) },
+                        onDismiss: { onToggleActions(message) }
+                    )
+                    .padding(.top, 2)
+                }
+                #endif
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-
-            ChatReplyButton {
-                onReply(message)
-            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        #if SKIP
+        .onLongPressGesture {
+            onToggleActions(message)
+        }
+        #else
+        .contentShape(Rectangle())
+        .contextMenu {
+            Button {
+                onReply(message)
+            } label: {
+                Label("Reply", systemImage: "arrowshape.turn.up.left")
+            }
+            Button {
+                copyChatMessageText(message)
+            } label: {
+                Label("Copy", systemImage: "doc.on.doc")
+            }
+        }
+        #endif
     }
 
     @ViewBuilder
@@ -1557,20 +1747,78 @@ enum ChatGifAttachmentPresentation {
     }
 }
 
-struct ChatReplyButton: View {
-    let action: () -> Void
+/// Copies the readable text of a message (GIF title when there is no text).
+func copyChatMessageText(_ message: ChatMessage) {
+    let content = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+    let text: String
+    if !content.isEmpty {
+        text = content
+    } else if let gif = message.gif {
+        text = ChatGifAttachmentPresentation.title(for: gif)
+    } else {
+        return
+    }
+    #if SKIP
+    ClipboardHelper.copyToClipboard(text: text, label: "Chat message")
+    #elseif canImport(UIKit)
+    UIPasteboard.general.string = text
+    #endif
+}
+
+#if SKIP
+/// Android stand-in for the iOS context menu: a compact action strip revealed
+/// by a long press, inline under the message.
+struct ChatMessageActionStrip: View {
+    let onReply: () -> Void
+    let onCopy: () -> Void
+    let onDismiss: () -> Void
 
     var body: some View {
+        HStack(spacing: 8) {
+            stripButton(title: "Reply", icon: "arrowshape.turn.up.left", androidIcon: "reply") {
+                onDismiss()
+                onReply()
+            }
+            stripButton(title: "Copy", icon: "doc.on.doc", androidIcon: "copy") {
+                onCopy()
+                onDismiss()
+            }
+
+            Button(action: onDismiss) {
+                ACMSystemIcon.icon("xmark", android: "close", size: 10)
+                    .foregroundStyle(ACMColors.textFaint)
+                    .frame(width: 28, height: 28)
+                    .acmColorBackground(ACMColors.surfaceRaised)
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Hide message actions")
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func stripButton(title: String, icon: String, androidIcon: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
-            ACMSystemIcon.icon("arrowshape.turn.up.left", android: "reply", size: 12)
-                .foregroundStyle(ACMColors.textMuted)
-                .frame(width: 26, height: 26)
-                .acmColorBackground(ACMColors.surfaceRaised)
-                .clipShape(Circle())
+            HStack(spacing: 5) {
+                ACMSystemIcon.icon(icon, android: androidIcon, size: 11, tint: "text")
+                    .foregroundStyle(ACMColors.text)
+                Text(title)
+                    .font(ACMFont.trial(12, weight: .medium))
+                    .foregroundStyle(ACMColors.text)
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 28)
+            .acmColorBackground(ACMColors.surfaceRaised)
+            .clipShape(Capsule())
+            .overlay {
+                Capsule().strokeBorder(lineWidth: 1).foregroundStyle(ACMColors.border)
+            }
         }
         .buttonStyle(.plain)
     }
 }
+#endif
 
 struct ChatReplyComposerView: View {
     let replyTo: ChatReplyPreview

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GamePresentation.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GamePresentation.swift
@@ -1,0 +1,494 @@
+import Foundation
+
+// Shared, testable presentation policies for the in-call games. The games
+// sheet (catalog/config/vote) and the on-stage game surface both read these.
+
+struct GameCatalogVisual: Equatable {
+    let icon: String
+    let androidIcon: String
+}
+
+enum GameCatalogPresentationPolicy {
+    static func visual(for gameId: String) -> GameCatalogVisual {
+        switch gameId {
+        case "trivia":
+            return GameCatalogVisual(icon: "questionmark.circle.fill", androidIcon: "info")
+        case "bluff":
+            return GameCatalogVisual(icon: "theatermasks.fill", androidIcon: "forum")
+        case "would-you-rather":
+            return GameCatalogVisual(icon: "arrow.left.arrow.right", androidIcon: "arrow.forward")
+        case "most-likely-to":
+            return GameCatalogVisual(icon: "person.2.fill", androidIcon: "participants")
+        case "reaction":
+            return GameCatalogVisual(icon: "bolt.fill", androidIcon: "warning")
+        case "imposter":
+            return GameCatalogVisual(icon: "eye.slash.fill", androidIcon: "ghost")
+        case "wordle":
+            return GameCatalogVisual(icon: "square.grid.3x3.fill", androidIcon: "grid")
+        default:
+            return GameCatalogVisual(icon: "gamecontroller.fill", androidIcon: "sports_esports")
+        }
+    }
+
+    static func catalogSubtitle(_ game: GameCatalogEntry) -> String {
+        let description = game.description.trimmingCharacters(in: .whitespacesAndNewlines)
+        return description.isEmpty ? playerRange(game) : description
+    }
+
+    static func playerRange(_ game: GameCatalogEntry) -> String {
+        if game.minPlayers == game.maxPlayers {
+            return "\(game.minPlayers)"
+        }
+        return "\(game.minPlayers)-\(game.maxPlayers)"
+    }
+
+    static func canOpenVote(catalogCount: Int, isActionInFlight: Bool) -> Bool {
+        !isActionInFlight && catalogCount >= 2
+    }
+
+    static func shouldShowDivider(after index: Int, total: Int, hasFooter: Bool) -> Bool {
+        index < total - 1 || hasFooter
+    }
+}
+
+enum GameVotePresentationPolicy {
+    static func leader(in vote: GameVoteState) -> GameCatalogEntry? {
+        var leader: GameCatalogEntry?
+        var leaderVotes = -1
+        for entry in vote.candidates {
+            let count = vote.tally[entry.id] ?? 0
+            if count > leaderVotes {
+                leader = entry
+                leaderVotes = count
+            }
+        }
+        return leader
+    }
+
+    static func startLeaderTitle(_ vote: GameVoteState) -> String {
+        guard let leader = leader(in: vote) else { return "Start leader" }
+        let votes = vote.tally[leader.id] ?? 0
+        return votes > 0 ? "Start \(leader.name)" : "Start leader"
+    }
+
+    static func shouldShowCandidateDivider(after index: Int, total: Int, hasHostActions: Bool) -> Bool {
+        index < total - 1 || hasHostActions
+    }
+}
+
+struct GameChoiceOption: Identifiable, Equatable {
+    let id: String
+    let text: String
+    let subtitle: String?
+    let isReal: Bool?
+}
+
+struct GameScoreRow: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let score: Int
+}
+
+struct GameReactionResultRow: Identifiable, Equatable {
+    let id: String
+    let rank: Int
+    let name: String
+    let resultText: String
+    let isEarly: Bool
+    let isWinner: Bool
+}
+
+enum GameDetailsPresentationPolicy {
+    static func scoreboardRows(from view: GameJSONValue?) -> [GameScoreRow] {
+        let rows = view?.objectArray("scoreboard") ?? []
+        return rows.compactMap(scoreboardRow).sorted { $0.score > $1.score }
+    }
+
+    static func intMap(from view: GameJSONValue?, key: String) -> [String: Int] {
+        guard let values = view?.dictionaryValue?[key] as? [String: Any] else {
+            return [:]
+        }
+        var result: [String: Int] = [:]
+        for (id, value) in values {
+            if let count = intValue(value) {
+                result[id] = count
+            }
+        }
+        return result
+    }
+
+    static func namesSummary(_ names: [String]) -> String {
+        let cleaned = names
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return cleaned.isEmpty ? "nobody" : cleaned.joined(separator: ", ")
+    }
+
+    static func roundPointsSummary(from view: GameJSONValue?) -> String? {
+        let rows = view?.objectArray("roundPoints") ?? []
+        var parts: [String] = []
+        for row in rows {
+            let name = (row["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !name.isEmpty, let points = intValue(row["points"]), points != 0 else {
+                continue
+            }
+            let prefix = points > 0 ? "+" : ""
+            parts.append("\(name) \(prefix)\(points)")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " - ")
+    }
+
+    static func reactionResultRows(from view: GameJSONValue?) -> [GameReactionResultRow] {
+        let rows = view?.objectArray("results") ?? []
+        return rows.enumerated().compactMap { index, row in
+            let id = (row["id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let resolvedId = id?.isEmpty == false ? id! : "reaction-\(index)"
+            let rawName = (row["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let name = rawName?.isEmpty == false ? rawName! : resolvedId
+            let isEarly = boolValue(row["early"]) ?? false
+            let resultText: String
+            if isEarly {
+                resultText = "too soon"
+            } else if let reactionMs = intValue(row["reactionMs"]) {
+                resultText = "\(reactionMs) ms"
+            } else {
+                resultText = "no tap"
+            }
+            return GameReactionResultRow(
+                id: resolvedId,
+                rank: index + 1,
+                name: name,
+                resultText: resultText,
+                isEarly: isEarly,
+                isWinner: index == 0 && !isEarly
+            )
+        }
+    }
+
+    static func gamePlayerOption(_ row: [String: Any]) -> GamePlayer? {
+        guard let id = row["id"] as? String else { return nil }
+        let name = (row["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return GamePlayer(id: id, name: name?.isEmpty == false ? name! : id)
+    }
+
+    static func intValue(_ value: Any?) -> Int? {
+        if let intValue = value as? Int { return intValue }
+        if let doubleValue = value as? Double { return Int(doubleValue) }
+        if let numberValue = value as? NSNumber { return numberValue.intValue }
+        return nil
+    }
+
+    static func boolValue(_ value: Any?) -> Bool? {
+        if let boolValue = value as? Bool { return boolValue }
+        if let intValue = value as? Int { return intValue != 0 }
+        if let doubleValue = value as? Double { return doubleValue != 0.0 }
+        if let numberValue = value as? NSNumber { return numberValue.intValue != 0 }
+        return nil
+    }
+
+    private static func scoreboardRow(_ row: [String: Any]) -> GameScoreRow? {
+        guard let id = row["id"] as? String else { return nil }
+        let name = (row["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return GameScoreRow(
+            id: id,
+            name: name?.isEmpty == false ? name! : id,
+            score: intValue(row["score"]) ?? 0
+        )
+    }
+}
+
+struct GameNumberPreset: Identifiable {
+    let value: Double
+    let label: String
+
+    var id: String { label }
+}
+
+enum GameConfigDraftPolicy {
+    static func initialDrafts(for game: GameCatalogEntry) -> [String: GameConfigValue] {
+        var options: [String: GameConfigValue] = [:]
+        for option in game.options {
+            let id = option.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !id.isEmpty else { continue }
+            options[id] = resolvedValue(for: option, draft: option.defaultConfigValue)
+        }
+        return options
+    }
+
+    static func resolvedOptions(
+        for game: GameCatalogEntry,
+        drafts: [String: GameConfigValue]
+    ) -> [String: GameConfigValue] {
+        var options: [String: GameConfigValue] = [:]
+        for option in game.options {
+            let id = option.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !id.isEmpty else { continue }
+            options[id] = resolvedValue(for: option, draft: drafts[option.id])
+        }
+        return options
+    }
+
+    static func resolvedValue(for option: GameOptionSpec, draft: GameConfigValue?) -> GameConfigValue {
+        switch option.type {
+        case "number":
+            let raw = draft?.numberValue ?? option.defaultConfigValue.numberValue ?? option.min ?? 0.0
+            return .number(clamp(raw, min: option.min, max: option.max))
+        case "select":
+            let choices = option.choices ?? []
+            let defaultValue = option.defaultConfigValue.stringValue ?? choices.first?.value ?? ""
+            let raw = draft?.stringValue ?? defaultValue
+            if choices.contains(where: { $0.value == raw }) {
+                return .string(raw)
+            }
+            return .string(defaultValue)
+        default:
+            let maxLength = max(0, option.maxLength ?? Int.max)
+            let raw = draft?.stringValue ?? option.defaultConfigValue.stringValue ?? ""
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.count <= maxLength {
+                return .string(trimmed)
+            }
+            return .string(String(trimmed.prefix(maxLength)))
+        }
+    }
+
+    static func numberPresets(for option: GameOptionSpec) -> [GameNumberPreset] {
+        let source = option.presets ?? [
+            option.min ?? option.defaultConfigValue.numberValue ?? 0.0,
+            option.defaultConfigValue.numberValue ?? option.min ?? 0.0,
+            option.max ?? option.defaultConfigValue.numberValue ?? 0.0
+        ]
+        var seen: [Double] = []
+        var presets: [GameNumberPreset] = []
+        for raw in source {
+            let value = clamp(raw, min: option.min, max: option.max)
+            if seen.contains(where: { numbersMatch($0, value) }) { continue }
+            seen.append(value)
+            presets.append(GameNumberPreset(
+                value: value,
+                label: formattedNumber(value, suffix: option.suffix)
+            ))
+        }
+        return presets
+    }
+
+    static func numbersMatch(_ lhs: Double, _ rhs: Double) -> Bool {
+        abs(lhs - rhs) < 0.0001
+    }
+
+    private static func clamp(_ value: Double, min: Double?, max: Double?) -> Double {
+        var next = value
+        if let min {
+            next = Swift.max(min, next)
+        }
+        if let max {
+            next = Swift.min(max, next)
+        }
+        return next
+    }
+
+    private static func formattedNumber(_ value: Double, suffix: String?) -> String {
+        let rounded = value.rounded()
+        let base = numbersMatch(value, rounded) ? "\(Int(rounded))" : "\(value)"
+        guard let suffix = suffix?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !suffix.isEmpty else { return base }
+        return "\(base) \(suffix)"
+    }
+}
+
+// MARK: - Stage text policies
+
+/// Text derivations for the on-stage game views. Pure string logic so it can
+/// be unit-tested without SwiftUI.
+enum GameStageTextPolicy {
+    static func progressKicker(_ view: GameJSONValue?, fallback: String) -> String {
+        let index = view?.int("questionIndex") ?? view?.int("index")
+        let total = view?.int("totalQuestions") ?? view?.int("total")
+        let category = view?.string("category")
+        if let index, let total, total > 0 {
+            let prefix = category.flatMap { $0.isEmpty ? nil : "\($0) · " } ?? ""
+            return "\(prefix)\(index + 1) of \(total)"
+        }
+        if let category, !category.isEmpty {
+            return category
+        }
+        return fallback
+    }
+
+    static func phaseLabel(_ phase: String) -> String {
+        switch phase {
+        case "lobby": return "Lobby"
+        case "question": return "Question"
+        case "choose": return "Choose"
+        case "vote": return "Vote"
+        case "write": return "Write"
+        case "arming": return "Get ready"
+        case "go": return "Go"
+        case "reveal": return "Reveal"
+        case "result": return "Result"
+        case "results": return "Results"
+        case "discuss": return "Discuss"
+        case "set-word": return "Set word"
+        case "playing": return "Playing"
+        default: return phase.capitalized
+        }
+    }
+
+    static func playersLine(count: Int) -> String {
+        count == 1 ? "1 player" : "\(count) players"
+    }
+
+    static func voteCountText(_ count: Int) -> String {
+        count == 1 ? "1 vote" : "\(count) votes"
+    }
+
+    static func triviaWinnerText(_ view: GameJSONValue?) -> String {
+        let rows = GameDetailsPresentationPolicy.scoreboardRows(from: view)
+        guard let winner = rows.first else { return "Scores are not available yet." }
+        return "\(winner.name) wins with \(winner.score)"
+    }
+
+    static func triviaPlayerStatus(_ playerView: GameJSONValue, phase: String) -> String {
+        if phase == "reveal" {
+            if playerView.bool("correct") == true {
+                let points = playerView.int("lastRoundPoints") ?? 0
+                return points > 0 ? "Correct +\(points)" : "Correct"
+            }
+            if playerView.bool("answered") == true {
+                return "Not quite"
+            }
+            return "Time's up"
+        }
+        let score = playerView.int("score") ?? 0
+        let rank = playerView.int("rank")
+        let rankSuffix = rank.map { " · #\($0)" } ?? ""
+        return "\(score) points\(rankSuffix)"
+    }
+
+    static func reactionTitle(phase: String, tapped: Bool, early: Bool, reactionMs: Int?) -> String {
+        if early { return "Too early" }
+        if let reactionMs { return "\(reactionMs) ms" }
+        if tapped { return "Locked in" }
+        if phase == "go" { return "Tap!" }
+        if phase == "reveal" { return "Round result" }
+        return "Wait for green"
+    }
+
+    static func reactionSubtitle(_ view: GameJSONValue?, phase: String) -> String {
+        if let winner = view?.string("winnerName"), !winner.isEmpty {
+            return "Fastest: \(winner)"
+        }
+        let tapped = view?.int("tappedCount") ?? 0
+        let total = view?.int("totalPlayers") ?? 0
+        if total > 0 {
+            return "\(tapped) of \(total) tapped"
+        }
+        return phaseLabel(phase)
+    }
+
+    static func bluffTitle(_ view: GameJSONValue?, phase: String) -> String {
+        let round = view?.int("round")
+        let total = view?.int("totalRounds")
+        let prefix: String
+        if let round, let total, total > 0 {
+            prefix = "\(round + 1) of \(total) · "
+        } else {
+            prefix = ""
+        }
+        switch phase {
+        case "write":
+            return "\(prefix)Write a bluff"
+        case "choose":
+            return "\(prefix)Find the truth"
+        case "reveal":
+            return "\(prefix)Reveal"
+        case "results":
+            return "Final scores"
+        default:
+            return phaseLabel(phase)
+        }
+    }
+
+    static func bluffSubmittedText(_ value: String?) -> String {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "Bluff submitted" : "Submitted: \(trimmed)"
+    }
+
+    static func bluffOption(_ row: [String: Any]) -> GameChoiceOption? {
+        guard let id = row["id"] as? String else { return nil }
+        let text = (row["text"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let text, !text.isEmpty else { return nil }
+        let kind = row["kind"] as? String
+        let votes = GameDetailsPresentationPolicy.intValue(row["votes"])
+        let ownerName = (row["ownerName"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let subtitleParts = [
+            kind == "real" ? "Truth" : (ownerName?.isEmpty == false ? ownerName : nil),
+            votes.map { count in voteCountText(count) }
+        ].compactMap { $0 }
+        return GameChoiceOption(
+            id: id,
+            text: text,
+            subtitle: subtitleParts.isEmpty ? nil : subtitleParts.joined(separator: " · "),
+            isReal: kind == nil ? nil : kind == "real"
+        )
+    }
+
+    static func imposterTitle(publicView: GameJSONValue?, playerView: GameJSONValue?, phase: String) -> String {
+        switch phase {
+        case "reveal", "discuss":
+            if playerView?.string("role") == "imposter" {
+                return "You are the imposter"
+            }
+            let word = playerView?.string("word")?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return word.isEmpty ? "Secret word" : word
+        case "vote":
+            return "Vote out the imposter"
+        case "result":
+            return imposterResultTitle(publicView)
+        default:
+            return phaseLabel(phase)
+        }
+    }
+
+    static func imposterSubtitle(publicView: GameJSONValue?, playerView: GameJSONValue?, phase: String) -> String? {
+        if phase == "vote" {
+            let voted = publicView?.stringArray("votedPlayerIds").count ?? 0
+            let total = publicView?.int("totalPlayers") ?? 0
+            return total > 0 ? "\(voted) of \(total) voted" : nil
+        }
+
+        let category = playerView?.string("category") ?? publicView?.string("category")
+        if phase == "reveal" || phase == "discuss",
+           playerView?.string("role") == "imposter" {
+            let base = "Blend in. You do not know the word."
+            if let category, !category.isEmpty {
+                return "\(base) Category: \(category)"
+            }
+            return base
+        }
+        if phase == "discuss",
+           let starter = publicView?.string("starterName"),
+           !starter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let prefix = category.flatMap { $0.isEmpty ? nil : "\($0) · " } ?? ""
+            return "\(prefix)\(starter) starts"
+        }
+        return category?.isEmpty == false ? category : nil
+    }
+
+    static func imposterResultTitle(_ view: GameJSONValue?) -> String {
+        guard let result = view?.dictionaryValue?["result"] as? [String: Any] else {
+            return "Result"
+        }
+        if GameDetailsPresentationPolicy.boolValue(result["tie"]) == true {
+            return "Vote tied"
+        }
+        return GameDetailsPresentationPolicy.boolValue(result["crewWon"]) == true ? "Crew wins" : "Imposter wins"
+    }
+
+    static func imposterVoteSubtitle(_ view: GameJSONValue?, playerId: String, isSelf: Bool) -> String? {
+        if isSelf { return "You" }
+        let counts = view?.dictionaryValue?["voteCounts"] as? [String: Any]
+        guard let count = GameDetailsPresentationPolicy.intValue(counts?[playerId]), count > 0 else { return nil }
+        return voteCountText(count)
+    }
+}

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GameStageComponents.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GameStageComponents.swift
@@ -1,0 +1,402 @@
+import SwiftUI
+
+// Shared building blocks for the on-stage game surface. Big, tappable, flat:
+// solid surfaces, 1 px borders, coral accent only.
+
+/// Kicker + headline + optional support line, the standard top block of a
+/// game phase.
+struct GameStagePrompt: View {
+    var kicker: String? = nil
+    let title: String
+    var subtitle: String? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let kicker = kicker?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !kicker.isEmpty {
+                Text(kicker)
+                    .font(ACMFont.trial(12, weight: .semibold))
+                    .foregroundStyle(ACMColors.primaryOrange)
+                    .lineLimit(1)
+            }
+
+            Text(title)
+                .font(ACMFont.trial(21, weight: .semibold))
+                .foregroundStyle(ACMColors.text)
+                .multilineTextAlignment(.leading)
+                .lineLimit(5)
+
+            if let subtitle = subtitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !subtitle.isEmpty {
+                Text(subtitle)
+                    .font(ACMFont.trial(14))
+                    .foregroundStyle(ACMColors.textMuted)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(4)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// A large answer/vote card. Selection is coral, reveal states go green/red,
+/// and an optional fill ratio paints a flat result bar behind the label.
+struct GameStageChoiceCard: View {
+    let title: String
+    var subtitle: String? = nil
+    var trailing: String? = nil
+    var isSelected: Bool = false
+    var isCorrect: Bool? = nil
+    var fillRatio: Double? = nil
+    var isDisabled: Bool = false
+    let action: () -> Void
+
+    private var resolvedTint: Color {
+        if isCorrect == true { return ACMColors.success }
+        if isCorrect == false && isSelected { return ACMColors.error }
+        if isSelected { return ACMColors.primaryOrange }
+        return ACMColors.text
+    }
+
+    var body: some View {
+        let tint = resolvedTint
+        Button(action: action) {
+            HStack(spacing: ACMSpacing.sm) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(title)
+                        .font(ACMFont.trial(16, weight: .medium))
+                        .foregroundStyle(tint)
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(3)
+                    if let subtitle = subtitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+                       !subtitle.isEmpty {
+                        Text(subtitle)
+                            .font(ACMFont.trial(12))
+                            .foregroundStyle(ACMColors.textFaint)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer(minLength: ACMSpacing.sm)
+
+                if let trailing = trailing?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !trailing.isEmpty {
+                    Text(trailing)
+                        .font(ACMFont.trial(14, weight: .semibold))
+                        .foregroundStyle(tint)
+                        .lineLimit(1)
+                }
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(tint)
+                }
+            }
+            .padding(.horizontal, ACMSpacing.md)
+            .padding(.vertical, 14)
+            .frame(minHeight: 56)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background { cardBackground(tint: tint) }
+            .overlay {
+                RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                    .strokeBorder(isSelected ? tint.opacity(0.44) : ACMColors.border, lineWidth: 1)
+            }
+            #if !SKIP
+            .contentShape(Rectangle())
+            #endif
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .opacity(isDisabled && !isSelected && isCorrect != true ? 0.62 : 1.0)
+    }
+
+    private func cardBackground(tint: Color) -> some View {
+        ZStack(alignment: .leading) {
+            RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                .fill(isSelected ? tint.opacity(0.12) : ACMColors.surfaceRaised)
+            if let fillRatio {
+                GeometryReader { geometry in
+                    RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                        .fill(tint.opacity(0.10))
+                        .frame(width: geometry.size.width * min(1.0, max(0.0, fillRatio)))
+                }
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous))
+    }
+}
+
+/// Full-width primary/secondary action used in the pinned bottom bar.
+struct GameStageActionButton: View {
+    let title: String
+    var isPrimary: Bool = true
+    var tint: Color = ACMColors.primaryOrange
+    var isDisabled: Bool = false
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(ACMFont.trial(15, weight: .semibold))
+                .foregroundStyle(isPrimary ? Color.white : tint)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity)
+                .frame(minHeight: 48)
+                .background(
+                    isPrimary ? (isDisabled ? ACMColors.surfaceRaised : tint) : ACMColors.surfaceRaised,
+                    in: RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                )
+                .overlay {
+                    if !isPrimary {
+                        RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                            .strokeBorder(lineWidth: 1)
+                            .foregroundStyle(ACMColors.border)
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.6 : 1.0)
+    }
+}
+
+/// Ranked scores; the leader carries the coral accent.
+struct GameStageScoreboard: View {
+    let rows: [GameScoreRow]
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if rows.isEmpty {
+                GameStageMetaLine(text: "Scores are not available yet.")
+            } else {
+                ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                    GameStageScoreRowView(rank: index + 1, name: row.name, score: row.score)
+                }
+            }
+        }
+    }
+}
+
+struct GameStageScoreRowView: View {
+    let rank: Int
+    let name: String
+    let score: Int
+
+    private var rankColor: Color {
+        switch rank {
+        case 1: return ACMColors.primaryOrange
+        case 2, 3: return ACMColors.textMuted
+        default: return ACMColors.textFaint
+        }
+    }
+
+    var body: some View {
+        let isLeader = rank == 1
+        HStack(spacing: ACMSpacing.sm) {
+            Text("\(rank)")
+                .font(ACMFont.trial(15, weight: .bold))
+                .foregroundStyle(rankColor)
+                .frame(width: 26, alignment: .center)
+
+            Text(name)
+                .font(ACMFont.trial(15, weight: .medium))
+                .foregroundStyle(ACMColors.text)
+                .lineLimit(1)
+
+            Spacer(minLength: ACMSpacing.xs)
+
+            Text("\(score)")
+                .font(ACMFont.trial(15, weight: .semibold))
+                .foregroundStyle(rankColor)
+        }
+        .padding(.horizontal, ACMSpacing.md)
+        .frame(minHeight: 48)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                .fill(isLeader ? ACMColors.primaryOrange.opacity(0.10) : ACMColors.surfaceRaised)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                .strokeBorder(isLeader ? ACMColors.primaryOrange.opacity(0.34) : ACMColors.border, lineWidth: 1)
+        }
+    }
+}
+
+struct GameStageMetaLine: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(ACMFont.trial(12, weight: .medium))
+            .foregroundStyle(ACMColors.textFaint)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// Centered standalone note for waiting/blocked states.
+struct GameStageNotice: View {
+    let icon: String
+    let androidIcon: String
+    let title: String
+    var subtitle: String? = nil
+
+    var body: some View {
+        VStack(spacing: ACMSpacing.sm) {
+            ACMSystemIcon.icon(icon, android: androidIcon, size: 26, tint: "muted")
+                .foregroundStyle(ACMColors.textMuted)
+
+            VStack(spacing: 4) {
+                Text(title)
+                    .font(ACMFont.trial(16, weight: .semibold))
+                    .foregroundStyle(ACMColors.text)
+                    .multilineTextAlignment(.center)
+
+                if let subtitle = subtitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !subtitle.isEmpty {
+                    Text(subtitle)
+                        .font(ACMFont.trial(13))
+                        .foregroundStyle(ACMColors.textMuted)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(3)
+                }
+            }
+        }
+        .padding(.horizontal, ACMSpacing.lg)
+        .padding(.vertical, ACMSpacing.xl)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+enum GameStageCountdownPolicy {
+    static func remainingSeconds(deadline: Double, nowMs: Double, clockOffsetMs: Double) -> Int {
+        let remainingMs = deadline - (nowMs + clockOffsetMs)
+        return max(0, Int((remainingMs / 1000.0).rounded(.up)))
+    }
+
+    static func progress(deadline: Double, durationMs: Double?, nowMs: Double, clockOffsetMs: Double) -> Double? {
+        guard let durationMs, durationMs > 0 else { return nil }
+        let remainingMs = deadline - (nowMs + clockOffsetMs)
+        return min(1.0, max(0.0, remainingMs / durationMs))
+    }
+}
+
+/// Server-clock countdown: a flat draining bar plus a seconds label. Only this
+/// small view re-renders on the tick.
+struct GameStageCountdown: View {
+    let deadline: Double
+    let serverNow: Double
+    var durationMs: Double? = nil
+
+    @State private var tick = 0
+    @State private var tickerTask: Task<Void, Never>?
+    @State private var clockOffsetMs = 0.0
+
+    private var nowMs: Double {
+        let _ = tick
+        return Date().timeIntervalSince1970 * 1000.0
+    }
+
+    var body: some View {
+        let now = nowMs
+        let seconds = GameStageCountdownPolicy.remainingSeconds(deadline: deadline, nowMs: now, clockOffsetMs: clockOffsetMs)
+        let progress = GameStageCountdownPolicy.progress(deadline: deadline, durationMs: durationMs, nowMs: now, clockOffsetMs: clockOffsetMs)
+
+        HStack(spacing: ACMSpacing.sm) {
+            if let progress {
+                GeometryReader { geometry in
+                    ZStack(alignment: .leading) {
+                        Capsule()
+                            .fill(ACMColors.surfaceRaised)
+                        Capsule()
+                            .fill(seconds <= 5 ? ACMColors.error : ACMColors.primaryOrange)
+                            .frame(width: max(6.0, geometry.size.width * progress))
+                    }
+                }
+                .frame(height: 6)
+            }
+
+            Text("\(seconds)s")
+                .font(ACMFont.trial(13, weight: .semibold))
+                .foregroundStyle(seconds <= 5 ? ACMColors.error : ACMColors.textMuted)
+                .frame(minWidth: 34, alignment: .trailing)
+        }
+        .onAppear {
+            syncClock()
+            startTicker()
+        }
+        .onDisappear { stopTicker() }
+        #if SKIP
+        .onChange(of: "\(serverNow)") {
+            syncClock()
+        }
+        #else
+        .onChange(of: serverNow) {
+            syncClock()
+        }
+        #endif
+    }
+
+    private func syncClock() {
+        if serverNow > 0 {
+            clockOffsetMs = serverNow - Date().timeIntervalSince1970 * 1000.0
+        }
+    }
+
+    private func startTicker() {
+        stopTicker()
+        tickerTask = Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                guard !Task.isCancelled else { return }
+                tick += 1
+            }
+        }
+    }
+
+    private func stopTicker() {
+        tickerTask?.cancel()
+        tickerTask = nil
+    }
+}
+
+/// One player identity chip for lobbies: avatar dot + name.
+struct GameStagePlayerChip: View {
+    let id: String
+    let name: String
+    var isPending: Bool = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(ACMColors.avatarColor(for: id))
+                .frame(width: 22, height: 22)
+                .overlay {
+                    Text(String(name.prefix(1)).uppercased())
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Color.white)
+                }
+
+            Text(name)
+                .font(ACMFont.trial(13, weight: .medium))
+                .foregroundStyle(isPending ? ACMColors.textMuted : ACMColors.text)
+                .lineLimit(1)
+
+            if isPending {
+                Text("next round")
+                    .font(ACMFont.trial(10, weight: .medium))
+                    .foregroundStyle(ACMColors.textFaint)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 34)
+        .background {
+            Capsule().fill(ACMColors.surfaceRaised)
+        }
+        .overlay {
+            Capsule().strokeBorder(lineWidth: 1).foregroundStyle(ACMColors.border)
+        }
+    }
+}

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GameStageGames.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GameStageGames.swift
@@ -1,0 +1,802 @@
+import SwiftUI
+import Observation
+
+// Per-game surfaces for the on-stage runtime. Each view parses the same
+// server projection the web client consumes and drives moves through the
+// view model. Layout contract: scrollable content on top, pinned action bar
+// at the bottom of the stage card.
+
+// MARK: - Trivia
+
+struct TriviaStageView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let activeGame: GamePublicState
+    let playerView: GameJSONValue?
+    let canPlay: Bool
+    let canManage: Bool
+
+    var body: some View {
+        let publicView = activeGame.view
+        let phase = publicView?.string("phase") ?? activeGame.phase
+        let options = publicView?.stringArray("options") ?? []
+        let reveal = phase == "reveal"
+        let results = phase == "results"
+        let answered = playerView?.bool("answered") ?? false
+        let selectedChoice = playerView?.int("choice")
+        let correctChoice = publicView?.int("correctIndex")
+        let counts = publicView?.intArray("optionCounts") ?? []
+        let deadline = publicView?.double("deadline")
+        let serverNow = publicView?.double("serverNow") ?? 0.0
+        let durationMs = publicView?.double("questionDurationMs")
+        let answeredCount = publicView?.int("answeredCount") ?? 0
+        let totalPlayers = publicView?.int("totalPlayers") ?? 0
+        let canAnswer = canPlay && phase == "question" && !answered && !viewModel.state.isGameActionInFlight
+
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: ACMSpacing.md) {
+                    GameStagePrompt(
+                        kicker: results ? "Results" : GameStageTextPolicy.progressKicker(publicView, fallback: "Question"),
+                        title: results
+                            ? GameStageTextPolicy.triviaWinnerText(publicView)
+                            : (publicView?.string("prompt") ?? "Waiting for the question."),
+                        subtitle: results ? nil : triviaSupportLine(
+                            phase: phase,
+                            answered: answered,
+                            answeredCount: answeredCount,
+                            totalPlayers: totalPlayers
+                        )
+                    )
+
+                    if phase == "question", let deadline, deadline > 0 {
+                        GameStageCountdown(deadline: deadline, serverNow: serverNow, durationMs: durationMs)
+                    }
+
+                    if results {
+                        GameStageScoreboard(rows: GameDetailsPresentationPolicy.scoreboardRows(from: publicView))
+                    } else {
+                        VStack(spacing: 8) {
+                            ForEach(Array(options.enumerated()), id: \.offset) { index, option in
+                                GameStageChoiceCard(
+                                    title: option,
+                                    trailing: reveal && index < counts.count ? "\(counts[index])" : nil,
+                                    isSelected: selectedChoice == index,
+                                    isCorrect: reveal ? correctChoice == index : nil,
+                                    isDisabled: !canAnswer
+                                ) {
+                                    viewModel.sendGameMove(
+                                        type: "answer",
+                                        payload: GameJSONValue.object(["choice": index])
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    if !results, let playerView {
+                        GameStageMetaLine(text: GameStageTextPolicy.triviaPlayerStatus(playerView, phase: phase))
+                    }
+                }
+                .padding(ACMSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if results {
+                GameStageResultsBar(viewModel: viewModel, canManage: canManage)
+            } else {
+                GameStageHostRoundBar(viewModel: viewModel, phase: phase, canManage: canManage)
+            }
+        }
+    }
+
+    private func triviaSupportLine(phase: String, answered: Bool, answeredCount: Int, totalPlayers: Int) -> String? {
+        guard phase == "question" else { return nil }
+        var parts: [String] = []
+        if answered {
+            parts.append("Answer locked in")
+        }
+        if totalPlayers > 0 {
+            parts.append("\(answeredCount) of \(totalPlayers) answered")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+}
+
+// MARK: - Reaction
+
+struct ReactionStageView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let activeGame: GamePublicState
+    let playerView: GameJSONValue?
+    let canPlay: Bool
+    let canManage: Bool
+
+    var body: some View {
+        let publicView = activeGame.view
+        let phase = publicView?.string("phase") ?? activeGame.phase
+        let tapped = playerView?.bool("tapped") ?? false
+        let early = playerView?.bool("early") ?? false
+        let reactionMs = playerView?.int("reactionMs")
+        let canTap = canPlay
+            && (phase == "arming" || phase == "go")
+            && !tapped
+            && !viewModel.state.isGameActionInFlight
+
+        VStack(spacing: 0) {
+            if phase == "arming" || phase == "go" {
+                // The pad is the whole stage: nothing to read, one thing to do.
+                reactionTapPad(
+                    phase: phase,
+                    tapped: tapped,
+                    early: early,
+                    reactionMs: reactionMs,
+                    canTap: canTap
+                )
+                .padding(ACMSpacing.md)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: ACMSpacing.md) {
+                        GameStagePrompt(
+                            kicker: phase == "results" ? "Results" : "Reaction",
+                            title: GameStageTextPolicy.reactionTitle(phase: phase, tapped: tapped, early: early, reactionMs: reactionMs),
+                            subtitle: GameStageTextPolicy.reactionSubtitle(publicView, phase: phase)
+                        )
+
+                        if phase == "reveal" {
+                            reactionResultsList(publicView)
+                        } else if phase == "results" {
+                            GameStageScoreboard(rows: GameDetailsPresentationPolicy.scoreboardRows(from: publicView))
+                        }
+                    }
+                    .padding(ACMSpacing.md)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                if phase == "results" {
+                    GameStageResultsBar(viewModel: viewModel, canManage: canManage)
+                } else {
+                    GameStageHostRoundBar(viewModel: viewModel, phase: phase, canManage: canManage)
+                }
+            }
+        }
+    }
+
+    private func reactionTapPad(
+        phase: String,
+        tapped: Bool,
+        early: Bool,
+        reactionMs: Int?,
+        canTap: Bool
+    ) -> some View {
+        let isGo = phase == "go"
+        let tint: Color = early ? ACMColors.error : (isGo ? ACMColors.success : ACMColors.errorDim)
+        let title = GameStageTextPolicy.reactionTitle(phase: phase, tapped: tapped, early: early, reactionMs: reactionMs)
+        let subtitle: String = {
+            if early { return "You jumped the gun." }
+            if reactionMs != nil { return "Nice. Wait for the others." }
+            if tapped { return "Locked. Wait for the reveal." }
+            return isGo ? "Tap anywhere!" : "Green means go."
+        }()
+
+        return Button {
+            HapticManager.shared.trigger(.medium)
+            viewModel.sendGameMove(type: "tap")
+        } label: {
+            VStack(spacing: 8) {
+                Text(title)
+                    .font(ACMFont.trial(isGo && !tapped ? 44.0 : 30.0, weight: .bold))
+                    .foregroundStyle(Color.white)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+                Text(subtitle)
+                    .font(ACMFont.trial(14, weight: .medium))
+                    .foregroundStyle(Color.white.opacity(0.82))
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(tint, in: RoundedRectangle(cornerRadius: ACMRadius.lg, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .disabled(!canTap)
+        .accessibilityLabel(isGo ? "Tap now" : "Wait for green")
+    }
+
+    private func reactionResultsList(_ view: GameJSONValue?) -> some View {
+        let rows = GameDetailsPresentationPolicy.reactionResultRows(from: view)
+        return VStack(spacing: 8) {
+            if rows.isEmpty {
+                GameStageMetaLine(text: "Results are not available yet.")
+            } else {
+                ForEach(rows) { row in
+                    HStack(spacing: ACMSpacing.sm) {
+                        Text("\(row.rank)")
+                            .font(ACMFont.trial(14, weight: .bold))
+                            .foregroundStyle(row.isWinner ? ACMColors.primaryOrange : ACMColors.textFaint)
+                            .frame(width: 26, alignment: .center)
+                        Text(row.name)
+                            .font(ACMFont.trial(15, weight: .medium))
+                            .foregroundStyle(ACMColors.text)
+                            .lineLimit(1)
+                        Spacer(minLength: ACMSpacing.xs)
+                        Text(row.resultText)
+                            .font(ACMFont.trial(14, weight: .semibold))
+                            .foregroundStyle(row.isEarly ? ACMColors.error : ACMColors.textMuted)
+                    }
+                    .padding(.horizontal, ACMSpacing.md)
+                    .frame(minHeight: 46)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background {
+                        RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                            .fill(row.isWinner ? ACMColors.primaryOrange.opacity(0.10) : ACMColors.surfaceRaised)
+                    }
+                    .overlay {
+                        RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                            .strokeBorder(row.isWinner ? ACMColors.primaryOrange.opacity(0.34) : ACMColors.border, lineWidth: 1)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Most likely to
+
+struct MostLikelyStageView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let activeGame: GamePublicState
+    let playerView: GameJSONValue?
+    let canPlay: Bool
+    let canManage: Bool
+
+    var body: some View {
+        let publicView = activeGame.view
+        let phase = publicView?.string("phase") ?? activeGame.phase
+        let playerRows = publicView?.objectArray("players") ?? []
+        let players = playerRows.compactMap { GameDetailsPresentationPolicy.gamePlayerOption($0) }
+        let votedFor = playerView?.string("yourVote")
+        let voteCounts = GameDetailsPresentationPolicy.intMap(from: publicView, key: "counts")
+        let maxVoteCount = max(1, voteCounts.values.max() ?? 0)
+        let reveal = phase == "reveal"
+        let results = phase == "results"
+        let winnerId = publicView?.string("winnerId")
+        let canVote = canPlay && phase == "vote" && !viewModel.state.isGameActionInFlight
+
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: ACMSpacing.md) {
+                    GameStagePrompt(
+                        kicker: results ? "Results" : GameStageTextPolicy.progressKicker(publicView, fallback: "Vote"),
+                        title: results
+                            ? "That is a wrap"
+                            : (publicView?.string("prompt") ?? "Waiting for the prompt."),
+                        subtitle: mostLikelySupportLine(publicView, phase: phase)
+                    )
+
+                    if phase == "vote" || reveal {
+                        VStack(spacing: 8) {
+                            ForEach(players) { player in
+                                let voteCount = voteCounts[player.id] ?? 0
+                                GameStageChoiceCard(
+                                    title: player.name,
+                                    trailing: reveal && voteCount > 0 ? GameStageTextPolicy.voteCountText(voteCount) : nil,
+                                    isSelected: votedFor == player.id,
+                                    isCorrect: reveal ? player.id == winnerId : nil,
+                                    fillRatio: reveal ? Double(voteCount) / Double(maxVoteCount) : nil,
+                                    isDisabled: !canVote || reveal
+                                ) {
+                                    viewModel.sendGameMove(
+                                        type: "vote",
+                                        payload: GameJSONValue.object(["target": player.id])
+                                    )
+                                }
+                            }
+                        }
+                    } else if results {
+                        GameStageNotice(
+                            icon: "person.2.fill",
+                            androidIcon: "participants",
+                            title: "No hard feelings",
+                            subtitle: "The votes were cast. The friendships survive."
+                        )
+                    }
+                }
+                .padding(ACMSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if results {
+                GameStageResultsBar(viewModel: viewModel, canManage: canManage)
+            } else {
+                GameStageHostRoundBar(viewModel: viewModel, phase: phase, canManage: canManage)
+            }
+        }
+    }
+
+    private func mostLikelySupportLine(_ view: GameJSONValue?, phase: String) -> String? {
+        if phase == "reveal", let winner = view?.string("winnerName"), !winner.isEmpty {
+            return "Most votes: \(winner)"
+        }
+        if phase == "vote" {
+            return "Pick the person this fits best."
+        }
+        return nil
+    }
+}
+
+// MARK: - Would you rather
+
+struct WouldYouRatherStageView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let activeGame: GamePublicState
+    let playerView: GameJSONValue?
+    let canPlay: Bool
+    let canManage: Bool
+
+    var body: some View {
+        let publicView = activeGame.view
+        let phase = publicView?.string("phase") ?? activeGame.phase
+        let selected = playerView?.int("choice")
+        let counts = publicView?.intArray("counts") ?? []
+        let reveal = phase == "reveal"
+        let results = phase == "results"
+        let canChoose = canPlay && phase == "choose" && !viewModel.state.isGameActionInFlight
+
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: ACMSpacing.md) {
+                    GameStagePrompt(
+                        kicker: results ? "Results" : GameStageTextPolicy.progressKicker(publicView, fallback: "Would you rather"),
+                        title: reveal ? "The room split" : "Pick a side"
+                    )
+
+                    VStack(spacing: 10) {
+                        GameStageChoiceCard(
+                            title: publicView?.string("optionA") ?? "Option A",
+                            trailing: reveal && !counts.isEmpty ? "\(counts[0])" : nil,
+                            isSelected: selected == 0,
+                            isDisabled: !canChoose || reveal
+                        ) {
+                            viewModel.sendGameMove(
+                                type: "choose",
+                                payload: GameJSONValue.object(["option": 0])
+                            )
+                        }
+
+                        Text("or")
+                            .font(ACMFont.trial(12, weight: .semibold))
+                            .foregroundStyle(ACMColors.textFaint)
+                            .frame(maxWidth: .infinity, alignment: .center)
+
+                        GameStageChoiceCard(
+                            title: publicView?.string("optionB") ?? "Option B",
+                            trailing: reveal && counts.count > 1 ? "\(counts[1])" : nil,
+                            isSelected: selected == 1,
+                            isDisabled: !canChoose || reveal
+                        ) {
+                            viewModel.sendGameMove(
+                                type: "choose",
+                                payload: GameJSONValue.object(["option": 1])
+                            )
+                        }
+                    }
+
+                    if reveal {
+                        revealSplit(publicView)
+                    }
+                }
+                .padding(ACMSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if results {
+                GameStageResultsBar(viewModel: viewModel, canManage: canManage)
+            } else {
+                GameStageHostRoundBar(viewModel: viewModel, phase: phase, canManage: canManage)
+            }
+        }
+    }
+
+    private func revealSplit(_ view: GameJSONValue?) -> some View {
+        let counts = view?.intArray("counts") ?? []
+        let first = counts.count > 0 ? counts[0] : 0
+        let second = counts.count > 1 ? counts[1] : 0
+        let total = max(1, first + second)
+        let firstNames = GameDetailsPresentationPolicy.namesSummary(view?.stringArray("namesA") ?? [])
+        let secondNames = GameDetailsPresentationPolicy.namesSummary(view?.stringArray("namesB") ?? [])
+
+        return VStack(alignment: .leading, spacing: ACMSpacing.xs) {
+            GeometryReader { geometry in
+                HStack(spacing: 2) {
+                    Rectangle()
+                        .fill(ACMColors.primaryOrange)
+                        .frame(width: max(4.0, geometry.size.width * Double(first) / Double(total)))
+                    Rectangle()
+                        .fill(ACMColors.surfaceHover)
+                }
+            }
+            .frame(height: 10)
+            .clipShape(Capsule())
+
+            HStack(alignment: .top, spacing: ACMSpacing.sm) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(first) picked")
+                        .font(ACMFont.trial(12, weight: .semibold))
+                        .foregroundStyle(ACMColors.primaryOrange)
+                    Text(firstNames)
+                        .font(ACMFont.trial(12))
+                        .foregroundStyle(ACMColors.textFaint)
+                        .lineLimit(3)
+                }
+                Spacer(minLength: ACMSpacing.sm)
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("\(second) picked")
+                        .font(ACMFont.trial(12, weight: .semibold))
+                        .foregroundStyle(ACMColors.textMuted)
+                    Text(secondNames)
+                        .font(ACMFont.trial(12))
+                        .foregroundStyle(ACMColors.textFaint)
+                        .lineLimit(3)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Bluff
+
+struct BluffStageView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let activeGame: GamePublicState
+    let playerView: GameJSONValue?
+    let canPlay: Bool
+    let canManage: Bool
+
+    @State private var bluffAnswerInput = ""
+
+    private var trimmedBluffAnswer: String {
+        bluffAnswerInput.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var bluffAnswerBinding: Binding<String> {
+        Binding(
+            get: { bluffAnswerInput },
+            set: { value in
+                bluffAnswerInput = String(value.prefix(60))
+            }
+        )
+    }
+
+    var body: some View {
+        let publicView = activeGame.view
+        let phase = publicView?.string("phase") ?? activeGame.phase
+        let question = publicView?.string("question") ?? "Waiting for the prompt."
+        let submitted = playerView?.bool("submitted") ?? false
+        let yourFake = playerView?.string("yourFake")
+        let yourPick = playerView?.string("yourPick")
+        let ownOptionId = playerView?.string("ownOptionId")
+        let score = playerView?.int("score")
+        let optionRows = publicView?.objectArray("options") ?? []
+        let options = optionRows.compactMap { GameStageTextPolicy.bluffOption($0) }
+        let results = phase == "results"
+        let canSubmit = canPlay
+            && phase == "write"
+            && !submitted
+            && !trimmedBluffAnswer.isEmpty
+            && !viewModel.state.isGameActionInFlight
+        let canChoose = canPlay && phase == "choose" && !viewModel.state.isGameActionInFlight
+
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: ACMSpacing.md) {
+                    GameStagePrompt(
+                        kicker: GameStageTextPolicy.bluffTitle(publicView, phase: phase),
+                        title: results ? GameStageTextPolicy.triviaWinnerText(publicView) : question
+                    )
+
+                    if phase == "write" {
+                        if submitted {
+                            GameStageMetaLine(text: GameStageTextPolicy.bluffSubmittedText(yourFake))
+                        } else if canPlay {
+                            bluffComposer(canSubmit: canSubmit)
+                        }
+                    } else if phase == "choose" {
+                        VStack(spacing: 8) {
+                            ForEach(options) { option in
+                                let isOwnOption = option.id == ownOptionId
+                                GameStageChoiceCard(
+                                    title: option.text,
+                                    subtitle: isOwnOption ? "Your bluff" : nil,
+                                    isSelected: yourPick == option.id,
+                                    isDisabled: !canChoose || isOwnOption
+                                ) {
+                                    viewModel.sendGameMove(
+                                        type: "choose",
+                                        payload: GameJSONValue.object(["optionId": option.id])
+                                    )
+                                }
+                            }
+                        }
+                    } else if phase == "reveal" {
+                        VStack(spacing: 8) {
+                            ForEach(options) { option in
+                                GameStageChoiceCard(
+                                    title: option.text,
+                                    subtitle: option.subtitle,
+                                    isSelected: yourPick == option.id,
+                                    isCorrect: option.isReal,
+                                    isDisabled: true
+                                ) {}
+                            }
+                        }
+                        if let roundPoints = GameDetailsPresentationPolicy.roundPointsSummary(from: publicView) {
+                            GameStageMetaLine(text: roundPoints)
+                        }
+                    } else if results {
+                        GameStageScoreboard(rows: GameDetailsPresentationPolicy.scoreboardRows(from: publicView))
+                    }
+
+                    if let score, !results {
+                        GameStageMetaLine(text: "\(score) points")
+                    }
+                }
+                .padding(ACMSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if results {
+                GameStageResultsBar(viewModel: viewModel, canManage: canManage)
+            } else if canManage {
+                bluffHostBar(phase: phase)
+            }
+        }
+        #if SKIP
+        .onChange(of: phase) {
+            bluffAnswerInput = ""
+        }
+        #else
+        .onChange(of: phase) {
+            bluffAnswerInput = ""
+        }
+        #endif
+    }
+
+    private func bluffComposer(canSubmit: Bool) -> some View {
+        VStack(alignment: .leading, spacing: ACMSpacing.sm) {
+            TextField("", text: bluffAnswerBinding, prompt: Text("Write something believable").foregroundStyle(ACMColors.textFaint))
+                .font(ACMFont.trial(15))
+                .foregroundStyle(ACMColors.text)
+                .tint(ACMColors.primaryOrange)
+                #if !SKIP
+                .autocorrectionDisabled(false)
+                #endif
+                .padding(.horizontal, ACMSpacing.md)
+                .frame(minHeight: 50)
+                .background {
+                    RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                        .fill(ACMColors.surfaceRaised)
+                }
+                .overlay {
+                    RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                        .strokeBorder(lineWidth: 1)
+                        .foregroundStyle(ACMColors.border)
+                }
+                .submitLabel(SubmitLabel.send)
+                .onSubmit {
+                    if canSubmit {
+                        submitBluffAnswer()
+                    }
+                }
+
+            GameStageActionButton(
+                title: "Submit bluff",
+                isDisabled: !canSubmit
+            ) {
+                submitBluffAnswer()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func bluffHostBar(phase: String) -> some View {
+        if phase == "write" || phase == "choose" {
+            GameStageBottomBar {
+                GameStageActionButton(
+                    title: phase == "write" ? "Skip writing" : "Reveal now",
+                    isPrimary: false,
+                    tint: ACMColors.text,
+                    isDisabled: viewModel.state.isGameActionInFlight
+                ) {
+                    viewModel.sendGameMove(type: "skip")
+                }
+            }
+        } else if phase == "reveal" {
+            GameStageBottomBar {
+                GameStageActionButton(
+                    title: "Next",
+                    isDisabled: viewModel.state.isGameActionInFlight
+                ) {
+                    viewModel.sendGameMove(type: "next")
+                }
+            }
+        }
+    }
+
+    private func submitBluffAnswer() {
+        let answer = trimmedBluffAnswer
+        guard !answer.isEmpty else { return }
+        viewModel.sendGameMove(
+            type: "submit",
+            payload: GameJSONValue.object(["text": answer])
+        )
+        bluffAnswerInput = ""
+    }
+}
+
+// MARK: - Imposter
+
+struct ImposterStageView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let activeGame: GamePublicState
+    let playerView: GameJSONValue?
+    let canPlay: Bool
+    let canManage: Bool
+
+    var body: some View {
+        let publicView = activeGame.view
+        let phase = publicView?.string("phase") ?? activeGame.phase
+        let playerRows = publicView?.objectArray("players") ?? []
+        let players = playerRows.compactMap { GameDetailsPresentationPolicy.gamePlayerOption($0) }
+        let yourVote = playerView?.string("yourVote")
+        let isImposter = playerView?.string("role") == "imposter"
+        let canVote = canPlay && phase == "vote" && !viewModel.state.isGameActionInFlight
+
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: ACMSpacing.md) {
+                    if (phase == "reveal" || phase == "discuss") && canPlay {
+                        imposterRoleCard(isImposter: isImposter)
+                    }
+
+                    GameStagePrompt(
+                        kicker: phase == "result" ? "Result" : GameStageTextPolicy.phaseLabel(phase),
+                        title: GameStageTextPolicy.imposterTitle(publicView: publicView, playerView: playerView, phase: phase),
+                        subtitle: GameStageTextPolicy.imposterSubtitle(publicView: publicView, playerView: playerView, phase: phase)
+                    )
+
+                    if phase == "vote" {
+                        VStack(spacing: 8) {
+                            ForEach(players) { player in
+                                let isSelf = viewModel.state.isLocalIdentityUserId(player.id)
+                                GameStageChoiceCard(
+                                    title: player.name,
+                                    subtitle: GameStageTextPolicy.imposterVoteSubtitle(publicView, playerId: player.id, isSelf: isSelf),
+                                    isSelected: yourVote == player.id,
+                                    isDisabled: !canVote || isSelf
+                                ) {
+                                    viewModel.sendGameMove(
+                                        type: "vote",
+                                        payload: GameJSONValue.object(["target": player.id])
+                                    )
+                                }
+                            }
+                        }
+                    } else if phase == "result" {
+                        imposterResultDetails(publicView)
+                    }
+                }
+                .padding(ACMSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            imposterHostBar(phase: phase)
+        }
+    }
+
+    /// Your secret, styled so a shoulder-surfer reads it less easily than a
+    /// plain headline. Imposters get the warning tone instead of a word.
+    private func imposterRoleCard(isImposter: Bool) -> some View {
+        HStack(spacing: ACMSpacing.sm) {
+            ACMSystemIcon.icon(
+                isImposter ? "eye.slash.fill" : "checkmark.seal.fill",
+                android: isImposter ? "ghost" : "check",
+                size: 18,
+                tint: isImposter ? "error" : "accent"
+            )
+            .foregroundStyle(isImposter ? ACMColors.error : ACMColors.primaryOrange)
+
+            Text(isImposter ? "You are the imposter" : "You know the word")
+                .font(ACMFont.trial(14, weight: .semibold))
+                .foregroundStyle(ACMColors.text)
+                .lineLimit(1)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, ACMSpacing.md)
+        .frame(minHeight: 46)
+        .background {
+            RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                .fill(isImposter ? ACMColors.error.opacity(0.10) : ACMColors.primaryOrangeFaint)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                .strokeBorder(isImposter ? ACMColors.error.opacity(0.34) : ACMColors.primaryOrange.opacity(0.34), lineWidth: 1)
+        }
+    }
+
+    @ViewBuilder
+    private func imposterResultDetails(_ view: GameJSONValue?) -> some View {
+        if let result = view?.dictionaryValue?["result"] as? [String: Any] {
+            let word = (result["word"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let imposter = (result["imposterName"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let votedOut = (result["votedOutName"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            VStack(alignment: .leading, spacing: 6) {
+                if !word.isEmpty {
+                    GameStageMetaLine(text: "Word: \(word)")
+                }
+                if !imposter.isEmpty {
+                    GameStageMetaLine(text: "Imposter: \(imposter)")
+                }
+                if !votedOut.isEmpty {
+                    GameStageMetaLine(text: "Voted out: \(votedOut)")
+                }
+            }
+        } else {
+            GameStageMetaLine(text: "Result pending")
+        }
+    }
+
+    @ViewBuilder
+    private func imposterHostBar(phase: String) -> some View {
+        if canManage {
+            if phase == "discuss" {
+                GameStageBottomBar {
+                    GameStageActionButton(
+                        title: "Call the vote",
+                        isDisabled: viewModel.state.isGameActionInFlight
+                    ) {
+                        viewModel.sendGameMove(type: "callVote")
+                    }
+                }
+            } else if phase == "vote" {
+                GameStageBottomBar {
+                    GameStageActionButton(
+                        title: "End vote",
+                        isDisabled: viewModel.state.isGameActionInFlight
+                    ) {
+                        viewModel.sendGameMove(type: "tally")
+                    }
+                }
+            } else if phase == "result" {
+                GameStageResultsBar(viewModel: viewModel, canManage: canManage)
+            }
+        }
+    }
+}
+
+// MARK: - Wordle
+
+/// Wordle already has a full native round UI; the stage wraps it in the
+/// scroll frame it expects.
+struct WordleStageView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let activeGame: GamePublicState
+    let playerView: GameJSONValue?
+    let canPlay: Bool
+    let canManage: Bool
+
+    var body: some View {
+        ScrollView {
+            WordleGameView(
+                viewModel: viewModel,
+                activeGame: activeGame,
+                publicView: activeGame.view,
+                playerView: playerView,
+                canPlay: canPlay,
+                canManage: canManage
+            )
+            .padding(.horizontal, ACMSpacing.xs)
+            .padding(.vertical, ACMSpacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GameStageView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GameStageView.swift
@@ -1,0 +1,538 @@
+import SwiftUI
+import Observation
+
+// The active game owns the meeting stage: a full game surface framed like the
+// shared-app stage, with the room kept visible in a thumbnail strip. The games
+// sheet only launches games; play happens here.
+
+struct GameStageLayoutView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let isCompact: Bool
+
+    private let controlsOverlap: CGFloat = 8
+
+    var body: some View {
+        let _ = PerformanceDiagnostics.render("GameStageLayoutView") {
+            "game=\(viewModel.state.gamePublicState?.gameId ?? "none") phase=\(viewModel.state.gamePublicState?.phase ?? "-")"
+        }
+        GeometryReader { geo in
+            if isCompact {
+                compactLayout(size: geo.size)
+            } else {
+                regularLayout
+            }
+        }
+    }
+
+    private func compactLayout(size: CGSize) -> some View {
+        let availableHeight = MeetingStageLayout.visibleHeight(
+            containerHeight: size.height,
+            controlsOverlap: controlsOverlap
+        )
+        let strip = viewModel.state.tileStripSnapshot()
+        return VStack(spacing: 8) {
+            gameStage
+                .frame(maxWidth: .infinity)
+                .frame(maxHeight: .infinity)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    if strip.shouldShowSelfTile {
+                        localThumbnail
+                    }
+                    ForEach(strip.participants) { participant in
+                        remoteThumbnail(participant: participant)
+                    }
+                }
+                .padding(.horizontal, 8)
+            }
+            .frame(height: 64)
+        }
+        .frame(width: size.width, height: availableHeight, alignment: .top)
+        .padding(8)
+    }
+
+    private var regularLayout: some View {
+        let strip = viewModel.state.tileStripSnapshot()
+        return HStack(spacing: 8) {
+            gameStage
+
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 8) {
+                    if strip.shouldShowSelfTile {
+                        localThumbnail
+                    }
+                    ForEach(strip.participants) { participant in
+                        remoteThumbnail(participant: participant)
+                    }
+                }
+                .padding(8)
+            }
+            .frame(width: 148)
+            .acmColorBackground(ACMColors.bgAlt)
+            .clipShape(RoundedRectangle(cornerRadius: ACMRadius.lg))
+        }
+        .padding(8)
+    }
+
+    private var gameStage: some View {
+        VStack(spacing: 0) {
+            if let activeGame = viewModel.state.gamePublicState {
+                GameStageChromeView(viewModel: viewModel, activeGame: activeGame)
+
+                Rectangle()
+                    .fill(ACMColors.border)
+                    .frame(height: 1)
+
+                if let errorMessage = viewModel.state.gameErrorMessage {
+                    GameStageErrorLine(message: errorMessage)
+                }
+
+                GameStageBodyView(viewModel: viewModel, activeGame: activeGame)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .acmColorBackground(ACMColors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: ACMRadius.lg))
+        .overlay {
+            RoundedRectangle(cornerRadius: ACMRadius.lg)
+                .strokeBorder(lineWidth: 1)
+                .foregroundStyle(ACMColors.border)
+        }
+        .overlay {
+            if viewModel.state.shouldShowDetachedSelfView && !viewModel.state.shouldShowSelfTile {
+                DetachedSelfViewOverlay(
+                    viewModel: viewModel,
+                    isCompact: isCompact,
+                    edgeInsets: MeetingDetachedSelfLayout.edgeInsets(isCompact: isCompact)
+                )
+            }
+        }
+    }
+
+    private var thumbnailWidth: CGFloat { isCompact ? 100.0 : 124.0 }
+    private var thumbnailHeight: CGFloat { isCompact ? 56.0 : 70.0 }
+
+    private var localThumbnail: some View {
+        let localVideoTrack = viewModel.webRTCClient.getLocalVideoTrack()
+        let captureSession = (!viewModel.state.isCameraOff && localVideoTrack == nil) ? viewModel.webRTCClient.getCaptureSession() : nil
+        return VideoGridItem(
+            displayName: viewModel.displayNameForUser(viewModel.state.userId),
+            isMuted: viewModel.state.isMuted,
+            isCameraOff: viewModel.state.isCameraOff,
+            isHandRaised: viewModel.state.isHandRaised,
+            isSpeaking: viewModel.state.isEffectiveActiveSpeaker(viewModel.state.userId),
+            isLocal: true,
+            isThumbnail: true,
+            avatarSizeOverride: 30.0,
+            localCameraFacing: viewModel.localCameraFacing,
+            captureSession: captureSession,
+            localVideoTrack: localVideoTrack
+        )
+        .frame(width: thumbnailWidth, height: thumbnailHeight)
+    }
+
+    private func remoteThumbnail(participant: Participant) -> some View {
+        VideoGridItem(
+            displayName: viewModel.displayNameForUser(participant.id),
+            isMuted: participant.isMuted,
+            isCameraOff: participant.isCameraOff,
+            isHandRaised: participant.isHandRaised,
+            isSpeaking: viewModel.state.isEffectiveActiveSpeaker(participant.id),
+            isLocal: false,
+            connectionStatus: participant.connectionStatus,
+            isThumbnail: true,
+            avatarSizeOverride: 30.0,
+            trackWrapper: viewModel.webRTCClient.remoteVideoTrack(forUserId: participant.id)
+        )
+        .frame(width: thumbnailWidth, height: thumbnailHeight)
+    }
+}
+
+// MARK: - Chrome
+
+/// Compact top bar of the stage: identity, live status, seat state, and the
+/// host's end control (armed, so one stray tap cannot kill the round).
+struct GameStageChromeView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let activeGame: GamePublicState
+    @State private var endArmed = false
+    @State private var endArmTask: Task<Void, Never>?
+
+    private var canManage: Bool {
+        viewModel.state.isAdmin
+            && viewModel.state.connectionState == .joined
+            && !viewModel.state.isWebinarAttendee
+    }
+
+    private var isPlayer: Bool {
+        viewModel.state.hasLocalGamePlayer(in: activeGame.players)
+    }
+
+    private var isPendingJoiner: Bool {
+        guard let pending = activeGame.pendingJoiners else { return false }
+        return viewModel.state.hasLocalGamePlayer(in: pending)
+    }
+
+    private var statusLine: String {
+        var parts = [GameStageTextPolicy.playersLine(count: activeGame.players.count)]
+        if let pending = activeGame.pendingJoiners, !pending.isEmpty {
+            parts.append("+\(pending.count) joining")
+        }
+        parts.append(GameStageTextPolicy.phaseLabel(activeGame.phase))
+        return parts.joined(separator: " · ")
+    }
+
+    var body: some View {
+        let visual = GameCatalogPresentationPolicy.visual(for: activeGame.gameId)
+        HStack(spacing: ACMSpacing.sm) {
+            Circle()
+                .fill(ACMColors.primaryOrangeFaint)
+                .frame(width: 34, height: 34)
+                .overlay {
+                    ACMSystemIcon.icon(visual.icon, android: visual.androidIcon, size: 16, tint: "accent")
+                        .foregroundStyle(ACMColors.primaryOrange)
+                }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(activeGame.name)
+                    .font(ACMFont.trial(15, weight: .semibold))
+                    .foregroundStyle(ACMColors.text)
+                    .lineLimit(1)
+                Text(statusLine)
+                    .font(ACMFont.trial(11))
+                    .foregroundStyle(ACMColors.textFaint)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: ACMSpacing.xs)
+
+            if !isPlayer {
+                seatStateView
+            }
+
+            if canManage {
+                endButton
+            }
+        }
+        .padding(.horizontal, ACMSpacing.sm)
+        .padding(.vertical, ACMSpacing.xs)
+        .onDisappear {
+            endArmTask?.cancel()
+            endArmTask = nil
+        }
+    }
+
+    @ViewBuilder
+    private var seatStateView: some View {
+        if isPendingJoiner {
+            MeetingSheetStatusPill(
+                "Joining next round",
+                tint: ACMColors.primaryOrange,
+                background: ACMColors.primaryOrange.opacity(0.14),
+                border: ACMColors.primaryOrange.opacity(0.34)
+            )
+        } else if activeGame.canJoinLate == true && !viewModel.state.isWebinarAttendee {
+            Button {
+                viewModel.joinActiveGame()
+            } label: {
+                Text("Join")
+                    .font(ACMFont.trial(13, weight: .semibold))
+                    .foregroundStyle(Color.white)
+                    .padding(.horizontal, 14)
+                    .frame(height: 32)
+                    .background(ACMColors.primaryOrange, in: Capsule())
+            }
+            .buttonStyle(.plain)
+            .disabled(viewModel.state.isGameActionInFlight)
+            .opacity(viewModel.state.isGameActionInFlight ? 0.6 : 1.0)
+            .accessibilityLabel("Join the game")
+        } else {
+            MeetingSheetStatusPill("Watching")
+        }
+    }
+
+    private var endButton: some View {
+        Button {
+            if endArmed {
+                endArmTask?.cancel()
+                endArmTask = nil
+                endArmed = false
+                viewModel.endActiveGame()
+            } else {
+                endArmed = true
+                endArmTask?.cancel()
+                endArmTask = Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    guard !Task.isCancelled else { return }
+                    endArmed = false
+                    endArmTask = nil
+                }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                ACMSystemIcon.icon("xmark", android: "close", size: 11, tint: "error")
+                    .foregroundStyle(ACMColors.error)
+                Text(endArmed ? "Sure?" : "End")
+                    .font(ACMFont.trial(12, weight: .semibold))
+                    .foregroundStyle(ACMColors.error)
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 32)
+            .background {
+                Capsule().fill(endArmed ? ACMColors.error.opacity(0.16) : ACMColors.surfaceRaised)
+            }
+            .overlay {
+                Capsule().strokeBorder(lineWidth: 1).foregroundStyle(endArmed ? ACMColors.error.opacity(0.5) : ACMColors.border)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.state.isGameActionInFlight)
+        .accessibilityLabel(endArmed ? "Confirm end game" : "End game")
+    }
+}
+
+struct GameStageErrorLine: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ACMSystemIcon.icon("exclamationmark.triangle.fill", android: "warning", size: 12, tint: "error")
+                .foregroundStyle(ACMColors.error)
+            Text(message)
+                .font(ACMFont.trial(12, weight: .medium))
+                .foregroundStyle(ACMColors.error)
+                .lineLimit(2)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, ACMSpacing.md)
+        .padding(.vertical, 6)
+        .acmColorBackground(ACMColors.error.opacity(0.10))
+    }
+}
+
+// MARK: - Body dispatch
+
+/// Picks the right surface for the current game and phase. Kept narrow so a
+/// phase change only rebuilds the game area, never the whole stage frame.
+struct GameStageBodyView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let activeGame: GamePublicState
+
+    private var isPlayer: Bool {
+        viewModel.state.hasLocalGamePlayer(in: activeGame.players)
+    }
+
+    private var playerView: GameJSONValue? {
+        guard viewModel.state.gamePlayerView?.gameId == activeGame.gameId else { return nil }
+        return viewModel.state.gamePlayerView?.view
+    }
+
+    private var canPlay: Bool {
+        viewModel.state.connectionState == .joined
+            && !viewModel.state.isWebinarAttendee
+            && isPlayer
+    }
+
+    private var canManage: Bool {
+        viewModel.state.isAdmin
+            && viewModel.state.connectionState == .joined
+            && !viewModel.state.isWebinarAttendee
+    }
+
+    var body: some View {
+        if activeGame.phase == "lobby" {
+            GameStageLobbyView(viewModel: viewModel, activeGame: activeGame, canManage: canManage)
+        } else if !isPlayer && activeGame.view == nil {
+            // This game keeps its state secret from spectators (imposter).
+            GameStageNotice(
+                icon: "eye.slash",
+                androidIcon: "ghost",
+                title: "Round in progress",
+                subtitle: "This game hides its round from spectators. You can join the next one."
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            switch activeGame.gameId {
+            case "trivia":
+                TriviaStageView(viewModel: viewModel, activeGame: activeGame, playerView: playerView, canPlay: canPlay, canManage: canManage)
+            case "reaction":
+                ReactionStageView(viewModel: viewModel, activeGame: activeGame, playerView: playerView, canPlay: canPlay, canManage: canManage)
+            case "most-likely-to":
+                MostLikelyStageView(viewModel: viewModel, activeGame: activeGame, playerView: playerView, canPlay: canPlay, canManage: canManage)
+            case "would-you-rather":
+                WouldYouRatherStageView(viewModel: viewModel, activeGame: activeGame, playerView: playerView, canPlay: canPlay, canManage: canManage)
+            case "bluff":
+                BluffStageView(viewModel: viewModel, activeGame: activeGame, playerView: playerView, canPlay: canPlay, canManage: canManage)
+            case "imposter":
+                ImposterStageView(viewModel: viewModel, activeGame: activeGame, playerView: playerView, canPlay: canPlay, canManage: canManage)
+            case "wordle":
+                WordleStageView(viewModel: viewModel, activeGame: activeGame, playerView: playerView, canPlay: canPlay, canManage: canManage)
+            default:
+                GenericGameStageView(viewModel: viewModel, activeGame: activeGame, canManage: canManage)
+            }
+        }
+    }
+}
+
+// MARK: - Lobby
+
+struct GameStageLobbyView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let activeGame: GamePublicState
+    let canManage: Bool
+
+    private var players: [GamePlayer] {
+        activeGame.players
+    }
+
+    private var pendingJoiners: [GamePlayer] {
+        activeGame.pendingJoiners ?? []
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: ACMSpacing.md) {
+                    GameStagePrompt(
+                        kicker: "Lobby",
+                        title: "Waiting to start",
+                        subtitle: canManage
+                            ? "Start when everyone is in."
+                            : "The host starts the game."
+                    )
+
+                    if !players.isEmpty {
+                        playerChipGrid
+                    }
+                }
+                .padding(ACMSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if canManage {
+                GameStageBottomBar {
+                    GameStageActionButton(
+                        title: "Start game",
+                        isDisabled: viewModel.state.isGameActionInFlight
+                    ) {
+                        viewModel.sendGameMove(type: "start")
+                    }
+                }
+            }
+        }
+    }
+
+    private var playerChipGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 130), spacing: 8, alignment: .leading)],
+            alignment: .leading,
+            spacing: 8
+        ) {
+            ForEach(players) { player in
+                GameStagePlayerChip(id: player.id, name: player.name)
+            }
+            ForEach(pendingJoiners) { player in
+                GameStagePlayerChip(id: player.id, name: player.name, isPending: true)
+            }
+        }
+    }
+}
+
+// MARK: - Generic fallback
+
+struct GenericGameStageView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let activeGame: GamePublicState
+    let canManage: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: ACMSpacing.md) {
+                    GameStagePrompt(
+                        kicker: activeGame.name,
+                        title: GameStageTextPolicy.phaseLabel(activeGame.phase),
+                        subtitle: GameStageTextPolicy.playersLine(count: activeGame.players.count)
+                    )
+                }
+                .padding(ACMSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            GameStageHostRoundBar(viewModel: viewModel, phase: activeGame.phase, canManage: canManage)
+        }
+    }
+}
+
+// MARK: - Shared bars
+
+/// Pinned bottom action area of the stage card.
+struct GameStageBottomBar<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        HStack(spacing: ACMSpacing.sm) {
+            content
+        }
+        .padding(.horizontal, ACMSpacing.md)
+        .padding(.vertical, ACMSpacing.sm)
+        .frame(maxWidth: .infinity)
+        .overlay(alignment: .top) {
+            Rectangle().fill(ACMColors.border).frame(height: 1)
+        }
+    }
+}
+
+/// Standard host controls for question/vote/choose/reveal round flows.
+struct GameStageHostRoundBar: View {
+    @Bindable var viewModel: MeetingViewModel
+    let phase: String
+    let canManage: Bool
+    var skipTitle: String? = nil
+
+    var body: some View {
+        if canManage {
+            if phase == "question" || phase == "vote" || phase == "choose" {
+                GameStageBottomBar {
+                    GameStageActionButton(
+                        title: skipTitle ?? (phase == "question" ? "Skip question" : "Reveal now"),
+                        isPrimary: false,
+                        tint: ACMColors.text,
+                        isDisabled: viewModel.state.isGameActionInFlight
+                    ) {
+                        viewModel.sendGameMove(type: "skip")
+                    }
+                }
+            } else if phase == "reveal" {
+                GameStageBottomBar {
+                    GameStageActionButton(
+                        title: "Next",
+                        isDisabled: viewModel.state.isGameActionInFlight
+                    ) {
+                        viewModel.sendGameMove(type: "next")
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Results bar: the host can run it back or close it out.
+struct GameStageResultsBar: View {
+    @Bindable var viewModel: MeetingViewModel
+    let canManage: Bool
+
+    var body: some View {
+        if canManage {
+            GameStageBottomBar {
+                GameStageActionButton(
+                    title: "Play again",
+                    isDisabled: viewModel.state.isGameActionInFlight
+                ) {
+                    viewModel.rematchActiveGame()
+                }
+            }
+        }
+    }
+}

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingView.swift
@@ -428,6 +428,15 @@ struct MeetingView: View {
                     isCompact: !isRegularSizeClass
                 )
             )
+        } else if viewModel.state.gamePublicState != nil {
+            // A running game owns the stage; play is interactive and timed,
+            // so it outranks a passive screen share on a phone.
+            stageSwapTransition(
+                GameStageLayoutView(
+                    viewModel: viewModel,
+                    isCompact: !isRegularSizeClass
+                )
+            )
         } else if viewModel.state.hasActiveScreenShare {
             stageSwapTransition(
                 PresentationLayoutView(

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift
@@ -8893,6 +8893,25 @@ final class MeetingViewModel {
         }
     }
 
+    /// Ask for a seat in the running game; the server grants it at the next
+    /// round boundary.
+    func joinActiveGame() {
+        performGameAction(requiresAdmin: false) {
+            try await self.socketManager.joinGame()
+        }
+    }
+
+    /// Start the same game again with the config the server reported for the
+    /// finished session (falls back to defaults when absent).
+    func rematchActiveGame() {
+        guard let publicState = state.gamePublicState, publicState.finished else { return }
+        let gameId = publicState.gameId
+        let options = publicState.config
+        performGameAction(requiresAdmin: true) {
+            try await self.socketManager.startGame(gameId: gameId, options: options)
+        }
+    }
+
     func openGameVote(candidateIds: [String]? = nil) {
         performGameAction(requiresAdmin: true) {
             try await self.socketManager.openGameVote(candidateIds: candidateIds)

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/MoreSheetView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/MoreSheetView.swift
@@ -265,7 +265,15 @@ struct MoreSheetView: View {
                 }
 
                 if canShowGamesSection {
-                    MoreRow(icon: "gamecontroller.fill", androidIcon: "sports_esports", title: "Games", showsChevron: true) {
+                    let liveGameName = viewModel.state.gamePublicState?.name
+                    MoreRow(
+                        icon: "gamecontroller.fill",
+                        androidIcon: "sports_esports",
+                        title: liveGameName.map { "Games · \($0) live" } ?? "Games",
+                        tint: liveGameName == nil ? ACMColors.text : ACMColors.primaryOrange,
+                        androidTint: liveGameName == nil ? "text" : "accent",
+                        showsChevron: true
+                    ) {
                         onOpenGames()
                     }
                 }
@@ -1509,87 +1517,15 @@ enum SharedBrowserURLDraftSyncPolicy {
     }
 }
 
-struct GameCatalogVisual: Equatable {
-    let icon: String
-    let androidIcon: String
-}
-
-enum GameCatalogPresentationPolicy {
-    static func visual(for gameId: String) -> GameCatalogVisual {
-        switch gameId {
-        case "trivia":
-            return GameCatalogVisual(icon: "questionmark.circle.fill", androidIcon: "info")
-        case "bluff":
-            return GameCatalogVisual(icon: "theatermasks.fill", androidIcon: "forum")
-        case "would-you-rather":
-            return GameCatalogVisual(icon: "arrow.left.arrow.right", androidIcon: "arrow.forward")
-        case "most-likely-to":
-            return GameCatalogVisual(icon: "person.2.fill", androidIcon: "participants")
-        case "reaction":
-            return GameCatalogVisual(icon: "bolt.fill", androidIcon: "warning")
-        case "imposter":
-            return GameCatalogVisual(icon: "eye.slash.fill", androidIcon: "ghost")
-        case "wordle":
-            return GameCatalogVisual(icon: "square.grid.3x3.fill", androidIcon: "grid")
-        default:
-            return GameCatalogVisual(icon: "gamecontroller.fill", androidIcon: "sports_esports")
-        }
-    }
-
-    static func catalogSubtitle(_ game: GameCatalogEntry) -> String {
-        let description = game.description.trimmingCharacters(in: .whitespacesAndNewlines)
-        return description.isEmpty ? playerRange(game) : description
-    }
-
-    static func playerRange(_ game: GameCatalogEntry) -> String {
-        if game.minPlayers == game.maxPlayers {
-            return "\(game.minPlayers)"
-        }
-        return "\(game.minPlayers)-\(game.maxPlayers)"
-    }
-
-    static func canOpenVote(catalogCount: Int, isActionInFlight: Bool) -> Bool {
-        !isActionInFlight && catalogCount >= 2
-    }
-
-    static func shouldShowDivider(after index: Int, total: Int, hasFooter: Bool) -> Bool {
-        index < total - 1 || hasFooter
-    }
-}
-
-enum GameVotePresentationPolicy {
-    static func leader(in vote: GameVoteState) -> GameCatalogEntry? {
-        var leader: GameCatalogEntry?
-        var leaderVotes = -1
-        for entry in vote.candidates {
-            let count = vote.tally[entry.id] ?? 0
-            if count > leaderVotes {
-                leader = entry
-                leaderVotes = count
-            }
-        }
-        return leader
-    }
-
-    static func startLeaderTitle(_ vote: GameVoteState) -> String {
-        guard let leader = leader(in: vote) else { return "Start leader" }
-        let votes = vote.tally[leader.id] ?? 0
-        return votes > 0 ? "Start \(leader.name)" : "Start leader"
-    }
-
-    static func shouldShowCandidateDivider(after index: Int, total: Int, hasHostActions: Bool) -> Bool {
-        index < total - 1 || hasHostActions
-    }
-}
-
 struct GamesSheetView: View {
     @Bindable var viewModel: MeetingViewModel
     var bodyReady: Bool = true
     var onBack: (() -> Void)? = nil
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.meetingSheetCloseAction) private var meetingSheetCloseAction
     @State private var configuringGame: GameCatalogEntry?
     @State private var gameConfigDrafts: [String: GameConfigValue] = [:]
-    @State private var bluffAnswerInput = ""
+    @State private var observedActiveGameId = ""
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1606,28 +1542,20 @@ struct GamesSheetView: View {
                             errorSection(message)
                         }
 
-                        if let configuringGame,
-                           canManageGames,
-                           viewModel.state.gamePublicState == nil,
-                           viewModel.state.gameVote == nil {
+                        if let activeGame = viewModel.state.gamePublicState {
+                            liveGameSection(activeGame)
+                        } else if let configuringGame, canManageGames, viewModel.state.gameVote == nil {
                             configSection(configuringGame)
-                        } else if let activeGame = viewModel.state.gamePublicState {
-                            activeGameSection(activeGame)
-                        }
+                        } else {
+                            if let vote = viewModel.state.gameVote {
+                                voteSection(vote)
+                            }
 
-                        if configuringGame == nil,
-                           let vote = viewModel.state.gameVote {
-                            voteSection(vote)
-                        }
-
-                        if configuringGame == nil &&
-                            canManageGames &&
-                            viewModel.state.gamePublicState == nil {
-                            catalogSection
-                        } else if configuringGame == nil &&
-                                    viewModel.state.gamePublicState == nil &&
-                                    viewModel.state.gameVote == nil {
-                            idleSection
+                            if canManageGames {
+                                catalogSection
+                            } else if viewModel.state.gameVote == nil {
+                                idleSection
+                            }
                         }
                     }
                     .padding(.horizontal, ACMSpacing.lg)
@@ -1646,18 +1574,33 @@ struct GamesSheetView: View {
         #endif
         .onAppear {
             viewModel.refreshGameState()
+            observedActiveGameId = viewModel.state.gamePublicState?.gameId ?? ""
         }
         .onChange(of: viewModel.state.gamePublicState?.gameId ?? "") {
             let gameId = viewModel.state.gamePublicState?.gameId ?? ""
+            let wasActive = !observedActiveGameId.isEmpty
+            observedActiveGameId = gameId
             if !gameId.isEmpty {
                 cancelConfiguringGame()
+                // A game just went live while this sheet was open: get out of
+                // the way so the stage can show it.
+                if !wasActive {
+                    closeSheet()
+                }
             }
-            bluffAnswerInput = ""
         }
         .onChange(of: viewModel.state.gameVote?.totalPlayers ?? -1) {
             if viewModel.state.gameVote != nil {
                 cancelConfiguringGame()
             }
+        }
+    }
+
+    private func closeSheet() {
+        if let close = meetingSheetCloseAction.close {
+            close()
+        } else {
+            dismiss()
         }
     }
 
@@ -1674,7 +1617,9 @@ struct GamesSheetView: View {
         }
     }
 
-    private func activeGameSection(_ activeGame: GamePublicState) -> some View {
+    /// The game itself lives on the meeting stage now; the sheet only offers
+    /// a pointer back to it plus host controls.
+    private func liveGameSection(_ activeGame: GamePublicState) -> some View {
         let visual = GameCatalogPresentationPolicy.visual(for: activeGame.gameId)
         return VStack(alignment: .leading, spacing: ACMSpacing.xs) {
             acmListSectionHeader("Active game")
@@ -1684,15 +1629,21 @@ struct GamesSheetView: View {
                     icon: visual.icon,
                     androidIcon: visual.androidIcon,
                     title: activeGame.name,
-                    subtitle: activeGameSubtitle(activeGame),
-                    trailing: activeGame.phase,
+                    subtitle: "On stage · \(GameStageTextPolicy.playersLine(count: activeGame.players.count))",
+                    trailing: GameStageTextPolicy.phaseLabel(activeGame.phase),
                     tint: ACMColors.primaryOrange,
                     androidTint: "accent",
                     isDisabled: true
                 ) {}
 
                 MoreRowDivider()
-                activeGameDetails(activeGame)
+                MoreRow(
+                    icon: "arrow.up.forward.app",
+                    androidIcon: "grid",
+                    title: "Show game"
+                ) {
+                    closeSheet()
+                }
 
                 if canManageGames {
                     MoreRowDivider()
@@ -1709,999 +1660,6 @@ struct GamesSheetView: View {
                 }
             }
         }
-    }
-
-    @ViewBuilder
-    private func activeGameDetails(_ activeGame: GamePublicState) -> some View {
-        if !isLocalGamePlayer(activeGame) &&
-            activeGame.phase != "lobby" &&
-            activeGame.view == nil {
-            gameStatusBlock(
-                title: "Game in progress",
-                subtitle: "You can watch this round and join the next one."
-            )
-        } else if activeGame.phase == "lobby" {
-            lobbyGameDetails(activeGame)
-        } else {
-            switch activeGame.gameId {
-            case "trivia":
-                triviaGameDetails(activeGame)
-            case "reaction":
-                reactionGameDetails(activeGame)
-            case "most-likely-to":
-                mostLikelyGameDetails(activeGame)
-            case "would-you-rather":
-                wouldYouRatherGameDetails(activeGame)
-            case "bluff":
-                bluffGameDetails(activeGame)
-            case "imposter":
-                imposterGameDetails(activeGame)
-            case "wordle":
-                WordleGameView(
-                    viewModel: viewModel,
-                    activeGame: activeGame,
-                    publicView: activeGame.view,
-                    playerView: playerGameView(for: activeGame),
-                    canPlay: canPlayActiveGame(activeGame),
-                    canManage: canManageGames
-                )
-            default:
-                genericGameDetails(activeGame)
-            }
-        }
-    }
-
-    private func lobbyGameDetails(_ activeGame: GamePublicState) -> some View {
-        VStack(alignment: .leading, spacing: ACMSpacing.sm) {
-            gameStatusBlock(
-                title: "Waiting to start",
-                subtitle: activeGame.players.map(\.name).filter { !$0.isEmpty }.joined(separator: ", ")
-            )
-
-            if canManageGames {
-                gameActionButton(
-                    title: "Start",
-                    tint: ACMColors.primaryOrange,
-                    isDisabled: viewModel.state.isGameActionInFlight
-                ) {
-                    viewModel.sendGameMove(type: "start")
-                }
-            }
-        }
-        .padding(.horizontal, ACMSpacing.sm)
-        .padding(.vertical, ACMSpacing.sm)
-    }
-
-    private func triviaGameDetails(_ activeGame: GamePublicState) -> some View {
-        let publicView = activeGame.view
-        let playerView = playerGameView(for: activeGame)
-        let phase = publicView?.string("phase") ?? activeGame.phase
-        let options = publicView?.stringArray("options") ?? []
-        let reveal = phase == "reveal"
-        let results = phase == "results"
-        let answered = playerView?.bool("answered") ?? false
-        let selectedChoice = playerView?.int("choice")
-        let correctChoice = publicView?.int("correctIndex")
-        let counts = publicView?.intArray("optionCounts") ?? []
-        let canAnswer = canPlayActiveGame(activeGame) && phase == "question" && !answered && !viewModel.state.isGameActionInFlight
-
-        return VStack(alignment: .leading, spacing: ACMSpacing.sm) {
-            gameStatusBlock(
-                title: results ? "Final scores" : gameProgressTitle(publicView, fallback: "Question"),
-                subtitle: results ? triviaWinnerText(publicView) : publicView?.string("prompt") ?? "Waiting for the question."
-            )
-
-            if results {
-                scoreboardBlock(publicView)
-            } else {
-                ForEach(Array(options.enumerated()), id: \.offset) { index, option in
-                    gameChoiceButton(
-                        title: option,
-                        subtitle: reveal && index < counts.count ? "\(counts[index]) picked" : nil,
-                        isSelected: selectedChoice == index,
-                        isCorrect: reveal ? correctChoice == index : nil,
-                        isDisabled: !canAnswer
-                    ) {
-                        viewModel.sendGameMove(
-                            type: "answer",
-                            payload: GameJSONValue.object(["choice": index])
-                        )
-                    }
-                }
-            }
-
-            if let playerView {
-                gameMetaLine(triviaPlayerStatus(playerView, phase: phase))
-            }
-
-            hostRoundControls(phase: phase)
-        }
-        .padding(.horizontal, ACMSpacing.sm)
-        .padding(.vertical, ACMSpacing.sm)
-    }
-
-    private func reactionGameDetails(_ activeGame: GamePublicState) -> some View {
-        let publicView = activeGame.view
-        let playerView = playerGameView(for: activeGame)
-        let phase = publicView?.string("phase") ?? activeGame.phase
-        let tapped = playerView?.bool("tapped") ?? false
-        let early = playerView?.bool("early") ?? false
-        let reactionMs = playerView?.int("reactionMs")
-        let canTap = canPlayActiveGame(activeGame)
-            && (phase == "arming" || phase == "go")
-            && !tapped
-            && !viewModel.state.isGameActionInFlight
-
-        return VStack(alignment: .leading, spacing: ACMSpacing.sm) {
-            gameStatusBlock(
-                title: reactionTitle(phase: phase, tapped: tapped, early: early, reactionMs: reactionMs),
-                subtitle: reactionSubtitle(publicView, phase: phase)
-            )
-
-            if phase == "arming" || phase == "go" {
-                reactionTapPad(phase: phase, tapped: tapped, early: early, reactionMs: reactionMs, canTap: canTap)
-            } else if phase == "reveal" {
-                reactionResultsBlock(publicView)
-            } else if phase == "results" {
-                scoreboardBlock(publicView)
-            }
-
-            hostRoundControls(phase: phase)
-        }
-        .padding(.horizontal, ACMSpacing.sm)
-        .padding(.vertical, ACMSpacing.sm)
-    }
-
-    private func mostLikelyGameDetails(_ activeGame: GamePublicState) -> some View {
-        let publicView = activeGame.view
-        let playerView = playerGameView(for: activeGame)
-        let phase = publicView?.string("phase") ?? activeGame.phase
-        let players = publicView?.objectArray("players") ?? []
-        let votedFor = playerView?.string("yourVote")
-        let voteCounts = GameDetailsPresentationPolicy.intMap(from: publicView, key: "counts")
-        let maxVoteCount = max(1, voteCounts.values.max() ?? 0)
-        let reveal = phase == "reveal"
-        let canVote = canPlayActiveGame(activeGame)
-            && phase == "vote"
-            && !viewModel.state.isGameActionInFlight
-
-        return VStack(alignment: .leading, spacing: ACMSpacing.sm) {
-            gameStatusBlock(
-                title: gameProgressTitle(publicView, fallback: "Vote"),
-                subtitle: publicView?.string("prompt") ?? "Waiting for the prompt."
-            )
-
-            if reveal, let winner = publicView?.string("winnerName"), !winner.isEmpty {
-                gameMetaLine("Most votes: \(winner)")
-            }
-
-            if phase == "vote" || reveal {
-                ForEach(players.compactMap(gamePlayerOption), id: \.id) { player in
-                    let voteCount = voteCounts[player.id] ?? 0
-                    gameChoiceButton(
-                        title: player.name,
-                        subtitle: reveal ? voteCountText(voteCount) : nil,
-                        trailing: reveal && voteCount > 0 ? "\(voteCount)" : nil,
-                        isSelected: votedFor == player.id,
-                        isCorrect: reveal ? player.id == publicView?.string("winnerId") : nil,
-                        fillRatio: reveal ? Double(voteCount) / Double(maxVoteCount) : nil,
-                        isDisabled: !canVote || reveal
-                    ) {
-                        viewModel.sendGameMove(
-                            type: "vote",
-                            payload: GameJSONValue.object(["target": player.id])
-                        )
-                    }
-                }
-            } else if phase == "results" {
-                gameStatusBlock(title: "That is a wrap", subtitle: "No hard feelings.")
-            }
-
-            hostRoundControls(phase: phase)
-        }
-        .padding(.horizontal, ACMSpacing.sm)
-        .padding(.vertical, ACMSpacing.sm)
-    }
-
-    private func wouldYouRatherGameDetails(_ activeGame: GamePublicState) -> some View {
-        let publicView = activeGame.view
-        let playerView = playerGameView(for: activeGame)
-        let phase = publicView?.string("phase") ?? activeGame.phase
-        let selected = playerView?.int("choice")
-        let canChoose = canPlayActiveGame(activeGame)
-            && phase == "choose"
-            && !viewModel.state.isGameActionInFlight
-        let counts = publicView?.intArray("counts") ?? []
-        let reveal = phase == "reveal"
-
-        return VStack(alignment: .leading, spacing: ACMSpacing.sm) {
-            gameStatusBlock(
-                title: gameProgressTitle(publicView, fallback: "Choose"),
-                subtitle: reveal ? "The room split." : "Pick a side."
-            )
-
-            gameChoiceButton(
-                title: publicView?.string("optionA") ?? "Option A",
-                subtitle: reveal && !counts.isEmpty ? "\(counts[0]) picked" : nil,
-                isSelected: selected == 0,
-                isDisabled: !canChoose || reveal
-            ) {
-                viewModel.sendGameMove(
-                    type: "choose",
-                    payload: GameJSONValue.object(["option": 0])
-                )
-            }
-
-            gameChoiceButton(
-                title: publicView?.string("optionB") ?? "Option B",
-                subtitle: reveal && counts.count > 1 ? "\(counts[1]) picked" : nil,
-                isSelected: selected == 1,
-                isDisabled: !canChoose || reveal
-            ) {
-                viewModel.sendGameMove(
-                    type: "choose",
-                    payload: GameJSONValue.object(["option": 1])
-                )
-            }
-
-            if reveal {
-                wouldYouRatherRevealSummary(publicView)
-            }
-
-            hostRoundControls(phase: phase)
-        }
-        .padding(.horizontal, ACMSpacing.sm)
-        .padding(.vertical, ACMSpacing.sm)
-    }
-
-    private func bluffGameDetails(_ activeGame: GamePublicState) -> some View {
-        let publicView = activeGame.view
-        let playerView = playerGameView(for: activeGame)
-        let phase = publicView?.string("phase") ?? activeGame.phase
-        let question = publicView?.string("question") ?? "Waiting for the prompt."
-        let submitted = playerView?.bool("submitted") ?? false
-        let yourFake = playerView?.string("yourFake")
-        let yourPick = playerView?.string("yourPick")
-        let ownOptionId = playerView?.string("ownOptionId")
-        let score = playerView?.int("score")
-        let optionRows = publicView?.objectArray("options") ?? []
-        let options = optionRows.compactMap(bluffOption)
-        let canSubmit = canPlayActiveGame(activeGame)
-            && phase == "write"
-            && !submitted
-            && !trimmedBluffAnswer.isEmpty
-            && !viewModel.state.isGameActionInFlight
-        let canChoose = canPlayActiveGame(activeGame)
-            && phase == "choose"
-            && !viewModel.state.isGameActionInFlight
-
-        return VStack(alignment: .leading, spacing: ACMSpacing.sm) {
-            gameStatusBlock(
-                title: bluffTitle(publicView, phase: phase),
-                subtitle: question
-            )
-
-            if phase == "write" {
-                if submitted {
-                    gameMetaLine(bluffSubmittedText(yourFake))
-                } else {
-                    TextField("", text: bluffAnswerBinding, prompt: Text("Your bluff").foregroundStyle(ACMColors.textFaint))
-                        .font(ACMFont.trial(14))
-                        .foregroundStyle(ACMColors.text)
-                        #if !SKIP
-                        .autocorrectionDisabled(false)
-                        #endif
-                        .padding(.horizontal, ACMSpacing.sm)
-                        .frame(minHeight: 44)
-                        .background {
-                            RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
-                                .fill(ACMColors.surfaceRaised)
-                        }
-                        .overlay {
-                            RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
-                                .strokeBorder(lineWidth: 1)
-                                .foregroundStyle(ACMColors.border)
-                        }
-
-                    gameActionButton(
-                        title: "Submit bluff",
-                        tint: ACMColors.primaryOrange,
-                        isDisabled: !canSubmit
-                    ) {
-                        submitBluffAnswer()
-                    }
-                }
-            } else if phase == "choose" {
-                ForEach(options) { option in
-                    let isOwnOption = option.id == ownOptionId
-                    gameChoiceButton(
-                        title: option.text,
-                        subtitle: isOwnOption ? "Your bluff" : nil,
-                        isSelected: yourPick == option.id,
-                        isDisabled: !canChoose || isOwnOption
-                    ) {
-                        viewModel.sendGameMove(
-                            type: "choose",
-                            payload: GameJSONValue.object(["optionId": option.id])
-                        )
-                    }
-                }
-            } else if phase == "reveal" {
-                ForEach(options) { option in
-                    gameChoiceButton(
-                        title: option.text,
-                        subtitle: option.subtitle,
-                        isSelected: yourPick == option.id,
-                        isCorrect: option.isReal,
-                        isDisabled: true
-                    ) {}
-                }
-                if let roundPoints = GameDetailsPresentationPolicy.roundPointsSummary(from: publicView) {
-                    gameMetaLine(roundPoints)
-                }
-            } else if phase == "results" {
-                scoreboardBlock(publicView)
-            }
-
-            if let score {
-                gameMetaLine("\(score) points")
-            }
-
-            hostBluffControls(phase: phase)
-        }
-        .padding(.horizontal, ACMSpacing.sm)
-        .padding(.vertical, ACMSpacing.sm)
-    }
-
-    private func imposterGameDetails(_ activeGame: GamePublicState) -> some View {
-        let publicView = activeGame.view
-        let playerView = playerGameView(for: activeGame)
-        let phase = publicView?.string("phase") ?? activeGame.phase
-        let playerRows = publicView?.objectArray("players") ?? []
-        let players = playerRows.compactMap(gamePlayerOption)
-        let yourVote = playerView?.string("yourVote")
-        let canVote = canPlayActiveGame(activeGame)
-            && phase == "vote"
-            && !viewModel.state.isGameActionInFlight
-
-        return VStack(alignment: .leading, spacing: ACMSpacing.sm) {
-            gameStatusBlock(
-                title: imposterTitle(publicView: publicView, playerView: playerView, phase: phase),
-                subtitle: imposterSubtitle(publicView: publicView, playerView: playerView, phase: phase)
-            )
-
-            if phase == "vote" {
-                ForEach(players) { player in
-                    let isSelf = viewModel.state.isLocalIdentityUserId(player.id)
-                    gameChoiceButton(
-                        title: player.name,
-                        subtitle: imposterVoteSubtitle(publicView, playerId: player.id, isSelf: isSelf),
-                        isSelected: yourVote == player.id,
-                        isDisabled: !canVote || isSelf
-                    ) {
-                        viewModel.sendGameMove(
-                            type: "vote",
-                            payload: GameJSONValue.object(["target": player.id])
-                        )
-                    }
-                }
-            } else if phase == "result" {
-                imposterResultBlock(publicView)
-            }
-
-            hostImposterControls(phase: phase)
-        }
-        .padding(.horizontal, ACMSpacing.sm)
-        .padding(.vertical, ACMSpacing.sm)
-    }
-
-    private func genericGameDetails(_ activeGame: GamePublicState) -> some View {
-        VStack(alignment: .leading, spacing: ACMSpacing.sm) {
-            gameStatusBlock(
-                title: activeGame.phase.capitalized,
-                subtitle: activeGameSubtitle(activeGame)
-            )
-            hostRoundControls(phase: activeGame.phase)
-        }
-        .padding(.horizontal, ACMSpacing.sm)
-        .padding(.vertical, ACMSpacing.sm)
-    }
-
-    private func gameStatusBlock(title: String, subtitle: String?) -> some View {
-        HStack(alignment: .top, spacing: ACMSpacing.sm) {
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
-                .fill(ACMColors.primaryOrange)
-                .frame(width: 3)
-                .frame(maxHeight: .infinity)
-
-            VStack(alignment: .leading, spacing: 5) {
-                Text(title)
-                    .font(ACMFont.trial(16, weight: .semibold))
-                    .foregroundStyle(ACMColors.text)
-                    .lineLimit(2)
-
-                if let subtitle = subtitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-                   !subtitle.isEmpty {
-                    Text(subtitle)
-                        .font(ACMFont.trial(13))
-                        .foregroundStyle(ACMColors.textMuted)
-                        .lineLimit(4)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func gameMetaLine(_ text: String) -> some View {
-        Text(text)
-            .font(ACMFont.trial(12, weight: .medium))
-            .foregroundStyle(ACMColors.textFaint)
-            .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func gameChoiceButton(
-        title: String,
-        subtitle: String? = nil,
-        trailing: String? = nil,
-        isSelected: Bool = false,
-        isCorrect: Bool? = nil,
-        fillRatio: Double? = nil,
-        isDisabled: Bool = false,
-        action: @escaping () -> Void
-    ) -> some View {
-        let resolvedTint: Color = {
-            if isCorrect == true { return ACMColors.success }
-            if isCorrect == false && isSelected { return ACMColors.error }
-            if isSelected { return ACMColors.primaryOrange }
-            return ACMColors.text
-        }()
-
-        return Button(action: action) {
-            HStack(spacing: ACMSpacing.sm) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                        .font(ACMFont.trial(14, weight: .medium))
-                        .foregroundStyle(resolvedTint)
-                        .lineLimit(3)
-                    if let subtitle = subtitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-                       !subtitle.isEmpty {
-                        Text(subtitle)
-                            .font(ACMFont.trial(12))
-                            .foregroundStyle(ACMColors.textFaint)
-                            .lineLimit(1)
-                    }
-                }
-
-                Spacer(minLength: ACMSpacing.sm)
-
-                if let trailing = trailing?.trimmingCharacters(in: .whitespacesAndNewlines),
-                   !trailing.isEmpty {
-                    Text(trailing)
-                        .font(ACMFont.trial(12, weight: .semibold))
-                        .foregroundStyle(resolvedTint)
-                        .lineLimit(1)
-                }
-
-                if isSelected {
-                    Image(systemName: "checkmark")
-                        .font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(resolvedTint)
-                }
-            }
-            .padding(.horizontal, ACMSpacing.sm)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background { gameChoiceBackground(isSelected: isSelected, tint: resolvedTint, fillRatio: fillRatio) }
-            .overlay {
-                RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
-                    .strokeBorder(isSelected ? resolvedTint.opacity(0.44) : ACMColors.border, lineWidth: 1)
-            }
-        }
-        .buttonStyle(.plain)
-        .disabled(isDisabled)
-        .opacity(isDisabled && !isSelected ? 0.56 : 1.0)
-    }
-
-    private func gameChoiceBackground(isSelected: Bool, tint: Color, fillRatio: Double?) -> some View {
-        ZStack(alignment: .leading) {
-            RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
-                .fill(isSelected ? tint.opacity(0.12) : ACMColors.surfaceRaised)
-            if let fillRatio {
-                GeometryReader { geometry in
-                    RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
-                        .fill(tint.opacity(0.10))
-                        .frame(width: geometry.size.width * min(1.0, max(0.0, fillRatio)))
-                }
-            }
-        }
-    }
-
-    private func reactionTapPad(
-        phase: String,
-        tapped: Bool,
-        early: Bool,
-        reactionMs: Int?,
-        canTap: Bool
-    ) -> some View {
-        let isGo = phase == "go"
-        let tint: Color = early ? ACMColors.error : (isGo ? ACMColors.success : ACMColors.errorDim)
-        let title: String = {
-            if early { return "Too soon" }
-            if let reactionMs { return "\(reactionMs) ms" }
-            if tapped { return "Locked in" }
-            return isGo ? "TAP" : "Wait for green"
-        }()
-        let subtitle = isGo && !tapped ? "Tap anywhere on this panel." : "Round in progress."
-
-        return Button {
-            viewModel.sendGameMove(type: "tap")
-        } label: {
-            VStack(spacing: 6) {
-                Text(title)
-                    .font(ACMFont.trial(isGo && !tapped ? 30.0 : 22.0, weight: .bold))
-                    .foregroundStyle(Color.white)
-                    .lineLimit(1)
-                Text(subtitle)
-                    .font(ACMFont.trial(12, weight: .medium))
-                    .foregroundStyle(Color.white.opacity(0.78))
-                    .lineLimit(1)
-            }
-            .frame(maxWidth: .infinity)
-            .frame(minHeight: 132)
-            .background(tint, in: RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous))
-        }
-        .buttonStyle(.plain)
-        .disabled(!canTap)
-        .opacity(canTap ? 1.0 : 0.82)
-    }
-
-    private func reactionResultsBlock(_ view: GameJSONValue?) -> some View {
-        let rows = GameDetailsPresentationPolicy.reactionResultRows(from: view)
-        return VStack(spacing: 6) {
-            if rows.isEmpty {
-                gameMetaLine("Results are not available yet.")
-            } else {
-                ForEach(rows) { row in
-                    HStack(spacing: ACMSpacing.sm) {
-                        Text("\(row.rank)")
-                            .font(ACMFont.trial(13, weight: .bold))
-                            .foregroundStyle(row.isWinner ? ACMColors.primaryOrange : ACMColors.textFaint)
-                            .frame(width: 22, alignment: .center)
-                        Text(row.name)
-                            .font(ACMFont.trial(14, weight: .medium))
-                            .foregroundStyle(ACMColors.text)
-                            .lineLimit(1)
-                        Spacer(minLength: ACMSpacing.xs)
-                        Text(row.resultText)
-                            .font(ACMFont.trial(13, weight: .semibold))
-                            .foregroundStyle(row.isEarly ? ACMColors.error : ACMColors.textMuted)
-                    }
-                    .padding(.horizontal, ACMSpacing.sm)
-                    .frame(minHeight: 40)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background {
-                        RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
-                            .fill(row.isWinner ? ACMColors.primaryOrange.opacity(0.10) : ACMColors.surfaceRaised)
-                    }
-                    .overlay {
-                        RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
-                            .strokeBorder(row.isWinner ? ACMColors.primaryOrange.opacity(0.34) : ACMColors.border, lineWidth: 1)
-                    }
-                }
-            }
-        }
-    }
-
-    private func wouldYouRatherRevealSummary(_ view: GameJSONValue?) -> some View {
-        let counts = view?.intArray("counts") ?? []
-        let first = counts.count > 0 ? counts[0] : 0
-        let second = counts.count > 1 ? counts[1] : 0
-        let total = max(1, first + second)
-        let firstNames = GameDetailsPresentationPolicy.namesSummary(view?.stringArray("namesA") ?? [])
-        let secondNames = GameDetailsPresentationPolicy.namesSummary(view?.stringArray("namesB") ?? [])
-
-        return VStack(alignment: .leading, spacing: ACMSpacing.xs) {
-            GeometryReader { geometry in
-                HStack(spacing: 0) {
-                    Rectangle()
-                        .fill(ACMColors.primaryOrange)
-                        .frame(width: geometry.size.width * Double(first) / Double(total))
-                    Rectangle()
-                        .fill(ACMColors.accentSecondary)
-                }
-            }
-            .frame(height: 10)
-            .clipShape(Capsule())
-
-            HStack(alignment: .top, spacing: ACMSpacing.sm) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("\(first) picked")
-                        .font(ACMFont.trial(12, weight: .semibold))
-                        .foregroundStyle(ACMColors.primaryOrange)
-                    Text(firstNames)
-                        .font(ACMFont.trial(12))
-                        .foregroundStyle(ACMColors.textFaint)
-                        .lineLimit(3)
-                }
-                Spacer(minLength: ACMSpacing.sm)
-                VStack(alignment: .trailing, spacing: 2) {
-                    Text("\(second) picked")
-                        .font(ACMFont.trial(12, weight: .semibold))
-                        .foregroundStyle(ACMColors.accentSecondary)
-                    Text(secondNames)
-                        .font(ACMFont.trial(12))
-                        .foregroundStyle(ACMColors.textFaint)
-                        .lineLimit(3)
-                }
-            }
-        }
-    }
-
-    private func gameActionButton(
-        title: String,
-        tint: Color,
-        isDisabled: Bool,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Text(title)
-                .font(ACMFont.trial(14, weight: .semibold))
-                .foregroundStyle(Color.white)
-                .lineLimit(1)
-                .frame(maxWidth: .infinity)
-                .frame(minHeight: 42)
-                .background(
-                    isDisabled ? ACMColors.surfaceRaised : tint,
-                    in: RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
-                )
-        }
-        .buttonStyle(.plain)
-        .disabled(isDisabled)
-        .opacity(isDisabled ? 0.62 : 1.0)
-    }
-
-    @ViewBuilder
-    private func hostRoundControls(phase: String) -> some View {
-        if canManageGames {
-            if phase == "question" || phase == "vote" || phase == "choose" {
-                gameActionButton(
-                    title: phase == "question" ? "Skip" : "Reveal",
-                    tint: ACMColors.primaryOrange,
-                    isDisabled: viewModel.state.isGameActionInFlight
-                ) {
-                    viewModel.sendGameMove(type: "skip")
-                }
-            } else if phase == "reveal" {
-                gameActionButton(
-                    title: "Next",
-                    tint: ACMColors.primaryOrange,
-                    isDisabled: viewModel.state.isGameActionInFlight
-                ) {
-                    viewModel.sendGameMove(type: "next")
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func hostBluffControls(phase: String) -> some View {
-        if canManageGames {
-            if phase == "write" || phase == "choose" {
-                gameActionButton(
-                    title: phase == "write" ? "Skip writing" : "Reveal",
-                    tint: ACMColors.primaryOrange,
-                    isDisabled: viewModel.state.isGameActionInFlight
-                ) {
-                    viewModel.sendGameMove(type: "skip")
-                }
-            } else if phase == "reveal" {
-                gameActionButton(
-                    title: "Next",
-                    tint: ACMColors.primaryOrange,
-                    isDisabled: viewModel.state.isGameActionInFlight
-                ) {
-                    viewModel.sendGameMove(type: "next")
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func hostImposterControls(phase: String) -> some View {
-        if canManageGames {
-            if phase == "discuss" {
-                gameActionButton(
-                    title: "Call vote",
-                    tint: ACMColors.primaryOrange,
-                    isDisabled: viewModel.state.isGameActionInFlight
-                ) {
-                    viewModel.sendGameMove(type: "callVote")
-                }
-            } else if phase == "vote" {
-                gameActionButton(
-                    title: "End vote",
-                    tint: ACMColors.primaryOrange,
-                    isDisabled: viewModel.state.isGameActionInFlight
-                ) {
-                    viewModel.sendGameMove(type: "tally")
-                }
-            }
-        }
-    }
-
-    private func playerGameView(for activeGame: GamePublicState) -> GameJSONValue? {
-        guard viewModel.state.gamePlayerView?.gameId == activeGame.gameId else { return nil }
-        return viewModel.state.gamePlayerView?.view
-    }
-
-    private func canPlayActiveGame(_ activeGame: GamePublicState) -> Bool {
-        viewModel.state.connectionState == .joined
-            && !viewModel.state.isWebinarAttendee
-            && isLocalGamePlayer(activeGame)
-    }
-
-    private func isLocalGamePlayer(_ activeGame: GamePublicState) -> Bool {
-        viewModel.state.hasLocalGamePlayer(in: activeGame.players)
-    }
-
-    private func gameProgressTitle(_ view: GameJSONValue?, fallback: String) -> String {
-        let index = view?.int("questionIndex") ?? view?.int("index")
-        let total = view?.int("totalQuestions") ?? view?.int("total")
-        let category = view?.string("category")
-        if let index, let total, total > 0 {
-            let prefix = category.flatMap { $0.isEmpty ? nil : "\($0) - " } ?? ""
-            return "\(prefix)\(index + 1)/\(total)"
-        }
-        if let category, !category.isEmpty {
-            return category
-        }
-        return fallback
-    }
-
-    private func reactionTitle(phase: String, tapped: Bool, early: Bool, reactionMs: Int?) -> String {
-        if early { return "Too early" }
-        if let reactionMs { return "\(reactionMs) ms" }
-        if tapped { return "Locked in" }
-        if phase == "go" { return "TAP" }
-        if phase == "reveal" { return "Round result" }
-        return "Wait"
-    }
-
-    private func reactionSubtitle(_ view: GameJSONValue?, phase: String) -> String {
-        if let winner = view?.string("winnerName"), !winner.isEmpty {
-            return "Fastest: \(winner)"
-        }
-        let tapped = view?.int("tappedCount") ?? 0
-        let total = view?.int("totalPlayers") ?? 0
-        if total > 0 {
-            return "\(tapped)/\(total) tapped"
-        }
-        return phase.capitalized
-    }
-
-    private func triviaWinnerText(_ view: GameJSONValue?) -> String {
-        let rows = GameDetailsPresentationPolicy.scoreboardRows(from: view)
-        guard let winner = rows.first else { return "Scores are not available yet." }
-        return "\(winner.name) wins with \(winner.score)"
-    }
-
-    private func triviaPlayerStatus(_ playerView: GameJSONValue, phase: String) -> String {
-        if phase == "reveal" {
-            if playerView.bool("correct") == true {
-                let points = playerView.int("lastRoundPoints") ?? 0
-                return points > 0 ? "Correct +\(points)" : "Correct"
-            }
-            if playerView.bool("answered") == true {
-                return "Not quite"
-            }
-            return "Time's up"
-        }
-        let score = playerView.int("score") ?? 0
-        let rank = playerView.int("rank")
-        let rankSuffix = rank.map { " - #\($0)" } ?? ""
-        return "\(score) points\(rankSuffix)"
-    }
-
-    private var trimmedBluffAnswer: String {
-        bluffAnswerInput.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var bluffAnswerBinding: Binding<String> {
-        Binding(
-            get: { bluffAnswerInput },
-            set: { value in
-                bluffAnswerInput = String(value.prefix(60))
-            }
-        )
-    }
-
-    private func submitBluffAnswer() {
-        let answer = trimmedBluffAnswer
-        guard !answer.isEmpty else { return }
-        viewModel.sendGameMove(
-            type: "submit",
-            payload: GameJSONValue.object(["text": answer])
-        )
-        bluffAnswerInput = ""
-    }
-
-    private func bluffTitle(_ view: GameJSONValue?, phase: String) -> String {
-        let round = view?.int("round")
-        let total = view?.int("totalRounds")
-        let prefix: String
-        if let round, let total, total > 0 {
-            prefix = "\(round + 1)/\(total) - "
-        } else {
-            prefix = ""
-        }
-        switch phase {
-        case "write":
-            return "\(prefix)Write a bluff"
-        case "choose":
-            return "\(prefix)Find the truth"
-        case "reveal":
-            return "\(prefix)Reveal"
-        case "results":
-            return "Final scores"
-        default:
-            return phase.capitalized
-        }
-    }
-
-    private func bluffSubmittedText(_ value: String?) -> String {
-        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? "Bluff submitted" : "Submitted: \(trimmed)"
-    }
-
-    private func bluffOption(_ row: [String: Any]) -> GameChoiceOption? {
-        guard let id = row["id"] as? String else { return nil }
-        let text = (row["text"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let text, !text.isEmpty else { return nil }
-        let kind = row["kind"] as? String
-        let votes = intValue(row["votes"])
-        let ownerName = (row["ownerName"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let subtitleParts = [
-            kind == "real" ? "Truth" : (ownerName?.isEmpty == false ? ownerName : nil),
-            votes.map { count in count == 1 ? "1 vote" : "\(count) votes" }
-        ].compactMap { $0 }
-        return GameChoiceOption(
-            id: id,
-            text: text,
-            subtitle: subtitleParts.isEmpty ? nil : subtitleParts.joined(separator: " - "),
-            isReal: kind == nil ? nil : kind == "real"
-        )
-    }
-
-    @ViewBuilder
-    private func scoreboardBlock(_ view: GameJSONValue?) -> some View {
-        let rows = GameDetailsPresentationPolicy.scoreboardRows(from: view)
-        if rows.isEmpty {
-            gameMetaLine("Scores are not available yet.")
-        } else {
-            VStack(spacing: 6) {
-                ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
-                    scoreboardLeaderRow(rank: index + 1, name: row.name, score: row.score)
-                }
-            }
-        }
-    }
-
-    private func scoreboardLeaderRow(rank: Int, name: String, score: Int) -> some View {
-        let rankColor: Color = {
-            switch rank {
-            case 1: return ACMColors.primaryOrange
-            case 2, 3: return ACMColors.textMuted
-            default: return ACMColors.textFaint
-            }
-        }()
-        let isLeader = rank == 1
-        return HStack(spacing: ACMSpacing.sm) {
-            Text("\(rank)")
-                .font(ACMFont.trial(14, weight: .bold))
-                .foregroundStyle(rankColor)
-                .frame(width: 22, alignment: .center)
-
-            Text(name)
-                .font(ACMFont.trial(14, weight: .medium))
-                .foregroundStyle(ACMColors.text)
-                .lineLimit(1)
-
-            Spacer(minLength: ACMSpacing.xs)
-
-            Text("\(score)")
-                .font(ACMFont.trial(14, weight: .semibold))
-                .foregroundStyle(rankColor)
-        }
-        .padding(.horizontal, ACMSpacing.sm)
-        .frame(minHeight: 40)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background {
-            RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
-                .fill(isLeader ? ACMColors.primaryOrange.opacity(0.10) : ACMColors.surfaceRaised)
-        }
-        .overlay {
-            RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
-                .strokeBorder(isLeader ? ACMColors.primaryOrange.opacity(0.34) : ACMColors.border, lineWidth: 1)
-        }
-    }
-
-    private func imposterTitle(publicView: GameJSONValue?, playerView: GameJSONValue?, phase: String) -> String {
-        switch phase {
-        case "reveal", "discuss":
-            if playerView?.string("role") == "imposter" {
-                return "You are the imposter"
-            }
-            let word = playerView?.string("word")?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            return word.isEmpty ? "Secret word" : "Secret word: \(word)"
-        case "vote":
-            return "Vote out the imposter"
-        case "result":
-            return imposterResultTitle(publicView)
-        default:
-            return phase.capitalized
-        }
-    }
-
-    private func imposterSubtitle(publicView: GameJSONValue?, playerView: GameJSONValue?, phase: String) -> String? {
-        if phase == "vote" {
-            let voted = publicView?.stringArray("votedPlayerIds").count ?? 0
-            let total = publicView?.int("totalPlayers") ?? 0
-            return total > 0 ? "\(voted)/\(total) voted" : nil
-        }
-
-        let category = playerView?.string("category") ?? publicView?.string("category")
-        let starter = publicView?.string("starterName")
-        if phase == "discuss",
-           let starter,
-           !starter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let prefix = category.flatMap { $0.isEmpty ? nil : "\($0) - " } ?? ""
-            return "\(prefix)\(starter) starts"
-        }
-        return category?.isEmpty == false ? category : nil
-    }
-
-    private func imposterVoteSubtitle(_ view: GameJSONValue?, playerId: String, isSelf: Bool) -> String? {
-        if isSelf { return "You" }
-        let counts = view?.dictionaryValue?["voteCounts"] as? [String: Any]
-        guard let count = intValue(counts?[playerId]), count > 0 else { return nil }
-        return count == 1 ? "1 vote" : "\(count) votes"
-    }
-
-    @ViewBuilder
-    private func imposterResultBlock(_ view: GameJSONValue?) -> some View {
-        if let result = view?.dictionaryValue?["result"] as? [String: Any] {
-            let word = (result["word"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let imposter = (result["imposterName"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let votedOut = (result["votedOutName"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            if !word.isEmpty {
-                gameMetaLine("Word: \(word)")
-            }
-            if !imposter.isEmpty {
-                gameMetaLine("Imposter: \(imposter)")
-            }
-            if !votedOut.isEmpty {
-                gameMetaLine("Voted out: \(votedOut)")
-            }
-        } else {
-            gameMetaLine("Result pending")
-        }
-    }
-
-    private func imposterResultTitle(_ view: GameJSONValue?) -> String {
-        guard let result = view?.dictionaryValue?["result"] as? [String: Any] else {
-            return "Result"
-        }
-        if boolValue(result["tie"]) == true {
-            return "Vote tied"
-        }
-        return boolValue(result["crewWon"]) == true ? "Crew wins" : "Imposter wins"
-    }
-
-    private func gamePlayerOption(_ row: [String: Any]) -> GamePlayer? {
-        guard let id = row["id"] as? String else { return nil }
-        let name = (row["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return GamePlayer(id: id, name: name?.isEmpty == false ? name! : id)
     }
 
     private func voteSection(_ vote: GameVoteState) -> some View {
@@ -2767,10 +1725,6 @@ struct GamesSheetView: View {
                 }
             }
         }
-    }
-
-    private func voteCountText(_ count: Int) -> String {
-        count == 1 ? "1 vote" : "\(count) votes"
     }
 
     private func configSection(_ game: GameCatalogEntry) -> some View {
@@ -2967,6 +1921,7 @@ struct GamesSheetView: View {
                 icon: "gamecontroller",
                 androidIcon: "sports_esports",
                 title: "No active game",
+                subtitle: "The host can start one from here",
                 isDisabled: true
             ) {}
         }
@@ -3053,12 +2008,6 @@ struct GamesSheetView: View {
             && !viewModel.state.isWebinarAttendee
     }
 
-    private func activeGameSubtitle(_ game: GamePublicState) -> String {
-        let count = game.players.count
-        let noun = count == 1 ? "player" : "players"
-        return "\(count) \(noun)"
-    }
-
     private func beginConfiguringGame(_ game: GameCatalogEntry) {
         configuringGame = game
         gameConfigDrafts = GameConfigDraftPolicy.initialDrafts(for: game)
@@ -3103,235 +2052,6 @@ struct GamesSheetView: View {
 
     private func defaultOptions(for game: GameCatalogEntry) -> [String: GameConfigValue] {
         GameConfigDraftPolicy.initialDrafts(for: game)
-    }
-
-    private func intValue(_ value: Any?) -> Int? {
-        if let intValue = value as? Int { return intValue }
-        if let doubleValue = value as? Double { return Int(doubleValue) }
-        if let numberValue = value as? NSNumber { return numberValue.intValue }
-        return nil
-    }
-
-    private func boolValue(_ value: Any?) -> Bool? {
-        if let boolValue = value as? Bool { return boolValue }
-        if let intValue = value as? Int { return intValue != 0 }
-        if let doubleValue = value as? Double { return doubleValue != 0.0 }
-        if let numberValue = value as? NSNumber { return numberValue.intValue != 0 }
-        return nil
-    }
-}
-
-struct GameChoiceOption: Identifiable, Equatable {
-    let id: String
-    let text: String
-    let subtitle: String?
-    let isReal: Bool?
-}
-
-struct GameScoreRow: Identifiable, Equatable {
-    let id: String
-    let name: String
-    let score: Int
-}
-
-struct GameReactionResultRow: Identifiable, Equatable {
-    let id: String
-    let rank: Int
-    let name: String
-    let resultText: String
-    let isEarly: Bool
-    let isWinner: Bool
-}
-
-enum GameDetailsPresentationPolicy {
-    static func scoreboardRows(from view: GameJSONValue?) -> [GameScoreRow] {
-        let rows = view?.objectArray("scoreboard") ?? []
-        return rows.compactMap(scoreboardRow).sorted { $0.score > $1.score }
-    }
-
-    static func intMap(from view: GameJSONValue?, key: String) -> [String: Int] {
-        guard let values = view?.dictionaryValue?[key] as? [String: Any] else {
-            return [:]
-        }
-        var result: [String: Int] = [:]
-        for (id, value) in values {
-            if let count = intValue(value) {
-                result[id] = count
-            }
-        }
-        return result
-    }
-
-    static func namesSummary(_ names: [String]) -> String {
-        let cleaned = names
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        return cleaned.isEmpty ? "nobody" : cleaned.joined(separator: ", ")
-    }
-
-    static func roundPointsSummary(from view: GameJSONValue?) -> String? {
-        let rows = view?.objectArray("roundPoints") ?? []
-        var parts: [String] = []
-        for row in rows {
-            let name = (row["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            guard !name.isEmpty, let points = intValue(row["points"]), points != 0 else {
-                continue
-            }
-            let prefix = points > 0 ? "+" : ""
-            parts.append("\(name) \(prefix)\(points)")
-        }
-        return parts.isEmpty ? nil : parts.joined(separator: " - ")
-    }
-
-    static func reactionResultRows(from view: GameJSONValue?) -> [GameReactionResultRow] {
-        let rows = view?.objectArray("results") ?? []
-        return rows.enumerated().compactMap { index, row in
-            let id = (row["id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let resolvedId = id?.isEmpty == false ? id! : "reaction-\(index)"
-            let rawName = (row["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let name = rawName?.isEmpty == false ? rawName! : resolvedId
-            let isEarly = boolValue(row["early"]) ?? false
-            let resultText: String
-            if isEarly {
-                resultText = "too soon"
-            } else if let reactionMs = intValue(row["reactionMs"]) {
-                resultText = "\(reactionMs) ms"
-            } else {
-                resultText = "no tap"
-            }
-            return GameReactionResultRow(
-                id: resolvedId,
-                rank: index + 1,
-                name: name,
-                resultText: resultText,
-                isEarly: isEarly,
-                isWinner: index == 0 && !isEarly
-            )
-        }
-    }
-
-    private static func scoreboardRow(_ row: [String: Any]) -> GameScoreRow? {
-        guard let id = row["id"] as? String else { return nil }
-        let name = (row["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return GameScoreRow(
-            id: id,
-            name: name?.isEmpty == false ? name! : id,
-            score: intValue(row["score"]) ?? 0
-        )
-    }
-
-    private static func intValue(_ value: Any?) -> Int? {
-        if let intValue = value as? Int { return intValue }
-        if let doubleValue = value as? Double { return Int(doubleValue) }
-        if let numberValue = value as? NSNumber { return numberValue.intValue }
-        return nil
-    }
-
-    private static func boolValue(_ value: Any?) -> Bool? {
-        if let boolValue = value as? Bool { return boolValue }
-        if let intValue = value as? Int { return intValue != 0 }
-        if let doubleValue = value as? Double { return doubleValue != 0.0 }
-        if let numberValue = value as? NSNumber { return numberValue.intValue != 0 }
-        return nil
-    }
-}
-
-struct GameNumberPreset: Identifiable {
-    let value: Double
-    let label: String
-
-    var id: String { label }
-}
-
-enum GameConfigDraftPolicy {
-    static func initialDrafts(for game: GameCatalogEntry) -> [String: GameConfigValue] {
-        var options: [String: GameConfigValue] = [:]
-        for option in game.options {
-            let id = option.id.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !id.isEmpty else { continue }
-            options[id] = resolvedValue(for: option, draft: option.defaultConfigValue)
-        }
-        return options
-    }
-
-    static func resolvedOptions(
-        for game: GameCatalogEntry,
-        drafts: [String: GameConfigValue]
-    ) -> [String: GameConfigValue] {
-        var options: [String: GameConfigValue] = [:]
-        for option in game.options {
-            let id = option.id.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !id.isEmpty else { continue }
-            options[id] = resolvedValue(for: option, draft: drafts[option.id])
-        }
-        return options
-    }
-
-    static func resolvedValue(for option: GameOptionSpec, draft: GameConfigValue?) -> GameConfigValue {
-        switch option.type {
-        case "number":
-            let raw = draft?.numberValue ?? option.defaultConfigValue.numberValue ?? option.min ?? 0.0
-            return .number(clamp(raw, min: option.min, max: option.max))
-        case "select":
-            let choices = option.choices ?? []
-            let defaultValue = option.defaultConfigValue.stringValue ?? choices.first?.value ?? ""
-            let raw = draft?.stringValue ?? defaultValue
-            if choices.contains(where: { $0.value == raw }) {
-                return .string(raw)
-            }
-            return .string(defaultValue)
-        default:
-            let maxLength = max(0, option.maxLength ?? Int.max)
-            let raw = draft?.stringValue ?? option.defaultConfigValue.stringValue ?? ""
-            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.count <= maxLength {
-                return .string(trimmed)
-            }
-            return .string(String(trimmed.prefix(maxLength)))
-        }
-    }
-
-    static func numberPresets(for option: GameOptionSpec) -> [GameNumberPreset] {
-        let source = option.presets ?? [
-            option.min ?? option.defaultConfigValue.numberValue ?? 0.0,
-            option.defaultConfigValue.numberValue ?? option.min ?? 0.0,
-            option.max ?? option.defaultConfigValue.numberValue ?? 0.0
-        ]
-        var seen: [Double] = []
-        var presets: [GameNumberPreset] = []
-        for raw in source {
-            let value = clamp(raw, min: option.min, max: option.max)
-            if seen.contains(where: { numbersMatch($0, value) }) { continue }
-            seen.append(value)
-            presets.append(GameNumberPreset(
-                value: value,
-                label: formattedNumber(value, suffix: option.suffix)
-            ))
-        }
-        return presets
-    }
-
-    static func numbersMatch(_ lhs: Double, _ rhs: Double) -> Bool {
-        abs(lhs - rhs) < 0.0001
-    }
-
-    private static func clamp(_ value: Double, min: Double?, max: Double?) -> Double {
-        var next = value
-        if let min {
-            next = Swift.max(min, next)
-        }
-        if let max {
-            next = Swift.min(max, next)
-        }
-        return next
-    }
-
-    private static func formattedNumber(_ value: Double, suffix: String?) -> String {
-        let rounded = value.rounded()
-        let base = numbersMatch(value, rounded) ? "\(Int(rounded))" : "\(value)"
-        guard let suffix = suffix?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !suffix.isEmpty else { return base }
-        return "\(base) \(suffix)"
     }
 }
 

--- a/apps/conclave-skip/Sources/Conclave/Skip/SocketIOManager+Android.kt
+++ b/apps/conclave-skip/Sources/Conclave/Skip/SocketIOManager+Android.kt
@@ -123,6 +123,7 @@ internal object SocketEvent {
     val gameMove = SfuClientEvent.gameMove.rawValue
     val gameEnd = SfuClientEvent.gameEnd.rawValue
     val gameGetState = SfuClientEvent.gameGetState.rawValue
+    val gameJoin = SfuClientEvent.gameJoin.rawValue
     val gameVoteOpen = SfuClientEvent.gameVoteOpen.rawValue
     val gameVoteCast = SfuClientEvent.gameVoteCast.rawValue
     val gameVoteCancel = SfuClientEvent.gameVoteCancel.rawValue
@@ -1036,6 +1037,11 @@ internal class SocketIOManager {
         return decodeGameActionResponse(data)
     }
 
+    internal suspend fun joinGame(): GameActionResponse {
+        val data = emitAckOnly(SocketEvent.gameJoin)
+        return decodeGameActionResponse(data)
+    }
+
     internal suspend fun openGameVote(candidateIds: skip.lib.Array<String>? = null): GameActionResponse {
         val payload = JSONObject()
         if (candidateIds != null) {
@@ -1939,6 +1945,16 @@ internal class SocketIOManager {
             val player = rawPlayers.optJSONObject(index)?.let { decodeGamePlayerObject(it) } ?: continue
             players.add(player)
         }
+        val rawPendingJoiners = obj.optJSONArray("pendingJoiners")
+        var pendingJoiners: skip.lib.Array<GamePlayer>? = null
+        if (rawPendingJoiners != null) {
+            val pending = mutableListOf<GamePlayer>()
+            for (index in 0 until rawPendingJoiners.length()) {
+                val player = rawPendingJoiners.optJSONObject(index)?.let { decodeGamePlayerObject(it) } ?: continue
+                pending.add(player)
+            }
+            pendingJoiners = skip.lib.Array(pending)
+        }
         return GamePublicState(
             gameId = stringField(obj, "gameId") ?: return null,
             name = stringField(obj, "name") ?: stringField(obj, "gameId") ?: return null,
@@ -1948,8 +1964,29 @@ internal class SocketIOManager {
             view = rawJsonField(obj, "view"),
             finished = boolField(obj, "finished") ?: false,
             hasLeaderboard = boolField(obj, "hasLeaderboard") ?: false,
-            roomId = stringField(obj, "roomId")
+            roomId = stringField(obj, "roomId"),
+            config = gameConfigMapField(obj, "config"),
+            pendingJoiners = pendingJoiners,
+            canJoinLate = boolField(obj, "canJoinLate")
         )
+    }
+
+    private fun gameConfigMapField(obj: JSONObject, field: String): Dictionary<String, GameConfigValue>? {
+        val raw = obj.optJSONObject(field) ?: return null
+        var values: Dictionary<String, GameConfigValue> = dictionaryOf()
+        val keys = raw.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            val value = when (val rawValue = raw.opt(key)) {
+                is Number -> GameConfigValue(numberValue = rawValue.toDouble(), stringValue = null)
+                is String -> GameConfigValue(numberValue = null, stringValue = rawValue)
+                else -> null
+            }
+            if (value != null) {
+                values[key] = value
+            }
+        }
+        return values
     }
 
     private fun decodeGamePlayerViewNotificationObject(obj: JSONObject): GamePlayerViewNotification? {

--- a/apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift
+++ b/apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift
@@ -485,9 +485,10 @@ final class ConclaveTests: XCTestCase {
         XCTAssertEqual(resolved["topic"]?.stringValue, "production")
     }
 
-    func testNativeGamesSheetCoversEveryWebGameRenderer() throws {
+    func testNativeGameStageCoversEveryWebGameRenderer() throws {
         let webRegistry = try repoFileContents("apps/web/src/app/components/games/registry.tsx")
-        let nativeSheet = try sourceFileContents("Sources/Conclave/Features/Meeting/MoreSheetView.swift")
+        let nativeStage = try sourceFileContents("Sources/Conclave/Features/Meeting/Games/GameStageView.swift")
+        let nativeStageGames = try sourceFileContents("Sources/Conclave/Features/Meeting/Games/GameStageGames.swift")
         let nativeWordle = try sourceFileContents("Sources/Conclave/Features/Meeting/WordleGameView.swift")
 
         let expectedGameIds = [
@@ -503,11 +504,11 @@ final class ConclaveTests: XCTestCase {
         for gameId in expectedGameIds {
             XCTAssertTrue(webRegistry.contains("\(gameId):") || webRegistry.contains("\"\(gameId)\":"))
             XCTAssertTrue(
-                nativeSheet.contains("case \"\(gameId)\""),
-                "Native games sheet is missing renderer branch for \(gameId)."
+                nativeStage.contains("case \"\(gameId)\""),
+                "Native game stage is missing renderer branch for \(gameId)."
             )
         }
-        XCTAssertTrue(nativeSheet.contains("WordleGameView("))
+        XCTAssertTrue(nativeStageGames.contains("WordleGameView("))
         XCTAssertTrue(nativeWordle.contains("struct WordleGameView"))
     }
 

--- a/apps/web/src/lib/sfu-url.ts
+++ b/apps/web/src/lib/sfu-url.ts
@@ -51,16 +51,22 @@ const productionSafeSfuUrl = (value: string): string => {
 };
 
 export const resolveSfuUrls = (): string[] => {
-  const configuredUrls = [
+  const poolUrls = [
     ...splitUrlList(process.env.SFU_URLS),
     ...splitUrlList(process.env.SFU_POOL_URLS),
     ...splitUrlList(process.env.SFU_POOL),
     ...splitUrlList(process.env.NEXT_PUBLIC_SFU_URLS),
+  ];
+  if (poolUrls.length > 0) {
+    return uniqueUrls(poolUrls);
+  }
+
+  const singletonUrls = [
     envValue(process.env.SFU_URL),
     envValue(process.env.NEXT_PUBLIC_SFU_URL),
   ].filter((value): value is string => Boolean(value));
 
-  return uniqueUrls(configuredUrls.length > 0 ? configuredUrls : [PUBLIC_SFU_URL]);
+  return uniqueUrls(singletonUrls.length > 0 ? singletonUrls : [PUBLIC_SFU_URL]);
 };
 
 export const resolveSfuUrl = (): string =>

--- a/apps/web/test/sfu-url.test.ts
+++ b/apps/web/test/sfu-url.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveSfuUrls } from "../src/lib/sfu-url";
+
+const sfuEnvKeys = [
+  "SFU_URLS",
+  "SFU_POOL_URLS",
+  "SFU_POOL",
+  "NEXT_PUBLIC_SFU_URLS",
+  "SFU_URL",
+  "NEXT_PUBLIC_SFU_URL",
+] as const;
+
+const originalEnv = Object.fromEntries(
+  sfuEnvKeys.map((key) => [key, process.env[key]]),
+) as Record<(typeof sfuEnvKeys)[number], string | undefined>;
+
+const clearSfuEnv = (): void => {
+  for (const key of sfuEnvKeys) {
+    delete process.env[key];
+  }
+};
+
+afterEach(() => {
+  clearSfuEnv();
+  for (const key of sfuEnvKeys) {
+    if (originalEnv[key] !== undefined) {
+      process.env[key] = originalEnv[key];
+    }
+  }
+});
+
+describe("resolveSfuUrls", () => {
+  it("uses explicit pool urls without appending singleton fallback urls", () => {
+    clearSfuEnv();
+    process.env.SFU_URLS = "https://sfu-a.acmvit.in,https://sfu-b.acmvit.in";
+    process.env.NEXT_PUBLIC_SFU_URL = "https://sfu.acmvit.in";
+
+    expect(resolveSfuUrls()).toEqual([
+      "https://sfu-a.acmvit.in",
+      "https://sfu-b.acmvit.in",
+    ]);
+  });
+
+  it("uses singleton urls when no pool is configured", () => {
+    clearSfuEnv();
+    process.env.NEXT_PUBLIC_SFU_URL = "https://sfu.acmvit.in";
+
+    expect(resolveSfuUrls()).toEqual(["https://sfu.acmvit.in"]);
+  });
+
+  it("normalizes labeled pool entries and removes exact duplicate urls", () => {
+    clearSfuEnv();
+    process.env.SFU_POOL =
+      "sfu-a=https://sfu-a.acmvit.in/,sfu-b=https://sfu-b.acmvit.in,duplicate=https://sfu-a.acmvit.in";
+
+    expect(resolveSfuUrls()).toEqual([
+      "https://sfu-a.acmvit.in",
+      "https://sfu-b.acmvit.in",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- move active native games into a dedicated meeting-stage takeover
- wire native game join/rematch socket support and Android decoding
- fix SFU URL resolution so explicit pool URLs do not append singleton fallback URLs

## Verification
- swift build
- pnpm -C apps/web exec vitest run test/sfu-url.test.ts

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR moves native games into the meeting stage. The main changes are:

- New full-stage game UI with player and host controls.
- Native join, rematch, and game-state socket wiring.
- Android decoding for new game state fields.
- Chat auto-scroll and message action updates.
- SFU URL pool resolution fixes with tests.

<h3>Confidence Score: 4/5</h3>

The game-stage host flow has two contained issues that should be fixed before merging.

Rematch can be blocked after finished game state is cleared, and the lobby start button can be visible for an admin but blocked by a player-only guard. The SFU URL change and Android optional-field decoding look consistent with the changed tests and models.

MeetingViewModel.swift and GameStageView.swift

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced the finished-state rematch path using a focused harness for the MeetingViewModel, observed that gamePublicState was cleared to nil after finishing, and invoked the host Play again/rematch action which produced no game:start event in the socket recorder; the Swift environment was unavailable in the container, so a narrow local harness was used.
- I prepared a focused Swift harness for the admin Start game with a player-gate scenario and attempted to run it, but the environment lacked a Swift toolchain, so execution could not proceed.
- I reviewed the pool-and-singleton resolution flow, noting that the base response included pool endpoints with a singleton fallback, while the head response removed the singleton fallback and one endpoint, and the after artifact surfaced a singleton-only and a duplicate-pool list.
- I compared native-game-socket decoding before and after probes, confirming the before state failed with EXIT\_CODE 1 and the after state passed with EXIT\_CODE 0 and a 200 OK evidence event for game:join under the androidDecoder config.
- I attached runtime proof logs and a shell script documenting the exact commands, working directory, exit codes, missing toolchain, and the base/head source excerpts used to identify the blocker; because the requested UI surface could not be executed, no UI mismatch was reported.

<a href="https://app.greptile.com/trex/runs/13058593/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift | Adds join and rematch actions; the rematch path depends on finished public game state that can already be cleared. |
| apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GameStageView.swift | Adds the game-stage layout and controls; the lobby start action is rendered for admins but dispatched through a player-only guard. |
| apps/conclave-skip/Sources/Conclave/Skip/SocketIOManager+Android.kt | Adds Android game join support and decoding for the new optional public game fields. |
| apps/conclave-skip/Sources/Conclave/Features/Meeting/ChatViews.swift | Adds chat auto-scroll suppression, unseen-message UI, and message copy/reply actions. |
| apps/web/src/lib/sfu-url.ts | Separates explicit SFU pool URLs from singleton fallback URLs. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FFeatures%2FMeeting%2FMeetingViewModel.swift%3A8907%0A**Finished%20State%20Clears%20Rematch**%0A%0AWhen%20the%20server%20sends%20the%20finished%20or%20ended%20game%20state%20before%20the%20host%20taps%20%60Play%20again%60%2C%20the%20existing%20clear%20path%20removes%20%60state.gamePublicState%60.%20This%20new%20guard%20then%20silently%20returns%2C%20so%20the%20rematch%20button%20either%20vanishes%20or%20does%20nothing%20instead%20of%20restarting%20the%20same%20game%20with%20the%20reported%20config.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FFeatures%2FMeeting%2FGames%2FGameStageView.swift%3A419%0A**Admin%20Start%20Uses%20Player%20Gate**%0A%0AThe%20lobby%20renders%20%60Start%20game%60%20from%20%60canManage%60%2C%20but%20this%20call%20goes%20through%20%60sendGameMove%60%2C%20whose%20view-model%20guard%20requires%20the%20local%20user%20to%20already%20be%20in%20%60activeGame.players%60.%20If%20an%20admin%20host%20is%20managing%20the%20lobby%20without%20being%20listed%20as%20a%20player%2C%20the%20button%20is%20visible%20but%20the%20action%20returns%20before%20emitting%20anything%2C%20leaving%20the%20round%20stuck%20in%20the%20lobby.%0A%0A&repo=acm-vit%2Fconclave&pr=148&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FFeatures%2FMeeting%2FMeetingViewModel.swift%3A8907%0A**Finished%20State%20Clears%20Rematch**%0A%0AWhen%20the%20server%20sends%20the%20finished%20or%20ended%20game%20state%20before%20the%20host%20taps%20%60Play%20again%60%2C%20the%20existing%20clear%20path%20removes%20%60state.gamePublicState%60.%20This%20new%20guard%20then%20silently%20returns%2C%20so%20the%20rematch%20button%20either%20vanishes%20or%20does%20nothing%20instead%20of%20restarting%20the%20same%20game%20with%20the%20reported%20config.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FFeatures%2FMeeting%2FGames%2FGameStageView.swift%3A419%0A**Admin%20Start%20Uses%20Player%20Gate**%0A%0AThe%20lobby%20renders%20%60Start%20game%60%20from%20%60canManage%60%2C%20but%20this%20call%20goes%20through%20%60sendGameMove%60%2C%20whose%20view-model%20guard%20requires%20the%20local%20user%20to%20already%20be%20in%20%60activeGame.players%60.%20If%20an%20admin%20host%20is%20managing%20the%20lobby%20without%20being%20listed%20as%20a%20player%2C%20the%20button%20is%20visible%20but%20the%20action%20returns%20before%20emitting%20anything%2C%20leaving%20the%20round%20stuck%20in%20the%20lobby.%0A%0A&repo=acm-vit%2Fconclave&pr=148&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FFeatures%2FMeeting%2FMeetingViewModel.swift%3A8907%0A**Finished%20State%20Clears%20Rematch**%0A%0AWhen%20the%20server%20sends%20the%20finished%20or%20ended%20game%20state%20before%20the%20host%20taps%20%60Play%20again%60%2C%20the%20existing%20clear%20path%20removes%20%60state.gamePublicState%60.%20This%20new%20guard%20then%20silently%20returns%2C%20so%20the%20rematch%20button%20either%20vanishes%20or%20does%20nothing%20instead%20of%20restarting%20the%20same%20game%20with%20the%20reported%20config.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fconclave-skip%2FSources%2FConclave%2FFeatures%2FMeeting%2FGames%2FGameStageView.swift%3A419%0A**Admin%20Start%20Uses%20Player%20Gate**%0A%0AThe%20lobby%20renders%20%60Start%20game%60%20from%20%60canManage%60%2C%20but%20this%20call%20goes%20through%20%60sendGameMove%60%2C%20whose%20view-model%20guard%20requires%20the%20local%20user%20to%20already%20be%20in%20%60activeGame.players%60.%20If%20an%20admin%20host%20is%20managing%20the%20lobby%20without%20being%20listed%20as%20a%20player%2C%20the%20button%20is%20visible%20but%20the%20action%20returns%20before%20emitting%20anything%2C%20leaving%20the%20round%20stuck%20in%20the%20lobby.%0A%0A&pr=148&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(native): move games into meeting st..."](https://github.com/acm-vit/conclave/commit/804f680d1f344e2c8870ff50799a480758bfd8a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41369681)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->