### PR TITLE
fix

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,0 +1,64 @@
+# Cloudflare Workers Static Assets headers.
+# These apply only to files served by the assets binding, not SSR/API responses.
+
+/effects/*
+  Cache-Control: public, max-age=31536000, immutable
+  Cross-Origin-Resource-Policy: same-origin
+  X-Content-Type-Options: nosniff
+
+/mediapipe/*
+  Cache-Control: public, max-age=31536000, immutable
+  Cross-Origin-Resource-Policy: same-origin
+  X-Content-Type-Options: nosniff
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+  Cross-Origin-Resource-Policy: same-origin
+  X-Content-Type-Options: nosniff
+
+/reactions/*
+  Cache-Control: public, max-age=31536000, immutable
+  Cross-Origin-Resource-Policy: same-origin
+  X-Content-Type-Options: nosniff
+
+/_/rtcvidproc/release/*
+  Cache-Control: public, max-age=31536000, immutable
+  Cross-Origin-Resource-Policy: same-origin
+  X-Content-Type-Options: nosniff
+
+/transcript-pcm-processor.js
+  Cache-Control: public, max-age=31536000, immutable
+  Cross-Origin-Resource-Policy: same-origin
+
+/conclave-animation.lottie
+  Cache-Control: public, max-age=31536000, immutable
+
+/conclave-lock.mp3
+  Cache-Control: public, max-age=31536000, immutable
+
+/apple-touch-icon.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+/favicon.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+/klipy.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+/logo.png
+  Cache-Control: public, max-age=31536000, immutable
+
+/logo.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+/og.png
+  Cache-Control: public, max-age=31536000, immutable
+
+/og.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+/pow-by-klipy.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+/roblox-logo.png
+  Cache-Control: public, max-age=31536000, immutable

--- a/apps/web/transcript-worker/src/index.ts
+++ b/apps/web/transcript-worker/src/index.ts
@@ -9,21 +9,34 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
     if (url.pathname === "/version") {
-      const headers = {
+      const corsHeaders = {
         "access-control-allow-origin": "*",
         "access-control-allow-methods": "GET, OPTIONS",
         "access-control-allow-headers": "content-type",
-        "cache-control": "public, max-age=60, stale-while-revalidate=300",
       };
       if (request.method === "OPTIONS") {
-        return new Response(null, { status: 204, headers });
+        return new Response(null, {
+          status: 204,
+          headers: {
+            ...corsHeaders,
+            "cache-control": "no-store",
+          },
+        });
       }
       if (request.method !== "GET") {
-        return json({ error: "Method not allowed" }, { status: 405, headers });
+        return json(
+          { error: "Method not allowed" },
+          { status: 405, headers: corsHeaders },
+        );
       }
       return json(
         { serviceVersion: getTranscriptServiceVersion(env) },
-        { headers },
+        {
+          headers: {
+            ...corsHeaders,
+            "cache-control": "public, max-age=60, stale-while-revalidate=300",
+          },
+        },
       );
     }
 

--- a/apps/web/wrangler.scheduling-email.jsonc
+++ b/apps/web/wrangler.scheduling-email.jsonc
@@ -6,7 +6,7 @@
   "compatibility_date": "2026-06-30",
   "compatibility_flags": ["global_fetch_strictly_public"],
   "cache": {
-    "enabled": true
+    "enabled": false
   },
   "workers_dev": false,
   "preview_urls": false,

--- a/apps/web/wrangler.transcript.jsonc
+++ b/apps/web/wrangler.transcript.jsonc
@@ -6,7 +6,7 @@
   "compatibility_date": "2026-06-17",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "cache": {
-    "enabled": true
+    "enabled": false
   },
   "workers_dev": false,
   "preview_urls": false,


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR updates caching behavior for static assets and Cloudflare Workers. The main changes are:

- Adds Cloudflare Static Assets `_headers` entries for long-lived public asset caching.
- Disables Worker cache in the scheduling-email and transcript Wrangler configs.
- Updates the transcript worker `/version` route so only successful `GET` responses receive short-lived cache headers.
- Notes that the PR title and commit message `fix` should be more descriptive.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

Changes are narrowly scoped to cache headers and Wrangler cache flags. The `/version` route keeps non-success responses uncached and caches only the intended successful `GET` response.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/public/_headers | Adds Cloudflare Static Assets cache and resource-policy headers for long-lived public assets. |
| apps/web/transcript-worker/src/index.ts | Separates CORS headers from cache headers so `/version` preflight and method errors are not cached while successful GETs remain short-lived cacheable. |
| apps/web/wrangler.scheduling-email.jsonc | Disables Wrangler Worker cache for the scheduling email worker configuration. |
| apps/web/wrangler.transcript.jsonc | Disables Wrangler Worker cache for the transcript worker configuration. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Browser
participant StaticAssets as Cloudflare Static Assets
participant Transcript as Transcript Worker
participant Room as TranscriptRoom DO

Browser->>StaticAssets: Request public asset
StaticAssets-->>Browser: Asset with _headers Cache-Control

Browser->>Transcript: GET /version
Transcript-->>Browser: serviceVersion + short cache headers

Browser->>Transcript: "WebSocket /rooms/{roomId}/ws"
Transcript->>Room: Forward upgrade request
Room-->>Browser: WebSocket response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Browser
participant StaticAssets as Cloudflare Static Assets
participant Transcript as Transcript Worker
participant Room as TranscriptRoom DO

Browser->>StaticAssets: Request public asset
StaticAssets-->>Browser: Asset with _headers Cache-Control

Browser->>Transcript: GET /version
Transcript-->>Browser: serviceVersion + short cache headers

Browser->>Transcript: "WebSocket /rooms/{roomId}/ws"
Transcript->>Room: Forward upgrade request
Room-->>Browser: WebSocket response
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/201a2e3e81a0809016e8286d8e8e750cb325b011) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42350973)</sub>

<!-- /greptile_comment -->