### PR TITLE
fix(sfu): canonicalize conclave client namespaces

### DIFF
--- a/apps/web/src/app/api/scheduling/calendar/google/callback/route.ts
+++ b/apps/web/src/app/api/scheduling/calendar/google/callback/route.ts
@@ -6,6 +6,7 @@ import {
   resolveSchedulingBase,
 } from "@/lib/scheduling";
 import { requireSfuSessionUser } from "@/lib/sfu-user-auth";
+import { canonicalizeSfuClientId } from "@/lib/sfu-client-id";
 
 
 const STATE_COOKIE = "conclave_google_calendar_state";
@@ -105,8 +106,12 @@ export async function GET(request: Request) {
       | { email?: string }
       | null;
     const headers = buildSchedulingHeaders(authResult.user, request);
-    if (typeof payload.clientId === "string" && payload.clientId.trim()) {
-      headers.set("x-sfu-client", payload.clientId.trim());
+    const clientId =
+      typeof payload.clientId === "string"
+        ? canonicalizeSfuClientId(payload.clientId)
+        : null;
+    if (clientId) {
+      headers.set("x-sfu-client", clientId);
     }
     headers.set("x-app-origin", origin);
     const response = await fetch(`${resolveSchedulingBase()}/calendar/google`, {

--- a/apps/web/src/app/api/scheduling/calendar/google/connect/route.ts
+++ b/apps/web/src/app/api/scheduling/calendar/google/connect/route.ts
@@ -1,6 +1,9 @@
 import { SignJWT } from "jose";
 import { NextResponse } from "next/server";
-import { resolveServerSfuClientId } from "@/lib/sfu-client-id";
+import {
+  canonicalizeSfuClientId,
+  resolveServerSfuClientId,
+} from "@/lib/sfu-client-id";
 import { requireSfuSessionUser } from "@/lib/sfu-user-auth";
 
 
@@ -48,7 +51,7 @@ export async function GET(request: Request) {
   const state = await new SignJWT({
     userId: authResult.user.id,
     clientId:
-      request.headers.get("x-sfu-client") ||
+      canonicalizeSfuClientId(request.headers.get("x-sfu-client")) ||
       resolveServerSfuClientId(),
   })
     .setProtectedHeader({ alg: "HS256" })

--- a/apps/web/src/app/api/sfu/admin/[...path]/route.ts
+++ b/apps/web/src/app/api/sfu/admin/[...path]/route.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/sfu-admin-auth";
 import { normalizeSfuUrl, resolveSfuUrls } from "@/lib/sfu-url";
 import { readResponseError } from "@/app/lib/utils";
+import { canonicalizeSfuClientId } from "@/lib/sfu-client-id";
 
 type RouteContext = {
   params: Promise<{
@@ -70,8 +71,8 @@ const proxyAdminRequest = async (
   // way; injecting the env default here (as join flows do) silently hid every
   // other tenant's rooms from the admin room list.
   const clientId =
-    incomingUrl.searchParams.get("clientId")?.trim() ||
-    request.headers.get("x-sfu-client")?.trim() ||
+    canonicalizeSfuClientId(incomingUrl.searchParams.get("clientId")) ||
+    canonicalizeSfuClientId(request.headers.get("x-sfu-client")) ||
     "";
   if (clientId) {
     targetUrl.searchParams.set("clientId", clientId);

--- a/apps/web/src/app/api/sfu/join/route.ts
+++ b/apps/web/src/app/api/sfu/join/route.ts
@@ -3,7 +3,10 @@ import { createHash } from "node:crypto";
 import { NextResponse } from "next/server";
 import { resolveHostGrant } from "@conclave/meeting-core";
 import { auth } from "@/lib/auth";
-import { resolveServerSfuClientId } from "@/lib/sfu-client-id";
+import {
+  canonicalizeSfuClientId,
+  resolveServerSfuClientId,
+} from "@/lib/sfu-client-id";
 import { lookupScheduledWebinarByRoomId } from "@/lib/sfu-user-auth";
 import {
   normalizeRoutedSfuUrl,
@@ -464,8 +467,10 @@ const resolveIceServers = async (): Promise<IceServer[]> => {
 };
 
 const resolveClientId = (request: Request, body?: JoinRequestBody) => {
-  const headerClientId = request.headers.get("x-sfu-client")?.trim() || "";
-  const bodyClientId = body?.clientId?.trim() || "";
+  const headerClientId = canonicalizeSfuClientId(
+    request.headers.get("x-sfu-client"),
+  );
+  const bodyClientId = canonicalizeSfuClientId(body?.clientId);
   return headerClientId || bodyClientId || resolveServerSfuClientId();
 };
 

--- a/apps/web/src/app/components/DevMeetToolsPanel.tsx
+++ b/apps/web/src/app/components/DevMeetToolsPanel.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Socket } from "socket.io-client";
 import type { JoinMode } from "../lib/types";
 import { generateSessionId, readResponseError } from "../lib/utils";
+import { resolveBrowserSfuClientId } from "@/lib/sfu-client-id";
 
 const DevVideoEffectsDiagnostic = dynamic(
   () => import("./DevVideoEffectsDiagnostic"),
@@ -25,7 +26,7 @@ const parseNumberInput = (
   return clampNumber(parsed, min, max);
 };
 
-const clientId = process.env.NEXT_PUBLIC_SFU_CLIENT_ID || "conclave";
+const clientId = resolveBrowserSfuClientId();
 
 const readError = readResponseError;
 

--- a/apps/web/src/app/hooks/useVoiceAgentParticipant.ts
+++ b/apps/web/src/app/hooks/useVoiceAgentParticipant.ts
@@ -17,6 +17,7 @@ import {
   type AudioProducerNetworkProfile,
 } from "../lib/constants";
 import { getBrowserNetworkSnapshot } from "../lib/network-information";
+import { resolveBrowserSfuClientId } from "@/lib/sfu-client-id";
 
 type VoiceAgentStatus = "idle" | "starting" | "running" | "error";
 
@@ -99,8 +100,7 @@ const getJoinRoomRedirectError = (
   const redirectUrl = normalizeJoinRedirectUrl(response.redirectUrl);
   return redirectUrl ? new JoinRoomRedirectError(response, redirectUrl) : null;
 };
-const SFU_CLIENT_ID =
-  process.env.NEXT_PUBLIC_SFU_CLIENT_ID || "conclave";
+const SFU_CLIENT_ID = resolveBrowserSfuClientId();
 const TURN_URL_PATTERN = /^turns?:/i;
 const ACTIVE_SPEAKER_HOLD_MS = 50;
 

--- a/apps/web/src/app/meets-client-page.tsx
+++ b/apps/web/src/app/meets-client-page.tsx
@@ -4,7 +4,10 @@ import { useCallback } from "react";
 import MeetsClient from "./meets-client";
 import type { JoinMode } from "./lib/types";
 import type { RoomInfo } from "@/lib/sfu-types";
-import { resolveBrowserSfuClientId } from "@/lib/sfu-client-id";
+import {
+  canonicalizeSfuClientId,
+  resolveBrowserSfuClientId,
+} from "@/lib/sfu-client-id";
 import { readResponseError } from "./lib/utils";
 
 const reactionAssets = [
@@ -20,12 +23,6 @@ const readError = readResponseError;
 
 const defaultClientId = resolveBrowserSfuClientId();
 const JOIN_INFO_REQUEST_TIMEOUT_MS = 15000;
-
-const normalizeClientId = (value: string | undefined): string | null => {
-  const normalized = value?.trim();
-  if (!normalized) return null;
-  return /^[a-zA-Z0-9._:-]{1,64}$/.test(normalized) ? normalized : null;
-};
 
 const fetchJoinInfoWithTimeout = async (
   init: RequestInit,
@@ -79,9 +76,9 @@ export default function MeetsClientPage({
 }: MeetsClientPageProps) {
   const defaultUser = user;
   const resolvedIsAdmin = isAdmin;
-  const resolvedClientId = normalizeClientId(sfuClientId) || defaultClientId;
-  const usesRoomRouting =
-    resolvedClientId === "conclave" || resolvedClientId === "public";
+  const resolvedClientId =
+    canonicalizeSfuClientId(sfuClientId) || defaultClientId;
+  const usesRoomRouting = resolvedClientId === "conclave";
 
   const getJoinInfo = useCallback(
     async (

--- a/apps/web/src/lib/meeting-links.ts
+++ b/apps/web/src/lib/meeting-links.ts
@@ -1,21 +1,20 @@
+import {
+  canonicalizeSfuClientId,
+  CONCLAVE_SFU_CLIENT_ID,
+} from "@/lib/sfu-client-id";
+
 type MeetingLinkInput = {
   roomCode: string;
   clientId?: string | null;
 };
 
-const shouldIncludeClientId = (
-  clientId: string | null | undefined,
-): clientId is string => {
-  const normalized = clientId?.trim();
-  return Boolean(normalized && normalized !== "default");
-};
-
 export const buildMeetingPath = (meeting: MeetingLinkInput): string => {
   const path = `/${encodeURIComponent(meeting.roomCode)}`;
-  if (!shouldIncludeClientId(meeting.clientId)) {
+  const clientId = canonicalizeSfuClientId(meeting.clientId);
+  if (!clientId || clientId === CONCLAVE_SFU_CLIENT_ID) {
     return path;
   }
-  return `${path}?clientId=${encodeURIComponent(meeting.clientId.trim())}`;
+  return `${path}?clientId=${encodeURIComponent(clientId)}`;
 };
 
 export const buildMeetingUrl = (

--- a/apps/web/src/lib/scheduled-meetings.ts
+++ b/apps/web/src/lib/scheduled-meetings.ts
@@ -4,6 +4,10 @@ import {
 } from "@/lib/sfu-user-auth";
 import { resolveSfuSecret, resolveSfuUrl } from "@/lib/sfu-admin-auth";
 import { readResponseError } from "@/app/lib/utils";
+import {
+  canonicalizeSfuClientId,
+  CONCLAVE_SFU_CLIENT_ID,
+} from "@/lib/sfu-client-id";
 
 export type ScheduledMeetingStatus =
   | "scheduled"
@@ -81,8 +85,10 @@ export const lookupPublicScheduledMeetingByRoomCode = async (
   roomCode: string,
 ): Promise<PublicScheduledMeeting | null> => {
   try {
+    const resolvedClientId =
+      canonicalizeSfuClientId(clientId) || CONCLAVE_SFU_CLIENT_ID;
     const base = resolveScheduledMeetingsBase();
-    const url = `${base}/public/by-room/${encodeURIComponent(roomCode)}?clientId=${encodeURIComponent(clientId)}`;
+    const url = `${base}/public/by-room/${encodeURIComponent(roomCode)}?clientId=${encodeURIComponent(resolvedClientId)}`;
     const response = await fetch(url, {
       method: "GET",
       headers: {
@@ -106,8 +112,10 @@ export const lookupScheduledMeetingHostEmail = async (
   roomCode: string,
 ): Promise<string | null> => {
   try {
+    const resolvedClientId =
+      canonicalizeSfuClientId(clientId) || CONCLAVE_SFU_CLIENT_ID;
     const base = resolveScheduledMeetingsBase();
-    const url = `${base}/by-room/${encodeURIComponent(roomCode)}?clientId=${encodeURIComponent(clientId)}`;
+    const url = `${base}/by-room/${encodeURIComponent(roomCode)}?clientId=${encodeURIComponent(resolvedClientId)}`;
     const response = await fetch(url, {
       method: "GET",
       headers: {

--- a/apps/web/src/lib/scheduling.ts
+++ b/apps/web/src/lib/scheduling.ts
@@ -13,7 +13,10 @@ import {
   readScheduledMeetingError,
 } from "@/lib/scheduled-meetings";
 import type { SfuAuthenticatedUser } from "@/lib/sfu-user-auth";
-import { resolveServerSfuClientId } from "@/lib/sfu-client-id";
+import {
+  canonicalizeSfuClientId,
+  resolveServerSfuClientId,
+} from "@/lib/sfu-client-id";
 
 export type {
   AvailableSlot,
@@ -72,7 +75,7 @@ export const buildPublicSchedulingHeaders = (request?: Request): Headers => {
   headers.set("accept", "application/json");
   headers.set("content-type", "application/json");
   const clientId =
-    request?.headers.get("x-sfu-client")?.trim() ||
+    canonicalizeSfuClientId(request?.headers.get("x-sfu-client")) ||
     resolveServerSfuClientId();
   headers.set("x-sfu-client", clientId);
   return headers;

--- a/apps/web/src/lib/sfu-admin-auth.ts
+++ b/apps/web/src/lib/sfu-admin-auth.ts
@@ -1,6 +1,9 @@
 import { createHmac } from "node:crypto";
 import { auth } from "@/lib/auth";
-import { resolveServerSfuClientId } from "@/lib/sfu-client-id";
+import {
+  canonicalizeSfuClientId,
+  resolveServerSfuClientId,
+} from "@/lib/sfu-client-id";
 export { resolveSfuUrl } from "@/lib/sfu-url";
 
 const firstNonEmpty = (...values: Array<string | undefined>): string | undefined => {
@@ -131,9 +134,19 @@ export const resolveSfuClientId = (
   request: Request,
   options?: { fallback?: string },
 ): string => {
-  const fromQuery = new URL(request.url).searchParams.get("clientId")?.trim() || "";
-  const fromHeader = request.headers.get("x-sfu-client")?.trim() || "";
-  return fromQuery || fromHeader || resolveServerSfuClientId() || options?.fallback || "";
+  const fromQuery = canonicalizeSfuClientId(
+    new URL(request.url).searchParams.get("clientId"),
+  );
+  const fromHeader = canonicalizeSfuClientId(
+    request.headers.get("x-sfu-client"),
+  );
+  return (
+    fromQuery ||
+    fromHeader ||
+    resolveServerSfuClientId() ||
+    canonicalizeSfuClientId(options?.fallback) ||
+    ""
+  );
 };
 
 export const requireSfuAdminUser = async (

--- a/apps/web/src/lib/sfu-client-id.ts
+++ b/apps/web/src/lib/sfu-client-id.ts
@@ -1,4 +1,5 @@
 export const CONCLAVE_SFU_CLIENT_ID = "conclave";
+const LEGACY_CONCLAVE_SFU_CLIENT_IDS = new Set(["default", "public"]);
 
 const normalizeSfuClientId = (value: string | undefined): string | null => {
   const normalized = value?.trim();
@@ -6,12 +7,22 @@ const normalizeSfuClientId = (value: string | undefined): string | null => {
   return /^[a-zA-Z0-9._:-]{1,64}$/.test(normalized) ? normalized : null;
 };
 
+export const canonicalizeSfuClientId = (
+  value: string | null | undefined,
+): string | null => {
+  const normalized = normalizeSfuClientId(value ?? undefined);
+  if (!normalized) return null;
+  return LEGACY_CONCLAVE_SFU_CLIENT_IDS.has(normalized.toLowerCase())
+    ? CONCLAVE_SFU_CLIENT_ID
+    : normalized;
+};
+
 export const resolveBrowserSfuClientId = (): string =>
-  normalizeSfuClientId(process.env.NEXT_PUBLIC_SFU_CLIENT_ID) ||
+  canonicalizeSfuClientId(process.env.NEXT_PUBLIC_SFU_CLIENT_ID) ||
   CONCLAVE_SFU_CLIENT_ID;
 
 export const resolveServerSfuClientId = (): string =>
-  normalizeSfuClientId(process.env.SFU_CLIENT_ID) ||
+  canonicalizeSfuClientId(process.env.SFU_CLIENT_ID) ||
   resolveBrowserSfuClientId();
 
 export const resolveSfuClientIdCandidates = (
@@ -19,7 +30,7 @@ export const resolveSfuClientIdCandidates = (
 ): string[] => {
   const seen = new Set<string>();
   const candidates = [
-    normalizeSfuClientId(preferred ?? undefined),
+    canonicalizeSfuClientId(preferred),
     resolveServerSfuClientId(),
     CONCLAVE_SFU_CLIENT_ID,
     "default",

--- a/packages/sfu/config/config.ts
+++ b/packages/sfu/config/config.ts
@@ -125,14 +125,11 @@ type ClientPolicy = {
 const defaultClientPolicies: Record<string, ClientPolicy> = {
   default: {
     allowNonHostRoomCreation: false,
-    // Secure by default: a bare `isHost` claim must NOT grant admin of an
-    // EXISTING room. Legit host of an existing room is always server-tracked
-    // (returning primary host / promoted admin) or a session-verified forced
-    // host; the room creator still becomes host via the createdRoom path. Only
-    // explicitly-trusted clients (the `internal` policy) keep claim-based host.
+    // Public/default/conclave share the same policy; a bare `isHost` claim
+    // still must not grant admin of an existing room.
     allowHostJoin: false,
-    useWaitingRoom: true,
-    allowDisplayNameUpdate: false,
+    useWaitingRoom: false,
+    allowDisplayNameUpdate: true,
   },
   public: {
     allowNonHostRoomCreation: false,

--- a/packages/sfu/server/admin/adminGateway.ts
+++ b/packages/sfu/server/admin/adminGateway.ts
@@ -4,6 +4,7 @@ import { Logger } from "../../utilities/loggers.js";
 import { renewRoomOwnerships } from "../rooms.js";
 import { listScheduledMeetings } from "../scheduledMeetings.js";
 import { listScheduledWebinars } from "../scheduledWebinars.js";
+import { canonicalizeClientId } from "../clientIds.js";
 import type { SfuState } from "../state.js";
 import {
   getAdminAuditEntries,
@@ -299,11 +300,27 @@ export const registerAdminGateway = (
   // first, capped so a busy booking-link tenant cannot flood the socket.
   const buildScheduled = (): AdminScheduledItem[] => {
     const items: AdminScheduledItem[] = [];
+    const seen = new Set<string>();
     const now = Date.now();
+    const addItem = (item: AdminScheduledItem): void => {
+      const normalizedItem = {
+        ...item,
+        clientId: canonicalizeClientId(item.clientId),
+      };
+      const key = [
+        normalizedItem.kind,
+        normalizedItem.clientId,
+        normalizedItem.roomId,
+      ].join(":");
+      if (seen.has(key)) return;
+      seen.add(key);
+      items.push(normalizedItem);
+    };
+
     for (const meeting of listScheduledMeetings(state.scheduledMeetings, {
       includeAll: true,
     })) {
-      items.push({
+      addItem({
         kind: "meeting",
         id: meeting.id,
         title: meeting.title,
@@ -319,7 +336,7 @@ export const registerAdminGateway = (
     for (const webinar of listScheduledWebinars(state.scheduledWebinars, {
       includeAll: true,
     })) {
-      items.push({
+      addItem({
         kind: "webinar",
         id: webinar.id,
         title: webinar.title,

--- a/packages/sfu/server/clientIds.ts
+++ b/packages/sfu/server/clientIds.ts
@@ -1,0 +1,32 @@
+export const CONCLAVE_CLIENT_ID = "conclave";
+
+const LEGACY_CONCLAVE_CLIENT_IDS = new Set(["default", "public"]);
+
+export const canonicalizeClientId = (clientId: string): string => {
+  const normalized = clientId.trim();
+  return LEGACY_CONCLAVE_CLIENT_IDS.has(normalized.toLowerCase())
+    ? CONCLAVE_CLIENT_ID
+    : normalized;
+};
+
+export const resolveDefaultClientId = (): string =>
+  canonicalizeClientId(
+    process.env.SFU_CLIENT_ID?.trim() ||
+      process.env.NEXT_PUBLIC_SFU_CLIENT_ID?.trim() ||
+      CONCLAVE_CLIENT_ID,
+  );
+
+export const clientIdCandidates = (primary: string): string[] => {
+  const seen = new Set<string>();
+  return [
+    canonicalizeClientId(primary),
+    resolveDefaultClientId(),
+    CONCLAVE_CLIENT_ID,
+    "default",
+    "public",
+  ].filter((clientId) => {
+    if (!clientId || seen.has(clientId)) return false;
+    seen.add(clientId);
+    return true;
+  });
+};

--- a/packages/sfu/server/http/createApp.ts
+++ b/packages/sfu/server/http/createApp.ts
@@ -33,6 +33,7 @@ import { registerScheduledMeetingRoutes } from "./scheduledMeetingRoutes.js";
 import { registerSchedulingRoutes } from "./schedulingRoutes.js";
 import type { SfuState } from "../state.js";
 import { resolveWebinarLinkTarget } from "../webinar.js";
+import { canonicalizeClientId } from "../clientIds.js";
 
 export type CreateSfuAppOptions = {
   state: SfuState;
@@ -140,7 +141,7 @@ const resolveClientId = (req: Request): string | undefined => {
   const headerValue = normalizeIdentifier(req.header("x-sfu-client")) ?? "";
   const queryValue = normalizeIdentifier(req.query.clientId) ?? "";
   const next = queryValue || headerValue;
-  return next || undefined;
+  return next ? canonicalizeClientId(next) : undefined;
 };
 
 const parseMediaKinds = (value: unknown): MediaKind[] | null | undefined => {
@@ -515,15 +516,16 @@ export const createSfuApp = ({
     }
 
     try {
+      const resolvedClientId = canonicalizeClientId(clientId);
       let roomId = requestedRoomId;
-      let channelId = getRoomChannelId(clientId, roomId);
+      let channelId = getRoomChannelId(resolvedClientId, roomId);
       let owner = await state.roomRegistry.getOwner(channelId);
 
       if (!owner) {
         const webinarTarget = resolveWebinarLinkTarget(
           state.webinarLinks,
           requestedRoomId,
-          clientId,
+          resolvedClientId,
         );
         if (webinarTarget) {
           roomId = webinarTarget.roomId;
@@ -535,7 +537,7 @@ export const createSfuApp = ({
       res.json({
         requestedRoomId,
         roomId,
-        clientId,
+        clientId: resolvedClientId,
         channelId,
         registryMode: state.roomRegistry.mode,
         local: state.roomRegistry.isLocalOwner(owner),

--- a/packages/sfu/server/http/scheduledMeetingRoutes.ts
+++ b/packages/sfu/server/http/scheduledMeetingRoutes.ts
@@ -7,11 +7,17 @@ import {
   getScheduledMeetingById,
   getScheduledMeetingByRoomCode,
   listScheduledMeetings,
+  moveScheduledMeetingToClient,
   persistScheduledMeetingChanges,
   persistScheduledMeetingDeletes,
   updateScheduledMeeting,
 } from "../scheduledMeetings.js";
 import type { SfuState } from "../state.js";
+import {
+  canonicalizeClientId,
+  clientIdCandidates,
+  resolveDefaultClientId,
+} from "../clientIds.js";
 import type {
   CreateScheduledMeetingRequest,
   ScheduledMeeting,
@@ -30,12 +36,6 @@ const MAX_EMAIL_LENGTH = 320;
 const MAX_NAME_LENGTH = 120;
 const MAX_STATUS_FILTER_LENGTH = 128;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
-const CONCLAVE_CLIENT_ID = "conclave";
-
-const resolveDefaultClientId = (): string =>
-  process.env.SFU_CLIENT_ID?.trim() ||
-  process.env.NEXT_PUBLIC_SFU_CLIENT_ID?.trim() ||
-  CONCLAVE_CLIENT_ID;
 
 const hasValidSecret = (req: Request, secret: string): boolean => {
   const provided = req.header("x-sfu-secret");
@@ -69,7 +69,7 @@ const resolveClientId = (
 ): string => {
   const fromQuery = normalizeIdentifier(req.query.clientId) || "";
   const fromHeader = normalizeIdentifier(req.header("x-sfu-client")) || "";
-  return fromQuery || fromHeader || fallback;
+  return canonicalizeClientId(fromQuery || fromHeader || fallback);
 };
 
 const resolveUserContext = (
@@ -165,14 +165,87 @@ export const registerScheduledMeetingRoutes = (
     }
   };
 
-  app.get("/scheduled-meetings", (req, res) => {
+  const migrateMeetingNamespace = async (
+    meeting: ScheduledMeeting,
+    clientId: string,
+  ): Promise<ScheduledMeeting | null> => {
+    if (meeting.clientId === clientId) return meeting;
+    try {
+      const migrated = moveScheduledMeetingToClient(
+        state.scheduledMeetings,
+        meeting.id,
+        clientId,
+      );
+      if (migrated) {
+        await persistChanged(migrated);
+      }
+      return migrated;
+    } catch (error) {
+      Logger.warn(
+        `Failed to migrate scheduled meeting ${meeting.id} from ${meeting.clientId} to ${clientId}`,
+        error,
+      );
+      return null;
+    }
+  };
+
+  const findMeetingByRoomCode = async (
+    clientId: string,
+    roomCode: string,
+  ): Promise<ScheduledMeeting | null> => {
+    for (const candidateClientId of clientIdCandidates(clientId)) {
+      const meeting = getScheduledMeetingByRoomCode(
+        state.scheduledMeetings,
+        candidateClientId,
+        roomCode,
+      );
+      if (!meeting) continue;
+      if (meeting.clientId === clientId) return meeting;
+      const migrated = await migrateMeetingNamespace(meeting, clientId);
+      return migrated ?? meeting;
+    }
+    return null;
+  };
+
+  const listMeetingsForClient = async (options: {
+    clientId: string;
+    ownerEmail?: string;
+    includeAll: boolean;
+    status?: ScheduledMeetingStatus[];
+  }): Promise<ScheduledMeeting[]> => {
+    const byId = new Map<string, ScheduledMeeting>();
+    const seenRoomCodes = new Set<string>();
+    for (const candidateClientId of clientIdCandidates(options.clientId)) {
+      const meetings = listScheduledMeetings(state.scheduledMeetings, {
+        clientId: candidateClientId,
+        ownerEmail: options.ownerEmail,
+        includeAll: options.includeAll,
+        status: options.status,
+      });
+      for (const meeting of meetings) {
+        if (seenRoomCodes.has(meeting.roomCode)) continue;
+        const normalized =
+          meeting.clientId === options.clientId
+            ? meeting
+            : await migrateMeetingNamespace(meeting, options.clientId);
+        if (!normalized) continue;
+        seenRoomCodes.add(normalized.roomCode);
+        byId.set(normalized.id, normalized);
+      }
+    }
+    return Array.from(byId.values()).sort(
+      (a, b) => a.scheduledStartAt - b.scheduledStartAt,
+    );
+  };
+
+  app.get("/scheduled-meetings", async (req, res) => {
     if (!requireSecret(req, res)) return;
     const user = resolveUserContext(req);
     const clientId = resolveClientId(req);
     const includeAll = req.query.scope === "all" && user.isAdmin;
     const statusFilter = parseStatusFilter(req.query.status);
 
-    const list = listScheduledMeetings(state.scheduledMeetings, {
+    const list = await listMeetingsForClient({
       clientId,
       ownerEmail: user.email || undefined,
       includeAll,
@@ -211,7 +284,7 @@ export const registerScheduledMeetingRoutes = (
     }
   });
 
-  app.get("/scheduled-meetings/by-room/:roomCode", (req, res) => {
+  app.get("/scheduled-meetings/by-room/:roomCode", async (req, res) => {
     if (!requireSecret(req, res)) return;
     const clientId = resolveClientId(req);
     const roomCode = normalizeIdentifier(
@@ -222,11 +295,7 @@ export const registerScheduledMeetingRoutes = (
       res.status(400).json({ error: "Room code is required" });
       return;
     }
-    const meeting = getScheduledMeetingByRoomCode(
-      state.scheduledMeetings,
-      clientId,
-      roomCode,
-    );
+    const meeting = await findMeetingByRoomCode(clientId, roomCode);
     if (!meeting) {
       res.status(404).json({ error: "Scheduled meeting not found" });
       return;
@@ -234,7 +303,7 @@ export const registerScheduledMeetingRoutes = (
     res.json({ scheduledMeeting: serializeMeeting(meeting) });
   });
 
-  app.get("/scheduled-meetings/public/by-room/:roomCode", (req, res) => {
+  app.get("/scheduled-meetings/public/by-room/:roomCode", async (req, res) => {
     if (!requireSecret(req, res)) return;
     const clientId = resolveClientId(req);
     const roomCode = normalizeIdentifier(
@@ -245,11 +314,7 @@ export const registerScheduledMeetingRoutes = (
       res.status(400).json({ error: "Room code is required" });
       return;
     }
-    const meeting = getScheduledMeetingByRoomCode(
-      state.scheduledMeetings,
-      clientId,
-      roomCode,
-    );
+    const meeting = await findMeetingByRoomCode(clientId, roomCode);
     if (!meeting) {
       res.status(404).json({ error: "Scheduled meeting not found" });
       return;

--- a/packages/sfu/server/http/scheduledWebinarRoutes.ts
+++ b/packages/sfu/server/http/scheduledWebinarRoutes.ts
@@ -18,12 +18,18 @@ import {
   getScheduledWebinarBySlug,
   getScheduledWebinarForRoom,
   listScheduledWebinars,
+  moveScheduledWebinarToClient,
   persistScheduledWebinarChanges,
   persistScheduledWebinarDeletes,
   updateScheduledWebinar,
 } from "../scheduledWebinars.js";
 import { clearWebinarLinkSlug } from "../webinar.js";
 import type { SfuState } from "../state.js";
+import {
+  canonicalizeClientId,
+  clientIdCandidates,
+  resolveDefaultClientId,
+} from "../clientIds.js";
 import type {
   CreateScheduledWebinarRequest,
   ScheduledWebinar,
@@ -72,14 +78,11 @@ const normalizeEmail = (value: unknown): string | null => {
 
 const resolveClientId = (
   req: Request,
-  fallback =
-    process.env.SFU_CLIENT_ID?.trim() ||
-    process.env.NEXT_PUBLIC_SFU_CLIENT_ID?.trim() ||
-    "conclave",
+  fallback = resolveDefaultClientId(),
 ): string => {
   const fromQuery = normalizeIdentifier(req.query.clientId) || "";
   const fromHeader = normalizeIdentifier(req.header("x-sfu-client")) || "";
-  return fromQuery || fromHeader || fallback;
+  return canonicalizeClientId(fromQuery || fromHeader || fallback);
 };
 
 const resolveUserContext = (
@@ -177,6 +180,78 @@ export const registerScheduledWebinarRoutes = (
     }
   };
 
+  const migrateWebinarNamespace = (
+    webinar: ScheduledWebinar,
+    clientId: string,
+  ): ScheduledWebinar | null => {
+    if (webinar.clientId === clientId) return webinar;
+    try {
+      const migrated = moveScheduledWebinarToClient(
+        state.scheduledWebinars,
+        webinar.id,
+        clientId,
+      );
+      if (migrated) {
+        persistChanged(migrated);
+      }
+      return migrated;
+    } catch (error) {
+      Logger.warn(
+        `Failed to migrate scheduled webinar ${webinar.id} from ${webinar.clientId} to ${clientId}`,
+        error,
+      );
+      return null;
+    }
+  };
+
+  const findWebinarForRoom = (
+    clientId: string,
+    roomId: string,
+  ): ScheduledWebinar | null => {
+    for (const candidateClientId of clientIdCandidates(clientId)) {
+      const webinar = getScheduledWebinarForRoom(
+        state.scheduledWebinars,
+        candidateClientId,
+        roomId,
+      );
+      if (!webinar) continue;
+      if (webinar.clientId === clientId) return webinar;
+      return migrateWebinarNamespace(webinar, clientId) ?? webinar;
+    }
+    return null;
+  };
+
+  const listWebinarsForClient = (options: {
+    clientId: string;
+    ownerEmail?: string;
+    includeAll: boolean;
+    status?: ScheduledWebinarStatus[];
+  }): ScheduledWebinar[] => {
+    const byId = new Map<string, ScheduledWebinar>();
+    const seenRoomIds = new Set<string>();
+    for (const candidateClientId of clientIdCandidates(options.clientId)) {
+      const webinars = listScheduledWebinars(state.scheduledWebinars, {
+        clientId: candidateClientId,
+        ownerEmail: options.ownerEmail,
+        includeAll: options.includeAll,
+        status: options.status,
+      });
+      for (const webinar of webinars) {
+        if (seenRoomIds.has(webinar.roomId)) continue;
+        const normalized =
+          webinar.clientId === options.clientId
+            ? webinar
+            : migrateWebinarNamespace(webinar, options.clientId);
+        if (!normalized) continue;
+        seenRoomIds.add(normalized.roomId);
+        byId.set(normalized.id, normalized);
+      }
+    }
+    return Array.from(byId.values()).sort(
+      (a, b) => a.scheduledStartAt - b.scheduledStartAt,
+    );
+  };
+
   app.get("/scheduled-webinars", (req, res) => {
     if (!requireSecret(req, res)) return;
     const user = resolveUserContext(req);
@@ -184,7 +259,7 @@ export const registerScheduledWebinarRoutes = (
     const includeAll = req.query.scope === "all" && user.isAdmin;
     const statusFilter = parseStatusFilter(req.query.status);
 
-    const list = listScheduledWebinars(state.scheduledWebinars, {
+    const list = listWebinarsForClient({
       clientId,
       ownerEmail: user.email || undefined,
       includeAll,
@@ -230,6 +305,7 @@ export const registerScheduledWebinarRoutes = (
 
   app.get("/scheduled-webinars/by-slug/:slug", (req, res) => {
     if (!requireSecret(req, res)) return;
+    const clientId = resolveClientId(req);
     const slug = normalizeIdentifier(req.params.slug);
     if (!slug) {
       res.status(400).json({ error: "Webinar link code is required" });
@@ -240,7 +316,14 @@ export const registerScheduledWebinarRoutes = (
       res.status(404).json({ error: "Scheduled webinar not found" });
       return;
     }
-    res.json({ scheduledWebinar: serializeScheduledWebinar(webinar) });
+    const normalizedWebinar =
+      webinar.clientId === clientId ||
+      clientIdCandidates(clientId).includes(webinar.clientId)
+        ? migrateWebinarNamespace(webinar, clientId) ?? webinar
+        : webinar;
+    res.json({
+      scheduledWebinar: serializeScheduledWebinar(normalizedWebinar),
+    });
   });
 
   app.get("/scheduled-webinars/by-room/:clientId/:roomId", (req, res) => {
@@ -251,11 +334,7 @@ export const registerScheduledWebinarRoutes = (
       res.status(400).json({ error: "Missing clientId or roomId" });
       return;
     }
-    const webinar = getScheduledWebinarForRoom(
-      state.scheduledWebinars,
-      clientId,
-      roomId,
-    );
+    const webinar = findWebinarForRoom(canonicalizeClientId(clientId), roomId);
     if (!webinar) {
       res.status(404).json({ error: "Scheduled webinar not found" });
       return;

--- a/packages/sfu/server/http/schedulingRoutes.ts
+++ b/packages/sfu/server/http/schedulingRoutes.ts
@@ -45,6 +45,11 @@ import {
 } from "../schedulingEmails.js";
 import { buildSchedulingMeetingLink } from "../schedulingLinks.js";
 import type { SfuState } from "../state.js";
+import {
+  canonicalizeClientId,
+  clientIdCandidates,
+  resolveDefaultClientId,
+} from "../clientIds.js";
 import type {
   BookingConfirmation,
   CalendarConnectionSummary,
@@ -71,25 +76,6 @@ const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_FREEBUSY_URL = "https://www.googleapis.com/calendar/v3/freeBusy";
 const GOOGLE_CALENDAR_API = "https://www.googleapis.com/calendar/v3";
 const localBookingSlotLocks = new Set<string>();
-
-const CONCLAVE_CLIENT_ID = "conclave";
-const LEGACY_WEB_CLIENT_IDS = ["default", "public"];
-
-const resolveDefaultClientId = (): string =>
-  process.env.SFU_CLIENT_ID?.trim() ||
-  process.env.NEXT_PUBLIC_SFU_CLIENT_ID?.trim() ||
-  CONCLAVE_CLIENT_ID;
-
-const clientIdCandidates = (primary: string): string[] => {
-  const seen = new Set<string>();
-  return [primary, resolveDefaultClientId(), CONCLAVE_CLIENT_ID, ...LEGACY_WEB_CLIENT_IDS]
-    .map((clientId) => clientId.trim())
-    .filter((clientId) => {
-      if (!clientId || seen.has(clientId)) return false;
-      seen.add(clientId);
-      return true;
-    });
-};
 
 const hasValidSecret = (req: Request, secret: string): boolean => {
   const provided = req.header("x-sfu-secret");
@@ -146,7 +132,7 @@ const resolveClientId = (
 ): string => {
   const fromQuery = normalizeIdentifier(req.query.clientId) || "";
   const fromHeader = normalizeIdentifier(req.header("x-sfu-client")) || "";
-  return fromQuery || fromHeader || fallback;
+  return canonicalizeClientId(fromQuery || fromHeader || fallback);
 };
 
 const resolveUserContext = (

--- a/packages/sfu/server/rooms.ts
+++ b/packages/sfu/server/rooms.ts
@@ -6,9 +6,10 @@ import { RoomOwnershipError } from "./roomRegistry.js";
 import { cleanupRoomBrowser } from "./socket/handlers/sharedBrowserHandlers.js";
 import type { EndedRoom, SfuState } from "./state.js";
 import { clearWebinarLinkSlug } from "./webinar.js";
+import { canonicalizeClientId } from "./clientIds.js";
 
 export const getRoomChannelId = (clientId: string, roomId: string): string =>
-  `${clientId}:${roomId}`;
+  `${canonicalizeClientId(clientId)}:${roomId}`;
 
 export const getEndedRoom = (
   state: SfuState,
@@ -66,9 +67,10 @@ export const clearEndedRoom = (state: SfuState, channelId: string): boolean =>
 
 export const getOrCreateRoom = async (
   state: SfuState,
-  clientId: string,
+  requestedClientId: string,
   roomId: string,
 ): Promise<Room> => {
+  const clientId = canonicalizeClientId(requestedClientId);
   const channelId = getRoomChannelId(clientId, roomId);
   let room = state.rooms.get(channelId);
   if (room) {

--- a/packages/sfu/server/scheduledMeetings.ts
+++ b/packages/sfu/server/scheduledMeetings.ts
@@ -23,6 +23,7 @@ import {
   shouldUseRedisPersistence,
   type RedisPersistenceClient,
 } from "./redisPersistence.js";
+import { canonicalizeClientId } from "./clientIds.js";
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -156,6 +157,7 @@ export const createScheduledMeeting = (
   request: CreateScheduledMeetingRequest,
   options: CreateScheduledMeetingOptions,
 ): ScheduledMeeting => {
+  const clientId = canonicalizeClientId(options.clientId);
   const title = sanitizeTitle(request.title);
   if (!title || title.length < MIN_TITLE_LENGTH) {
     throw new Error("Title is required.");
@@ -192,12 +194,12 @@ export const createScheduledMeeting = (
   if (!roomCode) {
     do {
       roomCode = generateRoomCode();
-    } while (isCodeTaken(store, options.clientId, roomCode));
+    } while (isCodeTaken(store, clientId, roomCode));
   } else {
     if (roomCode.length < ROOM_CODE_MIN_LENGTH) {
       throw new Error("Custom code must be at least 3 characters.");
     }
-    if (isCodeTaken(store, options.clientId, roomCode)) {
+    if (isCodeTaken(store, clientId, roomCode)) {
       throw new Error(
         "That meeting code is already booked for another scheduled meeting.",
       );
@@ -207,7 +209,7 @@ export const createScheduledMeeting = (
   const now = Date.now();
   const meeting: ScheduledMeeting = {
     id: randomUUID(),
-    clientId: options.clientId,
+    clientId,
     roomCode,
     title,
     hostEmail,
@@ -413,7 +415,7 @@ export const moveScheduledMeetingToClient = (
   clientId: string,
 ): ScheduledMeeting | null => {
   const meeting = store.byId.get(meetingId);
-  const nextClientId = clientId.trim();
+  const nextClientId = canonicalizeClientId(clientId);
   if (!meeting || !nextClientId || meeting.clientId === nextClientId) {
     return meeting ?? null;
   }
@@ -553,7 +555,7 @@ const normalizeStoredMeeting = (raw: unknown): ScheduledMeeting | null => {
   const now = Date.now();
   return {
     id: record.id,
-    clientId: record.clientId,
+    clientId: canonicalizeClientId(record.clientId),
     roomCode: record.roomCode,
     title: typeof record.title === "string" ? record.title : "Scheduled meeting",
     hostEmail: record.hostEmail,

--- a/packages/sfu/server/scheduledWebinars.ts
+++ b/packages/sfu/server/scheduledWebinars.ts
@@ -19,6 +19,7 @@ import {
   normalizeWebinarLinkSlug,
   normalizeHostEmail,
 } from "./webinar.js";
+import { canonicalizeClientId } from "./clientIds.js";
 
 const DEFAULT_EARLY_ENTRY_MINUTES = 10;
 const MAX_EARLY_ENTRY_MINUTES = 240;
@@ -205,6 +206,28 @@ export const getScheduledWebinarForRoom = (
 ): ScheduledWebinar | null => {
   const id = store.byRoomChannel.get(roomChannelKey(clientId, roomId));
   return id ? store.byId.get(id) ?? null : null;
+};
+
+export const moveScheduledWebinarToClient = (
+  store: ScheduledWebinarStore,
+  webinarId: string,
+  clientId: string,
+): ScheduledWebinar | null => {
+  const webinar = store.byId.get(webinarId);
+  const nextClientId = canonicalizeClientId(clientId);
+  if (!webinar || !nextClientId || webinar.clientId === nextClientId) {
+    return webinar ?? null;
+  }
+  const nextRoomChannel = roomChannelKey(nextClientId, webinar.roomId);
+  const owner = store.byRoomChannel.get(nextRoomChannel);
+  if (owner && owner !== webinar.id) {
+    throw new Error("That webinar room already exists in the target client.");
+  }
+  store.byRoomChannel.delete(roomChannelKey(webinar.clientId, webinar.roomId));
+  webinar.clientId = nextClientId;
+  webinar.updatedAt = Date.now();
+  store.byRoomChannel.set(nextRoomChannel, webinar.id);
+  return webinar;
 };
 
 export const listScheduledWebinars = (
@@ -535,7 +558,7 @@ const normalizeStoredWebinar = (raw: unknown): ScheduledWebinar | null => {
   const linkSlug = String(record.linkSlug);
   return {
     id: record.id,
-    clientId: record.clientId,
+    clientId: canonicalizeClientId(record.clientId),
     roomId: record.roomId,
     linkSlug,
     title: sanitizeString(record.title, { max: MAX_TITLE_LENGTH }) || "Untitled webinar",
@@ -634,6 +657,7 @@ export const createScheduledWebinar = (
   request: CreateScheduledWebinarRequest,
   options: CreateScheduledWebinarOptions,
 ): { webinar: ScheduledWebinar; inviteCodeHash: string | null } => {
+  const clientId = canonicalizeClientId(options.clientId);
   const title = sanitizeString(request.title, { max: MAX_TITLE_LENGTH });
   if (!title || title.length < MIN_TITLE_LENGTH) {
     throw new Error("Title is required.");
@@ -700,7 +724,7 @@ export const createScheduledWebinar = (
   const now = Date.now();
   const webinar: ScheduledWebinar = {
     id: randomUUID(),
-    clientId: options.clientId,
+    clientId,
     roomId: generateRoomId(),
     linkSlug,
     title,

--- a/packages/sfu/server/scheduling.ts
+++ b/packages/sfu/server/scheduling.ts
@@ -27,6 +27,10 @@ import {
   shouldUseRedisPersistence,
   type RedisPersistenceClient,
 } from "./redisPersistence.js";
+import {
+  canonicalizeClientId,
+  CONCLAVE_CLIENT_ID,
+} from "./clientIds.js";
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -325,7 +329,8 @@ export const ensureSchedulingProfile = (
     timeZone?: string;
   },
 ): SchedulingProfile => {
-  const key = userKey(input.clientId, input.userId);
+  const clientId = canonicalizeClientId(input.clientId);
+  const key = userKey(clientId, input.userId);
   const existingId = store.profileIdByUserKey.get(key);
   const existing = existingId ? store.profilesById.get(existingId) : undefined;
   const now = Date.now();
@@ -367,11 +372,11 @@ export const ensureSchedulingProfile = (
   );
   const profile: SchedulingProfile = {
     id: randomUUID(),
-    clientId: input.clientId,
+    clientId,
     userId: input.userId,
     email: input.email.trim().toLowerCase(),
     name: sanitizeText(input.name ?? "", TITLE_MAX_LENGTH) || input.email,
-    username: uniqueUsername(store, input.clientId, baseUsername),
+    username: uniqueUsername(store, clientId, baseUsername),
     timeZone: normalizeTimeZone(input.timeZone),
     createdAt: now,
     updatedAt: now,
@@ -427,7 +432,9 @@ export const getProfileByUser = (
   clientId: string,
   userId: string,
 ): SchedulingProfile | null => {
-  const id = store.profileIdByUserKey.get(userKey(clientId, userId));
+  const id = store.profileIdByUserKey.get(
+    userKey(canonicalizeClientId(clientId), userId),
+  );
   return id ? store.profilesById.get(id) ?? null : null;
 };
 
@@ -436,7 +443,7 @@ export const moveSchedulingProfileToClient = (
   profile: SchedulingProfile,
   clientId: string,
 ): SchedulingProfile => {
-  const nextClientId = clientId.trim();
+  const nextClientId = canonicalizeClientId(clientId);
   if (!nextClientId || profile.clientId === nextClientId) return profile;
 
   store.profileIdByUserKey.delete(userKey(profile.clientId, profile.userId));
@@ -471,7 +478,7 @@ export const getPublicProfile = (
   username: string,
 ): SchedulingProfile | null => {
   const id = store.profileIdByUsername.get(
-    `${clientId}:${username.trim().toLowerCase()}`,
+    `${canonicalizeClientId(clientId)}:${username.trim().toLowerCase()}`,
   );
   return id ? store.profilesById.get(id) ?? null : null;
 };
@@ -1030,12 +1037,35 @@ const deserializeCalendar = (
   refreshToken: decryptToken(calendar.refreshToken),
 });
 
-const normalizeSnapshot = (snapshot: Partial<SchedulingSnapshot>): SchedulingSnapshot => ({
-  profiles: Array.isArray(snapshot.profiles) ? snapshot.profiles : [],
+const normalizeSnapshotClientId = (clientId: unknown): string =>
+  typeof clientId === "string" && clientId.trim()
+    ? canonicalizeClientId(clientId)
+    : CONCLAVE_CLIENT_ID;
+
+const normalizeSnapshot = (
+  snapshot: Partial<SchedulingSnapshot>,
+): SchedulingSnapshot => ({
+  profiles: Array.isArray(snapshot.profiles)
+    ? snapshot.profiles.map((profile) => ({
+        ...profile,
+        clientId: normalizeSnapshotClientId(profile.clientId),
+      }))
+    : [],
   availability: Array.isArray(snapshot.availability) ? snapshot.availability : [],
-  eventTypes: Array.isArray(snapshot.eventTypes) ? snapshot.eventTypes : [],
+  eventTypes: Array.isArray(snapshot.eventTypes)
+    ? snapshot.eventTypes.map((eventType) => ({
+        ...eventType,
+        clientId: normalizeSnapshotClientId(eventType.clientId),
+      }))
+    : [],
   calendars: Array.isArray(snapshot.calendars)
-    ? snapshot.calendars.map(deserializeCalendar)
+    ? snapshot.calendars.map((calendar) => {
+        const deserialized = deserializeCalendar(calendar);
+        return {
+          ...deserialized,
+          clientId: normalizeSnapshotClientId(deserialized.clientId),
+        };
+      })
     : [],
 });
 

--- a/packages/sfu/server/schedulingLinks.ts
+++ b/packages/sfu/server/schedulingLinks.ts
@@ -1,4 +1,8 @@
 import type { ScheduledMeeting } from "../types.js";
+import {
+  canonicalizeClientId,
+  CONCLAVE_CLIENT_ID,
+} from "./clientIds.js";
 
 type MeetingLinkInput = Pick<ScheduledMeeting, "clientId" | "roomCode">;
 
@@ -10,8 +14,9 @@ export const buildSchedulingMeetingLink = (
     `/${encodeURIComponent(meeting.roomCode)}`,
     `${appOrigin.replace(/\/$/, "")}/`,
   );
-  if (meeting.clientId && meeting.clientId !== "default") {
-    url.searchParams.set("clientId", meeting.clientId);
+  const clientId = canonicalizeClientId(meeting.clientId);
+  if (clientId && clientId !== CONCLAVE_CLIENT_ID) {
+    url.searchParams.set("clientId", clientId);
   }
   return url.toString();
 };

--- a/packages/sfu/server/socket/handlers/adminHandlers.ts
+++ b/packages/sfu/server/socket/handlers/adminHandlers.ts
@@ -3,6 +3,7 @@ import { Admin } from "../../../config/classes/Admin.js";
 import type { ProducerType } from "../../../config/classes/Client.js";
 import type { RedirectData } from "../../../types.js";
 import { Logger } from "../../../utilities/loggers.js";
+import { canonicalizeClientId } from "../../clientIds.js";
 import {
   admitAllPendingUsers,
   applyRoomPolicyUpdate,
@@ -113,7 +114,9 @@ const normalizeProducerId = (value: unknown): string | null => {
 
 const resolveClientId = (context: ConnectionContext): string => {
   const raw = getSocketAuthUser(context.socket)?.clientId;
-  return typeof raw === "string" && raw.trim() ? raw.trim() : "default";
+  return canonicalizeClientId(
+    typeof raw === "string" && raw.trim() ? raw.trim() : "default",
+  );
 };
 
 const ensureAdminRoom = (

--- a/packages/sfu/server/socket/handlers/displayNameHandlers.ts
+++ b/packages/sfu/server/socket/handlers/displayNameHandlers.ts
@@ -1,5 +1,6 @@
 import { Admin } from "../../../config/classes/Admin.js";
 import { config } from "../../../config/config.js";
+import { canonicalizeClientId } from "../../clientIds.js";
 import { MAX_DISPLAY_NAME_LENGTH } from "../../constants.js";
 import { normalizeDisplayName } from "../../identity.js";
 import { getSocketAuthUser } from "../auth.js";
@@ -42,8 +43,9 @@ export const registerDisplayNameHandlers = (
         }
 
         const user = getSocketAuthUser(socket);
-        const clientId =
-          typeof user?.clientId === "string" ? user.clientId : "default";
+        const clientId = canonicalizeClientId(
+          typeof user?.clientId === "string" ? user.clientId : "default",
+        );
         const clientPolicy =
           config.clientPolicies[clientId] ?? config.clientPolicies.default;
         const canUpdateDisplayName =

--- a/packages/sfu/server/socket/handlers/joinRoom.ts
+++ b/packages/sfu/server/socket/handlers/joinRoom.ts
@@ -9,6 +9,7 @@ import type {
   JoinRoomResponse,
 } from "../../../types.js";
 import { Logger } from "../../../utilities/loggers.js";
+import { canonicalizeClientId } from "../../clientIds.js";
 import { MAX_DISPLAY_NAME_LENGTH } from "../../constants.js";
 import {
   buildUserIdentity,
@@ -123,7 +124,7 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           respond(callback, { error: "Invalid client ID" });
           return;
         }
-        const clientId = tokenClientId;
+        const clientId = canonicalizeClientId(tokenClientId);
         let roomId = requestedRoomId;
         if (isWebinarAttendeeJoin) {
           let webinarTarget = resolveWebinarLinkTarget(

--- a/packages/sfu/server/webinar.ts
+++ b/packages/sfu/server/webinar.ts
@@ -6,6 +6,7 @@ import type {
   WebinarFeedMode,
   WebinarUpdateRequest,
 } from "../types.js";
+import { canonicalizeClientId } from "./clientIds.js";
 
 export const DEFAULT_WEBINAR_MAX_ATTENDEES = 500;
 export const MIN_WEBINAR_MAX_ATTENDEES = 1;
@@ -167,7 +168,7 @@ const upsertWebinarLinkTarget = (
   webinarLinks.set(slug, {
     roomChannelId: room.channelId,
     roomId: room.id,
-    clientId: room.clientId,
+    clientId: canonicalizeClientId(room.clientId),
   });
 };
 
@@ -285,7 +286,10 @@ export const resolveWebinarLinkTarget = (
     return null;
   }
   const target = webinarLinks.get(normalizedSlug);
-  if (!target || target.clientId !== clientId) {
+  if (
+    !target ||
+    canonicalizeClientId(target.clientId) !== canonicalizeClientId(clientId)
+  ) {
     return null;
   }
   return target;

--- a/packages/sfu/test/client-ids.test.ts
+++ b/packages/sfu/test/client-ids.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalizeClientId,
+  clientIdCandidates,
+  CONCLAVE_CLIENT_ID,
+} from "../server/clientIds.js";
+import { getRoomChannelId } from "../server/rooms.js";
+
+describe("client ID canonicalization", () => {
+  it("maps legacy web client IDs to conclave", () => {
+    expect(canonicalizeClientId("default")).toBe(CONCLAVE_CLIENT_ID);
+    expect(canonicalizeClientId("public")).toBe(CONCLAVE_CLIENT_ID);
+    expect(canonicalizeClientId(" public ")).toBe(CONCLAVE_CLIENT_ID);
+  });
+
+  it("keeps custom client IDs separate", () => {
+    expect(canonicalizeClientId("partner-a")).toBe("partner-a");
+  });
+
+  it("uses the same room channel for public, default, and conclave", () => {
+    expect(getRoomChannelId("public", "room-1")).toBe("conclave:room-1");
+    expect(getRoomChannelId("default", "room-1")).toBe("conclave:room-1");
+    expect(getRoomChannelId("conclave", "room-1")).toBe("conclave:room-1");
+  });
+
+  it("keeps legacy IDs only as fallback candidates", () => {
+    const candidates = clientIdCandidates("public");
+    expect(candidates[0]).toBe("conclave");
+    expect(candidates).toContain("default");
+    expect(candidates).toContain("public");
+  });
+});


### PR DESCRIPTION
## Summary
- canonicalize legacy `public` and `default` SFU client IDs to `conclave` in web join/admin/scheduling paths
- enforce the same canonical room channel on the SFU and migrate legacy scheduled meeting/webinar/profile records when loaded or read
- dedupe admin scheduled snapshots after canonicalizing client IDs and keep legacy IDs only as lookup fallbacks

## Verification
- `pnpm -C packages/sfu run typecheck`
- `pnpm -C apps/web run lint`
- `pnpm -C packages/sfu exec vitest run test/client-ids.test.ts`
- `pnpm -C packages/sfu test`

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR canonicalizes legacy SFU client namespaces across the web app and SFU service. The main changes are:

- Maps legacy `public` and `default` client IDs to `conclave`.
- Applies canonical client IDs to join, admin, scheduling, and calendar routes.
- Migrates scheduled meetings, webinars, and scheduling profiles from legacy namespaces when loaded or read.
- Deduplicates admin scheduled snapshots after canonicalization.

<h3>Confidence Score: 4/5</h3>

This PR has one contained policy issue that should be fixed before merging.

Most canonicalization paths are consistent and covered by focused tests, but the changed `default` policy is used as the fallback for unknown client IDs and now disables protections that were previously restrictive.

packages/sfu/config/config.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed a focused Vitest runtime test for the unknown SFU client policy fallback and confirmed the effective fallback policy for the unconfigured client ID is permissive (useWaitingRoom: false, allowDisplayNameUpdate: true).
- Validated that after the canonicalization change, scheduled operations return 201 Created and 200 OK with scheduledMeeting.clientId canonicalized to conclave, while public read endpoints remain accessible.
- Verified that three room requests are now addressed by the conclave key, reducing finalRoomCount from 3 to 1.
- Compared pre/post persistence canonicalization artifacts and confirmed all legacy records are loaded and persisted as conclave, with legacy keys not retained after canonical load.
- Compared admin snapshot dedupe results and confirmed the head now emits two items, both canonicalized to conclave.

<a href="https://app.greptile.com/trex/runs/13087612/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/sfu/join/route.ts | Canonicalizes join header/body client IDs before falling back to the server default. |
| apps/web/src/lib/sfu-client-id.ts | Adds web-side SFU client ID canonicalization and candidate fallback ordering. |
| packages/sfu/config/config.ts | Canonical web policies are aligned, but the fallback default policy is now permissive for unknown clients. |
| packages/sfu/server/clientIds.ts | Introduces SFU-side canonical client ID helpers and legacy candidate ordering. |
| packages/sfu/server/http/scheduledMeetingRoutes.ts | Adds canonical scheduled-meeting lookup/listing with legacy namespace migration. |
| packages/sfu/server/http/scheduledWebinarRoutes.ts | Adds canonical scheduled-webinar lookup/listing with legacy namespace migration. |
| packages/sfu/server/rooms.ts | Canonicalizes room channel generation and room creation client IDs. |
| packages/sfu/server/scheduling.ts | Canonicalizes scheduling profiles, public lookup keys, and persisted snapshot client IDs. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Web as Web/API route
participant ClientIds as Client ID canonicalizer
participant SFU as SFU HTTP/socket handler
participant Store as Rooms/Scheduling stores
participant Persistence as Persistence

Web->>ClientIds: resolve header/query/body clientId
ClientIds-->>Web: conclave for default/public, custom otherwise
Web->>SFU: request with canonical x-sfu-client/clientId
SFU->>ClientIds: canonicalize inbound clientId
SFU->>Store: lookup canonical room/scheduled record
alt legacy record found via candidates
    Store-->>SFU: default/public record
    SFU->>Store: move record to conclave namespace
    SFU->>Persistence: persist migrated record
end
SFU-->>Web: canonical clientId and migrated resource
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Web as Web/API route
participant ClientIds as Client ID canonicalizer
participant SFU as SFU HTTP/socket handler
participant Store as Rooms/Scheduling stores
participant Persistence as Persistence

Web->>ClientIds: resolve header/query/body clientId
ClientIds-->>Web: conclave for default/public, custom otherwise
Web->>SFU: request with canonical x-sfu-client/clientId
SFU->>ClientIds: canonicalize inbound clientId
SFU->>Store: lookup canonical room/scheduled record
alt legacy record found via candidates
    Store-->>SFU: default/public record
    SFU->>Store: move record to conclave namespace
    SFU->>Persistence: persist migrated record
end
SFU-->>Web: canonical clientId and migrated resource
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fsfu%2Fconfig%2Fconfig.ts%3A131-132%0A**Tighten%20fallback%20policy**%0AUnknown%20or%20unconfigured%20client%20IDs%20still%20fall%20back%20through%20%60config.clientPolicies%5BclientId%5D%20%3F%3F%20config.clientPolicies.default%60%2C%20so%20changing%20%60default%60%20to%20disable%20the%20waiting%20room%20and%20allow%20display-name%20updates%20makes%20any%20tenant%20missing%20an%20explicit%20policy%20use%20the%20permissive%20Conclave%20behavior.%20Keep%20the%20fallback%20policy%20restrictive%20and%20let%20the%20explicit%20%60conclave%60%20and%20%60public%60%20entries%20carry%20the%20canonical%20web%20behavior.%0A%0A&repo=acm-vit%2Fconclave&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fsfu%2Fconfig%2Fconfig.ts%3A131-132%0A**Tighten%20fallback%20policy**%0AUnknown%20or%20unconfigured%20client%20IDs%20still%20fall%20back%20through%20%60config.clientPolicies%5BclientId%5D%20%3F%3F%20config.clientPolicies.default%60%2C%20so%20changing%20%60default%60%20to%20disable%20the%20waiting%20room%20and%20allow%20display-name%20updates%20makes%20any%20tenant%20missing%20an%20explicit%20policy%20use%20the%20permissive%20Conclave%20behavior.%20Keep%20the%20fallback%20policy%20restrictive%20and%20let%20the%20explicit%20%60conclave%60%20and%20%60public%60%20entries%20carry%20the%20canonical%20web%20behavior.%0A%0A&repo=acm-vit%2Fconclave&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fsfu%2Fconfig%2Fconfig.ts%3A131-132%0A**Tighten%20fallback%20policy**%0AUnknown%20or%20unconfigured%20client%20IDs%20still%20fall%20back%20through%20%60config.clientPolicies%5BclientId%5D%20%3F%3F%20config.clientPolicies.default%60%2C%20so%20changing%20%60default%60%20to%20disable%20the%20waiting%20room%20and%20allow%20display-name%20updates%20makes%20any%20tenant%20missing%20an%20explicit%20policy%20use%20the%20permissive%20Conclave%20behavior.%20Keep%20the%20fallback%20policy%20restrictive%20and%20let%20the%20explicit%20%60conclave%60%20and%20%60public%60%20entries%20carry%20the%20canonical%20web%20behavior.%0A%0A&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(sfu): canonicalize conclave client n..."](https://github.com/acm-vit/conclave/commit/cd6b221235d36cf7382ae0ab1bc03a6a89314130) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41429267)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->