### PR TITLE
feat(games): add live chess

### DIFF
--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GamePresentation.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GamePresentation.swift
@@ -25,6 +25,8 @@ enum GameCatalogPresentationPolicy {
             return GameCatalogVisual(icon: "eye.slash.fill", androidIcon: "ghost")
         case "wordle":
             return GameCatalogVisual(icon: "square.grid.3x3.fill", androidIcon: "grid")
+        case "chess":
+            return GameCatalogVisual(icon: "checkerboard.rectangle", androidIcon: "grid")
         default:
             return GameCatalogVisual(icon: "gamecontroller.fill", androidIcon: "sports_esports")
         }

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GameStageGames.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GameStageGames.swift
@@ -773,6 +773,310 @@ struct ImposterStageView: View {
     }
 }
 
+// MARK: - Chess
+
+struct ChessStageSquare: Identifiable {
+    let square: String
+    let piece: String?
+    let isDark: Bool
+
+    var id: String { square }
+}
+
+struct ChessStageView: View {
+    @Bindable var viewModel: MeetingViewModel
+    let activeGame: GamePublicState
+    let playerView: GameJSONValue?
+    let canPlay: Bool
+    let canManage: Bool
+
+    @State private var selectedSquare: String? = nil
+
+    private var side: String? {
+        playerView?.string("side")
+    }
+
+    private var canMove: Bool {
+        canPlay
+            && playerView?.bool("canMove") == true
+            && !viewModel.state.isGameActionInFlight
+    }
+
+    var body: some View {
+        let publicView = activeGame.view
+        let phase = publicView?.string("phase") ?? activeGame.phase
+        let fen = publicView?.string("fen") ?? ""
+        let squares = ChessStageView.boardSquares(from: fen, side: side)
+        let targets = selectedSquare.flatMap { legalTargets(for: $0, in: publicView) } ?? []
+
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: ACMSpacing.md) {
+                    GameStagePrompt(
+                        kicker: phase == "results" ? "Result" : "Chess",
+                        title: statusTitle(publicView: publicView, phase: phase),
+                        subtitle: roleSubtitle(publicView: publicView)
+                    )
+
+                    LazyVGrid(
+                        columns: Array(repeating: GridItem(.flexible(), spacing: 0), count: 8),
+                        spacing: 0
+                    ) {
+                        ForEach(squares) { item in
+                            chessSquare(item, isSelected: selectedSquare == item.square, isTarget: targets.contains(item.square))
+                        }
+                    }
+                    .aspectRatio(1.0, contentMode: .fit)
+                    .clipShape(RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: ACMRadius.md, style: .continuous)
+                            .strokeBorder(lineWidth: 1)
+                            .foregroundStyle(ACMColors.border)
+                    }
+
+                    teamSummary(publicView)
+
+                    if let drawOffer = publicView?.dictionaryValue?["drawOffer"] as? [String: Any],
+                       let name = drawOffer["byName"] as? String {
+                        GameStageMetaLine(text: "\(name) offered a draw.")
+                    }
+                }
+                .padding(ACMSpacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            bottomBar(publicView: publicView, phase: phase)
+        }
+    }
+
+    private func chessSquare(_ item: ChessStageSquare, isSelected: Bool, isTarget: Bool) -> some View {
+        Button {
+            handleSquare(item)
+        } label: {
+            ZStack {
+                Rectangle()
+                    .fill(squareColor(isDark: item.isDark, isSelected: isSelected, isTarget: isTarget))
+                if let piece = item.piece {
+                    Text(piece)
+                        .font(.system(size: 30, weight: .regular, design: .serif))
+                        .foregroundStyle(ChessStageView.isWhitePiece(piece) ? Color.white : Color.black)
+                        .shadow(color: Color.black.opacity(0.18), radius: 1, x: 0, y: 1)
+                }
+                if isTarget && item.piece == nil {
+                    Circle()
+                        .fill(Color.black.opacity(0.32))
+                        .frame(width: 12, height: 12)
+                }
+            }
+            .aspectRatio(1.0, contentMode: .fit)
+        }
+        .buttonStyle(.plain)
+        .disabled(!canMove)
+    }
+
+    private func squareColor(isDark: Bool, isSelected: Bool, isTarget: Bool) -> Color {
+        if isSelected { return ACMColors.primaryOrange }
+        if isTarget { return ACMColors.primaryOrange.opacity(0.42) }
+        return isDark ? Color(red: 0.38, green: 0.45, blue: 0.37) : Color(red: 0.83, green: 0.76, blue: 0.62)
+    }
+
+    private func handleSquare(_ item: ChessStageSquare) {
+        guard canMove else { return }
+        let pieceIsOwn = ChessStageView.side(forPiece: item.piece) == side
+        if selectedSquare == nil {
+            if pieceIsOwn { selectedSquare = item.square }
+            return
+        }
+        guard let selected = selectedSquare else { return }
+        let targets = legalTargets(for: selected, in: activeGame.view)
+        if selected == item.square {
+            selectedSquare = nil
+            return
+        }
+        if pieceIsOwn && !targets.contains(item.square) {
+            selectedSquare = item.square
+            return
+        }
+        guard targets.contains(item.square) else { return }
+        let movingPiece = ChessStageView.piece(at: selected, in: activeGame.view?.string("fen") ?? "")
+        let promotion = ChessStageView.shouldPromote(piece: movingPiece, to: item.square) ? "q" : ""
+        selectedSquare = nil
+        viewModel.sendGameMove(
+            type: "move",
+            payload: GameJSONValue.object([
+                "from": selected,
+                "to": item.square,
+                "promotion": promotion
+            ])
+        )
+    }
+
+    @ViewBuilder
+    private func bottomBar(publicView: GameJSONValue?, phase: String) -> some View {
+        if phase == "results" {
+            GameStageResultsBar(viewModel: viewModel, canManage: canManage)
+        } else if playerView?.bool("canRespondToDraw") == true {
+            GameStageBottomBar {
+                GameStageActionButton(
+                    title: "Accept draw",
+                    isDisabled: viewModel.state.isGameActionInFlight
+                ) {
+                    viewModel.sendGameMove(type: "acceptDraw")
+                }
+                GameStageActionButton(
+                    title: "Decline",
+                    isPrimary: false,
+                    tint: ACMColors.text,
+                    isDisabled: viewModel.state.isGameActionInFlight
+                ) {
+                    viewModel.sendGameMove(type: "declineDraw")
+                }
+            }
+        } else if playerView?.bool("canOfferDraw") == true || playerView?.bool("canResign") == true {
+            GameStageBottomBar {
+                GameStageActionButton(
+                    title: "Offer draw",
+                    isPrimary: false,
+                    tint: ACMColors.text,
+                    isDisabled: viewModel.state.isGameActionInFlight || publicView?.dictionaryValue?["drawOffer"] != nil
+                ) {
+                    viewModel.sendGameMove(type: "offerDraw")
+                }
+                GameStageActionButton(
+                    title: "Resign",
+                    isPrimary: false,
+                    tint: ACMColors.error,
+                    isDisabled: viewModel.state.isGameActionInFlight
+                ) {
+                    viewModel.sendGameMove(type: "resign")
+                }
+            }
+        }
+    }
+
+    private func statusTitle(publicView: GameJSONValue?, phase: String) -> String {
+        if let result = publicView?.dictionaryValue?["result"] as? [String: Any] {
+            let winner = (result["winner"] as? String) ?? "draw"
+            let reason = (result["reason"] as? String) ?? "result"
+            if winner == "draw" { return "Draw by \(reason)" }
+            return "\(winner.capitalized) wins by \(reason)"
+        }
+        if canMove { return "Your move" }
+        let turnSide = publicView?.string("turnSide") ?? "white"
+        return "\(turnSide.capitalized) to move"
+    }
+
+    private func roleSubtitle(publicView: GameJSONValue?) -> String? {
+        let role = playerView?.string("role") ?? "spectator"
+        if role == "spectator" { return "Watching" }
+        if publicView?.bool("inCheck") == true {
+            return "\(role.replacingOccurrences(of: "-", with: " ")). Check."
+        }
+        return role.replacingOccurrences(of: "-", with: " ")
+    }
+
+    private func legalTargets(for square: String, in view: GameJSONValue?) -> [String] {
+        guard let legal = view?.dictionaryValue?["legalMoves"] as? [String: Any] else { return [] }
+        return legal[square] as? [String] ?? []
+    }
+
+    private func teamSummary(_ view: GameJSONValue?) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            chessTeamLine(title: "White", rows: teamRows("white", in: view))
+            chessTeamLine(title: "Black", rows: teamRows("black", in: view))
+        }
+    }
+
+    private func chessTeamLine(title: String, rows: [[String: Any]]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(ACMFont.trial(12, weight: .semibold))
+                .foregroundStyle(ACMColors.textFaint)
+            Text(rows.map { row in
+                let name = (row["name"] as? String) ?? "Player"
+                let captain = GameDetailsPresentationPolicy.boolValue(row["captain"]) == true
+                return captain ? "\(name) lead" : name
+            }.joined(separator: ", "))
+            .font(ACMFont.trial(13))
+            .foregroundStyle(ACMColors.textMuted)
+            .lineLimit(2)
+        }
+    }
+
+    private func teamRows(_ side: String, in view: GameJSONValue?) -> [[String: Any]] {
+        guard let teams = view?.dictionaryValue?["teams"] as? [String: Any] else { return [] }
+        return teams[side] as? [[String: Any]] ?? []
+    }
+
+    static func boardSquares(from fen: String, side: String?) -> [ChessStageSquare] {
+        let placement = fen.split(separator: " ").first.map(String.init) ?? ""
+        let rows = placement.split(separator: "/").map(String.init)
+        let files = ["a", "b", "c", "d", "e", "f", "g", "h"]
+        let ranks = ["8", "7", "6", "5", "4", "3", "2", "1"]
+        var squares: [ChessStageSquare] = []
+        for (rankIndex, row) in rows.enumerated() {
+            var fileIndex = 0
+            for token in row {
+                if let count = Int(String(token)) {
+                    for _ in 0..<count {
+                        squares.append(ChessStageSquare(
+                            square: "\(files[fileIndex])\(ranks[rankIndex])",
+                            piece: nil,
+                            isDark: (fileIndex + rankIndex) % 2 == 1
+                        ))
+                        fileIndex += 1
+                    }
+                } else {
+                    squares.append(ChessStageSquare(
+                        square: "\(files[fileIndex])\(ranks[rankIndex])",
+                        piece: pieceSymbol(String(token)),
+                        isDark: (fileIndex + rankIndex) % 2 == 1
+                    ))
+                    fileIndex += 1
+                }
+            }
+        }
+        return side == "black" ? Array(squares.reversed()) : squares
+    }
+
+    static func pieceSymbol(_ code: String) -> String {
+        switch code {
+        case "P": return "♙"
+        case "N": return "♘"
+        case "B": return "♗"
+        case "R": return "♖"
+        case "Q": return "♕"
+        case "K": return "♔"
+        case "p": return "♟"
+        case "n": return "♞"
+        case "b": return "♝"
+        case "r": return "♜"
+        case "q": return "♛"
+        case "k": return "♚"
+        default: return ""
+        }
+    }
+
+    static func isWhitePiece(_ piece: String) -> Bool {
+        ["♙", "♘", "♗", "♖", "♕", "♔"].contains(piece)
+    }
+
+    static func side(forPiece piece: String?) -> String? {
+        guard let piece else { return nil }
+        return isWhitePiece(piece) ? "white" : "black"
+    }
+
+    static func piece(at square: String, in fen: String) -> String? {
+        boardSquares(from: fen, side: nil).first { $0.square == square }?.piece
+    }
+
+    static func shouldPromote(piece: String?, to square: String) -> Bool {
+        if piece == "♙" { return square.hasSuffix("8") }
+        if piece == "♟" { return square.hasSuffix("1") }
+        return false
+    }
+}
+
 // MARK: - Wordle
 
 /// Wordle already has a full native round UI; the stage wraps it in the

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GameStageView.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GameStageView.swift
@@ -368,6 +368,8 @@ struct GameStageBodyView: View {
                 ImposterStageView(viewModel: viewModel, activeGame: activeGame, playerView: playerView, canPlay: canPlay, canManage: canManage)
             case "wordle":
                 WordleStageView(viewModel: viewModel, activeGame: activeGame, playerView: playerView, canPlay: canPlay, canManage: canManage)
+            case "chess":
+                ChessStageView(viewModel: viewModel, activeGame: activeGame, playerView: playerView, canPlay: canPlay, canManage: canManage)
             default:
                 GenericGameStageView(viewModel: viewModel, activeGame: activeGame, canManage: canManage)
             }

--- a/apps/web/src/app/components/games/ChessGame.tsx
+++ b/apps/web/src/app/components/games/ChessGame.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { color, radius } from "@conclave/ui-tokens";
+import { createTypedMove } from "@conclave/apps-sdk";
+import {
+  Avatar,
+  GameLobby,
+  GhostButton,
+  HEAD_FONT,
+  PrimaryButton,
+  type GameViewProps,
+} from "./gameUi";
+import type { ChessMove } from "./moves";
+
+type ChessSide = "white" | "black";
+type ChessTurn = "w" | "b";
+type ChessRole = "white-captain" | "black-captain" | "white-team" | "black-team" | "spectator";
+
+type ChessTeamPlayer = {
+  id: string;
+  name: string;
+  captain: boolean;
+};
+
+type ChessMoveRecord = {
+  san: string;
+  from: string;
+  to: string;
+  color: ChessTurn;
+  byPlayerId: string;
+  byName: string;
+};
+
+type ChessPublic = {
+  phase: "lobby" | "playing" | "results";
+  mode: "duel" | "teams";
+  fen: string;
+  turn: ChessTurn;
+  turnSide: ChessSide;
+  inCheck: boolean;
+  legalMoves: Record<string, string[]>;
+  teams: Record<ChessSide, ChessTeamPlayer[]>;
+  moves: ChessMoveRecord[];
+  drawOffer: { side: ChessSide; byPlayerId: string; byName: string } | null;
+  result: { winner: ChessSide | "draw"; reason: string; byName?: string } | null;
+};
+
+type ChessMe = {
+  side: ChessSide | null;
+  role: ChessRole;
+  canMove: boolean;
+  canResign: boolean;
+  canOfferDraw: boolean;
+  canRespondToDraw: boolean;
+};
+
+type PieceCode = "P" | "N" | "B" | "R" | "Q" | "K" | "p" | "n" | "b" | "r" | "q" | "k";
+type BoardCell = { square: string; piece: PieceCode | null; dark: boolean };
+
+const PIECES: Record<PieceCode, string> = {
+  P: "♙",
+  N: "♘",
+  B: "♗",
+  R: "♖",
+  Q: "♕",
+  K: "♔",
+  p: "♟",
+  n: "♞",
+  b: "♝",
+  r: "♜",
+  q: "♛",
+  k: "♚",
+};
+
+const FILES = ["a", "b", "c", "d", "e", "f", "g", "h"];
+const RANKS = ["8", "7", "6", "5", "4", "3", "2", "1"];
+
+const parseBoard = (fen: string, side: ChessSide | null): BoardCell[] => {
+  const placement = fen.split(" ")[0] ?? "";
+  const rows = placement.split("/");
+  const board: BoardCell[] = [];
+  rows.forEach((row, rankIndex) => {
+    let fileIndex = 0;
+    for (const token of row) {
+      const empty = Number(token);
+      if (Number.isInteger(empty) && empty > 0) {
+        for (let i = 0; i < empty; i += 1) {
+          board.push(cell(fileIndex, rankIndex, null));
+          fileIndex += 1;
+        }
+      } else {
+        board.push(cell(fileIndex, rankIndex, token as PieceCode));
+        fileIndex += 1;
+      }
+    }
+  });
+  return side === "black" ? board.reverse() : board;
+};
+
+const cell = (fileIndex: number, rankIndex: number, piece: PieceCode | null): BoardCell => ({
+  square: `${FILES[fileIndex]}${RANKS[rankIndex]}`,
+  piece,
+  dark: (fileIndex + rankIndex) % 2 === 1,
+});
+
+const pieceSide = (piece: PieceCode | null): ChessSide | null => {
+  if (!piece) return null;
+  return piece === piece.toUpperCase() ? "white" : "black";
+};
+
+const statusText = (pub: ChessPublic, me: ChessMe): string => {
+  if (pub.result) {
+    if (pub.result.winner === "draw") return `Draw by ${pub.result.reason}`;
+    return `${pub.result.winner === "white" ? "White" : "Black"} wins by ${pub.result.reason}`;
+  }
+  if (me.canMove) return "Your move";
+  const turn = pub.turnSide === "white" ? "White" : "Black";
+  const captain = pub.teams[pub.turnSide].find((player) => player.captain)?.name;
+  return `${turn} to move${captain ? ` · ${captain}` : ""}${pub.inCheck ? " · check" : ""}`;
+};
+
+export default function ChessGame({
+  pub,
+  me,
+  players,
+  userId,
+  isAdmin,
+  readOnly = false,
+  move,
+}: GameViewProps<ChessPublic, ChessMe>) {
+  const send = createTypedMove<ChessMove>(move);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const board = useMemo(() => parseBoard(pub.fen, me.side), [pub.fen, me.side]);
+
+  const dispatch = async (next: ChessMove) => {
+    setError(null);
+    const result = await send(next);
+    if (!result.success) setError(result.error ?? "Move rejected");
+  };
+
+  if (pub.phase === "lobby") {
+    return (
+      <GameLobby
+        gameId="chess"
+        title={pub.mode === "teams" ? "Captain-led team chess" : "Live chess duel"}
+        blurb={
+          pub.mode === "teams"
+            ? "The room splits into White and Black. Each side can talk, but only its captain moves the pieces."
+            : "Two live members are randomly seated as White and Black. No bot, no engine, just the board."
+        }
+        players={players}
+        userId={userId}
+        isAdmin={isAdmin}
+        readOnly={readOnly}
+        canStart={players.length >= 2}
+        disabledLabel="Need at least 2 players"
+        onStart={() => dispatch({ type: "start" })}
+      />
+    );
+  }
+
+  const canMove = !readOnly && me.canMove;
+  const selectedTargets = selected ? pub.legalMoves[selected] ?? [] : [];
+
+  const handleSquare = (square: string, piece: PieceCode | null) => {
+    if (!canMove) return;
+    const ownPiece = pieceSide(piece) === me.side;
+    if (!selected) {
+      if (ownPiece) setSelected(square);
+      return;
+    }
+    if (selected === square) {
+      setSelected(null);
+      return;
+    }
+    if (ownPiece && !selectedTargets.includes(square)) {
+      setSelected(square);
+      return;
+    }
+    if (!selectedTargets.includes(square)) return;
+    const promotion = shouldPromote(board.find((c) => c.square === selected)?.piece ?? null, square) ? "q" : undefined;
+    setSelected(null);
+    void dispatch({ type: "move", from: selected, to: square, promotion });
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <div>
+        <p style={{ fontFamily: HEAD_FONT, fontSize: 18, color: color.text, margin: 0 }}>
+          {statusText(pub, me)}
+        </p>
+        <p style={{ fontSize: 12, color: color.textMuted, margin: "5px 0 0" }}>
+          {me.role === "spectator" ? "Watching" : roleLabel(me.role)}
+        </p>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(8, minmax(0, 1fr))",
+          width: "100%",
+          aspectRatio: "1 / 1",
+          borderRadius: radius.md,
+          overflow: "hidden",
+          border: `1px solid ${color.border}`,
+          background: color.surfaceRaised,
+        }}
+      >
+        {board.map((cell) => {
+          const active = selected === cell.square;
+          const target = selectedTargets.includes(cell.square);
+          return (
+            <button
+              key={cell.square}
+              type="button"
+              disabled={!canMove}
+              onClick={() => handleSquare(cell.square, cell.piece)}
+              title={cell.square}
+              style={{
+                position: "relative",
+                border: "none",
+                padding: 0,
+                background: active
+                  ? "rgba(239, 112, 71, 0.88)"
+                  : target
+                    ? "rgba(239, 112, 71, 0.32)"
+                    : cell.dark
+                      ? "#60725f"
+                      : "#d8c7a3",
+                color: pieceSide(cell.piece) === "white" ? "#fafafa" : "#151515",
+                fontSize: 30,
+                lineHeight: 1,
+                cursor: canMove ? "pointer" : "default",
+                fontFamily: "Georgia, serif",
+              }}
+            >
+              {cell.piece ? PIECES[cell.piece] : ""}
+              {target ? (
+                <span
+                  style={{
+                    position: "absolute",
+                    left: "50%",
+                    top: "50%",
+                    width: 12,
+                    height: 12,
+                    borderRadius: "50%",
+                    transform: "translate(-50%, -50%)",
+                    background: cell.piece ? "transparent" : "rgba(24, 24, 27, 0.45)",
+                    border: cell.piece ? "2px solid rgba(24, 24, 27, 0.45)" : "none",
+                    pointerEvents: "none",
+                  }}
+                />
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+
+      {error ? <p style={{ margin: 0, color: color.danger, fontSize: 12 }}>{error}</p> : null}
+      {pub.drawOffer ? (
+        <div style={{ padding: 10, borderRadius: radius.md, background: color.surfaceRaised, border: `1px solid ${color.border}` }}>
+          <p style={{ margin: 0, fontSize: 13, color: color.text }}>
+            {pub.drawOffer.byName} offered a draw.
+          </p>
+          {me.canRespondToDraw && !readOnly ? (
+            <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+              <PrimaryButton onClick={() => dispatch({ type: "acceptDraw" })}>Accept</PrimaryButton>
+              <GhostButton onClick={() => dispatch({ type: "declineDraw" })}>Decline</GhostButton>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <TeamList title="White" team={pub.teams.white} active={pub.turnSide === "white" && pub.phase === "playing"} />
+      <TeamList title="Black" team={pub.teams.black} active={pub.turnSide === "black" && pub.phase === "playing"} />
+
+      {pub.moves.length > 0 ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <p style={{ margin: 0, color: color.textFaint, fontSize: 11, fontFamily: HEAD_FONT }}>Moves</p>
+          {pub.moves.slice(-8).map((entry, index) => (
+            <div key={`${entry.from}-${entry.to}-${index}`} style={{ display: "flex", justifyContent: "space-between", fontSize: 12, color: color.textMuted }}>
+              <span>{pub.moves.length - Math.min(pub.moves.length, 8) + index + 1}. {entry.san}</span>
+              <span>{entry.byName}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {pub.phase === "playing" && (me.canOfferDraw || me.canResign) && !readOnly ? (
+        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+          <GhostButton disabled={Boolean(pub.drawOffer)} onClick={() => dispatch({ type: "offerDraw" })}>
+            Offer draw
+          </GhostButton>
+          <GhostButton onClick={() => dispatch({ type: "resign" })}>Resign</GhostButton>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function shouldPromote(piece: PieceCode | null, to: string) {
+  if (piece === "P") return to.endsWith("8");
+  if (piece === "p") return to.endsWith("1");
+  return false;
+}
+
+function roleLabel(role: ChessRole): string {
+  switch (role) {
+    case "white-captain": return "White captain";
+    case "black-captain": return "Black captain";
+    case "white-team": return "White team";
+    case "black-team": return "Black team";
+    default: return "Watching";
+  }
+}
+
+function TeamList({ title, team, active }: { title: string; team: ChessTeamPlayer[]; active: boolean }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <p style={{ margin: 0, color: active ? color.accent : color.textFaint, fontSize: 11, fontFamily: HEAD_FONT }}>
+        {title}
+      </p>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+        {team.map((player) => (
+          <div
+            key={player.id}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 7,
+              padding: "5px 8px",
+              borderRadius: radius.pill,
+              background: player.captain ? color.accentSoft : color.surfaceRaised,
+              border: `1px solid ${player.captain ? color.accent : color.border}`,
+            }}
+          >
+            <Avatar name={player.name} size={22} highlight={player.captain} />
+            <span style={{ color: color.text, fontSize: 12, maxWidth: 100, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {player.name}{player.captain ? " · lead" : ""}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/components/games/moves.ts
+++ b/apps/web/src/app/components/games/moves.ts
@@ -59,3 +59,12 @@ export type WordleMove =
   | { type: "setWord"; word: string }
   | { type: "guess"; word: string }
   | { type: "nextRound" };
+
+/** Mirrors ChessMove in modules/chess.ts. */
+export type ChessMove =
+  | { type: "start" }
+  | { type: "move"; from: string; to: string; promotion?: "q" | "r" | "b" | "n" }
+  | { type: "resign" }
+  | { type: "offerDraw" }
+  | { type: "acceptDraw" }
+  | { type: "declineDraw" };

--- a/apps/web/src/app/components/games/registry.tsx
+++ b/apps/web/src/app/components/games/registry.tsx
@@ -9,6 +9,7 @@ import MostLikelyToGame from "./MostLikelyToGame";
 import ReactionGame from "./ReactionGame";
 import ImposterGame from "./ImposterGame";
 import WordleGame from "./WordleGame";
+import ChessGame from "./ChessGame";
 
 // Add a web renderer here (one line). The key is the game id from the SFU
 // module. Everything else (launcher, stage routing) reads from this map.
@@ -20,6 +21,7 @@ export const GAME_RENDERERS: Record<string, React.ComponentType<GameViewProps>> 
   reaction: ReactionGame as React.ComponentType<GameViewProps>,
   imposter: ImposterGame as React.ComponentType<GameViewProps>,
   wordle: WordleGame as React.ComponentType<GameViewProps>,
+  chess: ChessGame as React.ComponentType<GameViewProps>,
 };
 
 export const getGameRenderer = (

--- a/packages/sfu/package.json
+++ b/packages/sfu/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@conclave/ui-tokens": "workspace:*",
     "@socket.io/redis-adapter": "^8.3.0",
+    "chess.js": "^1.4.0",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",

--- a/packages/sfu/server/games/modules/chess.ts
+++ b/packages/sfu/server/games/modules/chess.ts
@@ -1,0 +1,386 @@
+import { Chess, type Move as ChessJsMove } from "chess.js";
+import { selectOption } from "../config.js";
+import {
+  GameMoveError,
+  type GameContext,
+  type GameModule,
+  type GameMove,
+  type GamePlayer,
+} from "../types.js";
+import { payloadField, requireOneOf, requireString } from "../validation.js";
+
+type ChessPhase = "lobby" | "playing" | "results";
+type ChessMode = "duel" | "teams";
+type ChessSide = "white" | "black";
+type ChessTurn = "w" | "b";
+type ChessRole = "white-captain" | "black-captain" | "white-team" | "black-team" | "spectator";
+type Promotion = "q" | "r" | "b" | "n";
+
+type ChessTeam = {
+  captainId: string | null;
+  playerIds: string[];
+};
+
+type ChessMoveRecord = {
+  san: string;
+  from: string;
+  to: string;
+  color: ChessTurn;
+  promotion: Promotion | null;
+  byPlayerId: string;
+  byName: string;
+  at: number;
+};
+
+type ChessResult = {
+  winner: ChessSide | "draw";
+  reason: "checkmate" | "stalemate" | "threefold" | "insufficient" | "draw" | "resignation";
+  byPlayerId?: string;
+  byName?: string;
+};
+
+type DrawOffer = {
+  side: ChessSide;
+  byPlayerId: string;
+  byName: string;
+};
+
+type ChessState = {
+  phase: ChessPhase;
+  mode: ChessMode;
+  fen: string;
+  pgn: string;
+  turn: ChessTurn;
+  teams: {
+    white: ChessTeam;
+    black: ChessTeam;
+  };
+  moves: ChessMoveRecord[];
+  drawOffer: DrawOffer | null;
+  result: ChessResult | null;
+  startedAt: number | null;
+  finishedAt: number | null;
+};
+
+export type ChessMove =
+  | { type: "start" }
+  | { type: "move"; from: string; to: string; promotion?: Promotion }
+  | { type: "resign" }
+  | { type: "offerDraw" }
+  | { type: "acceptDraw" }
+  | { type: "declineDraw" };
+
+const PROMOTIONS = ["q", "r", "b", "n"] as const;
+const SQUARE_RE = /^[a-h][1-8]$/;
+
+const decodeChessMove = (move: GameMove): ChessMove => {
+  switch (move.type) {
+    case "start":
+    case "resign":
+    case "offerDraw":
+    case "acceptDraw":
+    case "declineDraw":
+      return { type: move.type };
+    case "move": {
+      const from = requireString(payloadField(move.payload, "from"), "Invalid source square").toLowerCase();
+      const to = requireString(payloadField(move.payload, "to"), "Invalid target square").toLowerCase();
+      if (!SQUARE_RE.test(from) || !SQUARE_RE.test(to)) {
+        throw new GameMoveError("Invalid square");
+      }
+      const rawPromotion = payloadField(move.payload, "promotion");
+      const promotion =
+        rawPromotion == null || rawPromotion === ""
+          ? undefined
+          : requireOneOf(rawPromotion, PROMOTIONS, "Invalid promotion");
+      return { type: "move", from, to, promotion };
+    }
+    default:
+      throw new GameMoveError(`Unknown move: ${move.type}`);
+  }
+};
+
+const sideForTurn = (turn: ChessTurn): ChessSide => (turn === "w" ? "white" : "black");
+const otherSide = (side: ChessSide): ChessSide => (side === "white" ? "black" : "white");
+const turnForSide = (side: ChessSide): ChessTurn => (side === "white" ? "w" : "b");
+
+const playerName = (ctx: GameContext, playerId: string): string =>
+  ctx.players.find((player) => player.id === playerId)?.name ?? playerId;
+
+const sideForPlayer = (state: ChessState, playerId: string): ChessSide | null => {
+  if (state.teams.white.playerIds.includes(playerId)) return "white";
+  if (state.teams.black.playerIds.includes(playerId)) return "black";
+  return null;
+};
+
+const roleForPlayer = (state: ChessState, playerId: string): ChessRole => {
+  if (state.teams.white.captainId === playerId) return "white-captain";
+  if (state.teams.black.captainId === playerId) return "black-captain";
+  if (state.teams.white.playerIds.includes(playerId)) return "white-team";
+  if (state.teams.black.playerIds.includes(playerId)) return "black-team";
+  return "spectator";
+};
+
+const requireCaptain = (state: ChessState, playerId: string, side: ChessSide): void => {
+  const captainId = state.teams[side].captainId;
+  if (captainId !== playerId) {
+    throw new GameMoveError(`Only the ${side} captain can move`);
+  }
+};
+
+const seatedTeams = (ctx: GameContext, mode: ChessMode) => {
+  const shuffled = ctx.rng.shuffle(ctx.activePlayers);
+  if (shuffled.length < 2) throw new GameMoveError("Chess needs at least 2 players");
+
+  if (mode === "duel") {
+    const [white, black] = shuffled;
+    return {
+      white: { captainId: white.id, playerIds: [white.id] },
+      black: { captainId: black.id, playerIds: [black.id] },
+    };
+  }
+
+  const whitePlayers: GamePlayer[] = [];
+  const blackPlayers: GamePlayer[] = [];
+  shuffled.forEach((player, index) => {
+    if (index % 2 === 0) whitePlayers.push(player);
+    else blackPlayers.push(player);
+  });
+
+  return {
+    white: { captainId: whitePlayers[0]?.id ?? null, playerIds: whitePlayers.map((player) => player.id) },
+    black: { captainId: blackPlayers[0]?.id ?? null, playerIds: blackPlayers.map((player) => player.id) },
+  };
+};
+
+const legalMoves = (game: Chess): Record<string, string[]> => {
+  const bySquare: Record<string, string[]> = {};
+  for (const move of game.moves({ verbose: true }) as ChessJsMove[]) {
+    bySquare[move.from] = [...(bySquare[move.from] ?? []), move.to];
+  }
+  return bySquare;
+};
+
+const resultForGame = (game: Chess): ChessResult | null => {
+  if (!game.isGameOver()) return null;
+  if (game.isCheckmate()) {
+    const losingSide = sideForTurn(game.turn());
+    return { winner: otherSide(losingSide), reason: "checkmate" };
+  }
+  if (game.isStalemate()) return { winner: "draw", reason: "stalemate" };
+  if (game.isThreefoldRepetition()) return { winner: "draw", reason: "threefold" };
+  if (game.isInsufficientMaterial()) return { winner: "draw", reason: "insufficient" };
+  return { winner: "draw", reason: "draw" };
+};
+
+const teamView = (team: ChessTeam, ctx: GameContext) =>
+  team.playerIds.map((id) => ({
+    id,
+    name: playerName(ctx, id),
+    captain: id === team.captainId,
+  }));
+
+export const chessModule: GameModule<ChessState> = {
+  id: "chess",
+  name: "Chess",
+  description: "Live chess for two players or two captain-led teams",
+  minPlayers: 2,
+  maxPlayers: 32,
+  spectatable: true,
+  options: [
+    {
+      id: "mode",
+      type: "select",
+      label: "Mode",
+      default: "duel",
+      choices: [
+        { value: "duel", label: "Duel" },
+        { value: "teams", label: "Team chess" },
+      ],
+    },
+  ],
+
+  setup(ctx): ChessState {
+    const game = new Chess();
+    const mode = selectOption(ctx.config, "mode", "duel") === "teams" ? "teams" : "duel";
+    return {
+      phase: "lobby",
+      mode,
+      fen: game.fen(),
+      pgn: game.pgn(),
+      turn: game.turn(),
+      teams: {
+        white: { captainId: null, playerIds: [] },
+        black: { captainId: null, playerIds: [] },
+      },
+      moves: [],
+      drawOffer: null,
+      result: null,
+      startedAt: null,
+      finishedAt: null,
+    };
+  },
+
+  onMove(state, move, ctx): ChessState {
+    const m = decodeChessMove(move);
+    switch (m.type) {
+      case "start": {
+        if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can start");
+        if (state.phase !== "lobby") throw new GameMoveError("Already running");
+        const teams = seatedTeams(ctx, state.mode);
+        return { ...state, phase: "playing", teams, startedAt: ctx.now };
+      }
+      case "move": {
+        if (state.phase !== "playing") throw new GameMoveError("Game is not running");
+        const side = sideForTurn(state.turn);
+        requireCaptain(state, move.playerId, side);
+
+        const game = new Chess(state.fen);
+        let played: ChessJsMove | null = null;
+        try {
+          played = game.move({ from: m.from, to: m.to, promotion: m.promotion ?? "q" });
+        } catch {
+          played = null;
+        }
+        if (!played) throw new GameMoveError("Illegal move");
+
+        const result = resultForGame(game);
+        return {
+          ...state,
+          phase: result ? "results" : "playing",
+          fen: game.fen(),
+          pgn: game.pgn(),
+          turn: game.turn(),
+          drawOffer: null,
+          result,
+          finishedAt: result ? ctx.now : null,
+          moves: [
+            ...state.moves,
+            {
+              san: played.san,
+              from: played.from,
+              to: played.to,
+              color: played.color,
+              promotion: (played.promotion as Promotion | undefined) ?? null,
+              byPlayerId: move.playerId,
+              byName: playerName(ctx, move.playerId),
+              at: ctx.now,
+            },
+          ],
+        };
+      }
+      case "resign": {
+        if (state.phase !== "playing") throw new GameMoveError("Game is not running");
+        const side = sideForPlayer(state, move.playerId);
+        if (!side) throw new GameMoveError("You are not on a side");
+        requireCaptain(state, move.playerId, side);
+        return {
+          ...state,
+          phase: "results",
+          drawOffer: null,
+          result: {
+            winner: otherSide(side),
+            reason: "resignation",
+            byPlayerId: move.playerId,
+            byName: playerName(ctx, move.playerId),
+          },
+          finishedAt: ctx.now,
+        };
+      }
+      case "offerDraw": {
+        if (state.phase !== "playing") throw new GameMoveError("Game is not running");
+        const side = sideForPlayer(state, move.playerId);
+        if (!side) throw new GameMoveError("You are not on a side");
+        requireCaptain(state, move.playerId, side);
+        return {
+          ...state,
+          drawOffer: { side, byPlayerId: move.playerId, byName: playerName(ctx, move.playerId) },
+        };
+      }
+      case "acceptDraw": {
+        if (state.phase !== "playing") throw new GameMoveError("Game is not running");
+        if (!state.drawOffer) throw new GameMoveError("No draw offer to accept");
+        const side = sideForPlayer(state, move.playerId);
+        if (!side || side === state.drawOffer.side) {
+          throw new GameMoveError("Only the opposing captain can accept");
+        }
+        requireCaptain(state, move.playerId, side);
+        return {
+          ...state,
+          phase: "results",
+          drawOffer: null,
+          result: { winner: "draw", reason: "draw", byPlayerId: move.playerId, byName: playerName(ctx, move.playerId) },
+          finishedAt: ctx.now,
+        };
+      }
+      case "declineDraw": {
+        if (state.phase !== "playing") throw new GameMoveError("Game is not running");
+        if (!state.drawOffer) return state;
+        const side = sideForPlayer(state, move.playerId);
+        if (!side || side === state.drawOffer.side) {
+          throw new GameMoveError("Only the opposing captain can decline");
+        }
+        requireCaptain(state, move.playerId, side);
+        return { ...state, drawOffer: null };
+      }
+      default: {
+        const _exhaustive: never = m;
+        throw new GameMoveError(`Unknown move: ${(_exhaustive as GameMove).type}`);
+      }
+    }
+  },
+
+  getPhase: (state) => state.phase,
+
+  publicView(state, ctx) {
+    const game = new Chess(state.fen);
+    return {
+      phase: state.phase,
+      mode: state.mode,
+      fen: state.fen,
+      pgn: state.pgn,
+      turn: state.turn,
+      turnSide: sideForTurn(state.turn),
+      inCheck: game.inCheck(),
+      legalMoves: state.phase === "playing" ? legalMoves(game) : {},
+      teams: {
+        white: teamView(state.teams.white, ctx),
+        black: teamView(state.teams.black, ctx),
+      },
+      captains: {
+        white: state.teams.white.captainId,
+        black: state.teams.black.captainId,
+      },
+      moves: state.moves,
+      drawOffer: state.drawOffer,
+      result: state.result,
+      startedAt: state.startedAt,
+      finishedAt: state.finishedAt,
+    };
+  },
+
+  playerView(state, playerId) {
+    const side = sideForPlayer(state, playerId);
+    const role = roleForPlayer(state, playerId);
+    const turnSide = sideForTurn(state.turn);
+    const canMove =
+      state.phase === "playing" &&
+      side === turnSide &&
+      state.teams[turnSide].captainId === playerId;
+    const canRespondToDraw =
+      state.phase === "playing" &&
+      state.drawOffer != null &&
+      side != null &&
+      side !== state.drawOffer.side &&
+      state.teams[side].captainId === playerId;
+    return {
+      side,
+      role,
+      canMove,
+      canResign: state.phase === "playing" && side != null && state.teams[side].captainId === playerId,
+      canOfferDraw: state.phase === "playing" && side != null && state.teams[side].captainId === playerId,
+      canRespondToDraw,
+    };
+  },
+
+  isFinished: (state) => state.phase === "results",
+};

--- a/packages/sfu/server/games/registry.ts
+++ b/packages/sfu/server/games/registry.ts
@@ -1,4 +1,5 @@
 import { bluffModule } from "./modules/bluff.js";
+import { chessModule } from "./modules/chess.js";
 import { imposterModule } from "./modules/imposter.js";
 import { mostLikelyToModule } from "./modules/mostLikelyTo.js";
 import { reactionModule } from "./modules/reaction.js";
@@ -16,6 +17,7 @@ const MODULES: GameModule[] = [
   reactionModule,
   imposterModule,
   wordleModule,
+  chessModule,
 ];
 
 const REGISTRY = new Map<string, GameModule>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
       '@socket.io/redis-adapter':
         specifier: ^8.3.0
         version: 8.3.0(socket.io-adapter@2.5.8)
+      chess.js:
+        specifier: ^1.4.0
+        version: 1.4.0
       cors:
         specifier: ^2.8.6
         version: 2.8.6
@@ -3228,6 +3231,9 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  chess.js@1.4.0:
+    resolution: {integrity: sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -9427,6 +9433,8 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   check-error@2.1.3: {}
+
+  chess.js@1.4.0: {}
 
   chokidar@4.0.3:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds a server-authoritative live Chess game using free/open-source `chess.js` for move legality.
- Supports Duel and Team Chess modes, with random/balanced team seating and captain-only piece movement.
- Adds web and native game-stage board renderers, draw offers, resign flow, and game catalog registration.

## Validation
- `git diff --check`
- Focused SFU TypeScript compile for `server/games/modules/chess.ts`
- Runtime smoke test covering team start, non-captain move rejection, captain move acceptance, and turn handoff

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds live chess as a new game across the SFU, web client, and native client. The main changes are:

- Server-authoritative chess state and move handling using `chess.js`.
- Duel and captain-led team chess modes with seating, turns, draws, and resignations.
- Web and native board renderers with move dispatch and game controls.
- Game catalog and renderer registration for the new `chess` game.

<h3>Confidence Score: 5/5</h3>

This PR appears safe to merge with low risk.

No blocking correctness or security issues were identified in the changed paths. Server-side move validation, role checks, and client move dispatch follow the existing game runtime contracts.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before state showed the base catalog lookup returning 400 NOT FOUND, indicating runtime module scenarios were unavailable.
- After state showed the catalog.lookup returning a 200 OK chess entry and related endpoints returning 200 OK for duel.start and teams.start, with team balanced true and appropriate turn handling, move restrictions, and a black win on resignation.
- Playwright evidence captured the after-state head renderer surface, including the board, teams, captains, draw controls, and emitted events, with log and script artifacts accompanying the capture.
- Native renderer workflow tooling was prepared, including a validation script for both checkouts and runtime tests, while the environment proof showed that the Swift toolchain, xcodebuild, and adb were unavailable.

<a href="https://app.greptile.com/trex/runs/13147689/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/sfu/server/games/modules/chess.ts | Introduces the server-authoritative chess module with seating, move legality, draw, resignation, and public/player projections; no blocking issues found. |
| apps/web/src/app/components/games/ChessGame.tsx | Adds the web chess lobby, board renderer, move dispatch, team display, and draw/resign controls; no blocking issues found. |
| apps/conclave-skip/Sources/Conclave/Features/Meeting/Games/GameStageGames.swift | Adds the native SwiftUI chess board, role/status display, draw controls, and move dispatch; no blocking issues found. |
| apps/web/src/app/components/games/registry.tsx | Registers the chess web renderer in the game renderer map; no issues found. |
| packages/sfu/server/games/registry.ts | Registers the chess module with the SFU game registry; no issues found. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Host as Host client
participant Player as Player client
participant SFU as SFU chess module
participant ChessJS as chess.js

Host->>SFU: start game
SFU->>SFU: seat white/black teams and captains
SFU-->>Player: publicView + playerView
Player->>SFU: move(from, to, promotion)
SFU->>SFU: require current-side captain
SFU->>ChessJS: validate/apply move from FEN
ChessJS-->>SFU: updated FEN, SAN, game-over status
SFU-->>Player: updated board, legal moves, result/draw state
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Host as Host client
participant Player as Player client
participant SFU as SFU chess module
participant ChessJS as chess.js

Host->>SFU: start game
SFU->>SFU: seat white/black teams and captains
SFU-->>Player: publicView + playerView
Player->>SFU: move(from, to, promotion)
SFU->>SFU: require current-side captain
SFU->>ChessJS: validate/apply move from FEN
ChessJS-->>SFU: updated FEN, SAN, game-over status
SFU-->>Player: updated board, legal moves, result/draw state
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Add live chess game"](https://github.com/acm-vit/conclave/commit/7b65dfd76d21f0ded379bd444ae0d94ae7978500) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41545807)</sub>

<!-- /greptile_comment -->