### PR TITLE
feat(noise-cancellation): implement noise cancellation feature

### DIFF
--- a/apps/web/src/app/components/ControlsBar.tsx
+++ b/apps/web/src/app/components/ControlsBar.tsx
@@ -92,6 +92,8 @@ function MediaClusterButton({
     | "selectedAudioOutputDeviceId"
     | "onAudioInputDeviceChange"
     | "onAudioOutputDeviceChange"
+    | "isNoiseCancellationEnabled"
+    | "onToggleNoiseCancellation"
   >;
   video?: Pick<
     MediaControlClusterProps,
@@ -365,11 +367,15 @@ function ControlsBar(props: ControlsBarProps) {
     onAudioInputDeviceChange,
     onAudioOutputDeviceChange,
     onVideoInputDeviceChange,
+    isNoiseCancellationEnabled,
+    onToggleNoiseCancellation,
     isMirrorCamera,
     onToggleMirror,
   } = props;
   const hasAudioDevicePicker = Boolean(
-    onAudioInputDeviceChange || onAudioOutputDeviceChange,
+    onAudioInputDeviceChange ||
+      onAudioOutputDeviceChange ||
+      onToggleNoiseCancellation,
   );
   const hasVideoDevicePicker = Boolean(
     onVideoInputDeviceChange || onToggleMirror,
@@ -553,6 +559,8 @@ function ControlsBar(props: ControlsBarProps) {
                   selectedAudioOutputDeviceId,
                   onAudioInputDeviceChange,
                   onAudioOutputDeviceChange,
+                  isNoiseCancellationEnabled,
+                  onToggleNoiseCancellation,
                 }}
               />
             );
@@ -942,6 +950,8 @@ function ControlsBar(props: ControlsBarProps) {
                       onAudioInputDeviceChange={onAudioInputDeviceChange}
                       onAudioOutputDeviceChange={onAudioOutputDeviceChange}
                       onVideoInputDeviceChange={onVideoInputDeviceChange}
+                      isNoiseCancellationEnabled={isNoiseCancellationEnabled}
+                      onToggleNoiseCancellation={onToggleNoiseCancellation}
                       isMirrorCamera={isMirrorCamera}
                       onToggleMirror={onToggleMirror}
                     />

--- a/apps/web/src/app/components/DeviceCaretMenu.tsx
+++ b/apps/web/src/app/components/DeviceCaretMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  AudioLines,
   Check,
   ChevronUp,
   FlipHorizontal2,
@@ -145,6 +146,8 @@ export type DeviceSettingsProps = Pick<
   | "onVideoInputDeviceChange"
   | "isMirrorCamera"
   | "onToggleMirror"
+  | "isNoiseCancellationEnabled"
+  | "onToggleNoiseCancellation"
 >;
 
 /**
@@ -164,10 +167,15 @@ export function DeviceSettingsSection({
   onVideoInputDeviceChange,
   isMirrorCamera,
   onToggleMirror,
+  isNoiseCancellationEnabled,
+  onToggleNoiseCancellation,
 }: DeviceSettingsProps & { active: boolean; bare?: boolean }) {
   const { audioInput, audioOutput, videoInput } = useEnumeratedDevices(active);
   const hasDevices =
-    audioInput.length > 0 || audioOutput.length > 0 || videoInput.length > 0;
+    audioInput.length > 0 ||
+    audioOutput.length > 0 ||
+    videoInput.length > 0 ||
+    Boolean(onToggleNoiseCancellation);
   if (!hasDevices && !onToggleMirror) return null;
   return (
     <div
@@ -188,6 +196,15 @@ export function DeviceSettingsSection({
             selectedId={selectedAudioOutputDeviceId}
             onSelect={onAudioOutputDeviceChange}
           />
+          {onToggleNoiseCancellation ? (
+            <SwitchRow
+              icon={AudioLines}
+              label="Noise cancellation"
+              checked={isNoiseCancellationEnabled ?? true}
+              onChange={() => onToggleNoiseCancellation?.()}
+              className="rounded-lg"
+            />
+          ) : null}
           <DeviceList
             heading="Camera"
             devices={videoInput}
@@ -231,6 +248,8 @@ export interface MediaControlClusterProps {
   onVideoInputDeviceChange?: (deviceId: string) => void;
   isMirrorCamera?: boolean;
   onToggleMirror?: () => void;
+  isNoiseCancellationEnabled?: boolean;
+  onToggleNoiseCancellation?: () => void;
 }
 
 /** Mic/camera toggle + device caret as one unified pill control. */
@@ -253,6 +272,8 @@ export function MediaControlCluster(props: MediaControlClusterProps) {
     onVideoInputDeviceChange,
     isMirrorCamera,
     onToggleMirror,
+    isNoiseCancellationEnabled,
+    onToggleNoiseCancellation,
   } = props;
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -385,7 +406,9 @@ export function MediaControlCluster(props: MediaControlClusterProps) {
             }}
           >
             {kind === "mic" ? (
-              audioInput.length === 0 && audioOutput.length === 0 ? (
+              audioInput.length === 0 &&
+              audioOutput.length === 0 &&
+              !onToggleNoiseCancellation ? (
                 <EmptyDevices kind="mic" />
               ) : (
                 <>
@@ -401,6 +424,15 @@ export function MediaControlCluster(props: MediaControlClusterProps) {
                     selectedId={selectedAudioOutputDeviceId}
                     onSelect={handleSelect(onAudioOutputDeviceChange)}
                   />
+                  {onToggleNoiseCancellation ? (
+                    <SwitchRow
+                      icon={AudioLines}
+                      label="Noise cancellation"
+                      checked={isNoiseCancellationEnabled ?? true}
+                      onChange={() => onToggleNoiseCancellation?.()}
+                      className="rounded-lg"
+                    />
+                  ) : null}
                 </>
               )
             ) : (

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -155,6 +155,8 @@ interface MeetsMainContentProps {
   onAudioInputDeviceChange?: (deviceId: string) => void;
   onAudioOutputDeviceChange?: (deviceId: string) => void;
   onVideoInputDeviceChange?: (deviceId: string) => void;
+  isNoiseCancellationEnabled?: boolean;
+  onToggleNoiseCancellation?: () => void;
   activeSpeakerId: string | null;
   currentUserId: string;
   audioOutputDeviceId?: string;
@@ -385,6 +387,8 @@ export default function MeetsMainContent({
   onAudioInputDeviceChange,
   onAudioOutputDeviceChange,
   onVideoInputDeviceChange,
+  isNoiseCancellationEnabled,
+  onToggleNoiseCancellation,
   activeSpeakerId,
   currentUserId,
   audioOutputDeviceId,
@@ -1974,6 +1978,8 @@ export default function MeetsMainContent({
                 onAudioInputDeviceChange={onAudioInputDeviceChange}
                 onAudioOutputDeviceChange={onAudioOutputDeviceChange}
                 onVideoInputDeviceChange={onVideoInputDeviceChange}
+                isNoiseCancellationEnabled={isNoiseCancellationEnabled}
+                onToggleNoiseCancellation={onToggleNoiseCancellation}
                 isMirrorCamera={isMirrorCamera}
                 onToggleMirror={onToggleMirror}
                 isVideoEffectsOpen={isVideoEffectsOpen}

--- a/apps/web/src/app/components/controls-config.ts
+++ b/apps/web/src/app/components/controls-config.ts
@@ -69,6 +69,8 @@ export interface ControlsBarProps {
   onAudioInputDeviceChange?: (deviceId: string) => void;
   onAudioOutputDeviceChange?: (deviceId: string) => void;
   onVideoInputDeviceChange?: (deviceId: string) => void;
+  isNoiseCancellationEnabled?: boolean;
+  onToggleNoiseCancellation?: () => void;
   isMirrorCamera?: boolean;
   onToggleMirror?: () => void;
   isVideoEffectsOpen?: boolean;

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -38,6 +38,13 @@ import {
 } from "../lib/captured-surface-control";
 import { prewarmVideoEffectsAssetsDeferred } from "../lib/video-effects-lazy";
 import {
+  createNoiseCancellationPipeline,
+  getNoiseCancellationSourceTrack,
+  isNoiseCancellationProcessedTrack,
+  setNoiseCancellationTrackEnabled,
+  stopNoiseCancellationForTrack,
+} from "../lib/noise-cancellation";
+import {
   applyAudioProducerNetworkProfile,
   applyScreenShareProducerNetworkProfile,
   applyWebcamProducerNetworkProfile,
@@ -81,6 +88,7 @@ interface UseMeetMediaOptions {
   setSelectedVideoInputDeviceId: React.Dispatch<
     React.SetStateAction<string | undefined>
   >;
+  isNoiseCancellationEnabled?: boolean;
   meetVolume?: number;
   videoQualityRef: React.MutableRefObject<VideoQuality>;
   dataSaverMode?: boolean;
@@ -428,6 +436,7 @@ export function useMeetMedia({
   setSelectedAudioOutputDeviceId,
   selectedVideoInputDeviceId,
   setSelectedVideoInputDeviceId,
+  isNoiseCancellationEnabled = true,
   meetVolume = DEFAULT_MEET_VOLUME,
   videoQualityRef,
   dataSaverMode = false,
@@ -475,6 +484,15 @@ export function useMeetMedia({
   const localAudioTrackHandlersRef = useRef<WeakSet<MediaStreamTrack>>(
     new WeakSet(),
   );
+  const noiseCancellationSourceHandlersRef = useRef<
+    WeakMap<
+      MediaStreamTrack,
+      {
+        processedTrack: MediaStreamTrack;
+        onEnded: () => void;
+      }
+    >
+  >(new WeakMap());
   const localVideoTrackHandlersRef = useRef<WeakSet<MediaStreamTrack>>(
     new WeakSet(),
   );
@@ -1097,15 +1115,34 @@ export function useMeetMedia({
     [onPreferredVideoPublishTrackRejected],
   );
 
+  const detachNoiseCancellationSourceHandler = useCallback(
+    (track?: MediaStreamTrack | null) => {
+      if (!track) return;
+      const sourceTrack = getNoiseCancellationSourceTrack(track) ?? track;
+      const entry = noiseCancellationSourceHandlersRef.current.get(sourceTrack);
+      if (!entry) return;
+      if (sourceTrack !== track && entry.processedTrack.id !== track.id) return;
+
+      sourceTrack.removeEventListener("ended", entry.onEnded);
+      noiseCancellationSourceHandlersRef.current.delete(sourceTrack);
+    },
+    [],
+  );
+
   const stopLocalTrack = useCallback(
     (track?: MediaStreamTrack | null) => {
       if (!track) return;
       intentionalTrackStopsRef.current.add(track);
+      detachNoiseCancellationSourceHandler(track);
+      stopNoiseCancellationForTrack(track, {
+        stopOutput: true,
+        stopSource: true,
+      });
       try {
         track.stop();
       } catch {}
     },
-    [intentionalTrackStopsRef]
+    [detachNoiseCancellationSourceHandler, intentionalTrackStopsRef]
   );
 
   const commitLocalStream = useCallback(
@@ -1114,6 +1151,37 @@ export function useMeetMedia({
       setLocalStream(nextStream);
     },
     [localStreamRef, setLocalStream],
+  );
+
+  const commitAudioTrackToLocalStream = useCallback(
+    (
+      audioTrack: MediaStreamTrack,
+      previousStream: MediaStream | null | undefined = localStreamRef.current,
+      options: { stopReplacedTracks?: boolean } = {},
+    ) => {
+      const sourceTrack = getNoiseCancellationSourceTrack(audioTrack);
+      const keepTrackIds = new Set(
+        [audioTrack.id, sourceTrack?.id].filter(
+          (trackId): trackId is string => Boolean(trackId),
+        ),
+      );
+      const remainingTracks =
+        previousStream?.getTracks().filter((track) => track.kind !== "audio") ??
+        [];
+      const nextStream = new MediaStream([...remainingTracks, audioTrack]);
+      commitLocalStream(nextStream);
+
+      if (options.stopReplacedTracks !== false) {
+        previousStream?.getAudioTracks().forEach((track) => {
+          if (!keepTrackIds.has(track.id)) {
+            stopLocalTrack(track);
+          }
+        });
+      }
+
+      return nextStream;
+    },
+    [commitLocalStream, localStreamRef, stopLocalTrack],
   );
 
   const stopTracksExcept = useCallback(
@@ -1372,6 +1440,80 @@ export function useMeetMedia({
       handleLocalTrackEnded,
       markAudioTrackForSpeech,
       scheduleLocalAudioMutedRecovery,
+    ],
+  );
+
+  const attachNoiseCancellationSourceHandlers = useCallback(
+    (processedTrack: MediaStreamTrack) => {
+      const sourceTrack = getNoiseCancellationSourceTrack(processedTrack);
+      if (!sourceTrack) {
+        return;
+      }
+
+      const existing =
+        noiseCancellationSourceHandlersRef.current.get(sourceTrack);
+      if (existing?.processedTrack.id === processedTrack.id) {
+        return;
+      }
+      if (existing) {
+        sourceTrack.removeEventListener("ended", existing.onEnded);
+      }
+
+      const onEnded = () => {
+        noiseCancellationSourceHandlersRef.current.delete(sourceTrack);
+        clearLocalAudioMutedRecoveryTimer(processedTrack.id);
+        handleLocalTrackEnded("audio", processedTrack);
+      };
+
+      noiseCancellationSourceHandlersRef.current.set(sourceTrack, {
+        processedTrack,
+        onEnded,
+      });
+      sourceTrack.addEventListener("ended", onEnded, { once: true });
+    },
+    [clearLocalAudioMutedRecoveryTimer, handleLocalTrackEnded],
+  );
+
+  const prepareAudioPublishTrack = useCallback(
+    async (track: MediaStreamTrack): Promise<MediaStreamTrack> => {
+      markAudioTrackForSpeech(track);
+      if (
+        !isNoiseCancellationEnabled ||
+        track.kind !== "audio" ||
+        track.readyState !== "live" ||
+        isNoiseCancellationProcessedTrack(track)
+      ) {
+        attachLocalAudioTrackHandlers(track);
+        return track;
+      }
+
+      try {
+        const pipeline = await createNoiseCancellationPipeline(track);
+        const processedTrack = pipeline.outputTrack;
+        setNoiseCancellationTrackEnabled(processedTrack, track.enabled);
+        markAudioTrackForSpeech(processedTrack);
+        attachLocalAudioTrackHandlers(processedTrack);
+        attachNoiseCancellationSourceHandlers(processedTrack);
+        console.info("[Meets] Noise cancellation enabled for microphone:", {
+          sourceTrackId: track.id,
+          outputTrackId: processedTrack.id,
+          worklet: pipeline.usedWorklet,
+        });
+        return processedTrack;
+      } catch (error) {
+        console.warn(
+          "[Meets] Noise cancellation unavailable; publishing raw microphone:",
+          error,
+        );
+        attachLocalAudioTrackHandlers(track);
+        return track;
+      }
+    },
+    [
+      attachLocalAudioTrackHandlers,
+      attachNoiseCancellationSourceHandlers,
+      isNoiseCancellationEnabled,
+      markAudioTrackForSpeech,
     ],
   );
 
@@ -1677,7 +1819,7 @@ export function useMeetMedia({
         }
       }
 
-      const nextAudioTrack =
+      let nextAudioTrack =
         getFirstLiveTrack(
           acquiredTracks.filter((track) => track.kind === "audio"),
         ) ?? reusableAudioTrack;
@@ -1685,6 +1827,9 @@ export function useMeetMedia({
         getFirstLiveTrack(
           acquiredTracks.filter((track) => track.kind === "video"),
         ) ?? reusableVideoTrack;
+      if (nextAudioTrack) {
+        nextAudioTrack = await prepareAudioPublishTrack(nextAudioTrack);
+      }
       const liveTracks = [nextAudioTrack, nextVideoTrack].filter(
         (track): track is MediaStreamTrack =>
           Boolean(track && track.readyState === "live"),
@@ -1710,8 +1855,7 @@ export function useMeetMedia({
       }
 
       if (nextAudioTrack) {
-        attachLocalAudioTrackHandlers(nextAudioTrack);
-        nextAudioTrack.enabled = !isMuted;
+        setNoiseCancellationTrackEnabled(nextAudioTrack, !isMuted);
       }
       liveTracks.forEach((track) => {
         track.onended = () => {
@@ -1758,15 +1902,17 @@ export function useMeetMedia({
             },
           );
           const audioTrack = audioStream.getAudioTracks()[0];
-          if (audioTrack) {
-            attachLocalAudioTrackHandlers(audioTrack);
-          }
+          const publishAudioTrack = audioTrack
+            ? await prepareAudioPublishTrack(audioTrack)
+            : null;
           setMediaState({
             hasAudioPermission: true,
             hasVideoPermission: false,
           });
           setIsCameraOff(true);
-          return audioStream;
+          return publishAudioTrack
+            ? new MediaStream([publishAudioTrack])
+            : audioStream;
         } catch {
           return null;
         }
@@ -1787,6 +1933,7 @@ export function useMeetMedia({
     attachLocalVideoTrackHandlers,
     buildAudioConstraints,
     buildVideoConstraints,
+    prepareAudioPublishTrack,
     localStreamRef,
     permissionHintTimeoutRef,
     setMeetError,
@@ -1811,10 +1958,10 @@ export function useMeetMedia({
           );
 
           acquiredAudioTracks = newStream.getAudioTracks();
-          const newAudioTrack = newStream.getAudioTracks()[0];
-          if (newAudioTrack) {
-            attachLocalAudioTrackHandlers(newAudioTrack);
-            newAudioTrack.enabled = !isMuted;
+          const rawAudioTrack = newStream.getAudioTracks()[0];
+          if (rawAudioTrack) {
+            const newAudioTrack = await prepareAudioPublishTrack(rawAudioTrack);
+            setNoiseCancellationTrackEnabled(newAudioTrack, !isMuted);
             const previousStream = localStreamRef.current;
             const previousAudioTracks = previousStream?.getAudioTracks() ?? [];
 
@@ -1831,15 +1978,9 @@ export function useMeetMedia({
               requestAudioProducerRecovery();
             }
 
-            const remainingTracks =
-              previousStream
-                ?.getTracks()
-                .filter((track) => track.kind !== "audio") ?? [];
-            const nextStream = new MediaStream([
-              ...remainingTracks,
-              newAudioTrack,
-            ]);
-            commitLocalStream(nextStream);
+            commitAudioTrackToLocalStream(newAudioTrack, previousStream, {
+              stopReplacedTracks: false,
+            });
             committedNewAudioTrack = newAudioTrack;
             stopTracksExcept(previousAudioTracks, [newAudioTrack]);
           }
@@ -1852,11 +1993,11 @@ export function useMeetMedia({
     [
       connectionState,
       isMuted,
-      attachLocalAudioTrackHandlers,
+      prepareAudioPublishTrack,
       setSelectedAudioInputDeviceId,
       audioProducerRef,
       localStreamRef,
-      commitLocalStream,
+      commitAudioTrackToLocalStream,
       buildAudioConstraints,
       closeLocalAudioProducerForReplacement,
       stopTracksExcept,
@@ -2416,7 +2557,7 @@ export function useMeetMedia({
           (track) => track.readyState === "live",
         );
         liveAudioTracks.forEach((track) => {
-          track.enabled = false;
+          setNoiseCancellationTrackEnabled(track, false);
         });
 
         if (producer) {
@@ -2433,7 +2574,7 @@ export function useMeetMedia({
             );
             liveAudioTracks.forEach((track) => {
               if (track.readyState === "live") {
-                track.enabled = true;
+                setNoiseCancellationTrackEnabled(track, true);
               }
             });
             try {
@@ -2469,33 +2610,29 @@ export function useMeetMedia({
             timeoutMs: MEDIA_CAPTURE_RECOVERY_TIMEOUT_MS,
           },
         );
-        const nextAudioTrack = stream.getAudioTracks()[0];
-        createdTrack = nextAudioTrack ?? null;
+        const rawAudioTrack = stream.getAudioTracks()[0];
 
-        if (!nextAudioTrack) throw new Error("No audio track obtained");
-        attachLocalAudioTrackHandlers(nextAudioTrack);
+        if (!rawAudioTrack) throw new Error("No audio track obtained");
+        const nextAudioTrack = await prepareAudioPublishTrack(rawAudioTrack);
+        createdTrack = nextAudioTrack;
 
         const previousStream = localStreamRef.current;
         previousStream?.getAudioTracks().forEach((track) => {
-          if (track.id !== nextAudioTrack.id) {
+          if (
+            track.id !== nextAudioTrack.id &&
+            track.id !== getNoiseCancellationSourceTrack(nextAudioTrack)?.id
+          ) {
             stopLocalTrack(track);
           }
         });
-        const remainingTracks =
-          previousStream
-            ?.getTracks()
-            .filter((track) => track.kind !== "audio") ?? [];
-        const nextStream = new MediaStream([
-          ...remainingTracks,
-          nextAudioTrack,
-        ]);
-        localStreamRef.current = nextStream;
-        setLocalStream(nextStream);
+        commitAudioTrackToLocalStream(nextAudioTrack, previousStream, {
+          stopReplacedTracks: false,
+        });
 
         audioTrack = nextAudioTrack;
       }
 
-      audioTrack.enabled = true;
+      setNoiseCancellationTrackEnabled(audioTrack, true);
 
       if (producer) {
         if (!producer.track || producer.track.id !== audioTrack.id) {
@@ -2526,7 +2663,7 @@ export function useMeetMedia({
         !shouldDisableMediaIntentAfterRecoveryFailure(err, meetErr);
 
       if (shouldRetryAudioUnmute) {
-        liveAudioTrackAfterFailure.enabled = true;
+        setNoiseCancellationTrackEnabled(liveAudioTrackAfterFailure, true);
         if (
           producer &&
           !producer.closed &&
@@ -2560,7 +2697,7 @@ export function useMeetMedia({
     isObserverMode,
     isMuted,
     selectedAudioInputDeviceId,
-    attachLocalAudioTrackHandlers,
+    prepareAudioPublishTrack,
     stopLocalTrack,
     buildAudioConstraints,
     socketRef,
@@ -2568,6 +2705,7 @@ export function useMeetMedia({
     audioProducerRef,
     localStreamRef,
     commitLocalStream,
+    commitAudioTrackToLocalStream,
     setMeetError,
     closeLocalAudioProducerForReplacement,
     confirmAudioProducerUnmuted,
@@ -2675,12 +2813,22 @@ export function useMeetMedia({
     let createdTrack: MediaStreamTrack | null = null;
     const removeCreatedTrackFromLocalStream = () => {
       if (!createdTrack) return;
+      const sourceTrack = getNoiseCancellationSourceTrack(createdTrack);
       stopLocalTrack(createdTrack);
       const currentStream = localStreamRef.current;
-      if (currentStream?.getTracks().includes(createdTrack)) {
+      const tracksToRemove = new Set(
+        [createdTrack.id, sourceTrack?.id].filter(
+          (trackId): trackId is string => Boolean(trackId),
+        ),
+      );
+      if (
+        currentStream
+          ?.getTracks()
+          .some((track) => tracksToRemove.has(track.id))
+      ) {
         const remaining = currentStream
           .getTracks()
-          .filter((track) => track !== createdTrack);
+          .filter((track) => !tracksToRemove.has(track.id));
         const nextStream = new MediaStream(remaining);
         localStreamRef.current = nextStream;
         setLocalStream(nextStream);
@@ -2716,6 +2864,7 @@ export function useMeetMedia({
         let audioTrack = getFirstLiveTrack(
           (localStreamRef.current ?? localStream)?.getAudioTracks() ?? [],
         );
+        const originalAudioTrack = audioTrack;
 
         if (!audioTrack || audioTrack.readyState !== "live") {
           const stream = await getUserMediaWithTimeout(
@@ -2726,32 +2875,25 @@ export function useMeetMedia({
             },
           );
           audioTrack = stream.getAudioTracks()[0] ?? null;
-          createdTrack = audioTrack;
         }
 
         if (!audioTrack) {
           throw new Error("No audio track available for recovery");
+        }
+        audioTrack = await prepareAudioPublishTrack(audioTrack);
+        if (!originalAudioTrack || audioTrack.id !== originalAudioTrack.id) {
+          createdTrack = audioTrack;
         }
         if (isMediaRecoveryBlocked()) {
           removeCreatedTrackFromLocalStream();
           return;
         }
 
-        attachLocalAudioTrackHandlers(audioTrack);
-        audioTrack.enabled = !shouldStartPaused;
+        setNoiseCancellationTrackEnabled(audioTrack, !shouldStartPaused);
 
         if (createdTrack) {
           const previousStream = localStreamRef.current;
-          previousStream?.getAudioTracks().forEach((track) => {
-            stopLocalTrack(track);
-          });
-          const remainingTracks =
-            previousStream
-              ?.getTracks()
-              .filter((track) => track.kind !== "audio") ?? [];
-          const nextStream = new MediaStream([...remainingTracks, audioTrack]);
-          localStreamRef.current = nextStream;
-          setLocalStream(nextStream);
+          commitAudioTrackToLocalStream(audioTrack, previousStream);
         }
         if (isMediaRecoveryBlocked()) {
           removeCreatedTrackFromLocalStream();
@@ -2829,18 +2971,118 @@ export function useMeetMedia({
     localStream,
     isMediaRecoveryBlocked,
     selectedAudioInputDeviceId,
-    attachLocalAudioTrackHandlers,
+    prepareAudioPublishTrack,
     stopLocalTrack,
     buildAudioConstraints,
     producerTransportRef,
     ensureProducerTransportRef,
     audioProducerRef,
     localStreamRef,
+    commitAudioTrackToLocalStream,
     setLocalStream,
     setIsMuted,
     setMeetError,
     closeLocalAudioProducerForReplacement,
     getPublishNetworkProfile,
+    requestAudioProducerRecovery,
+  ]);
+
+  useEffect(() => {
+    if (isObserverMode) return;
+    if (connectionState !== "joined") return;
+    if (isMediaRecoveryBlocked()) return;
+    if (audioRecoveryInFlightRef.current) return;
+
+    const currentStream = localStreamRef.current ?? localStream;
+    const currentAudioTrack = getFirstLiveTrack(
+      currentStream?.getAudioTracks() ?? [],
+    );
+    if (!currentAudioTrack) return;
+
+    const isProcessed = isNoiseCancellationProcessedTrack(currentAudioTrack);
+    if (isNoiseCancellationEnabled === isProcessed) return;
+
+    let cancelled = false;
+
+    const switchAudioProcessing = async () => {
+      audioRecoveryInFlightRef.current = true;
+      try {
+        const producer = audioProducerRef.current;
+        const nextTrack = isNoiseCancellationEnabled
+          ? await prepareAudioPublishTrack(currentAudioTrack)
+          : getNoiseCancellationSourceTrack(currentAudioTrack);
+
+        if (cancelled) {
+          if (
+            nextTrack &&
+            nextTrack.id !== currentAudioTrack.id &&
+            isNoiseCancellationProcessedTrack(nextTrack)
+          ) {
+            detachNoiseCancellationSourceHandler(nextTrack);
+            stopNoiseCancellationForTrack(nextTrack, {
+              stopOutput: true,
+              stopSource: false,
+            });
+          }
+          return;
+        }
+
+        if (
+          !nextTrack ||
+          nextTrack.readyState !== "live" ||
+          nextTrack.id === currentAudioTrack.id
+        ) {
+          return;
+        }
+
+        setNoiseCancellationTrackEnabled(nextTrack, currentAudioTrack.enabled);
+        if (producer && !producer.closed) {
+          await producer.replaceTrack({ track: nextTrack });
+        }
+
+        if (!isNoiseCancellationEnabled) {
+          detachNoiseCancellationSourceHandler(currentAudioTrack);
+          stopNoiseCancellationForTrack(currentAudioTrack, {
+            stopOutput: true,
+            stopSource: false,
+          });
+          attachLocalAudioTrackHandlers(nextTrack);
+        }
+
+        commitAudioTrackToLocalStream(nextTrack, currentStream, {
+          stopReplacedTracks: isNoiseCancellationEnabled,
+        });
+
+        if (!producer || producer.closed) {
+          requestAudioProducerRecovery();
+        }
+      } catch (error) {
+        console.warn("[Meets] Failed to switch microphone processing:", error);
+        if (!isMutedRef.current) {
+          requestAudioProducerRecovery();
+        }
+      } finally {
+        audioRecoveryInFlightRef.current = false;
+      }
+    };
+
+    void switchAudioProcessing();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    attachLocalAudioTrackHandlers,
+    audioProducerRef,
+    commitAudioTrackToLocalStream,
+    connectionState,
+    detachNoiseCancellationSourceHandler,
+    isMediaRecoveryBlocked,
+    isNoiseCancellationEnabled,
+    isObserverMode,
+    localStream,
+    localStreamRef,
+    prepareAudioPublishTrack,
     requestAudioProducerRecovery,
   ]);
 
@@ -4679,6 +4921,7 @@ export function useMeetMedia({
     updateVideoQualityRef,
     requestAudioProducerRecovery,
     requestCameraProducerRecovery,
+    prepareAudioPublishTrack,
     toggleMute,
     toggleCamera,
     toggleScreenShare,

--- a/apps/web/src/app/hooks/useMeetMediaSettings.ts
+++ b/apps/web/src/app/hooks/useMeetMediaSettings.ts
@@ -24,6 +24,17 @@ const getInitialVideoQuality = (): VideoQuality => {
   return shouldStartLowBandwidthVideo() ? "low" : "standard";
 };
 
+const NOISE_CANCELLATION_STORAGE_KEY = "conclave:noise-cancellation";
+
+const getInitialNoiseCancellationEnabled = (): boolean => {
+  if (typeof window === "undefined") return true;
+  try {
+    return window.localStorage.getItem(NOISE_CANCELLATION_STORAGE_KEY) !== "off";
+  } catch {
+    return true;
+  }
+};
+
 export function useMeetMediaSettings({
   videoQualityRef,
   networkManagedVideoQualityRef,
@@ -35,6 +46,9 @@ export function useMeetMediaSettings({
     useState<VideoQuality>(initialVideoQuality);
   const [isMirrorCamera, setIsMirrorCamera] = useState(true);
   const [isVideoSettingsOpen, setIsVideoSettingsOpen] = useState(false);
+  const [isNoiseCancellationEnabled, setIsNoiseCancellationEnabled] = useState(
+    getInitialNoiseCancellationEnabled,
+  );
   const [selectedAudioInputDeviceId, setSelectedAudioInputDeviceId] =
     useState<string>();
   const [selectedAudioOutputDeviceId, setSelectedAudioOutputDeviceId] =
@@ -128,6 +142,15 @@ export function useMeetMediaSettings({
     videoQualityRef,
   ]);
 
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        NOISE_CANCELLATION_STORAGE_KEY,
+        isNoiseCancellationEnabled ? "on" : "off",
+      );
+    } catch {}
+  }, [isNoiseCancellationEnabled]);
+
   return {
     videoQuality,
     setVideoQuality,
@@ -136,6 +159,8 @@ export function useMeetMediaSettings({
     setIsMirrorCamera,
     isVideoSettingsOpen,
     setIsVideoSettingsOpen,
+    isNoiseCancellationEnabled,
+    setIsNoiseCancellationEnabled,
     selectedAudioInputDeviceId,
     setSelectedAudioInputDeviceId,
     selectedAudioOutputDeviceId,

--- a/apps/web/src/app/lib/noise-cancellation.ts
+++ b/apps/web/src/app/lib/noise-cancellation.ts
@@ -1,0 +1,355 @@
+"use client";
+
+type CleanupOptions = {
+  stopSource?: boolean;
+  stopOutput?: boolean;
+};
+
+export type NoiseCancellationPipeline = {
+  sourceTrack: MediaStreamTrack;
+  outputTrack: MediaStreamTrack;
+  stream: MediaStream;
+  usedWorklet: boolean;
+  cleanup: (options?: CleanupOptions) => void;
+};
+
+type NoiseCancellationPipelineInternal = NoiseCancellationPipeline & {
+  context: AudioContext;
+  nodes: AudioNode[];
+  disposed: boolean;
+};
+
+const outputTrackPipelines = new WeakMap<
+  MediaStreamTrack,
+  NoiseCancellationPipelineInternal
+>();
+const sourceTrackPipelines = new WeakMap<
+  MediaStreamTrack,
+  NoiseCancellationPipelineInternal
+>();
+const workletLoadPromises = new WeakMap<AudioContext, Promise<boolean>>();
+
+const NOISE_CANCELLATION_WORKLET = `
+class ConclaveNoiseCancellationProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.noiseFloor = 0.0035;
+    this.gain = 1;
+    this.holdFrames = 0;
+  }
+
+  process(inputs, outputs) {
+    const input = inputs[0];
+    const output = outputs[0];
+    if (!input || input.length === 0 || !output || output.length === 0) {
+      return true;
+    }
+
+    const channels = Math.min(input.length, output.length);
+    let sumSquares = 0;
+    let sampleCount = 0;
+
+    for (let c = 0; c < channels; c += 1) {
+      const channel = input[c];
+      for (let i = 0; i < channel.length; i += 1) {
+        const sample = channel[i];
+        sumSquares += sample * sample;
+      }
+      sampleCount += channel.length;
+    }
+
+    const rms = Math.sqrt(sumSquares / Math.max(1, sampleCount));
+    const quietEnoughForFloor = rms < this.noiseFloor * 1.45 || rms < 0.012;
+    if (quietEnoughForFloor) {
+      this.noiseFloor = this.noiseFloor * 0.995 + rms * 0.005;
+    } else {
+      this.noiseFloor = Math.max(0.0025, this.noiseFloor * 0.9995);
+    }
+
+    const openThreshold = Math.max(0.012, this.noiseFloor * 3.6);
+    const closeThreshold = Math.max(0.006, this.noiseFloor * 2.2);
+    let targetGain = 1;
+
+    if (rms >= openThreshold) {
+      this.holdFrames = 16;
+      targetGain = 1;
+    } else if (this.holdFrames > 0) {
+      this.holdFrames -= 1;
+      targetGain = 0.96;
+    } else if (rms <= closeThreshold) {
+      targetGain = 0.07;
+    } else {
+      const position = (rms - closeThreshold) / Math.max(0.0001, openThreshold - closeThreshold);
+      targetGain = 0.07 + Math.max(0, Math.min(1, position)) * 0.89;
+    }
+
+    const smoothing = targetGain > this.gain ? 0.22 : 0.045;
+    this.gain += (targetGain - this.gain) * smoothing;
+
+    for (let c = 0; c < output.length; c += 1) {
+      const inputChannel = input[Math.min(c, input.length - 1)];
+      const outputChannel = output[c];
+      for (let i = 0; i < outputChannel.length; i += 1) {
+        outputChannel[i] = (inputChannel?.[i] ?? 0) * this.gain;
+      }
+    }
+
+    return true;
+  }
+}
+
+registerProcessor("conclave-noise-cancellation-processor", ConclaveNoiseCancellationProcessor);
+`;
+
+const getAudioContextConstructor = (): typeof AudioContext | null =>
+  window.AudioContext ||
+  (window as typeof window & { webkitAudioContext?: typeof AudioContext })
+    .webkitAudioContext ||
+  null;
+
+const resumeContext = (context: AudioContext) => {
+  if (context.state === "suspended") {
+    void context.resume().catch(() => {});
+  }
+};
+
+const loadNoiseCancellationWorklet = (context: AudioContext): Promise<boolean> => {
+  if (!context.audioWorklet) {
+    return Promise.resolve(false);
+  }
+
+  const existing = workletLoadPromises.get(context);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    const blob = new Blob([NOISE_CANCELLATION_WORKLET], {
+      type: "application/javascript",
+    });
+    const url = URL.createObjectURL(blob);
+    try {
+      await context.audioWorklet.addModule(url);
+      return true;
+    } catch (error) {
+      console.warn("[Meets] Noise cancellation worklet unavailable:", error);
+      return false;
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  })();
+
+  workletLoadPromises.set(context, promise);
+  return promise;
+};
+
+const disconnectNodes = (nodes: readonly AudioNode[]) => {
+  for (const node of nodes) {
+    try {
+      node.disconnect();
+    } catch {}
+  }
+};
+
+const connectNodes = (nodes: readonly AudioNode[]) => {
+  for (let index = 0; index < nodes.length - 1; index += 1) {
+    nodes[index]?.connect(nodes[index + 1]);
+  }
+};
+
+export const isNoiseCancellationProcessedTrack = (
+  track?: MediaStreamTrack | null,
+): boolean => Boolean(track && outputTrackPipelines.has(track));
+
+export const getNoiseCancellationSourceTrack = (
+  track?: MediaStreamTrack | null,
+): MediaStreamTrack | null =>
+  track ? outputTrackPipelines.get(track)?.sourceTrack ?? null : null;
+
+export const getNoiseCancellationOutputTrack = (
+  track?: MediaStreamTrack | null,
+): MediaStreamTrack | null =>
+  track ? sourceTrackPipelines.get(track)?.outputTrack ?? null : null;
+
+export const setNoiseCancellationTrackEnabled = (
+  track: MediaStreamTrack | null | undefined,
+  enabled: boolean,
+): void => {
+  if (!track) return;
+  track.enabled = enabled;
+
+  const linkedTrack =
+    getNoiseCancellationSourceTrack(track) ??
+    getNoiseCancellationOutputTrack(track);
+  if (linkedTrack && linkedTrack !== track) {
+    linkedTrack.enabled = enabled;
+  }
+};
+
+export const stopNoiseCancellationForTrack = (
+  track?: MediaStreamTrack | null,
+  options: CleanupOptions = {},
+): void => {
+  if (!track) return;
+  const pipeline =
+    outputTrackPipelines.get(track) ?? sourceTrackPipelines.get(track);
+  pipeline?.cleanup(options);
+};
+
+export async function createNoiseCancellationPipeline(
+  sourceTrack: MediaStreamTrack,
+): Promise<NoiseCancellationPipeline> {
+  if (sourceTrack.kind !== "audio") {
+    throw new Error("Noise cancellation requires an audio track");
+  }
+  if (sourceTrack.readyState !== "live") {
+    throw new Error("Noise cancellation source track is not live");
+  }
+
+  const existing = sourceTrackPipelines.get(sourceTrack);
+  if (existing && !existing.disposed && existing.outputTrack.readyState === "live") {
+    return existing;
+  }
+
+  const AudioContextConstructor = getAudioContextConstructor();
+  if (!AudioContextConstructor) {
+    throw new Error("Web Audio is not available in this browser");
+  }
+
+  const context = new AudioContextConstructor({
+    latencyHint: "interactive",
+    sampleRate: 48000,
+  });
+  resumeContext(context);
+
+  const sourceStream = new MediaStream([sourceTrack]);
+  const source = context.createMediaStreamSource(sourceStream);
+  const highPass = context.createBiquadFilter();
+  highPass.type = "highpass";
+  highPass.frequency.value = 95;
+  highPass.Q.value = 0.72;
+
+  const hum50 = context.createBiquadFilter();
+  hum50.type = "notch";
+  hum50.frequency.value = 50;
+  hum50.Q.value = 22;
+
+  const hum60 = context.createBiquadFilter();
+  hum60.type = "notch";
+  hum60.frequency.value = 60;
+  hum60.Q.value = 22;
+
+  const voicePresence = context.createBiquadFilter();
+  voicePresence.type = "peaking";
+  voicePresence.frequency.value = 2900;
+  voicePresence.Q.value = 0.85;
+  voicePresence.gain.value = 2.2;
+
+  const lowPass = context.createBiquadFilter();
+  lowPass.type = "lowpass";
+  lowPass.frequency.value = 8200;
+  lowPass.Q.value = 0.55;
+
+  const workletLoaded = await loadNoiseCancellationWorklet(context);
+  let gate: AudioNode | null = null;
+  if (workletLoaded) {
+    try {
+      gate = new AudioWorkletNode(
+        context,
+        "conclave-noise-cancellation-processor",
+        {
+          numberOfInputs: 1,
+          numberOfOutputs: 1,
+          outputChannelCount: [1],
+        },
+      );
+    } catch (error) {
+      console.warn("[Meets] Noise cancellation worklet init failed:", error);
+    }
+  }
+
+  const compressor = context.createDynamicsCompressor();
+  compressor.threshold.value = -26;
+  compressor.knee.value = 24;
+  compressor.ratio.value = 3.2;
+  compressor.attack.value = 0.004;
+  compressor.release.value = 0.16;
+
+  const limiter = context.createDynamicsCompressor();
+  limiter.threshold.value = -6;
+  limiter.knee.value = 2;
+  limiter.ratio.value = 12;
+  limiter.attack.value = 0.001;
+  limiter.release.value = 0.045;
+
+  const outputGain = context.createGain();
+  outputGain.gain.value = 1.05;
+
+  const destination = context.createMediaStreamDestination();
+  const nodes = [
+    source,
+    highPass,
+    hum50,
+    hum60,
+    voicePresence,
+    lowPass,
+    ...(gate ? [gate] : []),
+    compressor,
+    limiter,
+    outputGain,
+    destination,
+  ];
+  connectNodes(nodes);
+
+  const outputTrack = destination.stream.getAudioTracks()[0];
+  if (!outputTrack) {
+    disconnectNodes(nodes);
+    await context.close().catch(() => {});
+    throw new Error("Noise cancellation did not create an output track");
+  }
+
+  outputTrack.enabled = sourceTrack.enabled;
+  if ("contentHint" in outputTrack) {
+    outputTrack.contentHint = "speech";
+  }
+
+  const handleSourceEnded = () => {
+    pipeline.cleanup({ stopSource: false, stopOutput: true });
+  };
+
+  const pipeline: NoiseCancellationPipelineInternal = {
+    sourceTrack,
+    outputTrack,
+    stream: destination.stream,
+    usedWorklet: Boolean(gate),
+    context,
+    nodes,
+    disposed: false,
+    cleanup: (options: CleanupOptions = {}) => {
+      if (pipeline.disposed) return;
+      pipeline.disposed = true;
+
+      sourceTrack.removeEventListener("ended", handleSourceEnded);
+      outputTrackPipelines.delete(outputTrack);
+      sourceTrackPipelines.delete(sourceTrack);
+      disconnectNodes(nodes);
+
+      if (options.stopOutput !== false && outputTrack.readyState === "live") {
+        try {
+          outputTrack.stop();
+        } catch {}
+      }
+      if (options.stopSource === true && sourceTrack.readyState === "live") {
+        try {
+          sourceTrack.stop();
+        } catch {}
+      }
+
+      void context.close().catch(() => {});
+    },
+  };
+
+  sourceTrack.addEventListener("ended", handleSourceEnded, { once: true });
+  outputTrackPipelines.set(outputTrack, pipeline);
+  sourceTrackPipelines.set(sourceTrack, pipeline);
+
+  return pipeline;
+}

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -930,6 +930,8 @@ export default function MeetsClient({
     setSelectedAudioOutputDeviceId,
     selectedVideoInputDeviceId,
     setSelectedVideoInputDeviceId,
+    isNoiseCancellationEnabled,
+    setIsNoiseCancellationEnabled,
   } = useMeetMediaSettings({
     videoQualityRef: refs.videoQualityRef,
     networkManagedVideoQualityRef,
@@ -1110,6 +1112,7 @@ export default function MeetsClient({
     updateVideoQualityRef,
     requestAudioProducerRecovery,
     requestCameraProducerRecovery,
+    prepareAudioPublishTrack,
     toggleMute,
     isMuteTogglePending,
     toggleCamera,
@@ -1138,6 +1141,7 @@ export default function MeetsClient({
     setSelectedAudioOutputDeviceId,
     selectedVideoInputDeviceId,
     setSelectedVideoInputDeviceId,
+    isNoiseCancellationEnabled,
     meetVolume,
     videoQualityRef: refs.videoQualityRef,
     dataSaverMode: effectiveDataSaverMode,
@@ -2155,6 +2159,7 @@ export default function MeetsClient({
     requestMediaPermissions,
     requestAudioProducerRecovery,
     requestCameraProducerRecovery,
+    prepareAudioPublishTrack,
     stopLocalTrack,
     handleLocalTrackEnded,
     playNotificationSound: playNotificationSoundForEvents,
@@ -3072,6 +3077,10 @@ export default function MeetsClient({
         onAudioInputDeviceChange={handleAudioInputDeviceChange}
         onAudioOutputDeviceChange={handleAudioOutputDeviceChange}
         onVideoInputDeviceChange={handleVideoInputDeviceSelect}
+        isNoiseCancellationEnabled={isNoiseCancellationEnabled}
+        onToggleNoiseCancellation={() =>
+          setIsNoiseCancellationEnabled((value) => !value)
+        }
         activeSpeakerId={effectiveActiveSpeakerId}
         currentUserId={userId}
         audioOutputDeviceId={selectedAudioOutputDeviceId}


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds noise cancellation to meet audio controls. The main changes are:

- A Web Audio pipeline for processed microphone tracks.
- A persisted noise-cancellation setting with an enabled default.
- Device-menu controls for toggling noise cancellation.
- Media acquisition, mute, device-change, and recovery paths updated to handle processed tracks.

<h3>Confidence Score: 4/5</h3>

The live noise-cancellation switch path needs fixes before merging.

- A setting change can be skipped while audio recovery is in flight.
- The async switch can commit against an old stream snapshot after other media state changes.
- The rest of the UI plumbing and pipeline helper look contained.

apps/web/src/app/hooks/useMeetMedia.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/hooks/useMeetMedia.ts | Adds processed-track handling across media setup, mute, recovery, and live toggling; the toggle effect can lose or misapply state during overlapping audio work. |
| apps/web/src/app/lib/noise-cancellation.ts | Adds the Web Audio noise-cancellation pipeline and source/output track cleanup helpers. |
| apps/web/src/app/hooks/useMeetMediaSettings.ts | Adds persisted noise-cancellation preference state with an enabled-by-default fallback. |
| apps/web/src/app/components/DeviceCaretMenu.tsx | Adds the noise-cancellation switch to device settings and mic device menus. |
| apps/web/src/app/meets-client.tsx | Passes the noise-cancellation setting into media handling and the main meet controls. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A2994%0A**Processing%20Toggle%20Gets%20Dropped**%0A%0AWhen%20the%20user%20changes%20noise%20cancellation%20during%20an%20audio%20recovery%20or%20device-change%20operation%2C%20this%20branch%20returns%20without%20scheduling%20another%20switch.%20Since%20clearing%20%60audioRecoveryInFlightRef.current%60%20does%20not%20rerun%20the%20effect%2C%20the%20UI%20and%20stored%20setting%20can%20say%20noise%20cancellation%20is%20off%20while%20the%20active%20producer%20still%20publishes%20the%20processed%20track%2C%20or%20the%20reverse.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A3052-3054%0A**Stale%20Stream%20Replaces%20Media%20State**%0A%0A%60currentStream%60%20is%20captured%20before%20%60prepareAudioPublishTrack%60%20awaits%20pipeline%20creation.%20If%20another%20media%20action%20updates%20%60localStreamRef.current%60%20during%20that%20await%2C%20this%20commit%20rebuilds%20the%20local%20stream%20from%20the%20stale%20snapshot%20and%20can%20drop%20or%20resurrect%20tracks%20from%20the%20newer%20stream%2C%20causing%20the%20local%20preview%20or%20producer%20recovery%20state%20to%20diverge.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20commitAudioTrackToLocalStream%28nextTrack%2C%20localStreamRef.current%20%3F%3F%20currentStream%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20stopReplacedTracks%3A%20isNoiseCancellationEnabled%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A&repo=acm-vit%2Fconclave&pr=165&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A2994%0A**Processing%20Toggle%20Gets%20Dropped**%0A%0AWhen%20the%20user%20changes%20noise%20cancellation%20during%20an%20audio%20recovery%20or%20device-change%20operation%2C%20this%20branch%20returns%20without%20scheduling%20another%20switch.%20Since%20clearing%20%60audioRecoveryInFlightRef.current%60%20does%20not%20rerun%20the%20effect%2C%20the%20UI%20and%20stored%20setting%20can%20say%20noise%20cancellation%20is%20off%20while%20the%20active%20producer%20still%20publishes%20the%20processed%20track%2C%20or%20the%20reverse.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A3052-3054%0A**Stale%20Stream%20Replaces%20Media%20State**%0A%0A%60currentStream%60%20is%20captured%20before%20%60prepareAudioPublishTrack%60%20awaits%20pipeline%20creation.%20If%20another%20media%20action%20updates%20%60localStreamRef.current%60%20during%20that%20await%2C%20this%20commit%20rebuilds%20the%20local%20stream%20from%20the%20stale%20snapshot%20and%20can%20drop%20or%20resurrect%20tracks%20from%20the%20newer%20stream%2C%20causing%20the%20local%20preview%20or%20producer%20recovery%20state%20to%20diverge.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20commitAudioTrackToLocalStream%28nextTrack%2C%20localStreamRef.current%20%3F%3F%20currentStream%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20stopReplacedTracks%3A%20isNoiseCancellationEnabled%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A&repo=acm-vit%2Fconclave&pr=165&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A2994%0A**Processing%20Toggle%20Gets%20Dropped**%0A%0AWhen%20the%20user%20changes%20noise%20cancellation%20during%20an%20audio%20recovery%20or%20device-change%20operation%2C%20this%20branch%20returns%20without%20scheduling%20another%20switch.%20Since%20clearing%20%60audioRecoveryInFlightRef.current%60%20does%20not%20rerun%20the%20effect%2C%20the%20UI%20and%20stored%20setting%20can%20say%20noise%20cancellation%20is%20off%20while%20the%20active%20producer%20still%20publishes%20the%20processed%20track%2C%20or%20the%20reverse.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A3052-3054%0A**Stale%20Stream%20Replaces%20Media%20State**%0A%0A%60currentStream%60%20is%20captured%20before%20%60prepareAudioPublishTrack%60%20awaits%20pipeline%20creation.%20If%20another%20media%20action%20updates%20%60localStreamRef.current%60%20during%20that%20await%2C%20this%20commit%20rebuilds%20the%20local%20stream%20from%20the%20stale%20snapshot%20and%20can%20drop%20or%20resurrect%20tracks%20from%20the%20newer%20stream%2C%20causing%20the%20local%20preview%20or%20producer%20recovery%20state%20to%20diverge.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20commitAudioTrackToLocalStream%28nextTrack%2C%20localStreamRef.current%20%3F%3F%20currentStream%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20stopReplacedTracks%3A%20isNoiseCancellationEnabled%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A&pr=165&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(noise-cancellation): implement nois..."](https://github.com/acm-vit/conclave/commit/b0c5339519d2fca6bdf2b3738123293ef076eae9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42483848)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->