### PR TITLE
fix(admin): narrow watched room channel IDs

### DIFF
--- a/apps/web/src/app/sfu-admin/useAdminSocket.ts
+++ b/apps/web/src/app/sfu-admin/useAdminSocket.ts
@@ -273,22 +273,24 @@ export function useAdminSocket() {
             "admin:room",
             (data: { channelId?: string; room?: RoomSnapshot | null }) => {
               const watched = watchedRef.current;
+              const channelId = data?.channelId;
               if (
                 !watched ||
-                data?.channelId !== watched.channelId
+                !channelId ||
+                channelId !== watched.channelId
               ) {
                 return;
               }
               setDetail((prev) => {
                 if (data.room) {
                   return {
-                    selection: { instanceKey: key, channelId: data.channelId },
+                    selection: { instanceKey: key, channelId },
                     room: data.room,
                   };
                 }
                 if (
                   prev?.selection.instanceKey === key &&
-                  prev.selection.channelId === data.channelId
+                  prev.selection.channelId === channelId
                 ) {
                   return null;
                 }


### PR DESCRIPTION
## Summary
- bind the watched room snapshot channel ID before updating admin detail state
- fixes the production TypeScript error where `RoomSelection.channelId` was inferred as possibly undefined

## Verification
- `pnpm -C apps/web run build`
- `pnpm -C apps/web run lint`

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR updates the SFU admin room socket handler. The main changes are:

- Binds `admin:room` payload `channelId` before updating detail state.
- Ignores room snapshot events with missing or mismatched `channelId`.
- Keeps `RoomSelection.channelId` typed as a definite string in the detail state update.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to one socket event handler and preserves the existing guard for missing or mismatched room channel IDs.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran a focused TypeScript build on the before commit and captured a TypeScript failure related to channelId typing.
- T-Rex re-ran the focused TypeScript build after a clean checkout on the after commit and verified the command exited with code 0.

<a href="https://app.greptile.com/trex/runs/13091474/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/sfu-admin/useAdminSocket.ts | Binds the watched `admin:room` event `channelId` before the state updater so `RoomSelection` receives a definite string. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Socket as SFU admin socket
participant Handler as admin:room handler
participant Watch as watchedRef
participant State as detail state

Socket->>Handler: "admin:room { channelId?, room? }"
Handler->>Watch: read current watched room
alt no watched room or missing/mismatched channelId
    Handler-->>Socket: ignore event
else channelId matches watched room
    Handler->>State: setDetail using bound channelId
    alt room snapshot present
        State-->>State: store selection + room
    else snapshot cleared for current selection
        State-->>State: clear detail
    end
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Socket as SFU admin socket
participant Handler as admin:room handler
participant Watch as watchedRef
participant State as detail state

Socket->>Handler: "admin:room { channelId?, room? }"
Handler->>Watch: read current watched room
alt no watched room or missing/mismatched channelId
    Handler-->>Socket: ignore event
else channelId matches watched room
    Handler->>State: setDetail using bound channelId
    alt room snapshot present
        State-->>State: store selection + room
    else snapshot cleared for current selection
        State-->>State: clear detail
    end
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): narrow watched room channel ..."](https://github.com/acm-vit/conclave/commit/4cd91705cf3c2d3269e3a0e964e4b3f4e0c2e243) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41436574)</sub>

<!-- /greptile_comment -->