### PR TITLE
feat(cache): enable caching and set cache-control headers

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -34,6 +34,25 @@ const yProtocolsWebpackAlias = path.resolve(
   workspaceRoot,
   "node_modules/y-protocols",
 );
+const longLivedPublicAssetCacheControl =
+  "public, max-age=31536000, immutable";
+const longLivedPublicCacheHeaders = [
+  {
+    key: "Cache-Control",
+    value: longLivedPublicAssetCacheControl,
+  },
+];
+const longLivedSameOriginAssetHeaders = [
+  ...longLivedPublicCacheHeaders,
+  {
+    key: "Cross-Origin-Resource-Policy",
+    value: "same-origin",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+];
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
@@ -79,7 +98,7 @@ const nextConfig: NextConfig = {
         headers: [
           {
             key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
+            value: longLivedPublicAssetCacheControl,
           },
           {
             key: "Content-Type",
@@ -93,54 +112,36 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/mediapipe/:path*",
-        headers: [
-          {
-            key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
-          },
-          {
-            key: "Cross-Origin-Resource-Policy",
-            value: "same-origin",
-          },
-          {
-            key: "X-Content-Type-Options",
-            value: "nosniff",
-          },
-        ],
+        headers: longLivedSameOriginAssetHeaders,
       },
       {
         source: "/effects/:path*",
-        headers: [
-          {
-            key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
-          },
-          {
-            key: "Cross-Origin-Resource-Policy",
-            value: "same-origin",
-          },
-          {
-            key: "X-Content-Type-Options",
-            value: "nosniff",
-          },
-        ],
+        headers: longLivedSameOriginAssetHeaders,
+      },
+      {
+        source: "/assets/:path*",
+        headers: longLivedSameOriginAssetHeaders,
+      },
+      {
+        source: "/reactions/:path*",
+        headers: longLivedSameOriginAssetHeaders,
       },
       {
         source: "/_/rtcvidproc/release/:path*",
-        headers: [
-          {
-            key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
-          },
-          {
-            key: "Cross-Origin-Resource-Policy",
-            value: "same-origin",
-          },
-          {
-            key: "X-Content-Type-Options",
-            value: "nosniff",
-          },
-        ],
+        headers: longLivedSameOriginAssetHeaders,
+      },
+      {
+        source:
+          "/:asset(apple-touch-icon|favicon|klipy|logo|og|pow-by-klipy|roblox-logo).:extension(svg|png)",
+        headers: longLivedPublicCacheHeaders,
+      },
+      {
+        source: "/conclave-animation.lottie",
+        headers: longLivedPublicCacheHeaders,
+      },
+      {
+        source: "/conclave-lock.mp3",
+        headers: longLivedPublicCacheHeaders,
       },
     ];
   },

--- a/apps/web/scheduling-email-worker/src/index.ts
+++ b/apps/web/scheduling-email-worker/src/index.ts
@@ -51,6 +51,7 @@ const json = (
     ...init,
     headers: {
       "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store",
       ...(init.headers ?? {}),
     },
   });
@@ -267,6 +268,7 @@ export default {
         headers: {
           "access-control-allow-methods": "POST, OPTIONS",
           "access-control-allow-headers": "authorization, content-type",
+          "cache-control": "no-store",
         },
       });
     }

--- a/apps/web/transcript-worker/src/index.ts
+++ b/apps/web/transcript-worker/src/index.ts
@@ -13,6 +13,7 @@ export default {
         "access-control-allow-origin": "*",
         "access-control-allow-methods": "GET, OPTIONS",
         "access-control-allow-headers": "content-type",
+        "cache-control": "public, max-age=60, stale-while-revalidate=300",
       };
       if (request.method === "OPTIONS") {
         return new Response(null, { status: 204, headers });

--- a/apps/web/transcript-worker/src/utils.ts
+++ b/apps/web/transcript-worker/src/utils.ts
@@ -14,6 +14,7 @@ export const json = (data: unknown, init: ResponseInit = {}): Response =>
     ...init,
     headers: {
       "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store",
       ...(init.headers ?? {}),
     },
   });

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -5,6 +5,9 @@
   "account_id": "4ee36e42cabfd44e8ce61b2a6bd637c5",
   "compatibility_date": "2026-06-30",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "cache": {
+    "enabled": true
+  },
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"

--- a/apps/web/wrangler.scheduling-email.jsonc
+++ b/apps/web/wrangler.scheduling-email.jsonc
@@ -5,6 +5,9 @@
   "account_id": "4ee36e42cabfd44e8ce61b2a6bd637c5",
   "compatibility_date": "2026-06-30",
   "compatibility_flags": ["global_fetch_strictly_public"],
+  "cache": {
+    "enabled": true
+  },
   "workers_dev": false,
   "preview_urls": false,
   "routes": [

--- a/apps/web/wrangler.transcript.jsonc
+++ b/apps/web/wrangler.transcript.jsonc
@@ -5,6 +5,9 @@
   "account_id": "4ee36e42cabfd44e8ce61b2a6bd637c5",
   "compatibility_date": "2026-06-17",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "cache": {
+    "enabled": true
+  },
   "workers_dev": false,
   "preview_urls": false,
   "routes": [


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR enables caching and adds explicit cache headers across the web app and workers. The main changes are:

- Enables Cloudflare Workers Cache in the web, scheduling email, and transcript Wrangler configs.
- Adds long-lived cache headers for selected public assets in `next.config.ts`.
- Adds `Cache-Control: no-store` to dynamic JSON responses in the email and transcript workers.
- Adds short-lived public caching for the transcript worker `/version` endpoint.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are limited to cache configuration and response headers. Dynamic and sensitive worker JSON responses use `no-store`, while static assets and the transcript version endpoint have explicit cache lifetimes.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Conducted type/config validation for the cache-control changes by reviewing transcript typecheck logs and wrangler dry-run outputs.
- Reviewed runtime header behavior by examining health headers and transcript version headers for the affected paths.
- Confirmed that the changed worker and runtime paths did not reproduce any cache-control breakage.
- Examined the accompanying shell scripts that drive the checks to ensure tooling was set up correctly.

<a href="https://app.greptile.com/trex/runs/13528199/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/next.config.ts | Refactors repeated long-lived cache headers and applies them to additional static public asset paths. |
| apps/web/scheduling-email-worker/src/index.ts | Adds `no-store` cache-control headers to JSON responses and CORS preflight responses. |
| apps/web/transcript-worker/src/index.ts | Adds short-lived public caching for the transcript service `/version` endpoint. |
| apps/web/transcript-worker/src/utils.ts | Updates the shared JSON response helper to default transcript worker JSON responses to `Cache-Control: no-store`. |
| apps/web/wrangler.jsonc | Enables Cloudflare Workers Cache for the main web worker configuration. |
| apps/web/wrangler.scheduling-email.jsonc | Enables Cloudflare Workers Cache for the scheduling email worker configuration. |
| apps/web/wrangler.transcript.jsonc | Enables Cloudflare Workers Cache for the transcript worker configuration. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client
participant CF as Cloudflare Workers Cache
participant Web as conclave-web Worker / Assets
participant Email as scheduling-email Worker
participant Transcript as transcript Worker

Client->>CF: Request static web asset
CF->>Web: Cache miss forwards request
Web-->>CF: Asset response with long-lived Cache-Control
CF-->>Client: Cached asset response

Client->>CF: POST /send-booking
CF->>Email: Forward request
Email-->>CF: JSON response with Cache-Control: no-store
CF-->>Client: Uncached email response

Client->>CF: GET /version
CF->>Transcript: Cache miss forwards request
Transcript-->>CF: "Version JSON with max-age=60"
CF-->>Client: Short-lived cached version response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client
participant CF as Cloudflare Workers Cache
participant Web as conclave-web Worker / Assets
participant Email as scheduling-email Worker
participant Transcript as transcript Worker

Client->>CF: Request static web asset
CF->>Web: Cache miss forwards request
Web-->>CF: Asset response with long-lived Cache-Control
CF-->>Client: Cached asset response

Client->>CF: POST /send-booking
CF->>Email: Forward request
Email-->>CF: JSON response with Cache-Control: no-store
CF-->>Client: Uncached email response

Client->>CF: GET /version
CF->>Transcript: Cache miss forwards request
Transcript-->>CF: "Version JSON with max-age=60"
CF-->>Client: Short-lived cached version response
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(cache): enable caching and set cach..."](https://github.com/acm-vit/conclave/commit/6767ac402f03736e1b027faccfe7dced413b0996) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42333378)</sub>

<!-- /greptile_comment -->