### PR TITLE
feat(fix(games)): polish chess board and timers

### DIFF
--- a/apps/web/src/app/components/games/ChessGame.tsx
+++ b/apps/web/src/app/components/games/ChessGame.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { color, radius } from "@conclave/ui-tokens";
 import { createTypedMove } from "@conclave/apps-sdk";
 import {
@@ -32,9 +32,18 @@ type ChessMoveRecord = {
   byName: string;
 };
 
+type ChessResult = {
+  winner: ChessSide | "draw";
+  reason: string;
+  byName?: string;
+};
+
 type ChessPublic = {
   phase: "lobby" | "playing" | "results";
   mode: "duel" | "teams";
+  serverNow: number;
+  timeControlMs: number | null;
+  clocks: Record<ChessSide, number | null>;
   fen: string;
   turn: ChessTurn;
   turnSide: ChessSide;
@@ -43,7 +52,7 @@ type ChessPublic = {
   teams: Record<ChessSide, ChessTeamPlayer[]>;
   moves: ChessMoveRecord[];
   drawOffer: { side: ChessSide; byPlayerId: string; byName: string } | null;
-  result: { winner: ChessSide | "draw"; reason: string; byName?: string } | null;
+  result: ChessResult | null;
 };
 
 type ChessMe = {
@@ -59,22 +68,33 @@ type PieceCode = "P" | "N" | "B" | "R" | "Q" | "K" | "p" | "n" | "b" | "r" | "q"
 type BoardCell = { square: string; piece: PieceCode | null; dark: boolean };
 
 const PIECES: Record<PieceCode, string> = {
-  P: "♙",
-  N: "♘",
-  B: "♗",
-  R: "♖",
-  Q: "♕",
-  K: "♔",
-  p: "♟",
-  n: "♞",
-  b: "♝",
-  r: "♜",
-  q: "♛",
-  k: "♚",
+  P: "\u2659",
+  N: "\u2658",
+  B: "\u2657",
+  R: "\u2656",
+  Q: "\u2655",
+  K: "\u2654",
+  p: "\u265F",
+  n: "\u265E",
+  b: "\u265D",
+  r: "\u265C",
+  q: "\u265B",
+  k: "\u265A",
 };
 
 const FILES = ["a", "b", "c", "d", "e", "f", "g", "h"];
 const RANKS = ["8", "7", "6", "5", "4", "3", "2", "1"];
+const DARK_SQUARE = "#8d3f3a";
+const LIGHT_SQUARE = "#f2e7db";
+const ACTIVE_SQUARE = "#ef7047";
+const TARGET_SQUARE = "rgba(239, 112, 71, 0.42)";
+
+const WIN_QUOTES = [
+  "A royal finish. Absolute endgame aura.",
+  "That was not just a win. That was board control.",
+  "Checkmate energy. Clean, calm, clinical.",
+  "The crown stays with the cooler head.",
+];
 
 const parseBoard = (fen: string, side: ChessSide | null): BoardCell[] => {
   const placement = fen.split(" ")[0] ?? "";
@@ -111,13 +131,12 @@ const pieceSide = (piece: PieceCode | null): ChessSide | null => {
 
 const statusText = (pub: ChessPublic, me: ChessMe): string => {
   if (pub.result) {
-    if (pub.result.winner === "draw") return `Draw by ${pub.result.reason}`;
-    return `${pub.result.winner === "white" ? "White" : "Black"} wins by ${pub.result.reason}`;
+    if (pub.result.winner === "draw") return `Draw by ${resultReason(pub.result.reason)}`;
+    return `${sideLabel(pub.result.winner)} wins by ${resultReason(pub.result.reason)}`;
   }
   if (me.canMove) return "Your move";
-  const turn = pub.turnSide === "white" ? "White" : "Black";
   const captain = pub.teams[pub.turnSide].find((player) => player.captain)?.name;
-  return `${turn} to move${captain ? ` · ${captain}` : ""}${pub.inCheck ? " · check" : ""}`;
+  return `${sideLabel(pub.turnSide)} to move${captain ? ` - ${captain}` : ""}${pub.inCheck ? " - check" : ""}`;
 };
 
 export default function ChessGame({
@@ -133,6 +152,8 @@ export default function ChessGame({
   const [selected, setSelected] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const board = useMemo(() => parseBoard(pub.fen, me.side), [pub.fen, me.side]);
+  const whiteClock = useChessClock(pub, "white");
+  const blackClock = useChessClock(pub, "black");
 
   const dispatch = async (next: ChessMove) => {
     setError(null);
@@ -186,7 +207,10 @@ export default function ChessGame({
   };
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+    <div style={{ display: "flex", flexDirection: "column", gap: 14, minWidth: 0 }}>
+      <ChessAnimationStyles />
+      {pub.phase === "results" ? <ResultCelebration result={pub.result} /> : null}
+
       <div>
         <p style={{ fontFamily: HEAD_FONT, fontSize: 18, color: color.text, margin: 0 }}>
           {statusText(pub, me)}
@@ -196,66 +220,117 @@ export default function ChessGame({
         </p>
       </div>
 
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(8, minmax(0, 1fr))",
-          width: "100%",
-          aspectRatio: "1 / 1",
-          borderRadius: radius.md,
-          overflow: "hidden",
-          border: `1px solid ${color.border}`,
-          background: color.surfaceRaised,
-        }}
-      >
-        {board.map((cell) => {
-          const active = selected === cell.square;
-          const target = selectedTargets.includes(cell.square);
-          return (
-            <button
-              key={cell.square}
-              type="button"
-              disabled={!canMove}
-              onClick={() => handleSquare(cell.square, cell.piece)}
-              title={cell.square}
-              style={{
-                position: "relative",
-                border: "none",
-                padding: 0,
-                background: active
-                  ? "rgba(239, 112, 71, 0.88)"
-                  : target
-                    ? "rgba(239, 112, 71, 0.32)"
-                    : cell.dark
-                      ? "#60725f"
-                      : "#d8c7a3",
-                color: pieceSide(cell.piece) === "white" ? "#fafafa" : "#151515",
-                fontSize: 30,
-                lineHeight: 1,
-                cursor: canMove ? "pointer" : "default",
-                fontFamily: "Georgia, serif",
-              }}
-            >
-              {cell.piece ? PIECES[cell.piece] : ""}
-              {target ? (
-                <span
-                  style={{
-                    position: "absolute",
-                    left: "50%",
-                    top: "50%",
-                    width: 12,
-                    height: 12,
-                    borderRadius: "50%",
-                    transform: "translate(-50%, -50%)",
-                    background: cell.piece ? "transparent" : "rgba(24, 24, 27, 0.45)",
-                    border: cell.piece ? "2px solid rgba(24, 24, 27, 0.45)" : "none",
-                    pointerEvents: "none",
-                  }}
-                />
-              ) : null}
-            </button>
-          );
-        })}
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <ClockRow
+          side="black"
+          team={pub.teams.black}
+          active={pub.turnSide === "black" && pub.phase === "playing"}
+          remainingMs={blackClock}
+          totalMs={pub.timeControlMs}
+        />
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(8, minmax(0, 1fr))",
+            gridTemplateRows: "repeat(8, minmax(0, 1fr))",
+            width: "min(100%, 420px)",
+            maxWidth: "100%",
+            aspectRatio: "1 / 1",
+            margin: "0 auto",
+            borderRadius: 8,
+            overflow: "hidden",
+            border: "1px solid rgba(255,255,255,0.12)",
+            background: LIGHT_SQUARE,
+            boxShadow: "0 12px 28px rgba(0,0,0,0.24)",
+            flex: "0 0 auto",
+          }}
+        >
+          {board.map((cell) => {
+            const active = selected === cell.square;
+            const target = selectedTargets.includes(cell.square);
+            const side = pieceSide(cell.piece);
+            return (
+              <button
+                key={cell.square}
+                type="button"
+                disabled={!canMove}
+                onClick={() => handleSquare(cell.square, cell.piece)}
+                title={cell.square}
+                aria-label={cell.piece ? `${cell.square} ${side ?? ""} piece` : cell.square}
+                style={{
+                  position: "relative",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: "100%",
+                  height: "100%",
+                  minWidth: 0,
+                  minHeight: 0,
+                  aspectRatio: "1 / 1",
+                  boxSizing: "border-box",
+                  border: "none",
+                  padding: 0,
+                  overflow: "hidden",
+                  background: active
+                    ? ACTIVE_SQUARE
+                    : target
+                      ? TARGET_SQUARE
+                      : cell.dark
+                        ? DARK_SQUARE
+                        : LIGHT_SQUARE,
+                  cursor: canMove ? "pointer" : "default",
+                }}
+              >
+                {cell.piece ? (
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      display: "block",
+                      width: "100%",
+                      height: "100%",
+                      lineHeight: "1",
+                      textAlign: "center",
+                      color: side === "white" ? "#fffaf2" : "#18181b",
+                      fontFamily: "'Segoe UI Symbol', 'Noto Sans Symbols 2', 'Apple Symbols', 'Arial Unicode MS', sans-serif",
+                      fontSize: "clamp(23px, 8.5vw, 38px)",
+                      transform: "translateY(5%)",
+                      textShadow: side === "white"
+                        ? "0 2px 2px rgba(0,0,0,0.44), 0 0 1px rgba(0,0,0,0.7)"
+                        : "0 1px 1px rgba(255,255,255,0.25)",
+                      pointerEvents: "none",
+                      userSelect: "none",
+                    }}
+                  >
+                    {PIECES[cell.piece]}
+                  </span>
+                ) : null}
+                {target ? (
+                  <span
+                    style={{
+                      position: "absolute",
+                      left: "50%",
+                      top: "50%",
+                      width: cell.piece ? "72%" : 12,
+                      height: cell.piece ? "72%" : 12,
+                      borderRadius: "50%",
+                      transform: "translate(-50%, -50%)",
+                      background: cell.piece ? "transparent" : "rgba(24, 24, 27, 0.36)",
+                      border: cell.piece ? "3px solid rgba(24, 24, 27, 0.35)" : "none",
+                      pointerEvents: "none",
+                    }}
+                  />
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+        <ClockRow
+          side="white"
+          team={pub.teams.white}
+          active={pub.turnSide === "white" && pub.phase === "playing"}
+          remainingMs={whiteClock}
+          totalMs={pub.timeControlMs}
+        />
       </div>
 
       {error ? <p style={{ margin: 0, color: color.danger, fontSize: 12 }}>{error}</p> : null}
@@ -300,6 +375,138 @@ export default function ChessGame({
   );
 }
 
+function useChessClock(pub: ChessPublic, side: ChessSide): number | null {
+  const [, setTick] = useState(0);
+  const baseRef = useRef({ clocks: pub.clocks, serverNow: pub.serverNow, localAt: Date.now() });
+
+  useEffect(() => {
+    baseRef.current = { clocks: pub.clocks, serverNow: pub.serverNow, localAt: Date.now() };
+  }, [pub.clocks, pub.serverNow, pub.turnSide, pub.phase]);
+
+  useEffect(() => {
+    if (pub.timeControlMs == null || pub.phase !== "playing") return;
+    const id = window.setInterval(() => setTick((value) => value + 1), 250);
+    return () => window.clearInterval(id);
+  }, [pub.phase, pub.timeControlMs]);
+
+  const base = baseRef.current.clocks[side];
+  if (base == null || pub.timeControlMs == null) return base;
+  if (pub.phase !== "playing" || pub.turnSide !== side) return base;
+  return Math.max(0, base - (Date.now() - baseRef.current.localAt));
+}
+
+function ClockRow({
+  side,
+  team,
+  active,
+  remainingMs,
+  totalMs,
+}: {
+  side: ChessSide;
+  team: ChessTeamPlayer[];
+  active: boolean;
+  remainingMs: number | null;
+  totalMs: number | null;
+}) {
+  const low = active && totalMs != null && remainingMs != null && remainingMs <= totalMs * 0.1;
+  const captain = team.find((player) => player.captain);
+  return (
+    <div
+      className={low ? "chess-clock-low" : undefined}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "8px 10px",
+        borderRadius: radius.md,
+        background: active ? "rgba(239, 112, 71, 0.16)" : color.surfaceRaised,
+        border: `1px solid ${active ? "rgba(239, 112, 71, 0.48)" : color.border}`,
+      }}
+    >
+      <span style={{ width: 8, height: 8, borderRadius: 999, background: side === "white" ? "#fffaf2" : "#18181b", border: "1px solid rgba(255,255,255,0.35)" }} />
+      <span style={{ minWidth: 0, flex: 1, fontSize: 12, color: color.textMuted, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {sideLabel(side)}{captain ? ` - ${captain.name}` : ""}
+      </span>
+      <span style={{ fontFamily: HEAD_FONT, fontSize: 15, fontWeight: 600, color: low ? color.danger : color.text }}>
+        {formatClock(remainingMs)}
+      </span>
+    </div>
+  );
+}
+
+function ResultCelebration({ result }: { result: ChessResult | null }) {
+  if (!result) return null;
+  const title = result.winner === "draw" ? "Draw agreed" : `${sideLabel(result.winner)} wins`;
+  const quote = WIN_QUOTES[Math.abs(result.reason.length + title.length) % WIN_QUOTES.length];
+  return (
+    <div
+      style={{
+        position: "relative",
+        overflow: "hidden",
+        borderRadius: radius.md,
+        padding: "14px 14px 16px",
+        background: "linear-gradient(135deg, rgba(239,112,71,0.24), rgba(255,255,255,0.06))",
+        border: "1px solid rgba(239,112,71,0.38)",
+      }}
+    >
+      <div className="chess-confetti" />
+      <p style={{ position: "relative", margin: 0, fontFamily: HEAD_FONT, fontSize: 18, color: color.text }}>
+        {title}
+      </p>
+      <p style={{ position: "relative", margin: "5px 0 0", fontSize: 12.5, color: color.textMuted, lineHeight: 1.5 }}>
+        {quote}
+      </p>
+    </div>
+  );
+}
+
+function ChessAnimationStyles() {
+  return (
+    <style>{`
+      @keyframes chess-clock-shake {
+        0%, 100% { transform: translateX(0); }
+        25% { transform: translateX(-1px); }
+        50% { transform: translateX(1px); }
+        75% { transform: translateX(-1px); }
+      }
+      @keyframes chess-confetti-rise {
+        0% { transform: translateY(14px) rotate(0deg); opacity: 0; }
+        18% { opacity: 1; }
+        100% { transform: translateY(-46px) rotate(28deg); opacity: 0; }
+      }
+      .chess-clock-low {
+        animation: chess-clock-shake 420ms ease-in-out infinite;
+      }
+      .chess-confetti::before,
+      .chess-confetti::after {
+        content: "";
+        position: absolute;
+        left: 12%;
+        bottom: 0;
+        width: 7px;
+        height: 18px;
+        border-radius: 2px;
+        background: #ef7047;
+        animation: chess-confetti-rise 1100ms ease-out infinite;
+      }
+      .chess-confetti::after {
+        left: 82%;
+        height: 14px;
+        background: #fffaf2;
+        animation-delay: 220ms;
+      }
+    `}</style>
+  );
+}
+
+function formatClock(ms: number | null) {
+  if (ms == null) return "\u221e";
+  const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
 function shouldPromote(piece: PieceCode | null, to: string) {
   if (piece === "P") return to.endsWith("8");
   if (piece === "p") return to.endsWith("1");
@@ -313,6 +520,22 @@ function roleLabel(role: ChessRole): string {
     case "white-team": return "White team";
     case "black-team": return "Black team";
     default: return "Watching";
+  }
+}
+
+function sideLabel(side: ChessSide): string {
+  return side === "white" ? "White" : "Black";
+}
+
+function resultReason(reason: string): string {
+  switch (reason) {
+    case "checkmate": return "checkmate";
+    case "stalemate": return "stalemate";
+    case "threefold": return "threefold repetition";
+    case "insufficient": return "insufficient material";
+    case "resignation": return "resignation";
+    case "timeout": return "timeout";
+    default: return reason;
   }
 }
 
@@ -338,7 +561,7 @@ function TeamList({ title, team, active }: { title: string; team: ChessTeamPlaye
           >
             <Avatar name={player.name} size={22} highlight={player.captain} />
             <span style={{ color: color.text, fontSize: 12, maxWidth: 100, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-              {player.name}{player.captain ? " · lead" : ""}
+              {player.name}{player.captain ? " - lead" : ""}
             </span>
           </div>
         ))}

--- a/packages/sfu/server/games/modules/chess.ts
+++ b/packages/sfu/server/games/modules/chess.ts
@@ -14,6 +14,7 @@ type ChessMode = "duel" | "teams";
 type ChessSide = "white" | "black";
 type ChessTurn = "w" | "b";
 type ChessRole = "white-captain" | "black-captain" | "white-team" | "black-team" | "spectator";
+type TimeControl = "infinite" | "120" | "300" | "600";
 type Promotion = "q" | "r" | "b" | "n";
 
 type ChessTeam = {
@@ -34,7 +35,7 @@ type ChessMoveRecord = {
 
 type ChessResult = {
   winner: ChessSide | "draw";
-  reason: "checkmate" | "stalemate" | "threefold" | "insufficient" | "draw" | "resignation";
+  reason: "checkmate" | "stalemate" | "threefold" | "insufficient" | "draw" | "resignation" | "timeout";
   byPlayerId?: string;
   byName?: string;
 };
@@ -48,9 +49,12 @@ type DrawOffer = {
 type ChessState = {
   phase: ChessPhase;
   mode: ChessMode;
+  timeControlMs: number | null;
+  clocks: Record<ChessSide, number | null>;
   fen: string;
   pgn: string;
   turn: ChessTurn;
+  turnStartedAt: number | null;
   teams: {
     white: ChessTeam;
     black: ChessTeam;
@@ -72,6 +76,12 @@ export type ChessMove =
 
 const PROMOTIONS = ["q", "r", "b", "n"] as const;
 const SQUARE_RE = /^[a-h][1-8]$/;
+const TIME_CONTROLS: Record<TimeControl, number | null> = {
+  infinite: null,
+  "120": 120_000,
+  "300": 300_000,
+  "600": 600_000,
+};
 
 const decodeChessMove = (move: GameMove): ChessMove => {
   switch (move.type) {
@@ -101,7 +111,6 @@ const decodeChessMove = (move: GameMove): ChessMove => {
 
 const sideForTurn = (turn: ChessTurn): ChessSide => (turn === "w" ? "white" : "black");
 const otherSide = (side: ChessSide): ChessSide => (side === "white" ? "black" : "white");
-const turnForSide = (side: ChessSide): ChessTurn => (side === "white" ? "w" : "b");
 
 const playerName = (ctx: GameContext, playerId: string): string =>
   ctx.players.find((player) => player.id === playerId)?.name ?? playerId;
@@ -179,6 +188,37 @@ const teamView = (team: ChessTeam, ctx: GameContext) =>
     captain: id === team.captainId,
   }));
 
+const resolveClocks = (state: ChessState, now: number): Record<ChessSide, number | null> => {
+  if (state.timeControlMs == null || state.phase !== "playing" || state.turnStartedAt == null) {
+    return { ...state.clocks };
+  }
+  const side = sideForTurn(state.turn);
+  const elapsed = Math.max(0, now - state.turnStartedAt);
+  return {
+    ...state.clocks,
+    [side]: Math.max(0, (state.clocks[side] ?? state.timeControlMs) - elapsed),
+  };
+};
+
+const timeoutResult = (timedOutSide: ChessSide): ChessResult => ({
+  winner: otherSide(timedOutSide),
+  reason: "timeout",
+});
+
+const timeoutState = (state: ChessState, ctx: GameContext): ChessState | null => {
+  if (state.phase !== "playing" || state.timeControlMs == null) return null;
+  const side = sideForTurn(state.turn);
+  const clocks = resolveClocks(state, ctx.now);
+  if ((clocks[side] ?? 0) > 0) return null;
+  return {
+    ...state,
+    phase: "results",
+    clocks,
+    result: timeoutResult(side),
+    finishedAt: ctx.now,
+  };
+};
+
 export const chessModule: GameModule<ChessState> = {
   id: "chess",
   name: "Chess",
@@ -186,6 +226,7 @@ export const chessModule: GameModule<ChessState> = {
   minPlayers: 2,
   maxPlayers: 32,
   spectatable: true,
+  tickMs: 500,
   options: [
     {
       id: "mode",
@@ -197,17 +238,34 @@ export const chessModule: GameModule<ChessState> = {
         { value: "teams", label: "Team chess" },
       ],
     },
+    {
+      id: "timeControl",
+      type: "select",
+      label: "Timer",
+      default: "infinite",
+      choices: [
+        { value: "120", label: "2 min" },
+        { value: "300", label: "5 min" },
+        { value: "600", label: "10 min" },
+        { value: "infinite", label: "Infinite" },
+      ],
+    },
   ],
 
   setup(ctx): ChessState {
     const game = new Chess();
     const mode = selectOption(ctx.config, "mode", "duel") === "teams" ? "teams" : "duel";
+    const timeControl = selectOption(ctx.config, "timeControl", "infinite") as TimeControl;
+    const timeControlMs = TIME_CONTROLS[timeControl] ?? null;
     return {
       phase: "lobby",
       mode,
+      timeControlMs,
+      clocks: { white: timeControlMs, black: timeControlMs },
       fen: game.fen(),
       pgn: game.pgn(),
       turn: game.turn(),
+      turnStartedAt: null,
       teams: {
         white: { captainId: null, playerIds: [] },
         black: { captainId: null, playerIds: [] },
@@ -227,10 +285,12 @@ export const chessModule: GameModule<ChessState> = {
         if (!ctx.isAdmin(move.playerId)) throw new GameMoveError("Only the host can start");
         if (state.phase !== "lobby") throw new GameMoveError("Already running");
         const teams = seatedTeams(ctx, state.mode);
-        return { ...state, phase: "playing", teams, startedAt: ctx.now };
+        return { ...state, phase: "playing", teams, startedAt: ctx.now, turnStartedAt: ctx.now };
       }
       case "move": {
         if (state.phase !== "playing") throw new GameMoveError("Game is not running");
+        const timedOut = timeoutState(state, ctx);
+        if (timedOut) return timedOut;
         const side = sideForTurn(state.turn);
         requireCaptain(state, move.playerId, side);
 
@@ -244,12 +304,15 @@ export const chessModule: GameModule<ChessState> = {
         if (!played) throw new GameMoveError("Illegal move");
 
         const result = resultForGame(game);
+        const clocks = resolveClocks(state, ctx.now);
         return {
           ...state,
           phase: result ? "results" : "playing",
+          clocks,
           fen: game.fen(),
           pgn: game.pgn(),
           turn: game.turn(),
+          turnStartedAt: result ? null : ctx.now,
           drawOffer: null,
           result,
           finishedAt: result ? ctx.now : null,
@@ -270,12 +333,15 @@ export const chessModule: GameModule<ChessState> = {
       }
       case "resign": {
         if (state.phase !== "playing") throw new GameMoveError("Game is not running");
+        const timedOut = timeoutState(state, ctx);
+        if (timedOut) return timedOut;
         const side = sideForPlayer(state, move.playerId);
         if (!side) throw new GameMoveError("You are not on a side");
         requireCaptain(state, move.playerId, side);
         return {
           ...state,
           phase: "results",
+          clocks: resolveClocks(state, ctx.now),
           drawOffer: null,
           result: {
             winner: otherSide(side),
@@ -288,6 +354,8 @@ export const chessModule: GameModule<ChessState> = {
       }
       case "offerDraw": {
         if (state.phase !== "playing") throw new GameMoveError("Game is not running");
+        const timedOut = timeoutState(state, ctx);
+        if (timedOut) return timedOut;
         const side = sideForPlayer(state, move.playerId);
         if (!side) throw new GameMoveError("You are not on a side");
         requireCaptain(state, move.playerId, side);
@@ -298,6 +366,8 @@ export const chessModule: GameModule<ChessState> = {
       }
       case "acceptDraw": {
         if (state.phase !== "playing") throw new GameMoveError("Game is not running");
+        const timedOut = timeoutState(state, ctx);
+        if (timedOut) return timedOut;
         if (!state.drawOffer) throw new GameMoveError("No draw offer to accept");
         const side = sideForPlayer(state, move.playerId);
         if (!side || side === state.drawOffer.side) {
@@ -307,6 +377,7 @@ export const chessModule: GameModule<ChessState> = {
         return {
           ...state,
           phase: "results",
+          clocks: resolveClocks(state, ctx.now),
           drawOffer: null,
           result: { winner: "draw", reason: "draw", byPlayerId: move.playerId, byName: playerName(ctx, move.playerId) },
           finishedAt: ctx.now,
@@ -314,6 +385,8 @@ export const chessModule: GameModule<ChessState> = {
       }
       case "declineDraw": {
         if (state.phase !== "playing") throw new GameMoveError("Game is not running");
+        const timedOut = timeoutState(state, ctx);
+        if (timedOut) return timedOut;
         if (!state.drawOffer) return state;
         const side = sideForPlayer(state, move.playerId);
         if (!side || side === state.drawOffer.side) {
@@ -329,13 +402,21 @@ export const chessModule: GameModule<ChessState> = {
     }
   },
 
+  onTick(state, ctx): ChessState {
+    return timeoutState(state, ctx) ?? state;
+  },
+
   getPhase: (state) => state.phase,
 
   publicView(state, ctx) {
     const game = new Chess(state.fen);
+    const clocks = resolveClocks(state, ctx.now);
     return {
       phase: state.phase,
       mode: state.mode,
+      serverNow: ctx.now,
+      timeControlMs: state.timeControlMs,
+      clocks,
       fen: state.fen,
       pgn: state.pgn,
       turn: state.turn,


### PR DESCRIPTION
## Summary
- Fix the chess board layout so squares stay locked in a stable 8x8 grid while pieces move.
- Replace broken chess glyph rendering with stable Unicode escapes and a safer symbol font stack.
- Restyle the board with ACM-style red and cream colors instead of the earlier green board.
- Add chess timer options: 2 min, 5 min, 10 min, and Infinite.
- Add server-side clock tracking, timeout results, low-time pulse at 10% remaining, and a lightweight win celebration.

## Validation
- `git diff --check --cached`
- Focused SFU TypeScript compile for `server/games/modules/chess.ts`

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds chess timers and polishes the chess game UI. The main changes are:

- Server-side clock tracking with 2, 5, 10 minute, and infinite timer options.
- Timeout handling through chess module ticks and move-time clock resolution.
- Public clock state exposed to the web client for live timer rendering.
- Updated board sizing, square colors, Unicode piece rendering, low-time animation, and result celebration.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are limited to the chess module and its UI, with server-authoritative move and clock handling preserved. No correctness or security issues were found in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the end-to-end artifacts and noted that the after-state image does not render ChessGame, so the head changes cannot be fully validated from these artifacts.
- Verified the module invocation results show HTTP 200 OK and expose timer options (2, 5, 10 minutes and Infinite) with corresponding clock mappings and publicView fields.
- Compared the before/after logs: before state lacks finite timer fields while after state includes timeControl, timeControlMs, clocks, a decrementing clock, and a timeout outcome with black as winner.

<a href="https://app.greptile.com/trex/runs/13153017/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/components/games/ChessGame.tsx | Updates chess UI with stable board sizing, Unicode piece rendering, clock display, low-time animation, and result celebration. |
| packages/sfu/server/games/modules/chess.ts | Adds timer configuration, server-authoritative clock resolution, timeout detection on ticks and moves, and public clock state. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Host
participant SFU as Chess module
participant Tick as Server tick
participant Client as Chess UI

Host->>SFU: start game with timeControl
SFU->>SFU: initialize clocks and turnStartedAt
SFU-->>Client: publicView(serverNow, clocks, turnSide)
Client->>Client: render board and local ticking clock
Tick->>SFU: onTick(now)
SFU->>SFU: resolve active clock / timeoutState
alt clock expired
    SFU-->>Client: results with timeout winner
else move submitted before timeout
    Client->>SFU: move(from, to, promotion)
    SFU->>SFU: deduct elapsed time and advance turnStartedAt
    SFU-->>Client: updated fen, clocks, turnSide
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Host
participant SFU as Chess module
participant Tick as Server tick
participant Client as Chess UI

Host->>SFU: start game with timeControl
SFU->>SFU: initialize clocks and turnStartedAt
SFU-->>Client: publicView(serverNow, clocks, turnSide)
Client->>Client: render board and local ticking clock
Tick->>SFU: onTick(now)
SFU->>SFU: resolve active clock / timeoutState
alt clock expired
    SFU-->>Client: results with timeout winner
else move submitted before timeout
    Client->>SFU: move(from, to, promotion)
    SFU->>SFU: deduct elapsed time and advance turnStartedAt
    SFU-->>Client: updated fen, clocks, turnSide
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(games): polish chess board and time..."](https://github.com/acm-vit/conclave/commit/ced5868a343ec7acfc61e0c90f292aca451ebc23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41556316)</sub>

<!-- /greptile_comment -->