### PR TITLE
fix

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -53,6 +53,12 @@ const longLivedSameOriginAssetHeaders = [
     value: "nosniff",
   },
 ];
+const noStoreResponseHeaders = [
+  {
+    key: "Cache-Control",
+    value: "private, no-store, max-age=0, must-revalidate",
+  },
+];
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
@@ -94,6 +100,10 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: "/:path*",
+        headers: noStoreResponseHeaders,
+      },
+      {
         source: "/transcript-pcm-processor.js",
         headers: [
           {
@@ -109,6 +119,10 @@ const nextConfig: NextConfig = {
             value: "same-origin",
           },
         ],
+      },
+      {
+        source: "/_next/static/:path*",
+        headers: longLivedPublicCacheHeaders,
       },
       {
         source: "/mediapipe/:path*",


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR updates the web app cache headers. The main changes are:

- Adds a default `Cache-Control: private, no-store` header for all routes.
- Keeps long-lived caching for `/_next/static/:path*` assets.
- Preserves existing long-lived cache behavior for configured public asset paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to Next.js header configuration, and the asset-specific rules are ordered after the catch-all rule so their Cache-Control values take precedence for matching static asset paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Generated and ran the runtime validation script to import and validate the Next config.
- Compared the pre-change header state with the post-change header state and confirmed the after-state shows the new flags defaultNoStore, nextStaticLongLived, transcriptPreserved, and assetSameOriginPreserved.
- Reviewed the generated validation script to confirm it executes the config validation as intended.
- Inspected the dev-server and HTTP logs to understand startup timing and the attempted request path.

<a href="https://app.greptile.com/trex/runs/13534235/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/next.config.ts | Adds a global no-store cache header while preserving long-lived cache headers for static asset routes via later matching header rules. |

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/ea2b5583c0dc01c7a75e58029376140ecd5f5a5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42346760)</sub>

<!-- /greptile_comment -->