### PR TITLE
fix(admin): collapse duplicate SFU room rows

### DIFF
--- a/apps/web/src/app/sfu-admin/ActivityDrawer.tsx
+++ b/apps/web/src/app/sfu-admin/ActivityDrawer.tsx
@@ -15,13 +15,13 @@ import { Dot, Tag, btnTiny } from "./ui";
 
 const EVENT_TONE: Record<AdminEventType, string> = {
   "room-opened": color.success,
-  "room-closed": color.textFaint as string,
+  "room-closed": color.textFaint,
   "user-joined": color.success,
-  "user-left": color.textFaint as string,
+  "user-left": color.textFaint,
   "screen-started": color.accent,
-  "screen-stopped": color.textFaint as string,
+  "screen-stopped": color.textFaint,
   "room-locked": color.warning,
-  "room-unlocked": color.textFaint as string,
+  "room-unlocked": color.textFaint,
   waiting: color.warning,
 };
 
@@ -61,6 +61,14 @@ const formatRelative = (at: number, now: number): string => {
 
 const PAST_STATUSES = new Set(["ended", "cancelled", "canceled", "completed", "expired"]);
 const LIVE_STATUSES = new Set(["live", "started", "in_progress"]);
+
+const eventIdentity = (event: TaggedAdminEvent): string =>
+  [
+    Math.floor(event.at / 1000),
+    event.channelId,
+    event.type,
+    event.message,
+  ].join(":");
 
 function CopyLinkButton({ path }: { path: string }) {
   const [copied, setCopied] = useState(false);
@@ -123,12 +131,17 @@ export function ActivityDrawer({
   }, [instances]);
 
   const visibleEvents = useMemo(() => {
-    if (!onlySelectedRoom || !selected) return events;
-    return events.filter(
-      (event) =>
-        event.instanceKey === selected.instanceKey &&
-        event.channelId === selected.channelId,
-    );
+    const scoped =
+      onlySelectedRoom && selected
+        ? events.filter((event) => event.channelId === selected.channelId)
+        : events;
+    const seen = new Set<string>();
+    return scoped.filter((event) => {
+      const key = eventIdentity(event);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
   }, [events, onlySelectedRoom, selected]);
 
   const scheduledGroups = useMemo(() => {
@@ -140,7 +153,6 @@ export function ActivityDrawer({
       const status = item.status.toLowerCase();
       const activeRoom = rooms.find(
         (room) =>
-          room.instanceKey === item.instanceKey &&
           room.roomId === item.roomId &&
           room.clientId === item.clientId,
       );
@@ -163,7 +175,6 @@ export function ActivityDrawer({
     const status = item.status.toLowerCase();
     const activeRoom = rooms.find(
       (room) =>
-        room.instanceKey === item.instanceKey &&
         room.roomId === item.roomId &&
         room.clientId === item.clientId,
     );
@@ -178,7 +189,7 @@ export function ActivityDrawer({
 
     return (
       <div
-        key={`${item.instanceKey}-${item.kind}-${item.id}`}
+        key={`${item.kind}-${item.clientId}-${item.id}`}
         className="rounded-lg border px-2.5 py-2"
         style={{ borderColor: color.border, backgroundColor: color.surface }}
       >
@@ -302,7 +313,15 @@ export function ActivityDrawer({
                 <li key={`${event.at}-${index}`}>
                   <button
                     type="button"
-                    onClick={() => onPickRoom(event.instanceKey, event.channelId)}
+                    onClick={() => {
+                      const activeRoom = rooms.find(
+                        (room) => room.channelId === event.channelId,
+                      );
+                      onPickRoom(
+                        activeRoom?.instanceKey ?? event.instanceKey,
+                        event.channelId,
+                      );
+                    }}
                     className="flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-white/[0.04]"
                   >
                     <span className="mt-[5px]">

--- a/apps/web/src/app/sfu-admin/useAdminSocket.ts
+++ b/apps/web/src/app/sfu-admin/useAdminSocket.ts
@@ -23,6 +23,20 @@ import type {
 const EVENTS_CAP = 300;
 const AUDIT_CAP = 200;
 const FIND_TIMEOUT_MS = 2_500;
+const LIVE_SCHEDULE_STATUSES = new Set(["live", "started", "in_progress"]);
+const PAST_SCHEDULE_STATUSES = new Set([
+  "ended",
+  "cancelled",
+  "canceled",
+  "completed",
+  "expired",
+]);
+const CONNECTION_RANK: Record<ConnectionState, number> = {
+  offline: 0,
+  connecting: 1,
+  reconnecting: 2,
+  live: 3,
+};
 
 type RoomDetailState = {
   selection: RoomSelection;
@@ -32,6 +46,78 @@ type RoomDetailState = {
 type RoomChatState = {
   selection: RoomSelection;
   messages: AdminChatMessage[];
+};
+
+const roomIdentity = (
+  room: Pick<AdminRoomSummary, "channelId" | "clientId" | "roomId">,
+): string => room.channelId || `${room.clientId}:${room.roomId}`;
+
+const scheduledIdentity = (
+  item: Pick<AdminScheduledItem, "kind" | "clientId" | "id">,
+): string => `${item.kind}:${item.clientId}:${item.id}`;
+
+const scheduleRoomIdentity = (
+  item: Pick<AdminScheduledItem, "clientId" | "roomId">,
+): string => `${item.clientId}:${item.roomId}`;
+
+const roomScore = (room: TaggedRoomSummary): number =>
+  room.participants * 1_000 +
+  room.admins * 100 +
+  room.pending * 10 +
+  (room.screenShare ? 4 : 0) +
+  (room.activeGame ? 2 : 0) +
+  (room.activeAppId ? 1 : 0);
+
+const scheduleStatusRank = (item: AdminScheduledItem): number => {
+  const status = item.status.toLowerCase();
+  if (LIVE_SCHEDULE_STATUSES.has(status)) return 3;
+  if (PAST_SCHEDULE_STATUSES.has(status)) return 1;
+  return 2;
+};
+
+const instanceOrder = (instances: InstanceStatus[]): Map<string, number> => {
+  const order = new Map<string, number>();
+  instances.forEach((instance, index) => order.set(instance.key, index));
+  return order;
+};
+
+const prefersInstance = (
+  nextKey: string,
+  currentKey: string,
+  order: Map<string, number>,
+): boolean => {
+  const nextRank = order.get(nextKey) ?? Number.MAX_SAFE_INTEGER;
+  const currentRank = order.get(currentKey) ?? Number.MAX_SAFE_INTEGER;
+  return nextRank < currentRank;
+};
+
+const prefersRoom = (
+  next: TaggedRoomSummary,
+  current: TaggedRoomSummary,
+  order: Map<string, number>,
+): boolean => {
+  const nextScore = roomScore(next);
+  const currentScore = roomScore(current);
+  if (nextScore !== currentScore) return nextScore > currentScore;
+  return prefersInstance(next.instanceKey, current.instanceKey, order);
+};
+
+const prefersScheduledItem = (
+  next: TaggedScheduledItem,
+  current: TaggedScheduledItem,
+  activeRoomByIdentity: Map<string, TaggedRoomSummary>,
+  order: Map<string, number>,
+): boolean => {
+  const activeRoom = activeRoomByIdentity.get(scheduleRoomIdentity(next));
+  if (activeRoom) {
+    if (next.instanceKey === activeRoom.instanceKey) return true;
+    if (current.instanceKey === activeRoom.instanceKey) return false;
+  }
+
+  const nextRank = scheduleStatusRank(next);
+  const currentRank = scheduleStatusRank(current);
+  if (nextRank !== currentRank) return nextRank > currentRank;
+  return prefersInstance(next.instanceKey, current.instanceKey, order);
 };
 
 /**
@@ -101,6 +187,21 @@ export function useAdminSocket() {
       );
     };
 
+    const clearInstanceLiveState = (key: string) => {
+      setRoomsByInstance((prev) =>
+        prev[key]?.length ? { ...prev, [key]: [] } : prev,
+      );
+      setScheduledByInstance((prev) =>
+        prev[key]?.length ? { ...prev, [key]: [] } : prev,
+      );
+      setDetail((prev) =>
+        prev?.selection.instanceKey === key ? null : prev,
+      );
+      setRoomChat((prev) =>
+        prev?.selection.instanceKey === key ? null : prev,
+      );
+    };
+
     void (async () => {
       try {
         const minted = await mint();
@@ -114,7 +215,7 @@ export function useAdminSocket() {
           minted.map(({ url }) => ({
             key: url,
             url,
-            connection: "connecting" as ConnectionState,
+            connection: "connecting",
             instanceId: null,
             overview: null,
           })),
@@ -150,11 +251,13 @@ export function useAdminSocket() {
             patchInstance(key, {
               connection: hasConnected ? "reconnecting" : "offline",
             });
+            clearInstanceLiveState(key);
           });
           socket.on("connect_error", () => {
             patchInstance(key, {
               connection: hasConnected ? "reconnecting" : "offline",
             });
+            clearInstanceLiveState(key);
           });
 
           socket.on("admin:hello", (data: { instanceId?: string }) => {
@@ -183,7 +286,7 @@ export function useAdminSocket() {
               setDetail(
                 data.room
                   ? {
-                      selection: { instanceKey: key, channelId: data.channelId! },
+                      selection: { instanceKey: key, channelId: data.channelId },
                       room: data.room,
                     }
                   : null,
@@ -258,7 +361,7 @@ export function useAdminSocket() {
                 return;
               }
               setRoomChat({
-                selection: { instanceKey: key, channelId: data.channelId! },
+                selection: { instanceKey: key, channelId: data.channelId },
                 messages: Array.isArray(data.messages) ? data.messages : [],
               });
             },
@@ -361,43 +464,87 @@ export function useAdminSocket() {
 
   const retry = useCallback(() => setRetryNonce((nonce) => nonce + 1), []);
 
-  const rooms: TaggedRoomSummary[] = useMemo(() => {
-    const merged: TaggedRoomSummary[] = [];
+  const visibleInstances = useMemo(() => {
+    const byIdentity = new Map<string, InstanceStatus>();
     for (const instance of instances) {
-      for (const room of roomsByInstance[instance.key] ?? []) {
-        merged.push({ ...room, instanceKey: instance.key, instanceUrl: instance.url });
+      const identity = instance.instanceId
+        ? `instance:${instance.instanceId}`
+        : `url:${instance.url}`;
+      const existing = byIdentity.get(identity);
+      if (
+        !existing ||
+        CONNECTION_RANK[instance.connection] > CONNECTION_RANK[existing.connection]
+      ) {
+        byIdentity.set(identity, instance);
       }
     }
-    return merged;
-  }, [instances, roomsByInstance]);
+    return Array.from(byIdentity.values());
+  }, [instances]);
+
+  const rooms: TaggedRoomSummary[] = useMemo(() => {
+    const order = instanceOrder(visibleInstances);
+    const byRoom = new Map<string, TaggedRoomSummary>();
+    for (const instance of visibleInstances) {
+      for (const room of roomsByInstance[instance.key] ?? []) {
+        const tagged = {
+          ...room,
+          instanceKey: instance.key,
+          instanceUrl: instance.url,
+        };
+        const key = roomIdentity(tagged);
+        const existing = byRoom.get(key);
+        if (!existing || prefersRoom(tagged, existing, order)) {
+          byRoom.set(key, tagged);
+        }
+      }
+    }
+    return Array.from(byRoom.values());
+  }, [roomsByInstance, visibleInstances]);
 
   const scheduled: TaggedScheduledItem[] = useMemo(() => {
-    const merged: TaggedScheduledItem[] = [];
-    for (const instance of instances) {
+    const order = instanceOrder(visibleInstances);
+    const activeRoomByIdentity = new Map<string, TaggedRoomSummary>();
+    for (const room of rooms) {
+      activeRoomByIdentity.set(`${room.clientId}:${room.roomId}`, room);
+    }
+
+    const byItem = new Map<string, TaggedScheduledItem>();
+    for (const instance of visibleInstances) {
       for (const item of scheduledByInstance[instance.key] ?? []) {
-        merged.push({ ...item, instanceKey: instance.key });
+        const tagged = { ...item, instanceKey: instance.key };
+        const key = scheduledIdentity(tagged);
+        const existing = byItem.get(key);
+        if (
+          !existing ||
+          prefersScheduledItem(tagged, existing, activeRoomByIdentity, order)
+        ) {
+          byItem.set(key, tagged);
+        }
       }
     }
+    const merged = Array.from(byItem.values());
     merged.sort((a, b) => a.startAt - b.startAt);
     return merged;
-  }, [instances, scheduledByInstance]);
+  }, [rooms, scheduledByInstance, visibleInstances]);
 
   const connection: ConnectionState = useMemo(() => {
     if (bootError) return "offline";
-    if (instances.length === 0) return "connecting";
-    if (instances.some((instance) => instance.connection === "live")) return "live";
-    if (instances.some((instance) => instance.connection === "reconnecting")) {
+    if (visibleInstances.length === 0) return "connecting";
+    if (visibleInstances.some((instance) => instance.connection === "live")) {
+      return "live";
+    }
+    if (visibleInstances.some((instance) => instance.connection === "reconnecting")) {
       return "reconnecting";
     }
-    if (instances.every((instance) => instance.connection === "offline")) {
+    if (visibleInstances.every((instance) => instance.connection === "offline")) {
       return "offline";
     }
     return "connecting";
-  }, [bootError, instances]);
+  }, [bootError, visibleInstances]);
 
   /** Cross-pool participant history, index-aligned from the newest sample. */
   const participantsHistory: number[] = useMemo(() => {
-    const series = instances
+    const series = visibleInstances
       .map((instance) => historyByInstance[instance.key] ?? [])
       .filter((points) => points.length > 0);
     if (series.length === 0) return [];
@@ -412,12 +559,12 @@ export function useAdminSocket() {
       summed.push(total);
     }
     return summed;
-  }, [historyByInstance, instances]);
+  }, [historyByInstance, visibleInstances]);
 
   return {
     connection,
     bootError,
-    instances,
+    instances: visibleInstances,
     rooms,
     roomDetail: detail?.room ?? null,
     detailSelection: detail?.selection ?? null,

--- a/packages/sfu/server/admin/adminGateway.ts
+++ b/packages/sfu/server/admin/adminGateway.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import type { Server as SocketIOServer } from "socket.io";
 import { Logger } from "../../utilities/loggers.js";
+import { renewRoomOwnerships } from "../rooms.js";
 import { listScheduledMeetings } from "../scheduledMeetings.js";
 import { listScheduledWebinars } from "../scheduledWebinars.js";
 import type { SfuState } from "../state.js";
@@ -28,6 +29,7 @@ const HISTORY_MAX_POINTS = 360;
 const EVENTS_MAX = 200;
 const EVENTS_PER_TICK_MAX = 40;
 const FIND_MATCH_LIMIT = 20;
+const OWNERSHIP_RECONCILE_MS = 2_000;
 
 export type AdminRoomSummary = {
   channelId: string;
@@ -381,6 +383,39 @@ export const registerAdminGateway = (
   const eventLog: AdminEvent[] = [];
   const history: AdminHistoryPoint[] = [];
   let lastHistorySampleAt = 0;
+  let lastOwnershipReconcileAt = 0;
+  let ownershipReconcilePromise: Promise<void> | null = null;
+  let tickInFlight = false;
+
+  const reconcileRoomOwnerships = async (
+    now: number,
+    opts?: { force?: boolean },
+  ): Promise<void> => {
+    if (state.rooms.size === 0) {
+      lastOwnershipReconcileAt = now;
+      return;
+    }
+    if (
+      !opts?.force &&
+      now - lastOwnershipReconcileAt < OWNERSHIP_RECONCILE_MS
+    ) {
+      return;
+    }
+    if (ownershipReconcilePromise) {
+      await ownershipReconcilePromise;
+      return;
+    }
+
+    lastOwnershipReconcileAt = now;
+    ownershipReconcilePromise = renewRoomOwnerships(state)
+      .catch((error) => {
+        Logger.warn("[AdminGateway] room ownership reconciliation failed", error);
+      })
+      .finally(() => {
+        ownershipReconcilePromise = null;
+      });
+    await ownershipReconcilePromise;
+  };
 
   const watchedChannelIds = (): string[] => {
     const channels: string[] = [];
@@ -447,9 +482,12 @@ export const registerAdminGateway = (
     }
   };
 
-  const tick = () => {
+  const tick = async () => {
+    if (tickInFlight) return;
+    tickInFlight = true;
     const now = Date.now();
     try {
+      await reconcileRoomOwnerships(now);
       // History and the activity log keep recording while nobody watches, so
       // a fresh session opens with context instead of a blank hour.
       sampleHistory(now);
@@ -523,10 +561,14 @@ export const registerAdminGateway = (
       }
     } catch (error) {
       Logger.warn("[AdminGateway] tick failed", error);
+    } finally {
+      tickInFlight = false;
     }
   };
 
-  const interval = setInterval(tick, TICK_MS);
+  const interval = setInterval(() => {
+    void tick();
+  }, TICK_MS);
   interval.unref?.();
 
   const unsubscribeAudit = subscribeAdminAudit((entry) => {
@@ -543,12 +585,20 @@ export const registerAdminGateway = (
       version,
       serverNow: Date.now(),
     });
-    socket.emit("admin:overview", buildOverview());
-    socket.emit("admin:rooms", { rooms: buildRoomSummaries() });
-    socket.emit("admin:history", { points: [...history] });
-    socket.emit("admin:events", { events: [...eventLog], snapshot: true });
-    socket.emit("admin:audit", { entries: getAdminAuditEntries() });
-    socket.emit("admin:scheduled", { items: buildScheduled() });
+    void (async () => {
+      try {
+        await reconcileRoomOwnerships(Date.now(), { force: true });
+        if (!socket.connected) return;
+        socket.emit("admin:overview", buildOverview());
+        socket.emit("admin:rooms", { rooms: buildRoomSummaries() });
+        socket.emit("admin:history", { points: [...history] });
+        socket.emit("admin:events", { events: [...eventLog], snapshot: true });
+        socket.emit("admin:audit", { entries: getAdminAuditEntries() });
+        socket.emit("admin:scheduled", { items: buildScheduled() });
+      } catch (error) {
+        Logger.warn("[AdminGateway] initial snapshot failed", error);
+      }
+    })();
 
     socket.on(
       "admin:watchRoom",


### PR DESCRIPTION
## Summary
- reconcile room ownership before SFU admin snapshots so stale local rooms are closed before they can be counted/listed
- collapse admin room and scheduled rows by stable room/schedule identity across instance feeds
- route activity/scheduled clicks to the current live room owner and hide duplicate historical activity rows

## Verification
- pnpm -C packages/sfu run typecheck
- pnpm -C apps/web run lint

## Notes
- Live routing check showed Redis ownership for the sampled room belonged to only one SFU while the dashboard could still render per-instance rows.

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR reduces duplicate SFU admin rows across instance feeds. The main changes are:

- Reconciles room ownership before admin snapshots.
- Collapses duplicate room, scheduled, and instance rows in the web admin socket hook.
- Routes activity and scheduled actions toward the current live room owner.

<h3>Confidence Score: 4/5</h3>

The changed activity drawer path needs fixes before merging.

- The activity event key can hide rapid repeated events.
- Activity and scheduled clicks can bind to the wrong instance while stale rows are still visible.
- The server-side reconciliation path has cleanup guards and does not show a blocking issue from the reviewed context.

apps/web/src/app/sfu-admin/ActivityDrawer.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/sfu-admin/ActivityDrawer.tsx | Adds activity de-duplication and live-owner routing, but the matching keys can hide repeated events and bind rows to the wrong instance. |
| apps/web/src/app/sfu-admin/useAdminSocket.ts | Adds visible-instance, room, and scheduled de-duplication with ranking logic for live dashboard rows. |
| packages/sfu/server/admin/adminGateway.ts | Adds ownership reconciliation before ticks and initial snapshots, with guarded async tick execution. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FActivityDrawer.tsx%3A67%0A**Same-Second%20Events%20Disappear**%0A%0AWhen%20two%20real%20events%20for%20the%20same%20channel%20have%20the%20same%20type%20and%20message%20within%20one%20second%2C%20this%20key%20treats%20them%20as%20the%20same%20row%20because%20it%20truncates%20%60event.at%60%20with%20%60Math.floor%60.%20The%20previous%20list%20rendered%20both%20events%2C%20but%20the%20new%20filter%20drops%20the%20later%20one%2C%20so%20operators%20can%20miss%20rapid%20repeated%20activity.%0A%0A%60%60%60suggestion%0A%20%20%20%20event.at%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FActivityDrawer.tsx%3A315-320%0A**Channel%20Match%20Picks%20Wrong%20Instance**%0A%0ADuring%20the%20stale-room%20window%20this%20change%20is%20meant%20to%20handle%2C%20two%20instance%20feeds%20can%20still%20contain%20the%20same%20%60channelId%60.%20%60rooms.find%60%20returns%20the%20first%20matching%20live%20row%20instead%20of%20the%20event's%20owning%20instance%2C%20so%20clicking%20an%20event%20can%20open%20details%20on%20a%20different%20SFU%20instance%20and%20show%20stale%20or%20empty%20room%20data.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FActivityDrawer.tsx%3A153-158%0A**Scheduled%20Rows%20Bind%20Cross-Instance**%0A%0AWhen%20a%20stale%20scheduled%20item%20and%20a%20live%20room%20with%20the%20same%20%60clientId%60%20and%20%60roomId%60%20are%20still%20present%20on%20different%20instances%2C%20this%20lookup%20now%20marks%20the%20scheduled%20row%20as%20live%20using%20the%20other%20instance's%20room.%20The%20row%20can%20route%20to%20the%20wrong%20owner%20and%20show%20a%20live%20action%20for%20a%20stale%20schedule%20entry.%0A%0A&repo=acm-vit%2Fconclave&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FActivityDrawer.tsx%3A67%0A**Same-Second%20Events%20Disappear**%0A%0AWhen%20two%20real%20events%20for%20the%20same%20channel%20have%20the%20same%20type%20and%20message%20within%20one%20second%2C%20this%20key%20treats%20them%20as%20the%20same%20row%20because%20it%20truncates%20%60event.at%60%20with%20%60Math.floor%60.%20The%20previous%20list%20rendered%20both%20events%2C%20but%20the%20new%20filter%20drops%20the%20later%20one%2C%20so%20operators%20can%20miss%20rapid%20repeated%20activity.%0A%0A%60%60%60suggestion%0A%20%20%20%20event.at%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FActivityDrawer.tsx%3A315-320%0A**Channel%20Match%20Picks%20Wrong%20Instance**%0A%0ADuring%20the%20stale-room%20window%20this%20change%20is%20meant%20to%20handle%2C%20two%20instance%20feeds%20can%20still%20contain%20the%20same%20%60channelId%60.%20%60rooms.find%60%20returns%20the%20first%20matching%20live%20row%20instead%20of%20the%20event's%20owning%20instance%2C%20so%20clicking%20an%20event%20can%20open%20details%20on%20a%20different%20SFU%20instance%20and%20show%20stale%20or%20empty%20room%20data.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FActivityDrawer.tsx%3A153-158%0A**Scheduled%20Rows%20Bind%20Cross-Instance**%0A%0AWhen%20a%20stale%20scheduled%20item%20and%20a%20live%20room%20with%20the%20same%20%60clientId%60%20and%20%60roomId%60%20are%20still%20present%20on%20different%20instances%2C%20this%20lookup%20now%20marks%20the%20scheduled%20row%20as%20live%20using%20the%20other%20instance's%20room.%20The%20row%20can%20route%20to%20the%20wrong%20owner%20and%20show%20a%20live%20action%20for%20a%20stale%20schedule%20entry.%0A%0A&repo=acm-vit%2Fconclave&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FActivityDrawer.tsx%3A67%0A**Same-Second%20Events%20Disappear**%0A%0AWhen%20two%20real%20events%20for%20the%20same%20channel%20have%20the%20same%20type%20and%20message%20within%20one%20second%2C%20this%20key%20treats%20them%20as%20the%20same%20row%20because%20it%20truncates%20%60event.at%60%20with%20%60Math.floor%60.%20The%20previous%20list%20rendered%20both%20events%2C%20but%20the%20new%20filter%20drops%20the%20later%20one%2C%20so%20operators%20can%20miss%20rapid%20repeated%20activity.%0A%0A%60%60%60suggestion%0A%20%20%20%20event.at%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FActivityDrawer.tsx%3A315-320%0A**Channel%20Match%20Picks%20Wrong%20Instance**%0A%0ADuring%20the%20stale-room%20window%20this%20change%20is%20meant%20to%20handle%2C%20two%20instance%20feeds%20can%20still%20contain%20the%20same%20%60channelId%60.%20%60rooms.find%60%20returns%20the%20first%20matching%20live%20row%20instead%20of%20the%20event's%20owning%20instance%2C%20so%20clicking%20an%20event%20can%20open%20details%20on%20a%20different%20SFU%20instance%20and%20show%20stale%20or%20empty%20room%20data.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FActivityDrawer.tsx%3A153-158%0A**Scheduled%20Rows%20Bind%20Cross-Instance**%0A%0AWhen%20a%20stale%20scheduled%20item%20and%20a%20live%20room%20with%20the%20same%20%60clientId%60%20and%20%60roomId%60%20are%20still%20present%20on%20different%20instances%2C%20this%20lookup%20now%20marks%20the%20scheduled%20row%20as%20live%20using%20the%20other%20instance's%20room.%20The%20row%20can%20route%20to%20the%20wrong%20owner%20and%20show%20a%20live%20action%20for%20a%20stale%20schedule%20entry.%0A%0A&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): collapse duplicate SFU room ..."](https://github.com/acm-vit/conclave/commit/e22d549a7744fc50764836173f311032468eedb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41389490)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->