### PR TITLE
fix(sfu): keep admin stream off redis adapter

### DIFF
--- a/packages/sfu/server/admin/adminGateway.ts
+++ b/packages/sfu/server/admin/adminGateway.ts
@@ -450,7 +450,7 @@ export const registerAdminGateway = (
     const json = JSON.stringify(snapshot);
     if (!opts?.force && lastRoomDetailJson.get(channelId) === json) return;
     lastRoomDetailJson.set(channelId, json);
-    nsp.to(`${WATCH_PREFIX}${channelId}`).emit("admin:room", {
+    nsp.local.to(`${WATCH_PREFIX}${channelId}`).emit("admin:room", {
       channelId,
       room: snapshot,
     });
@@ -464,7 +464,7 @@ export const registerAdminGateway = (
     const json = JSON.stringify(messages);
     if (!opts?.force && lastRoomChatJson.get(channelId) === json) return;
     lastRoomChatJson.set(channelId, json);
-    nsp.to(`${WATCH_PREFIX}${channelId}`).emit("admin:chat", {
+    nsp.local.to(`${WATCH_PREFIX}${channelId}`).emit("admin:chat", {
       channelId,
       messages,
     });
@@ -495,7 +495,7 @@ export const registerAdminGateway = (
       history.splice(0, history.length - HISTORY_MAX_POINTS);
     }
     if (nsp.sockets.size > 0) {
-      nsp.emit("admin:historyPoint", point);
+      nsp.local.emit("admin:historyPoint", point);
     }
   };
 
@@ -523,7 +523,7 @@ export const registerAdminGateway = (
             eventLog.splice(0, eventLog.length - EVENTS_MAX);
           }
           if (nsp.sockets.size > 0) {
-            nsp.emit("admin:events", { events });
+            nsp.local.emit("admin:events", { events });
           }
         }
       }
@@ -542,14 +542,14 @@ export const registerAdminGateway = (
       const overviewHash = JSON.stringify({ ...overview, uptime: 0, timestamp: "" });
       if (overviewHash !== lastOverviewJson) {
         lastOverviewJson = overviewHash;
-        nsp.emit("admin:overview", overview);
+        nsp.local.emit("admin:overview", overview);
       }
 
       const rooms = buildRoomSummaries();
       const roomsJson = JSON.stringify(rooms);
       if (roomsJson !== lastRoomsJson) {
         lastRoomsJson = roomsJson;
-        nsp.emit("admin:rooms", { rooms });
+        nsp.local.emit("admin:rooms", { rooms });
       }
 
       // The calendar changes rarely; check it on a slow cadence.
@@ -559,7 +559,7 @@ export const registerAdminGateway = (
         const scheduledJson = JSON.stringify(scheduled);
         if (scheduledJson !== lastScheduledJson) {
           lastScheduledJson = scheduledJson;
-          nsp.emit("admin:scheduled", { items: scheduled });
+          nsp.local.emit("admin:scheduled", { items: scheduled });
         }
       }
 
@@ -592,7 +592,7 @@ export const registerAdminGateway = (
 
   const unsubscribeAudit = subscribeAdminAudit((entry) => {
     if (nsp.sockets.size === 0) return;
-    nsp.emit("admin:auditEntry", entry);
+    nsp.local.emit("admin:auditEntry", entry);
   });
 
   nsp.on("connection", (socket) => {

--- a/packages/sfu/server/redisErrors.ts
+++ b/packages/sfu/server/redisErrors.ts
@@ -14,9 +14,15 @@ const REDIS_TRANSIENT_ERROR_NAMES = new Set([
 
 const REDIS_TRANSIENT_ERROR_CODES = new Set([
   "EAI_AGAIN",
+  "EAI_FAIL",
+  // Local interface changed/went away mid-connection (sleep, VPN, Wi-Fi hop):
+  // surfaces as `read EADDRNOTAVAIL` from the TLS socket with a node-internal
+  // stack, so the code is the only reliable signal.
+  "EADDRNOTAVAIL",
   "ECONNRESET",
   "ECONNREFUSED",
   "ECONNABORTED",
+  "ENETDOWN",
   "EPIPE",
   "EHOSTUNREACH",
   "ENOTFOUND",
@@ -65,7 +71,10 @@ export const isRedisTransientError = (error: unknown): boolean => {
     return true;
   }
 
-  if (redisStack && /timeout|closed|offline|connect/i.test(message)) {
+  if (
+    redisStack &&
+    /timeout|closed|offline|connect|queue is full|commands queue/i.test(message)
+  ) {
     return true;
   }
 

--- a/packages/sfu/test/redis-errors.test.ts
+++ b/packages/sfu/test/redis-errors.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { isRedisTransientError } from "../server/redisErrors.js";
+
+const nodeSocketError = (code: string, message: string): Error => {
+  const error = new Error(message) as Error & { code: string; syscall: string };
+  error.code = code;
+  error.syscall = "read";
+  // Node-internal stream stack: no @redis/client frames, so the code is the
+  // only classification signal (this shape crashed a live SFU once).
+  error.stack = `Error: ${message}\n    at TLSWrap.onStreamRead (node:internal/stream_base_commons:216:20)`;
+  return error;
+};
+
+describe("isRedisTransientError", () => {
+  it("classifies interface-loss reads from the redis TLS socket as transient", () => {
+    expect(
+      isRedisTransientError(nodeSocketError("EADDRNOTAVAIL", "read EADDRNOTAVAIL")),
+    ).toBe(true);
+  });
+
+  it("classifies DNS and reset errnos as transient", () => {
+    expect(
+      isRedisTransientError(
+        nodeSocketError("ENOTFOUND", "getaddrinfo ENOTFOUND star-pig.upstash.io"),
+      ),
+    ).toBe(true);
+    expect(
+      isRedisTransientError(nodeSocketError("ECONNRESET", "read ECONNRESET")),
+    ).toBe(true);
+  });
+
+  it("classifies redis command queue saturation as transient", () => {
+    const error = new Error("The queue is full");
+    error.stack = [
+      "Error: The queue is full",
+      "    at RedisCommandsQueue.addCommand (/app/node_modules/@redis/client/lib/client/commands-queue.ts:264:29)",
+      "    at Class.publish (/app/node_modules/@redis/client/lib/client/index.ts:297:25)",
+    ].join("\n");
+    expect(isRedisTransientError(error)).toBe(true);
+  });
+
+  it("does not swallow unrelated programming errors", () => {
+    expect(isRedisTransientError(new TypeError("x is not a function"))).toBe(false);
+    expect(isRedisTransientError(new Error("boom"))).toBe(false);
+  });
+
+  it("does not treat startup port conflicts as transient", () => {
+    expect(
+      isRedisTransientError(nodeSocketError("EADDRINUSE", "listen EADDRINUSE")),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- emit admin dashboard namespace updates with `nsp.local` so room detail/chat/overview streams do not publish through the Redis Socket.IO adapter
- classify Redis command queue saturation as transient so ignored adapter publish rejections do not crash the SFU process
- add regression coverage for Redis queue-full classification

## Verification
- `pnpm -C packages/sfu run typecheck`
- `pnpm -C packages/sfu exec vitest run test/admin-gateway.test.ts test/redis-errors.test.ts`
- `pnpm -C packages/sfu test`

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR keeps admin dashboard updates local to each SFU instance. The main changes are:

- Admin room detail, chat, overview, history, events, scheduled, and audit emits now use `nsp.local`.
- Redis transient error detection now includes additional network errors and command queue saturation.
- Tests were added for Redis error classification and negative cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped and match the intended behavior for local admin stream delivery and Redis transient error handling. Tests cover the new Redis error classification cases and unchanged negative cases. No correctness or security issues were identified in the changed files.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the admin-local-emits tests and compared the before and after artifacts to confirm that all broadcasts remained local and the nonLocalBroadcastCount stayed at zero, while the local client received room, chat, audit, history, overview, rooms, and scheduled events.
- T-Rex executed the regression test to exercise the publish queue; the before state reported queueFullPublishRejection=false and commandsQueueSaturation=false, and the after state reported queueFullPublishRejection=true and commandsQueueSaturation=true, with the test completing successfully and five tests passing.

<a href="https://app.greptile.com/trex/runs/13093469/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/sfu/server/admin/adminGateway.ts | Admin dashboard broadcasts now use Socket.IO `nsp.local` to avoid Redis adapter fan-out. |
| packages/sfu/server/redisErrors.ts | Redis transient error classification now includes more network errnos and Redis command queue saturation messages. |
| packages/sfu/test/redis-errors.test.ts | Adds tests for Redis transient classification of interface loss, DNS/reset failures, queue saturation, and negative cases. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant SFU as SFU admin gateway
participant Local as Local admin clients
participant Redis as Redis Socket.IO adapter
participant Guard as Redis crash guard

SFU->>SFU: Build admin overview/room/chat/audit update
SFU->>Local: nsp.local.emit / nsp.local.to(room).emit
Note over SFU,Redis: Admin dashboard stream is not published through Redis adapter
Redis-->>Guard: Network or command queue saturation error
Guard->>Guard: isRedisTransientError(error)
Guard-->>SFU: Suppress transient Redis rejection/exception
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant SFU as SFU admin gateway
participant Local as Local admin clients
participant Redis as Redis Socket.IO adapter
participant Guard as Redis crash guard

SFU->>SFU: Build admin overview/room/chat/audit update
SFU->>Local: nsp.local.emit / nsp.local.to(room).emit
Note over SFU,Redis: Admin dashboard stream is not published through Redis adapter
Redis-->>Guard: Network or command queue saturation error
Guard->>Guard: isRedisTransientError(error)
Guard-->>SFU: Suppress transient Redis rejection/exception
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(sfu): keep admin stream off redis ad..."](https://github.com/acm-vit/conclave/commit/c705a8cce947c46843e70168ab2d54c30b0f82c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41440152)</sub>

<!-- /greptile_comment -->