### PR TITLE
feat: add audio processing switch handling in useMeetMedia

### DIFF
--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -518,6 +518,9 @@ export function useMeetMedia({
   );
   const [audioProducerRecoveryPulse, setAudioProducerRecoveryPulse] =
     useState(0);
+  const pendingAudioProcessingSwitchRef = useRef(false);
+  const [audioProcessingSwitchPulse, setAudioProcessingSwitchPulse] =
+    useState(0);
   const cameraRecoveryInFlightRef = useRef(false);
   const [cameraProducerRecoveryPulse, setCameraProducerRecoveryPulse] =
     useState(0);
@@ -575,6 +578,11 @@ export function useMeetMedia({
     },
     [],
   );
+  const flushPendingAudioProcessingSwitch = useCallback(() => {
+    if (!pendingAudioProcessingSwitchRef.current) return;
+    pendingAudioProcessingSwitchRef.current = false;
+    setAudioProcessingSwitchPulse((value) => value + 1);
+  }, []);
   const notificationVolume = clampMeetVolume(meetVolume);
   const requestAudioProducerRecovery = useCallback(() => {
     if (isMediaRecoveryBlocked()) {
@@ -2955,6 +2963,7 @@ export function useMeetMedia({
         }
       } finally {
         audioRecoveryInFlightRef.current = false;
+        flushPendingAudioProcessingSwitch();
       }
     };
 
@@ -2985,6 +2994,7 @@ export function useMeetMedia({
     setIsMuted,
     setMeetError,
     closeLocalAudioProducerForReplacement,
+    flushPendingAudioProcessingSwitch,
     getPublishNetworkProfile,
     requestAudioProducerRecovery,
   ]);
@@ -2993,18 +3003,28 @@ export function useMeetMedia({
     if (isObserverMode) return;
     if (connectionState !== "joined") return;
     if (isMediaRecoveryBlocked()) return;
-    if (audioRecoveryInFlightRef.current) return;
+    if (audioRecoveryInFlightRef.current) {
+      pendingAudioProcessingSwitchRef.current = true;
+      return;
+    }
 
     const currentStream = localStreamRef.current ?? localStream;
     const currentAudioTrack = getFirstLiveTrack(
       currentStream?.getAudioTracks() ?? [],
     );
-    if (!currentAudioTrack) return;
+    if (!currentAudioTrack) {
+      pendingAudioProcessingSwitchRef.current = false;
+      return;
+    }
 
     const isProcessed = isNoiseCancellationProcessedTrack(currentAudioTrack);
-    if (isNoiseCancellationEnabled === isProcessed) return;
+    if (isNoiseCancellationEnabled === isProcessed) {
+      pendingAudioProcessingSwitchRef.current = false;
+      return;
+    }
 
     let cancelled = false;
+    pendingAudioProcessingSwitchRef.current = false;
 
     const switchAudioProcessing = async () => {
       audioRecoveryInFlightRef.current = true;
@@ -3051,9 +3071,13 @@ export function useMeetMedia({
           attachLocalAudioTrackHandlers(nextTrack);
         }
 
-        commitAudioTrackToLocalStream(nextTrack, currentStream, {
-          stopReplacedTracks: isNoiseCancellationEnabled,
-        });
+        commitAudioTrackToLocalStream(
+          nextTrack,
+          localStreamRef.current ?? currentStream,
+          {
+            stopReplacedTracks: isNoiseCancellationEnabled,
+          },
+        );
 
         if (!producer || producer.closed) {
           requestAudioProducerRecovery();
@@ -3065,6 +3089,7 @@ export function useMeetMedia({
         }
       } finally {
         audioRecoveryInFlightRef.current = false;
+        flushPendingAudioProcessingSwitch();
       }
     };
 
@@ -3075,10 +3100,12 @@ export function useMeetMedia({
     };
   }, [
     attachLocalAudioTrackHandlers,
+    audioProcessingSwitchPulse,
     audioProducerRef,
     commitAudioTrackToLocalStream,
     connectionState,
     detachNoiseCancellationSourceHandler,
+    flushPendingAudioProcessingSwitch,
     isMediaRecoveryBlocked,
     isNoiseCancellationEnabled,
     isObserverMode,


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds retry handling for audio processing switches in the meet media hook. The main changes are:

- Tracks pending noise-cancellation switches while audio recovery is in flight.
- Adds an `audioProcessingSwitchPulse` state value to rerun the switch effect.
- Flushes pending audio-processing switches after audio producer recovery or switch attempts finish.
- Uses the latest local stream ref when committing the replacement audio track.

<h3>Confidence Score: 4/5</h3>

This PR has one contained behavior issue in the new retry path.

The change is localized, but toggles during blocked media recovery can still be silently skipped.

`apps/web/src/app/hooks/useMeetMedia.ts`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran a focused Node harness that models the audio processing switch guard ordering with a joined connection, observer mode disabled, and a live raw local audio track.
- The blocked noise-cancellation toggle returned with pendingAudioProcessingSwitchRef false and there were zero calls to prepare, replaceTrack, and commit.
- Clearing the recovery block did not flush anything and the local stream remained on the old raw audio track.
- A later explicit effect rerun re-applied the previously dropped switch after another dependency change.
- T-Rex produced a proof for a posted P1 finding and ran the requested verification, noting that local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/13708087/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/hooks/useMeetMedia.ts | Adds queued retry handling for audio processing switches during audio recovery, but still drops switches that occur while media recovery is blocked. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Hook as useMeetMedia effect
participant Recovery as Audio recovery guard
participant Producer as audioProducer
participant Stream as localStream

User->>Hook: Toggle noise cancellation
Hook->>Recovery: Check joined/observer/blocked/in-flight
alt audio recovery in flight
    Hook->>Hook: "pendingAudioProcessingSwitchRef = true"
    Recovery-->>Hook: flushPendingAudioProcessingSwitch()
    Hook->>Hook: increment audioProcessingSwitchPulse
    Hook->>Hook: rerun switch effect
else switch can run now
    Hook->>Hook: prepare raw/processed track
    Hook->>Producer: replaceTrack(nextTrack)
    Hook->>Stream: commitAudioTrackToLocalStream(nextTrack)
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Hook as useMeetMedia effect
participant Recovery as Audio recovery guard
participant Producer as audioProducer
participant Stream as localStream

User->>Hook: Toggle noise cancellation
Hook->>Recovery: Check joined/observer/blocked/in-flight
alt audio recovery in flight
    Hook->>Hook: "pendingAudioProcessingSwitchRef = true"
    Recovery-->>Hook: flushPendingAudioProcessingSwitch()
    Hook->>Hook: increment audioProcessingSwitchPulse
    Hook->>Hook: rerun switch effect
else switch can run now
    Hook->>Hook: prepare raw/processed track
    Hook->>Producer: replaceTrack(nextTrack)
    Hook->>Stream: commitAudioTrackToLocalStream(nextTrack)
end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Queued audio-processing switch is not retried after an in-flight processing switch completes**

   - **Bug**
     - When isNoiseCancellationEnabled changes back while an audio-processing switch is already in flight, the hook sets pendingAudioProcessingSwitchRef, but the focused runtime harness did not observe the expected follow-up raw→processed replaceTrack after the in-flight processed→raw switch completed. The first unblocked switch completed (`replace:raw-1`, `commit:raw-1`), but the queued retry assertion failed because `replace:processed-1` never occurred.
   - **Cause**
     - The in-flight audio-processing effect path around audioRecoveryInFlightRef/pendingAudioProcessingSwitchRef/audioProcessingSwitchPulse does not reliably cause a subsequent processing switch to run against the just-committed current audio track after the first switch finishes. In the exercised path, flushPendingAudioProcessingSwitch did not result in the expected raw→processed retry behavior.
   - **Fix**
     - Rework the queued processing switch flush so that after audioRecoveryInFlightRef is cleared, the effect reliably re-evaluates the latest localStreamRef/current track and latest isNoiseCancellationEnabled value. Add a regression test equivalent to the generated harness: delay replaceTrack, toggle isNoiseCancellationEnabled during the delay, then assert the second replaceTrack and local stream commit happen after the first commit.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A3005-3008%0A**Queue%20blocked%20switches**%0AWhen%20%60isMediaRecoveryBlocked%28%29%60%20is%20true%2C%20a%20noise-cancellation%20toggle%20returns%20before%20setting%20%60pendingAudioProcessingSwitchRef%60%2C%20and%20the%20existing%20unblock%20flush%20only%20handles%20producer%20recoveries.%20If%20the%20user%20toggles%20audio%20processing%20during%20a%20blocked%20recovery%20window%2C%20no%20dependency%20changes%20when%20the%20ref%20clears%2C%20so%20the%20local%20and%20producer%20audio%20track%20stays%20on%20the%20old%20processing%20mode%20until%20the%20user%20toggles%20again.%0A%0A&repo=acm-vit%2Fconclave&pr=169&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A3005-3008%0A**Queue%20blocked%20switches**%0AWhen%20%60isMediaRecoveryBlocked%28%29%60%20is%20true%2C%20a%20noise-cancellation%20toggle%20returns%20before%20setting%20%60pendingAudioProcessingSwitchRef%60%2C%20and%20the%20existing%20unblock%20flush%20only%20handles%20producer%20recoveries.%20If%20the%20user%20toggles%20audio%20processing%20during%20a%20blocked%20recovery%20window%2C%20no%20dependency%20changes%20when%20the%20ref%20clears%2C%20so%20the%20local%20and%20producer%20audio%20track%20stays%20on%20the%20old%20processing%20mode%20until%20the%20user%20toggles%20again.%0A%0A&repo=acm-vit%2Fconclave&pr=169&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetMedia.ts%3A3005-3008%0A**Queue%20blocked%20switches**%0AWhen%20%60isMediaRecoveryBlocked%28%29%60%20is%20true%2C%20a%20noise-cancellation%20toggle%20returns%20before%20setting%20%60pendingAudioProcessingSwitchRef%60%2C%20and%20the%20existing%20unblock%20flush%20only%20handles%20producer%20recoveries.%20If%20the%20user%20toggles%20audio%20processing%20during%20a%20blocked%20recovery%20window%2C%20no%20dependency%20changes%20when%20the%20ref%20clears%2C%20so%20the%20local%20and%20producer%20audio%20track%20stays%20on%20the%20old%20processing%20mode%20until%20the%20user%20toggles%20again.%0A%0A&pr=169&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: add audio processing switch handli..."](https://github.com/acm-vit/conclave/commit/9e28e5747ec71119ae303b139abca5e384e59fb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42754195)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->