### PR TITLE
that was bad

### DIFF
--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -6,7 +6,7 @@
   "compatibility_date": "2026-06-30",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "cache": {
-    "enabled": true
+    "enabled": false
   },
   "assets": {
     "directory": ".open-next/assets",


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR changes the Cloudflare Wrangler configuration for the web app. The main change is:

- Disables the worker cache flag in `apps/web/wrangler.jsonc`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal functional risk.

The changeset is a single configuration toggle, and no correctness or security issues were identified in the changed file.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the pre-change cache config, noting BASE(HEAD^) cache.enabled = true at HEAD^ and HEAD(worktree) cache.enabled = false, with a git diff showing the exact flip in apps/web/wrangler.jsonc.
- Observed Wrangler 4.105.0 loading the real config and failing only because .open-next/worker.js is missing, which matches the expected build-output blocker.
- Checked for changed-behavior failures and found none attributable to disabling the Wrangler/OpenNext cache.

<a href="https://app.greptile.com/trex/runs/13534581/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/wrangler.jsonc | Disables the Wrangler/OpenNext cache flag while leaving the rest of the worker configuration unchanged. |

<sub>Reviews (1): Last reviewed commit: ["that was bad"](https://github.com/acm-vit/conclave/commit/ee4d7198076e6fac64b37e9748636feaeb875076) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42347520)</sub>

<!-- /greptile_comment -->