### PR TITLE
fix(admin): watch rooms across SFU instances

### DIFF
--- a/apps/web/src/app/sfu-admin/ActivityDrawer.tsx
+++ b/apps/web/src/app/sfu-admin/ActivityDrawer.tsx
@@ -64,11 +64,22 @@ const LIVE_STATUSES = new Set(["live", "started", "in_progress"]);
 
 const eventIdentity = (event: TaggedAdminEvent): string =>
   [
-    Math.floor(event.at / 1000),
+    event.at,
     event.channelId,
     event.type,
     event.message,
   ].join(":");
+
+const findScheduledRoom = (
+  item: TaggedScheduledItem,
+  rooms: TaggedRoomSummary[],
+): TaggedRoomSummary | null =>
+  rooms.find(
+    (room) =>
+      room.instanceKey === item.instanceKey &&
+      room.roomId === item.roomId &&
+      room.clientId === item.clientId,
+  ) ?? null;
 
 function CopyLinkButton({ path }: { path: string }) {
   const [copied, setCopied] = useState(false);
@@ -135,11 +146,12 @@ export function ActivityDrawer({
       onlySelectedRoom && selected
         ? events.filter((event) => event.channelId === selected.channelId)
         : events;
-    const seen = new Set<string>();
+    const seen = new Map<string, string>();
     return scoped.filter((event) => {
       const key = eventIdentity(event);
-      if (seen.has(key)) return false;
-      seen.add(key);
+      const instanceKey = seen.get(key);
+      if (instanceKey && instanceKey !== event.instanceKey) return false;
+      seen.set(key, event.instanceKey);
       return true;
     });
   }, [events, onlySelectedRoom, selected]);
@@ -151,11 +163,7 @@ export function ActivityDrawer({
     const past: TaggedScheduledItem[] = [];
     for (const item of scheduled) {
       const status = item.status.toLowerCase();
-      const activeRoom = rooms.find(
-        (room) =>
-          room.roomId === item.roomId &&
-          room.clientId === item.clientId,
-      );
+      const activeRoom = findScheduledRoom(item, rooms);
       if (LIVE_STATUSES.has(status) || activeRoom) {
         live.push(item);
       } else if (PAST_STATUSES.has(status) || item.endAt < now) {
@@ -173,11 +181,7 @@ export function ActivityDrawer({
 
   const renderScheduledItem = (item: TaggedScheduledItem, now: number) => {
     const status = item.status.toLowerCase();
-    const activeRoom = rooms.find(
-      (room) =>
-        room.roomId === item.roomId &&
-        room.clientId === item.clientId,
-    );
+    const activeRoom = findScheduledRoom(item, rooms);
     const tone = activeRoom || LIVE_STATUSES.has(status)
       ? color.success
       : PAST_STATUSES.has(status)
@@ -313,15 +317,7 @@ export function ActivityDrawer({
                 <li key={`${event.at}-${index}`}>
                   <button
                     type="button"
-                    onClick={() => {
-                      const activeRoom = rooms.find(
-                        (room) => room.channelId === event.channelId,
-                      );
-                      onPickRoom(
-                        activeRoom?.instanceKey ?? event.instanceKey,
-                        event.channelId,
-                      );
-                    }}
+                    onClick={() => onPickRoom(event.instanceKey, event.channelId)}
                     className="flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-white/[0.04]"
                   >
                     <span className="mt-[5px]">

--- a/apps/web/src/app/sfu-admin/sfu-admin-dashboard.tsx
+++ b/apps/web/src/app/sfu-admin/sfu-admin-dashboard.tsx
@@ -93,6 +93,16 @@ export default function SfuAdminDashboard() {
     watchRoom(next);
   }, [rooms, selected, watchRoom]);
 
+  useEffect(() => {
+    if (
+      detailSelection &&
+      selected?.channelId === detailSelection.channelId &&
+      selected.instanceKey !== detailSelection.instanceKey
+    ) {
+      setSelected(detailSelection);
+    }
+  }, [detailSelection, selected]);
+
   const selectRoom = useCallback(
     (selection: RoomSelection) => {
       setSelected(selection);

--- a/apps/web/src/app/sfu-admin/useAdminSocket.ts
+++ b/apps/web/src/app/sfu-admin/useAdminSocket.ts
@@ -75,38 +75,26 @@ const scheduleStatusRank = (item: AdminScheduledItem): number => {
   return 2;
 };
 
-const instanceOrder = (instances: InstanceStatus[]): Map<string, number> => {
-  const order = new Map<string, number>();
-  instances.forEach((instance, index) => order.set(instance.key, index));
-  return order;
-};
-
-const prefersInstance = (
-  nextKey: string,
-  currentKey: string,
-  order: Map<string, number>,
-): boolean => {
-  const nextRank = order.get(nextKey) ?? Number.MAX_SAFE_INTEGER;
-  const currentRank = order.get(currentKey) ?? Number.MAX_SAFE_INTEGER;
-  return nextRank < currentRank;
-};
-
 const prefersRoom = (
   next: TaggedRoomSummary,
   current: TaggedRoomSummary,
-  order: Map<string, number>,
+  connectionByInstance: Map<string, ConnectionState>,
 ): boolean => {
+  const nextConnection = CONNECTION_RANK[connectionByInstance.get(next.instanceKey) ?? "offline"];
+  const currentConnection =
+    CONNECTION_RANK[connectionByInstance.get(current.instanceKey) ?? "offline"];
+  if (nextConnection !== currentConnection) return nextConnection > currentConnection;
   const nextScore = roomScore(next);
   const currentScore = roomScore(current);
   if (nextScore !== currentScore) return nextScore > currentScore;
-  return prefersInstance(next.instanceKey, current.instanceKey, order);
+  return next.instanceKey.localeCompare(current.instanceKey) < 0;
 };
 
 const prefersScheduledItem = (
   next: TaggedScheduledItem,
   current: TaggedScheduledItem,
   activeRoomByIdentity: Map<string, TaggedRoomSummary>,
-  order: Map<string, number>,
+  connectionByInstance: Map<string, ConnectionState>,
 ): boolean => {
   const activeRoom = activeRoomByIdentity.get(scheduleRoomIdentity(next));
   if (activeRoom) {
@@ -117,7 +105,11 @@ const prefersScheduledItem = (
   const nextRank = scheduleStatusRank(next);
   const currentRank = scheduleStatusRank(current);
   if (nextRank !== currentRank) return nextRank > currentRank;
-  return prefersInstance(next.instanceKey, current.instanceKey, order);
+  const nextConnection = CONNECTION_RANK[connectionByInstance.get(next.instanceKey) ?? "offline"];
+  const currentConnection =
+    CONNECTION_RANK[connectionByInstance.get(current.instanceKey) ?? "offline"];
+  if (nextConnection !== currentConnection) return nextConnection > currentConnection;
+  return next.instanceKey.localeCompare(current.instanceKey) < 0;
 };
 
 /**
@@ -188,6 +180,11 @@ export function useAdminSocket() {
     };
 
     const clearInstanceLiveState = (key: string) => {
+      setInstances((prev) =>
+        prev.map((instance) =>
+          instance.key === key ? { ...instance, overview: null } : instance,
+        ),
+      );
       setRoomsByInstance((prev) =>
         prev[key]?.length ? { ...prev, [key]: [] } : prev,
       );
@@ -243,7 +240,7 @@ export function useAdminSocket() {
             hasConnected = true;
             patchInstance(key, { connection: "live" });
             const watched = watchedRef.current;
-            if (watched && watched.instanceKey === key) {
+            if (watched) {
               socket.emit("admin:watchRoom", { channelId: watched.channelId });
             }
           });
@@ -278,19 +275,25 @@ export function useAdminSocket() {
               const watched = watchedRef.current;
               if (
                 !watched ||
-                watched.instanceKey !== key ||
                 data?.channelId !== watched.channelId
               ) {
                 return;
               }
-              setDetail(
-                data.room
-                  ? {
-                      selection: { instanceKey: key, channelId: data.channelId },
-                      room: data.room,
-                    }
-                  : null,
-              );
+              setDetail((prev) => {
+                if (data.room) {
+                  return {
+                    selection: { instanceKey: key, channelId: data.channelId },
+                    room: data.room,
+                  };
+                }
+                if (
+                  prev?.selection.instanceKey === key &&
+                  prev.selection.channelId === data.channelId
+                ) {
+                  return null;
+                }
+                return prev;
+              });
             },
           );
           socket.on("admin:history", (data: { points?: AdminHistoryPoint[] }) => {
@@ -355,7 +358,6 @@ export function useAdminSocket() {
               const watched = watchedRef.current;
               if (
                 !watched ||
-                watched.instanceKey !== key ||
                 data?.channelId !== watched.channelId
               ) {
                 return;
@@ -417,13 +419,17 @@ export function useAdminSocket() {
       setRoomChat(null);
     }
 
-    if (previous && (!selection || previous.instanceKey !== selection.instanceKey)) {
-      socketsRef.current.get(previous.instanceKey)?.emit("admin:watchRoom", {});
+    if (previous && (!selection || previous.channelId !== selection.channelId)) {
+      for (const socket of socketsRef.current.values()) {
+        socket.emit("admin:watchRoom", {});
+      }
     }
     if (selection) {
-      socketsRef.current
-        .get(selection.instanceKey)
-        ?.emit("admin:watchRoom", { channelId: selection.channelId });
+      for (const socket of socketsRef.current.values()) {
+        if (socket.connected) {
+          socket.emit("admin:watchRoom", { channelId: selection.channelId });
+        }
+      }
     }
   }, []);
 
@@ -431,9 +437,11 @@ export function useAdminSocket() {
   const resyncRoom = useCallback(() => {
     const watched = watchedRef.current;
     if (!watched) return;
-    socketsRef.current
-      .get(watched.instanceKey)
-      ?.emit("admin:watchRoom", { channelId: watched.channelId });
+    for (const socket of socketsRef.current.values()) {
+      if (socket.connected) {
+        socket.emit("admin:watchRoom", { channelId: watched.channelId });
+      }
+    }
   }, []);
 
   /** Search every connected instance for a person, merged and tagged. */
@@ -464,27 +472,17 @@ export function useAdminSocket() {
 
   const retry = useCallback(() => setRetryNonce((nonce) => nonce + 1), []);
 
-  const visibleInstances = useMemo(() => {
-    const byIdentity = new Map<string, InstanceStatus>();
+  const connectionByInstance = useMemo(() => {
+    const map = new Map<string, ConnectionState>();
     for (const instance of instances) {
-      const identity = instance.instanceId
-        ? `instance:${instance.instanceId}`
-        : `url:${instance.url}`;
-      const existing = byIdentity.get(identity);
-      if (
-        !existing ||
-        CONNECTION_RANK[instance.connection] > CONNECTION_RANK[existing.connection]
-      ) {
-        byIdentity.set(identity, instance);
-      }
+      map.set(instance.key, instance.connection);
     }
-    return Array.from(byIdentity.values());
+    return map;
   }, [instances]);
 
   const rooms: TaggedRoomSummary[] = useMemo(() => {
-    const order = instanceOrder(visibleInstances);
     const byRoom = new Map<string, TaggedRoomSummary>();
-    for (const instance of visibleInstances) {
+    for (const instance of instances) {
       for (const room of roomsByInstance[instance.key] ?? []) {
         const tagged = {
           ...room,
@@ -493,30 +491,34 @@ export function useAdminSocket() {
         };
         const key = roomIdentity(tagged);
         const existing = byRoom.get(key);
-        if (!existing || prefersRoom(tagged, existing, order)) {
+        if (!existing || prefersRoom(tagged, existing, connectionByInstance)) {
           byRoom.set(key, tagged);
         }
       }
     }
     return Array.from(byRoom.values());
-  }, [roomsByInstance, visibleInstances]);
+  }, [connectionByInstance, instances, roomsByInstance]);
 
   const scheduled: TaggedScheduledItem[] = useMemo(() => {
-    const order = instanceOrder(visibleInstances);
     const activeRoomByIdentity = new Map<string, TaggedRoomSummary>();
     for (const room of rooms) {
       activeRoomByIdentity.set(`${room.clientId}:${room.roomId}`, room);
     }
 
     const byItem = new Map<string, TaggedScheduledItem>();
-    for (const instance of visibleInstances) {
+    for (const instance of instances) {
       for (const item of scheduledByInstance[instance.key] ?? []) {
         const tagged = { ...item, instanceKey: instance.key };
         const key = scheduledIdentity(tagged);
         const existing = byItem.get(key);
         if (
           !existing ||
-          prefersScheduledItem(tagged, existing, activeRoomByIdentity, order)
+          prefersScheduledItem(
+            tagged,
+            existing,
+            activeRoomByIdentity,
+            connectionByInstance,
+          )
         ) {
           byItem.set(key, tagged);
         }
@@ -525,26 +527,26 @@ export function useAdminSocket() {
     const merged = Array.from(byItem.values());
     merged.sort((a, b) => a.startAt - b.startAt);
     return merged;
-  }, [rooms, scheduledByInstance, visibleInstances]);
+  }, [connectionByInstance, instances, rooms, scheduledByInstance]);
 
   const connection: ConnectionState = useMemo(() => {
     if (bootError) return "offline";
-    if (visibleInstances.length === 0) return "connecting";
-    if (visibleInstances.some((instance) => instance.connection === "live")) {
+    if (instances.length === 0) return "connecting";
+    if (instances.some((instance) => instance.connection === "live")) {
       return "live";
     }
-    if (visibleInstances.some((instance) => instance.connection === "reconnecting")) {
+    if (instances.some((instance) => instance.connection === "reconnecting")) {
       return "reconnecting";
     }
-    if (visibleInstances.every((instance) => instance.connection === "offline")) {
+    if (instances.every((instance) => instance.connection === "offline")) {
       return "offline";
     }
     return "connecting";
-  }, [bootError, visibleInstances]);
+  }, [bootError, instances]);
 
   /** Cross-pool participant history, index-aligned from the newest sample. */
   const participantsHistory: number[] = useMemo(() => {
-    const series = visibleInstances
+    const series = instances
       .map((instance) => historyByInstance[instance.key] ?? [])
       .filter((points) => points.length > 0);
     if (series.length === 0) return [];
@@ -559,12 +561,12 @@ export function useAdminSocket() {
       summed.push(total);
     }
     return summed;
-  }, [historyByInstance, visibleInstances]);
+  }, [historyByInstance, instances]);
 
   return {
     connection,
     bootError,
-    instances: visibleInstances,
+    instances,
     rooms,
     roomDetail: detail?.room ?? null,
     detailSelection: detail?.selection ?? null,

--- a/packages/sfu/server/admin/adminGateway.ts
+++ b/packages/sfu/server/admin/adminGateway.ts
@@ -487,7 +487,9 @@ export const registerAdminGateway = (
     tickInFlight = true;
     const now = Date.now();
     try {
-      await reconcileRoomOwnerships(now);
+      if (nsp.sockets.size > 0) {
+        await reconcileRoomOwnerships(now);
+      }
       // History and the activity log keep recording while nobody watches, so
       // a fresh session opens with context instead of a blank hour.
       sampleHistory(now);
@@ -625,6 +627,7 @@ export const registerAdminGateway = (
             return;
           }
 
+          await reconcileRoomOwnerships(Date.now(), { force: true });
           await socket.join(`${WATCH_PREFIX}${channelId}`);
           ack?.({ ok: true });
           emitRoomDetail(channelId, { force: true });


### PR DESCRIPTION
## Summary
- stop hiding configured SFU sockets behind instanceId/clientId heuristics
- fan out room watches to all connected SFU admin sockets so the real owner can return the snapshot
- clear stale overview counters on instance drop and sync selected room to the confirmed detail source
- address PR #149 review comments for search visibility, idle ownership renewals, event dedupe, event clicks, and scheduled live binding

## Debugged
- live routing for cedar-lilac-taki showed Redis owner sfu-b; sfu-a returned 404 for that room while the UI had selected sfu-a

## Verification
- pnpm -C packages/sfu run typecheck
- pnpm -C apps/web run lint

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR updates the SFU admin dashboard to watch rooms across all configured SFU instances. The main changes are:

- Room watch requests now fan out to all connected SFU admin sockets.
- The selected room syncs to the instance that returns confirmed room detail.
- Instance lists, room summaries, schedules, history, and counters now keep configured sockets visible instead of hiding them by instance identity.
- The SFU admin gateway forces ownership reconciliation before returning watched room details.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the contained multi-SFU chat handling issue.

The room watch fan-out and ownership reconciliation paths are focused, but `admin:chat` responses can be applied from the wrong SFU instance and hide the room chat.

`apps/web/src/app/sfu-admin/useAdminSocket.ts`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Vitest reproduction modeling the admin:chat overwrite and observed owner chat before a non-owner snapshot and null roomChat after.
- Observed fanout watch behavior: after enabling fanoutWatch, admin:watchRoom was broadcast to both SFUs, the owner room snapshot was received from sfu-b, and UI selection moved to sfu-b.
- Captured Playwright traces and verbose logs under trex-artifacts, documenting base single-identity behavior and later multi-socket interactions with beta sequencing.
- Recorded gateway ownership renewal tests showing idle reconciliation was skipped and then a watch-triggered forced reconciliation occurred, evidenced by watch ack and added watch.

<a href="https://app.greptile.com/trex/runs/13084955/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/sfu-admin/ActivityDrawer.tsx | Updates event dedupe, scheduled live-room binding, and event click routing; same-instance duplicate events still pass through the new dedupe map. |
| apps/web/src/app/sfu-admin/sfu-admin-dashboard.tsx | Synchronizes the selected room to the instance that returned confirmed room detail. |
| apps/web/src/app/sfu-admin/useAdminSocket.ts | Fans room watches out to all connected SFU sockets and merges instances directly, but chat snapshots can be overwritten by non-owner SFUs. |
| packages/sfu/server/admin/adminGateway.ts | Reconciles ownership only while admins are connected and forces ownership refresh before room watch detail emission. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant UI as Admin Dashboard
participant Hook as useAdminSocket
participant A as SFU admin socket A
participant B as SFU admin socket B
participant Owner as Redis ownership

UI->>Hook: select/watch channelId
Hook->>A: admin:watchRoom(channelId)
Hook->>B: admin:watchRoom(channelId)
A->>Owner: reconcileRoomOwnerships(force)
B->>Owner: reconcileRoomOwnerships(force)
A-->>Hook: admin:room(null or snapshot)
B-->>Hook: admin:room(null or snapshot)
Hook-->>UI: "detailSelection = responding owner"
A-->>Hook: admin:chat(messages or empty)
B-->>Hook: admin:chat(messages or empty)
Hook-->>UI: roomDetail / roomChat
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant UI as Admin Dashboard
participant Hook as useAdminSocket
participant A as SFU admin socket A
participant B as SFU admin socket B
participant Owner as Redis ownership

UI->>Hook: select/watch channelId
Hook->>A: admin:watchRoom(channelId)
Hook->>B: admin:watchRoom(channelId)
A->>Owner: reconcileRoomOwnerships(force)
B->>Owner: reconcileRoomOwnerships(force)
A-->>Hook: admin:room(null or snapshot)
B-->>Hook: admin:room(null or snapshot)
Hook-->>UI: "detailSelection = responding owner"
A-->>Hook: admin:chat(messages or empty)
B-->>Hook: admin:chat(messages or empty)
Hook-->>UI: roomDetail / roomChat
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/app/sfu-admin/useAdminSocket.ts`, line 365-367 ([link](https://github.com/acm-vit/conclave/blob/a00c38a228f51ac03d8287dd75966e7dffde7e37/apps/web/src/app/sfu-admin/useAdminSocket.ts#L365-L367)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Chat can be overwritten**
   `admin:watchRoom` is now emitted to every SFU, but `admin:chat` still accepts every matching `channelId`. A non-owner SFU emits an empty chat snapshot for the same channel, and if that arrives after the owner snapshot it sets `roomChat.selection.instanceKey` to the non-owner; the return filter then hides chat because it no longer matches `detail.selection`. Only accept chat from the confirmed detail source, or ignore empty non-owner snapshots while another instance owns the detail.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused Vitest harness for owner chat overwritten by non-owner empty snapshot](https://app.greptile.com/trex/artifacts/b2b0080f-3c4a-43c3-b04a-056820c37bb8)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: verbose Vitest output showing owner chat present before non-owner snapshot and null returned chat afterward](https://app.greptile.com/trex/artifacts/3fe37638-ee17-4268-aada-d865e463e58a)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/13084955/artifacts?artifact=b2b0080f-3c4a-43c3-b04a-056820c37bb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=2"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=2"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FuseAdminSocket.ts%0ALine%3A%20365-367%0A%0AComment%3A%0A**Chat%20can%20be%20overwritten**%0A%60admin%3AwatchRoom%60%20is%20now%20emitted%20to%20every%20SFU%2C%20but%20%60admin%3Achat%60%20still%20accepts%20every%20matching%20%60channelId%60.%20A%20non-owner%20SFU%20emits%20an%20empty%20chat%20snapshot%20for%20the%20same%20channel%2C%20and%20if%20that%20arrives%20after%20the%20owner%20snapshot%20it%20sets%20%60roomChat.selection.instanceKey%60%20to%20the%20non-owner%3B%20the%20return%20filter%20then%20hides%20chat%20because%20it%20no%20longer%20matches%20%60detail.selection%60.%20Only%20accept%20chat%20from%20the%20confirmed%20detail%20source%2C%20or%20ignore%20empty%20non-owner%20snapshots%20while%20another%20instance%20owns%20the%20detail.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=150&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FuseAdminSocket.ts%0ALine%3A%20365-367%0A%0AComment%3A%0A**Chat%20can%20be%20overwritten**%0A%60admin%3AwatchRoom%60%20is%20now%20emitted%20to%20every%20SFU%2C%20but%20%60admin%3Achat%60%20still%20accepts%20every%20matching%20%60channelId%60.%20A%20non-owner%20SFU%20emits%20an%20empty%20chat%20snapshot%20for%20the%20same%20channel%2C%20and%20if%20that%20arrives%20after%20the%20owner%20snapshot%20it%20sets%20%60roomChat.selection.instanceKey%60%20to%20the%20non-owner%3B%20the%20return%20filter%20then%20hides%20chat%20because%20it%20no%20longer%20matches%20%60detail.selection%60.%20Only%20accept%20chat%20from%20the%20confirmed%20detail%20source%2C%20or%20ignore%20empty%20non-owner%20snapshots%20while%20another%20instance%20owns%20the%20detail.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=acm-vit%2Fconclave&pr=150&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FuseAdminSocket.ts%0ALine%3A%20365-367%0A%0AComment%3A%0A**Chat%20can%20be%20overwritten**%0A%60admin%3AwatchRoom%60%20is%20now%20emitted%20to%20every%20SFU%2C%20but%20%60admin%3Achat%60%20still%20accepts%20every%20matching%20%60channelId%60.%20A%20non-owner%20SFU%20emits%20an%20empty%20chat%20snapshot%20for%20the%20same%20channel%2C%20and%20if%20that%20arrives%20after%20the%20owner%20snapshot%20it%20sets%20%60roomChat.selection.instanceKey%60%20to%20the%20non-owner%3B%20the%20return%20filter%20then%20hides%20chat%20because%20it%20no%20longer%20matches%20%60detail.selection%60.%20Only%20accept%20chat%20from%20the%20confirmed%20detail%20source%2C%20or%20ignore%20empty%20non-owner%20snapshots%20while%20another%20instance%20owns%20the%20detail.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=150&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FuseAdminSocket.ts%3A365-367%0A**Chat%20can%20be%20overwritten**%0A%60admin%3AwatchRoom%60%20is%20now%20emitted%20to%20every%20SFU%2C%20but%20%60admin%3Achat%60%20still%20accepts%20every%20matching%20%60channelId%60.%20A%20non-owner%20SFU%20emits%20an%20empty%20chat%20snapshot%20for%20the%20same%20channel%2C%20and%20if%20that%20arrives%20after%20the%20owner%20snapshot%20it%20sets%20%60roomChat.selection.instanceKey%60%20to%20the%20non-owner%3B%20the%20return%20filter%20then%20hides%20chat%20because%20it%20no%20longer%20matches%20%60detail.selection%60.%20Only%20accept%20chat%20from%20the%20confirmed%20detail%20source%2C%20or%20ignore%20empty%20non-owner%20snapshots%20while%20another%20instance%20owns%20the%20detail.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FActivityDrawer.tsx%3A152-154%0A**Duplicates%20still%20pass**%0AThe%20new%20%60Map%60%20only%20suppresses%20duplicates%20when%20the%20second%20copy%20comes%20from%20a%20different%20%60instanceKey%60%3B%20identical%20events%20repeated%20by%20the%20same%20SFU%20still%20render%20because%20%60instanceKey%20%3D%3D%3D%20event.instanceKey%60%20falls%20through%20to%20%60seen.set%28...%29%60%20and%20returns%20%60true%60.%20If%20the%20goal%20is%20event%20dedupe%2C%20return%20%60false%60%20whenever%20%60seen.has%28key%29%60%2C%20or%20include%20%60instanceKey%60%20in%20the%20identity%20when%20same-instance%20repeats%20should%20remain%20visible.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20instanceKey%20%3D%20seen.get%28key%29%3B%0A%20%20%20%20%20%20if%20%28instanceKey%29%20return%20false%3B%0A%20%20%20%20%20%20seen.set%28key%2C%20event.instanceKey%29%3B%0A%60%60%60%0A%0A&repo=acm-vit%2Fconclave&pr=150&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FuseAdminSocket.ts%3A365-367%0A**Chat%20can%20be%20overwritten**%0A%60admin%3AwatchRoom%60%20is%20now%20emitted%20to%20every%20SFU%2C%20but%20%60admin%3Achat%60%20still%20accepts%20every%20matching%20%60channelId%60.%20A%20non-owner%20SFU%20emits%20an%20empty%20chat%20snapshot%20for%20the%20same%20channel%2C%20and%20if%20that%20arrives%20after%20the%20owner%20snapshot%20it%20sets%20%60roomChat.selection.instanceKey%60%20to%20the%20non-owner%3B%20the%20return%20filter%20then%20hides%20chat%20because%20it%20no%20longer%20matches%20%60detail.selection%60.%20Only%20accept%20chat%20from%20the%20confirmed%20detail%20source%2C%20or%20ignore%20empty%20non-owner%20snapshots%20while%20another%20instance%20owns%20the%20detail.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FActivityDrawer.tsx%3A152-154%0A**Duplicates%20still%20pass**%0AThe%20new%20%60Map%60%20only%20suppresses%20duplicates%20when%20the%20second%20copy%20comes%20from%20a%20different%20%60instanceKey%60%3B%20identical%20events%20repeated%20by%20the%20same%20SFU%20still%20render%20because%20%60instanceKey%20%3D%3D%3D%20event.instanceKey%60%20falls%20through%20to%20%60seen.set%28...%29%60%20and%20returns%20%60true%60.%20If%20the%20goal%20is%20event%20dedupe%2C%20return%20%60false%60%20whenever%20%60seen.has%28key%29%60%2C%20or%20include%20%60instanceKey%60%20in%20the%20identity%20when%20same-instance%20repeats%20should%20remain%20visible.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20instanceKey%20%3D%20seen.get%28key%29%3B%0A%20%20%20%20%20%20if%20%28instanceKey%29%20return%20false%3B%0A%20%20%20%20%20%20seen.set%28key%2C%20event.instanceKey%29%3B%0A%60%60%60%0A%0A&repo=acm-vit%2Fconclave&pr=150&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FuseAdminSocket.ts%3A365-367%0A**Chat%20can%20be%20overwritten**%0A%60admin%3AwatchRoom%60%20is%20now%20emitted%20to%20every%20SFU%2C%20but%20%60admin%3Achat%60%20still%20accepts%20every%20matching%20%60channelId%60.%20A%20non-owner%20SFU%20emits%20an%20empty%20chat%20snapshot%20for%20the%20same%20channel%2C%20and%20if%20that%20arrives%20after%20the%20owner%20snapshot%20it%20sets%20%60roomChat.selection.instanceKey%60%20to%20the%20non-owner%3B%20the%20return%20filter%20then%20hides%20chat%20because%20it%20no%20longer%20matches%20%60detail.selection%60.%20Only%20accept%20chat%20from%20the%20confirmed%20detail%20source%2C%20or%20ignore%20empty%20non-owner%20snapshots%20while%20another%20instance%20owns%20the%20detail.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fsfu-admin%2FActivityDrawer.tsx%3A152-154%0A**Duplicates%20still%20pass**%0AThe%20new%20%60Map%60%20only%20suppresses%20duplicates%20when%20the%20second%20copy%20comes%20from%20a%20different%20%60instanceKey%60%3B%20identical%20events%20repeated%20by%20the%20same%20SFU%20still%20render%20because%20%60instanceKey%20%3D%3D%3D%20event.instanceKey%60%20falls%20through%20to%20%60seen.set%28...%29%60%20and%20returns%20%60true%60.%20If%20the%20goal%20is%20event%20dedupe%2C%20return%20%60false%60%20whenever%20%60seen.has%28key%29%60%2C%20or%20include%20%60instanceKey%60%20in%20the%20identity%20when%20same-instance%20repeats%20should%20remain%20visible.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20instanceKey%20%3D%20seen.get%28key%29%3B%0A%20%20%20%20%20%20if%20%28instanceKey%29%20return%20false%3B%0A%20%20%20%20%20%20seen.set%28key%2C%20event.instanceKey%29%3B%0A%60%60%60%0A%0A&pr=150&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): watch rooms across SFU insta..."](https://github.com/acm-vit/conclave/commit/a00c38a228f51ac03d8287dd75966e7dffde7e37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41424063)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->