### PR TITLE
fix(meets): keep side-panel toggles stationary on hover

### DIFF
--- a/apps/web/src/app/components/ControlsBar.tsx
+++ b/apps/web/src/app/components/ControlsBar.tsx
@@ -173,54 +173,29 @@ function PanelClusterItem({
 }
 
 /**
- * The side-panel toggles (participants, games, transcript, chat) collapse into
- * one overlapping "squabble" of icons to keep the bar uncrowded. Hover (or
- * keyboard focus) fans them out so any one can be picked. Badges and the
- * transcript live/paused dot stay visible even while collapsed, so the cluster
- * still surfaces unread chat and transcript state at a glance.
+ * The side-panel toggles (participants, games, transcript, chat) sit in a
+ * static pill with fixed positions. They used to collapse into an overlapping
+ * stack that fanned out on hover, but buttons sliding out from under the
+ * cursor caused misclicks, so nothing moves anymore. Badges and the
+ * transcript live/paused dot keep surfacing unread chat and transcript state
+ * at a glance.
  */
 function PanelCluster({
   items,
   transcriptStatus,
-  forceOpen = false,
 }: {
   items: ControlDescriptor[];
   transcriptStatus?: PanelStatus;
-  forceOpen?: boolean;
 }) {
-  const [hovered, setHovered] = useState(false);
-  const open = hovered || forceOpen;
-
   return (
-    <div
-      className="relative flex items-center rounded-full transition-colors duration-150"
-      style={{ backgroundColor: open ? "rgba(255,255,255,0.04)" : "transparent" }}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      onFocusCapture={() => setHovered(true)}
-      onBlurCapture={(event) => {
-        if (!event.currentTarget.contains(event.relatedTarget)) {
-          setHovered(false);
-        }
-      }}
-    >
-      {items.map((d, index) => {
-        const status = d.id === "transcript" ? (transcriptStatus ?? null) : null;
-        const raised =
-          d.variant === "active" || Boolean(status) || (d.badge ?? 0) > 0;
-        return (
-          <div
-            key={d.id}
-            className="transition-[margin] duration-200 ease-out"
-            style={{
-              marginLeft: index === 0 ? 0 : open ? 2 : -12,
-              zIndex: raised ? 20 : 10 - index,
-            }}
-          >
-            <PanelClusterItem d={d} status={status} />
-          </div>
-        );
-      })}
+    <div className="flex items-center gap-0.5">
+      {items.map((d) => (
+        <PanelClusterItem
+          key={d.id}
+          d={d}
+          status={d.id === "transcript" ? (transcriptStatus ?? null) : null}
+        />
+      ))}
     </div>
   );
 }
@@ -967,7 +942,6 @@ function ControlsBar(props: ControlsBarProps) {
               <PanelCluster
                 items={panelItems}
                 transcriptStatus={transcriptClusterStatus}
-                forceOpen={panelCoachmarkVisible}
               />
             </div>
             {panelCoachmarkVisible && gamesTip.visible ? (


### PR DESCRIPTION
## Problem

The side-panel toggle cluster (participants / games / transcript / chat / host controls) at the right of the controls bar collapses into an overlapping stack, then fans out on hover via an animated `margin-left` transition (`-12px` → `2px`).

Because the cluster is right-anchored, expanding it shifts every icon leftward **right as the cursor arrives** — the button you aimed at slides out from under you, so you misclick or hit the neighboring toggle. On mouse-leave everything snaps back, so the bar wiggles constantly during normal use.

This is the same annoyance #124 addresses, but #124 keeps the buttons moving (anchored `translateX` spread) and its review flagged that the spread gets clipped by the pill's `overflow-hidden` wrapper.

## Fix

Remove the movement entirely — lay the cluster out statically:

- Icons keep fixed positions at all times: no overlap, no fan-out, no margin animation. Nothing shifts on hover, so nothing can be misclicked.
- `PanelCluster` loses its `hovered` state, focus/blur handlers, z-index juggling, and the `forceOpen` escape hatch (coachmarks needed it to reveal collapsed icons; now they're always visible).
- Badges, the transcript live/attention dot, tooltips, and per-button hover highlights are unchanged.

Space cost is ~56px worst case (5 icons). The non-compact bar only renders when the stage is ≥900px (`useCompactControls` in `MeetsMainContent`), so the expanded width always fits; below that the toggles fold into the More menu as before.

## Testing

- `pnpm run typecheck:web` ✅
- `eslint src/app/components/ControlsBar.tsx` ✅
- Verified in the running app: measured a cluster button's `getBoundingClientRect().x` before and during hover — identical (no movement), badges/status dot render as before.

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR makes the desktop side-panel toggle cluster stay fixed instead of expanding on hover. The main changes are:

- Removes hover and focus state from `PanelCluster`.
- Renders panel toggles in a static row with fixed spacing.
- Drops the `forceOpen` coachmark prop because all toggles are always visible.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is localized to one presentational component and preserves the existing button rendering, badge, status, tooltip, and click behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the base run log trex-artifacts/static-toggle-cluster-01-before.log to inspect x positions before and during hover, observing 0px deltas for all cluster buttons.
- Reviewed the head run log trex-artifacts/static-toggle-cluster-02-after.log to inspect x positions for five UI elements during hover, with unchanged values: Participants 919→919, Game in progress 961→961, Live transcript 1003→1003, Chat 1045→1045, Host controls 1087→1087.
- Viewed the head video/poster to verify all five icons are visible in a static row, with chat/pending badges and the live transcript status dot retained during hover.

<a href="https://app.greptile.com/trex/runs/13225381/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/components/ControlsBar.tsx | Updates the desktop side-panel toggle cluster from hover-expanded overlap to a static fixed-position row; no blocking issues found. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant ControlsBar
  participant PanelCluster
  participant PanelClusterItem
  participant User

  ControlsBar->>ControlsBar: Build panelItems and transcriptClusterStatus
  ControlsBar->>PanelCluster: Render static items
  loop Each side-panel control
      PanelCluster->>PanelClusterItem: Pass descriptor and transcript status when applicable
      PanelClusterItem-->>User: Render fixed-position toggle with badge/status
  end
  User->>PanelClusterItem: Hover or click toggle
  PanelClusterItem->>ControlsBar: Invoke descriptor onPress without cluster repositioning
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant ControlsBar
  participant PanelCluster
  participant PanelClusterItem
  participant User

  ControlsBar->>ControlsBar: Build panelItems and transcriptClusterStatus
  ControlsBar->>PanelCluster: Render static items
  loop Each side-panel control
      PanelCluster->>PanelClusterItem: Pass descriptor and transcript status when applicable
      PanelClusterItem-->>User: Render fixed-position toggle with badge/status
  end
  User->>PanelClusterItem: Hover or click toggle
  PanelClusterItem->>ControlsBar: Invoke descriptor onPress without cluster repositioning
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(meets): keep side-panel toggles stat..."](https://github.com/acm-vit/conclave/commit/6e31ed01a6721e3e2c142163b9fd879ed264e725) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41703737)</sub>

<!-- /greptile_comment -->