### PR TITLE
fix

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -121,10 +121,6 @@ const nextConfig: NextConfig = {
         ],
       },
       {
-        source: "/_next/static/:path*",
-        headers: longLivedPublicCacheHeaders,
-      },
-      {
         source: "/mediapipe/:path*",
         headers: longLivedSameOriginAssetHeaders,
       },


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR updates the Next.js header configuration for static assets. The main change is:

- Removes the custom long-lived cache header rule for `/_next/static/:path*`, leaving those assets to use framework-managed headers.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to removing one header rule from `apps/web/next.config.ts`, and no correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The before-and-after header configuration comparison showed the removed /\_next/static/:path\* rule and the retained /mediapipe/:path\* headers.
- The after-side evaluation reported 10 rules, hasNextStaticRule: false, and the retained /mediapipe/:path\* long-lived same-origin headers.
- A TypeScript smoke check passed as part of the contract validation.
- An attempt was made to run runtime server validation with the Next dev server; the server reported readiness but the page compilation or request flow exceeded the tool timeout before HTTP header traces could be completed.
- Artifacts were collected and prepared for review, including header configuration logs and TypeScript smoke check results.

<a href="https://app.greptile.com/trex/runs/13534310/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/next.config.ts | Removes the custom `/_next/static/:path*` cache header override so Next.js static assets fall back to framework-managed headers. |

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/de4fae761509ae8da8bb4ad85c894e69a75fbcf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42347002)</sub>

<!-- /greptile_comment -->