### PR TITLE
fix: race with connect initialization on SFU

### DIFF
--- a/apps/web/test/transcript-rate-limit.test.ts
+++ b/apps/web/test/transcript-rate-limit.test.ts
@@ -36,4 +36,19 @@ describe("takeTranscriptRateLimit", () => {
     expect(takeTranscriptRateLimit(state, "qa", 2_000)).toBe(false);
     expect(takeTranscriptRateLimit(state, "minutes", 2_000)).toBe(true);
   });
+
+  it("keeps relay control traffic separate from user session commands", () => {
+    const state: TranscriptRateLimitState = {};
+    const now = 3_000;
+
+    for (let index = 0; index < 8; index += 1) {
+      expect(takeTranscriptRateLimit(state, "session", now)).toBe(true);
+    }
+    expect(takeTranscriptRateLimit(state, "session", now)).toBe(false);
+
+    for (let index = 0; index < 120; index += 1) {
+      expect(takeTranscriptRateLimit(state, "control", now)).toBe(true);
+    }
+    expect(takeTranscriptRateLimit(state, "control", now)).toBe(false);
+  });
 });

--- a/apps/web/transcript-worker/src/constants.ts
+++ b/apps/web/transcript-worker/src/constants.ts
@@ -31,6 +31,7 @@ export const MINUTES_MAX_WAIT_MS = 45_000;
 export const MINUTES_MIN_WORDS = 24;
 export const MAX_CLIENT_MESSAGE_BYTES = 192 * 1024;
 export const MAX_AUDIO_CHUNK_BASE64_BYTES = 48 * 1024;
+export const SFU_RELAY_DISCONNECT_SUPPRESSION_MS = 15000;
 export const OPENAI_REALTIME_URL = "https://api.openai.com/v1/realtime";
 export const OPENAI_REALTIME_TRANSCRIPTION_INTENT = "transcription";
 export const OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";

--- a/apps/web/transcript-worker/src/rate-limit.ts
+++ b/apps/web/transcript-worker/src/rate-limit.ts
@@ -1,5 +1,6 @@
 export type TranscriptRateBucketName =
   | "audio"
+  | "control"
   | "export"
   | "minutes"
   | "qa"
@@ -20,6 +21,7 @@ const limits: Record<
   { max: number; windowMs: number }
 > = {
   audio: { max: 600, windowMs: 10_000 },
+  control: { max: 120, windowMs: 60_000 },
   export: { max: 20, windowMs: 60_000 },
   minutes: { max: 12, windowMs: 60_000 },
   qa: { max: 10, windowMs: 60_000 },

--- a/apps/web/transcript-worker/src/room.ts
+++ b/apps/web/transcript-worker/src/room.ts
@@ -24,6 +24,7 @@ import {
   MINUTES_QUIET_DEBOUNCE_MS,
   MINUTES_MAX_WAIT_MS,
   MINUTES_MIN_WORDS,
+  SFU_RELAY_DISCONNECT_SUPPRESSION_MS,
 } from "./constants";
 import {
   signTranscriptSfuRelayStartToken,
@@ -417,6 +418,9 @@ export class TranscriptRoom {
           minutesStatus: this.minutesStatus,
         });
         return;
+      case "relay.ping":
+        this.handleSfuRelayPing(viewer, message.id);
+        return;
       case "relay.handoff.prepare":
         this.prepareSfuRelayHandoff(viewer, message.id);
         return;
@@ -595,7 +599,8 @@ export class TranscriptRoom {
       return;
     }
 
-    this.suppressSfuRelayDisconnectsUntil = Date.now() + 5000;
+    this.suppressSfuRelayDisconnectsUntil =
+      Date.now() + SFU_RELAY_DISCONNECT_SUPPRESSION_MS;
     this.suppressSfuRelayDisconnectCount += 1;
     this.closeTranscriptionProvider();
     const roomId = this.session?.roomId || "unknown";
@@ -826,10 +831,19 @@ export class TranscriptRoom {
 
   private prepareSfuRelayHandoff(viewer: Viewer, id?: string): void {
     if (!this.canRelayAudio(viewer)) return;
-    this.suppressSfuRelayDisconnectsUntil = Date.now() + 5000;
+    this.suppressSfuRelayDisconnectsUntil =
+      Date.now() + SFU_RELAY_DISCONNECT_SUPPRESSION_MS;
     this.suppressSfuRelayDisconnectCount += 1;
     this.send(viewer.socket, {
       type: "relay.handoff.ready",
+      id: trimText(id ?? "", 120),
+    });
+  }
+
+  private handleSfuRelayPing(viewer: Viewer, id?: string): void {
+    if (!this.canRelayAudio(viewer)) return;
+    this.send(viewer.socket, {
+      type: "relay.pong",
       id: trimText(id ?? "", 120),
     });
   }
@@ -1320,13 +1334,15 @@ export class TranscriptRoom {
       case "audio.commit":
       case "audio.clear":
         return "audio";
+      case "relay.handoff.prepare":
+      case "relay.ping":
+        return "control";
       case "export.snapshot":
         return "export";
       case "minutes.refresh":
         return "minutes";
       case "qa.ask":
         return "qa";
-      case "relay.handoff.prepare":
       case "session.start":
       case "session.stop":
       case "session.pause":

--- a/apps/web/transcript-worker/src/types.ts
+++ b/apps/web/transcript-worker/src/types.ts
@@ -94,6 +94,7 @@ export type ClientEnvelope =
   | { type: "qa.ask"; id?: string; question?: string; model?: string }
   | { type: "minutes.refresh" }
   | { type: "export.snapshot" }
+  | { type: "relay.ping"; id?: string }
   | { type: "relay.handoff.prepare"; id?: string };
 
 export type SessionStartEnvelope = Extract<

--- a/packages/sfu/server/socket/handlers/transportHandlers.ts
+++ b/packages/sfu/server/socket/handlers/transportHandlers.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../../types.js";
 import { Logger } from "../../../utilities/loggers.js";
 import type { ConnectionContext } from "../context.js";
+import { connectWebRtcTransportOnce } from "../transportConnect.js";
 import { respond } from "./ack.js";
 import { RATE_LIMITS, takeToken } from "../rateLimit.js";
 
@@ -169,14 +170,10 @@ export const registerTransportHandlers = (context: ConnectionContext): void => {
           respond(callback, { error: "Producer transport is closed" });
           return;
         }
-        if (producerTransport.dtlsState === "connected") {
-          respond(callback, { success: true });
-          return;
-        }
-
-        await producerTransport.connect({
-          dtlsParameters: data.dtlsParameters,
-        });
+        await connectWebRtcTransportOnce(
+          producerTransport,
+          data.dtlsParameters,
+        );
 
         respond(callback, { success: true });
       } catch (error) {
@@ -217,14 +214,10 @@ export const registerTransportHandlers = (context: ConnectionContext): void => {
           respond(callback, { error: "Consumer transport is closed" });
           return;
         }
-        if (consumerTransport.dtlsState === "connected") {
-          respond(callback, { success: true });
-          return;
-        }
-
-        await consumerTransport.connect({
-          dtlsParameters: data.dtlsParameters,
-        });
+        await connectWebRtcTransportOnce(
+          consumerTransport,
+          data.dtlsParameters,
+        );
 
         respond(callback, { success: true });
       } catch (error) {

--- a/packages/sfu/server/socket/transportConnect.ts
+++ b/packages/sfu/server/socket/transportConnect.ts
@@ -1,0 +1,46 @@
+import type { DtlsParameters, WebRtcTransport } from "mediasoup/types";
+
+const pendingTransportConnects = new WeakMap<WebRtcTransport, Promise<void>>();
+
+const isAlreadyConnectingState = (state: WebRtcTransport["dtlsState"]): boolean =>
+  state === "connecting" || state === "connected";
+
+const isTerminalConnectState = (state: WebRtcTransport["dtlsState"]): boolean =>
+  state === "failed" || state === "closed";
+
+const isConnectAlreadyCalledError = (error: unknown): boolean =>
+  error instanceof Error && /connect\(\) already called/i.test(error.message);
+
+export const connectWebRtcTransportOnce = async (
+  transport: WebRtcTransport,
+  dtlsParameters: DtlsParameters,
+): Promise<void> => {
+  if (transport.closed) {
+    throw new Error("Transport is closed");
+  }
+
+  const pending = pendingTransportConnects.get(transport);
+  if (pending) {
+    await pending;
+    return;
+  }
+
+  if (isAlreadyConnectingState(transport.dtlsState)) {
+    return;
+  }
+  if (isTerminalConnectState(transport.dtlsState)) {
+    throw new Error(`Transport DTLS state is ${transport.dtlsState}`);
+  }
+
+  const connectPromise = transport
+    .connect({ dtlsParameters })
+    .catch((error: unknown) => {
+      if (isConnectAlreadyCalledError(error)) return;
+      throw error;
+    })
+    .finally(() => {
+      pendingTransportConnects.delete(transport);
+    });
+  pendingTransportConnects.set(transport, connectPromise);
+  await connectPromise;
+};

--- a/packages/sfu/server/transcript/workerClient.ts
+++ b/packages/sfu/server/transcript/workerClient.ts
@@ -1,7 +1,8 @@
 import type { TranscriptSpeaker } from "../../types.js";
 
 const WORKER_CONNECT_TIMEOUT_MS = 8000;
-const WORKER_HANDOFF_TIMEOUT_MS = 1000;
+const WORKER_HANDOFF_TIMEOUT_MS = 5000;
+const WORKER_HEARTBEAT_INTERVAL_MS = 20000;
 
 const toWorkerWebSocketUrl = (
   workerUrl: string,
@@ -21,6 +22,7 @@ const toWorkerWebSocketUrl = (
 
 export class TranscriptWorkerRelayClient {
   private socket: WebSocket | null = null;
+  private heartbeatTimer: NodeJS.Timeout | null = null;
   private readonly handoffResolvers = new Map<string, (ok: boolean) => void>();
 
   constructor(
@@ -57,6 +59,8 @@ export class TranscriptWorkerRelayClient {
         ) {
           this.handoffResolvers.get(message.id)?.(true);
           this.handoffResolvers.delete(message.id);
+        } else if (message.type === "relay.pong") {
+          return;
         } else if (message.type === "error" && message.message) {
           this.options.onError?.(message.message);
         }
@@ -69,7 +73,10 @@ export class TranscriptWorkerRelayClient {
         settled = true;
         clearTimeout(timeout);
         if (error) reject(error);
-        else resolve();
+        else {
+          this.startHeartbeat(socket);
+          resolve();
+        }
       };
       const timeout = setTimeout(() => {
         try {
@@ -90,6 +97,7 @@ export class TranscriptWorkerRelayClient {
         const isCurrentSocket = this.socket === socket;
         if (isCurrentSocket) {
           this.socket = null;
+          this.stopHeartbeat();
         }
         if (!settled) {
           finish(new Error("Transcript worker relay connection closed."));
@@ -134,6 +142,7 @@ export class TranscriptWorkerRelayClient {
   close(): void {
     const socket = this.socket;
     this.socket = null;
+    this.stopHeartbeat();
     for (const resolve of this.handoffResolvers.values()) {
       resolve(false);
     }
@@ -145,8 +154,32 @@ export class TranscriptWorkerRelayClient {
 
   private send(payload: unknown): boolean {
     if (this.socket?.readyState !== WebSocket.OPEN) return false;
-    this.socket.send(JSON.stringify(payload));
-    return true;
+    try {
+      this.socket.send(JSON.stringify(payload));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private startHeartbeat(socket: WebSocket): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      if (this.socket !== socket || socket.readyState !== WebSocket.OPEN) {
+        this.stopHeartbeat();
+        return;
+      }
+      this.send({
+        type: "relay.ping",
+        id: `ping-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      });
+    }, WORKER_HEARTBEAT_INTERVAL_MS);
+  }
+
+  private stopHeartbeat(): void {
+    if (!this.heartbeatTimer) return;
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
   }
 }
 

--- a/packages/sfu/test/transport-connect.test.ts
+++ b/packages/sfu/test/transport-connect.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import type { DtlsParameters, WebRtcTransport } from "mediasoup/types";
+import { connectWebRtcTransportOnce } from "../server/socket/transportConnect.js";
+
+const dtlsParameters = {
+  fingerprints: [],
+  role: "auto",
+} as DtlsParameters;
+
+class FakeWebRtcTransport {
+  closed = false;
+  dtlsState: WebRtcTransport["dtlsState"] = "new";
+  connectCalls = 0;
+  connectImplementation: () => Promise<void> = async () => {};
+
+  async connect(): Promise<void> {
+    this.connectCalls += 1;
+    await this.connectImplementation();
+  }
+}
+
+const asTransport = (transport: FakeWebRtcTransport): WebRtcTransport =>
+  transport as unknown as WebRtcTransport;
+
+describe("connectWebRtcTransportOnce", () => {
+  it("coalesces overlapping connect calls for the same transport", async () => {
+    const transport = new FakeWebRtcTransport();
+    let resolveConnect!: () => void;
+    const pendingConnect = new Promise<void>((resolve) => {
+      resolveConnect = resolve;
+    });
+    transport.connectImplementation = () => pendingConnect;
+
+    const first = connectWebRtcTransportOnce(
+      asTransport(transport),
+      dtlsParameters,
+    );
+    const second = connectWebRtcTransportOnce(
+      asTransport(transport),
+      dtlsParameters,
+    );
+
+    expect(transport.connectCalls).toBe(1);
+    resolveConnect();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(transport.connectCalls).toBe(1);
+  });
+
+  it("treats connecting and connected transports as already connected", async () => {
+    const transport = new FakeWebRtcTransport();
+    transport.dtlsState = "connecting";
+
+    await expect(
+      connectWebRtcTransportOnce(asTransport(transport), dtlsParameters),
+    ).resolves.toBeUndefined();
+    expect(transport.connectCalls).toBe(0);
+
+    transport.dtlsState = "connected";
+    await expect(
+      connectWebRtcTransportOnce(asTransport(transport), dtlsParameters),
+    ).resolves.toBeUndefined();
+    expect(transport.connectCalls).toBe(0);
+  });
+
+  it("treats mediasoup duplicate connect errors as idempotent success", async () => {
+    const transport = new FakeWebRtcTransport();
+    transport.connectImplementation = async () => {
+      throw new Error(
+        "connect() already called [method:webRtcTransport.connect]",
+      );
+    };
+
+    await expect(
+      connectWebRtcTransportOnce(asTransport(transport), dtlsParameters),
+    ).resolves.toBeUndefined();
+    expect(transport.connectCalls).toBe(1);
+  });
+
+  it("rejects failed transports", async () => {
+    const transport = new FakeWebRtcTransport();
+    transport.dtlsState = "failed";
+
+    await expect(
+      connectWebRtcTransportOnce(asTransport(transport), dtlsParameters),
+    ).rejects.toThrow("Transport DTLS state is failed");
+    expect(transport.connectCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR fixes SFU connection races and improves transcript relay stability. The main changes are:

- Adds an idempotent helper for overlapping mediasoup WebRTC transport connect calls.
- Routes producer and consumer transport connects through the shared helper.
- Adds transcript relay heartbeat ping/pong handling.
- Separates relay control messages from user session rate limits.
- Extends relay handoff and disconnect suppression timing.
- Adds tests for transport connect coalescing and transcript control rate limits.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are focused and covered by targeted tests for the main race and rate-limit paths. No blocking correctness or security issues were identified in the changed code.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated SFU transport-connect tests via Vitest; the log shows the command, working directory, timestamps, exit code 0, and all 4 vitest cases passing.
- Validated SFU TypeScript typecheck; the log confirms command, working directory, timestamps, and exit code 0.
- Validated transcript rate-limit tests via Vitest; the log shows command, working directory, timestamps, exit code 0, and all 4 vitest cases passing.

<a href="https://app.greptile.com/trex/runs/13803768/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/sfu/server/socket/transportConnect.ts | Adds a WeakMap-backed helper that coalesces overlapping mediasoup WebRTC transport connect calls and treats duplicate connect errors as success. |
| packages/sfu/server/socket/handlers/transportHandlers.ts | Routes producer and consumer transport connects through the idempotent connection helper. |
| packages/sfu/server/transcript/workerClient.ts | Extends handoff timeout, adds relay heartbeat pings, and makes WebSocket sends failure-safe. |
| apps/web/transcript-worker/src/room.ts | Handles relay heartbeat pings, moves relay control traffic to the new bucket, and extends disconnect suppression using the shared constant. |
| apps/web/transcript-worker/src/rate-limit.ts | Adds a dedicated `control` bucket for relay handoff and heartbeat traffic. |
| packages/sfu/test/transport-connect.test.ts | Adds tests for connect coalescing, already-connected states, duplicate-connect handling, and failed transport rejection. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client as SFU Client
participant Socket as SFU Socket Handler
participant Helper as connectWebRtcTransportOnce
participant Transport as WebRtcTransport
participant Relay as TranscriptWorkerRelayClient
participant Worker as TranscriptRoom Worker

Client->>Socket: connectProducer/ConsumerTransport(dtlsParameters)
Socket->>Helper: connectWebRtcTransportOnce(transport, dtlsParameters)
alt existing pending connect
    Helper-->>Helper: await shared promise
else new/eligible transport
    Helper->>Transport: "connect({ dtlsParameters })"
    Transport-->>Helper: connected or duplicate-connect success
end
Helper-->>Socket: success
Socket-->>Client: ack success

Relay->>Worker: relay.handoff.prepare
Worker-->>Relay: relay.handoff.ready
loop heartbeat
    Relay->>Worker: relay.ping
    Worker-->>Relay: relay.pong
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client as SFU Client
participant Socket as SFU Socket Handler
participant Helper as connectWebRtcTransportOnce
participant Transport as WebRtcTransport
participant Relay as TranscriptWorkerRelayClient
participant Worker as TranscriptRoom Worker

Client->>Socket: connectProducer/ConsumerTransport(dtlsParameters)
Socket->>Helper: connectWebRtcTransportOnce(transport, dtlsParameters)
alt existing pending connect
    Helper-->>Helper: await shared promise
else new/eligible transport
    Helper->>Transport: "connect({ dtlsParameters })"
    Transport-->>Helper: connected or duplicate-connect success
end
Helper-->>Socket: success
Socket-->>Client: ack success

Relay->>Worker: relay.handoff.prepare
Worker-->>Relay: relay.handoff.ready
loop heartbeat
    Relay->>Worker: relay.ping
    Worker-->>Relay: relay.pong
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: race with connect initialization on..."](https://github.com/acm-vit/conclave/commit/3747ea9f2a0a920103f1009f7bedffef301e2e71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42940521)</sub>

<!-- /greptile_comment -->