### PR TITLE
yt live

### DIFF
--- a/apps/web/src/app/api/youtube/rate-limit.ts
+++ b/apps/web/src/app/api/youtube/rate-limit.ts
@@ -8,7 +8,10 @@ type RateLimitBucket = {
 
 type RateLimitOptions = {
   scope: string;
-  binding: "YOUTUBE_SEARCH_RATE_LIMITER" | "YOUTUBE_TRENDING_RATE_LIMITER";
+  binding:
+    | "YOUTUBE_SEARCH_RATE_LIMITER"
+    | "YOUTUBE_TRENDING_RATE_LIMITER"
+    | "YOUTUBE_METADATA_RATE_LIMITER";
   limit: number;
   windowMs: number;
 };

--- a/apps/web/src/app/api/youtube/video/route.ts
+++ b/apps/web/src/app/api/youtube/video/route.ts
@@ -82,7 +82,7 @@ export async function GET(request: Request): Promise<Response> {
 
   const rateLimit = await takeYouTubeRateLimit(request, {
     scope: "video-metadata",
-    binding: "YOUTUBE_TRENDING_RATE_LIMITER",
+    binding: "YOUTUBE_METADATA_RATE_LIMITER",
     limit: RATE_LIMIT_REQUESTS,
     windowMs: RATE_LIMIT_WINDOW_MS,
   });

--- a/apps/web/src/app/api/youtube/video/route.ts
+++ b/apps/web/src/app/api/youtube/video/route.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from "next/server";
+import {
+  takeYouTubeRateLimit,
+  youtubeRateLimitResponse,
+} from "../rate-limit";
+
+const YOUTUBE_VIDEOS_URL = "https://www.googleapis.com/youtube/v3/videos";
+const VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+const LIVE_CACHE_TTL_MS = 30 * 1000;
+const VIDEO_CACHE_TTL_MS = 15 * 60 * 1000;
+const CACHE_MAX_ENTRIES = 128;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_REQUESTS = 30;
+
+export type YouTubeVideoMetadata = {
+  videoId: string;
+  title: string;
+  isLive: boolean;
+};
+
+type CacheEntry = {
+  at: number;
+  value: YouTubeVideoMetadata;
+};
+
+const cache = new Map<string, CacheEntry>();
+
+type VideosResponse = {
+  items?: Array<{
+    id?: unknown;
+    snippet?: {
+      title?: unknown;
+      liveBroadcastContent?: unknown;
+    };
+    liveStreamingDetails?: {
+      actualEndTime?: unknown;
+      activeLiveChatId?: unknown;
+    };
+  }>;
+};
+
+const readCache = (videoId: string): YouTubeVideoMetadata | null => {
+  const entry = cache.get(videoId);
+  if (!entry) return null;
+  const ttl = entry.value.isLive ? LIVE_CACHE_TTL_MS : VIDEO_CACHE_TTL_MS;
+  if (Date.now() - entry.at >= ttl) {
+    cache.delete(videoId);
+    return null;
+  }
+  return entry.value;
+};
+
+const writeCache = (value: YouTubeVideoMetadata): void => {
+  if (cache.size >= CACHE_MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(value.videoId, { at: Date.now(), value });
+};
+
+/**
+ * Resolve the currently-playing video's live status server-side. The iframe
+ * API reports a growing, finite duration for broadcasts, so duration alone
+ * cannot distinguish a DVR-enabled live stream from an ordinary video.
+ */
+export async function GET(request: Request): Promise<Response> {
+  const apiKey = process.env.YOUTUBE_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "YouTube metadata is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const videoId = new URL(request.url).searchParams.get("id")?.trim() ?? "";
+  if (!VIDEO_ID_PATTERN.test(videoId)) {
+    return NextResponse.json({ error: "Invalid video id" }, { status: 400 });
+  }
+
+  const cached = readCache(videoId);
+  if (cached) return NextResponse.json(cached);
+
+  const rateLimit = await takeYouTubeRateLimit(request, {
+    scope: "video-metadata",
+    binding: "YOUTUBE_TRENDING_RATE_LIMITER",
+    limit: RATE_LIMIT_REQUESTS,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+  });
+  if (!rateLimit.ok) return youtubeRateLimitResponse(rateLimit);
+
+  const url = new URL(YOUTUBE_VIDEOS_URL);
+  url.searchParams.set("part", "snippet,liveStreamingDetails");
+  url.searchParams.set("id", videoId);
+  url.searchParams.set("key", apiKey);
+
+  try {
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: "YouTube metadata lookup failed" },
+        { status: 502 },
+      );
+    }
+    const payload = (await response.json()) as VideosResponse;
+    const item = payload.items?.find((candidate) => candidate.id === videoId);
+    const title = item?.snippet?.title;
+    if (!item || typeof title !== "string") {
+      return NextResponse.json({ error: "Video not found" }, { status: 404 });
+    }
+
+    const isLive =
+      item.snippet?.liveBroadcastContent === "live" &&
+      typeof item.liveStreamingDetails?.actualEndTime !== "string";
+    const value: YouTubeVideoMetadata = { videoId, title, isLive };
+    writeCache(value);
+    return NextResponse.json(value);
+  } catch {
+    return NextResponse.json(
+      { error: "YouTube metadata lookup failed" },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/test/watch-playback.test.ts
+++ b/apps/web/test/watch-playback.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  advanceQueue,
   createWatchDoc,
+  enqueue,
   getPlayback,
+  playQueueItemNow,
   setVideo,
   writePlayback,
 } from "../../../packages/apps-sdk/src/apps/watch/core/doc/index";
@@ -12,21 +15,34 @@ import {
 } from "../../../packages/apps-sdk/src/apps/watch/web/playbackSync";
 
 describe("watch-together live playback", () => {
-  it("persists live-edge mode and clears it for the next video", () => {
+  it("keeps fresh live-edge intent but preserves an early explicit seek", () => {
     const doc = createWatchDoc();
     setVideo(doc, "abcdefghijk", { play: true });
-    expect(getPlayback(doc).liveEdge).toBe(false);
+    expect(getPlayback(doc).liveEdge).toBe(true);
 
     writePlayback(doc, {
       state: "playing",
-      positionSeconds: 3_600,
+      positionSeconds: 0.25,
       rate: 1,
-      liveEdge: true,
+      liveEdge: false,
     });
-    expect(getPlayback(doc).liveEdge).toBe(true);
+    expect(getPlayback(doc).liveEdge).toBe(false);
 
     setVideo(doc, "lmnopqrstuv", { play: true });
-    expect(getPlayback(doc).liveEdge).toBe(false);
+    expect(getPlayback(doc).liveEdge).toBe(true);
+
+    const playNow = enqueue(doc, { videoId: "01234567890" });
+    playQueueItemNow(doc, playNow.id);
+    expect(getPlayback(doc).liveEdge).toBe(true);
+
+    writePlayback(doc, {
+      state: "playing",
+      positionSeconds: 15,
+      liveEdge: false,
+    });
+    enqueue(doc, { videoId: "zyxwvutsrqp" });
+    advanceQueue(doc, "01234567890");
+    expect(getPlayback(doc).liveEdge).toBe(true);
   });
 
   it("keeps small playing drift seamless and seeks real jumps", () => {

--- a/apps/web/test/watch-playback.test.ts
+++ b/apps/web/test/watch-playback.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  createWatchDoc,
+  getPlayback,
+  setVideo,
+  writePlayback,
+} from "../../../packages/apps-sdk/src/apps/watch/core/doc/index";
+import {
+  liveEdgeLag,
+  liveEdgeTime,
+  planPlaybackCorrection,
+} from "../../../packages/apps-sdk/src/apps/watch/web/playbackSync";
+
+describe("watch-together live playback", () => {
+  it("persists live-edge mode and clears it for the next video", () => {
+    const doc = createWatchDoc();
+    setVideo(doc, "abcdefghijk", { play: true });
+    expect(getPlayback(doc).liveEdge).toBe(false);
+
+    writePlayback(doc, {
+      state: "playing",
+      positionSeconds: 3_600,
+      rate: 1,
+      liveEdge: true,
+    });
+    expect(getPlayback(doc).liveEdge).toBe(true);
+
+    setVideo(doc, "lmnopqrstuv", { play: true });
+    expect(getPlayback(doc).liveEdge).toBe(false);
+  });
+
+  it("keeps small playing drift seamless and seeks real jumps", () => {
+    expect(
+      planPlaybackCorrection({
+        current: 10,
+        target: 10.3,
+        state: "playing",
+        baseRate: 1,
+      }),
+    ).toEqual({ kind: "settled", rate: 1 });
+
+    expect(
+      planPlaybackCorrection({
+        current: 10,
+        target: 12,
+        state: "playing",
+        baseRate: 1,
+      }),
+    ).toEqual({ kind: "rate", rate: 1.25 });
+
+    expect(
+      planPlaybackCorrection({
+        current: 10,
+        target: 12,
+        state: "playing",
+        baseRate: 1,
+        forceSeek: true,
+      }),
+    ).toEqual({ kind: "seek", rate: 1, target: 12 });
+  });
+
+  it("leaves headroom at the live edge and reports viewer delay", () => {
+    expect(liveEdgeTime(100)).toBe(98.75);
+    expect(liveEdgeLag(90, 100)).toBe(8.75);
+    expect(liveEdgeTime(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -44,6 +44,14 @@
         "limit": 30,
         "period": 60
       }
+    },
+    {
+      "name": "YOUTUBE_METADATA_RATE_LIMITER",
+      "namespace_id": "2003",
+      "simple": {
+        "limit": 30,
+        "period": 60
+      }
     }
   ],
   "r2_buckets": [

--- a/packages/apps-sdk/src/apps/watch/core/doc/index.ts
+++ b/packages/apps-sdk/src/apps/watch/core/doc/index.ts
@@ -28,6 +28,7 @@ const PB_STATE = "state";
 const PB_POSITION = "positionSeconds";
 const PB_UPDATED_AT = "updatedAt";
 const PB_RATE = "rate";
+const PB_LIVE_EDGE = "liveEdge";
 
 const DEFAULT_RATE = 1;
 
@@ -165,6 +166,7 @@ export const getPlayback = (doc: Y.Doc): PlaybackRecord => {
     positionSeconds: normalizePosition(playback.get(PB_POSITION)),
     updatedAt: normalizeUpdatedAt(playback.get(PB_UPDATED_AT)),
     rate: normalizeRate(playback.get(PB_RATE)),
+    liveEdge: playback.get(PB_LIVE_EDGE) === true,
   };
 };
 
@@ -192,6 +194,7 @@ export const writePlayback = (
     state: PlaybackState;
     positionSeconds: number;
     rate?: number;
+    liveEdge?: boolean;
   },
 ): void => {
   const playback = getPlaybackMap(doc);
@@ -199,6 +202,7 @@ export const writePlayback = (
     playback.set(PB_STATE, normalizeState(next.state));
     playback.set(PB_POSITION, normalizePosition(next.positionSeconds));
     playback.set(PB_RATE, normalizeRate(next.rate ?? DEFAULT_RATE));
+    playback.set(PB_LIVE_EDGE, next.liveEdge === true);
     playback.set(PB_UPDATED_AT, Date.now());
   });
 };
@@ -221,6 +225,7 @@ export const setVideo = (
     playback.set(PB_STATE, options?.play === false ? "paused" : "playing");
     playback.set(PB_POSITION, normalizePosition(options?.positionSeconds ?? 0));
     playback.set(PB_RATE, DEFAULT_RATE);
+    playback.set(PB_LIVE_EDGE, false);
     playback.set(PB_UPDATED_AT, Date.now());
   });
 };
@@ -290,6 +295,7 @@ export const playQueueItemNow = (doc: Y.Doc, itemId: string): void => {
     playback.set(PB_STATE, "playing");
     playback.set(PB_POSITION, 0);
     playback.set(PB_RATE, DEFAULT_RATE);
+    playback.set(PB_LIVE_EDGE, false);
     playback.set(PB_UPDATED_AT, Date.now());
   });
 };
@@ -330,6 +336,7 @@ export const advanceQueue = (
     playback.set(PB_STATE, "playing");
     playback.set(PB_POSITION, 0);
     playback.set(PB_RATE, DEFAULT_RATE);
+    playback.set(PB_LIVE_EDGE, false);
     playback.set(PB_UPDATED_AT, Date.now());
     advancedTo = next.videoId;
   });

--- a/packages/apps-sdk/src/apps/watch/core/doc/index.ts
+++ b/packages/apps-sdk/src/apps/watch/core/doc/index.ts
@@ -215,7 +215,12 @@ export const writePlayback = (
 export const setVideo = (
   doc: Y.Doc,
   videoId: string,
-  options?: { play?: boolean; positionSeconds?: number; title?: string | null },
+  options?: {
+    play?: boolean;
+    positionSeconds?: number;
+    title?: string | null;
+    liveEdge?: boolean;
+  },
 ): void => {
   const root = getRoot(doc);
   const playback = getPlaybackMap(doc);
@@ -225,7 +230,10 @@ export const setVideo = (
     playback.set(PB_STATE, options?.play === false ? "paused" : "playing");
     playback.set(PB_POSITION, normalizePosition(options?.positionSeconds ?? 0));
     playback.set(PB_RATE, DEFAULT_RATE);
-    playback.set(PB_LIVE_EDGE, false);
+    // Preserve explicit room-start intent until a real play/pause/seek write.
+    // It is dormant for ordinary videos and becomes the default latest mode
+    // only when metadata confirms that the source is actively live.
+    playback.set(PB_LIVE_EDGE, options?.liveEdge !== false);
     playback.set(PB_UPDATED_AT, Date.now());
   });
 };
@@ -295,7 +303,7 @@ export const playQueueItemNow = (doc: Y.Doc, itemId: string): void => {
     playback.set(PB_STATE, "playing");
     playback.set(PB_POSITION, 0);
     playback.set(PB_RATE, DEFAULT_RATE);
-    playback.set(PB_LIVE_EDGE, false);
+    playback.set(PB_LIVE_EDGE, true);
     playback.set(PB_UPDATED_AT, Date.now());
   });
 };
@@ -336,7 +344,7 @@ export const advanceQueue = (
     playback.set(PB_STATE, "playing");
     playback.set(PB_POSITION, 0);
     playback.set(PB_RATE, DEFAULT_RATE);
-    playback.set(PB_LIVE_EDGE, false);
+    playback.set(PB_LIVE_EDGE, true);
     playback.set(PB_UPDATED_AT, Date.now());
     advancedTo = next.videoId;
   });

--- a/packages/apps-sdk/src/apps/watch/core/model/types.ts
+++ b/packages/apps-sdk/src/apps/watch/core/model/types.ts
@@ -12,6 +12,8 @@ export type PlaybackRecord = {
   updatedAt: number;
   /** Playback rate; default 1. */
   rate: number;
+  /** Active live broadcasts follow their moving edge instead of a fixed time. */
+  liveEdge: boolean;
 };
 
 /** An up-next queue entry. */

--- a/packages/apps-sdk/src/apps/watch/core/model/types.ts
+++ b/packages/apps-sdk/src/apps/watch/core/model/types.ts
@@ -12,7 +12,10 @@ export type PlaybackRecord = {
   updatedAt: number;
   /** Playback rate; default 1. */
   rate: number;
-  /** Active live broadcasts follow their moving edge instead of a fixed time. */
+  /**
+   * Fresh videos keep this intent until the first explicit playback action;
+   * active live broadcasts then follow their moving edge instead of a time.
+   */
   liveEdge: boolean;
 };
 

--- a/packages/apps-sdk/src/apps/watch/web/components/GestureOverlay.tsx
+++ b/packages/apps-sdk/src/apps/watch/web/components/GestureOverlay.tsx
@@ -1,94 +1,108 @@
 import React from "react";
 import type { GestureNeed } from "../hooks/useSyncedPlayback";
-import { thumbnailUrl } from "../youtubeMeta";
 
 type GestureOverlayProps = {
   need: GestureNeed;
   onResolve: () => void;
-  /** The current video, shown as a dimmed poster so the tap has context. */
-  videoId: string | null;
   title: string | null;
 };
 
 /**
- * Autoplay gesture overlay. Instead of a bare button in a void, the video's
- * own thumbnail sits dimmed behind the prompt with its title, so joining
- * reads as "join this". One solid coral pill, no animation.
+ * Browser autoplay recovery. Muted playback gets a small, non-blocking sound
+ * chip; only a genuinely blocked player uses the centered recovery surface.
+ * Both actions are explicitly local, so nobody mistakes them for room-wide
+ * playback controls.
  */
 export function GestureOverlay({
   need,
   onResolve,
-  videoId,
   title,
 }: GestureOverlayProps) {
   if (need === "none") return null;
-  const label = need === "sound" ? "Join with sound" : "Tap to sync";
-  const sub =
-    need === "sound"
-      ? "You are watching muted until you join."
-      : "Your browser needs a tap before playback can start.";
+
+  if (need === "sound") {
+    return (
+      <div className="pointer-events-none absolute inset-x-0 top-3 z-20 flex justify-center px-3">
+        <button
+          type="button"
+          onClick={onResolve}
+          className="pointer-events-auto inline-flex h-9 cursor-pointer items-center gap-2 rounded-full border border-white/10 px-3 text-[12px] font-medium text-[#f4f4f5] shadow-[0_8px_28px_rgba(0,0,0,0.3)] transition-colors hover:border-white/20 hover:bg-[#202027]"
+          style={{
+            backgroundColor: "rgba(17, 17, 21, 0.9)",
+            backdropFilter: "blur(10px)",
+          }}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <polygon
+              points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"
+              fill="currentColor"
+              stroke="none"
+            />
+            <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+          </svg>
+          Audio is muted
+          <span className="text-[#ff8a78]">Turn on</span>
+        </button>
+      </div>
+    );
+  }
 
   return (
-    <div className="absolute inset-0 z-20 overflow-hidden">
-      {videoId ? (
-        <img
-          src={thumbnailUrl(videoId)}
-          alt=""
-          aria-hidden="true"
-          className="absolute inset-0 h-full w-full object-cover"
-          draggable={false}
-        />
-      ) : null}
+    <div
+      className="absolute inset-0 z-20 flex items-center justify-center px-5"
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.46)" }}
+    >
       <div
-        className="absolute inset-0"
-        style={{ backgroundColor: "rgba(0, 0, 0, 0.74)" }}
-      />
-
-      <div className="relative flex h-full w-full items-center justify-center p-6">
-        <div className="flex w-full max-w-sm flex-col items-center text-center">
-          <p className="flex items-center gap-1.5 text-[11px] font-medium text-[#a1a1aa]">
-            <span
-              className="h-1.5 w-1.5 rounded-full"
-              style={{ backgroundColor: "#F95F4A" }}
-            />
-            Playing for the room
-          </p>
-          {title ? (
-            <p
-              className="mt-2 text-[15px] font-medium leading-snug text-[#fafafa]"
-              style={{
-                display: "-webkit-box",
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: "vertical",
-                overflow: "hidden",
-              }}
-            >
-              {title}
-            </p>
-          ) : null}
-          <button
-            type="button"
-            onClick={onResolve}
-            className="mt-5 inline-flex h-11 cursor-pointer items-center gap-2.5 rounded-full px-6 text-[13.5px] font-medium text-white transition-opacity hover:opacity-90"
-            style={{ backgroundColor: "#F95F4A" }}
+        className="flex w-full max-w-[22rem] flex-col items-center rounded-2xl border border-white/10 px-6 py-5 text-center shadow-[0_18px_60px_rgba(0,0,0,0.48)]"
+        style={{
+          backgroundColor: "rgba(16, 16, 20, 0.94)",
+          backdropFilter: "blur(12px)",
+        }}
+      >
+        <div
+          className="flex h-10 w-10 items-center justify-center rounded-full"
+          style={{ backgroundColor: "rgba(249, 95, 74, 0.14)" }}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="#F95F4A"
+            aria-hidden="true"
+            style={{ marginLeft: 2 }}
           >
-            {need === "sound" ? (
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" fill="currentColor" stroke="none" />
-                <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
-                <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
-              </svg>
-            ) : (
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <polygon points="6 4 20 12 6 20 6 4" />
-              </svg>
-            )}
-            {label}
-          </button>
-          <p className="mt-3 max-w-[16rem] text-[12px] leading-relaxed text-[#a1a1aa]">
-            {sub}
-          </p>
+            <polygon points="6 4 20 12 6 20 6 4" />
+          </svg>
         </div>
+        <p className="mt-3 text-[14px] font-semibold text-[#fafafa]">
+          Resume playback on this device
+        </p>
+        {title ? (
+          <p className="mt-1 max-w-full truncate text-[12px] text-[#8b8b93]">
+            {title}
+          </p>
+        ) : null}
+        <button
+          type="button"
+          onClick={onResolve}
+          className="mt-4 inline-flex h-10 cursor-pointer items-center rounded-full px-5 text-[13px] font-semibold text-white transition-opacity hover:opacity-90"
+          style={{ backgroundColor: "#F95F4A" }}
+        >
+          Resume for me
+        </button>
+        <p className="mt-2.5 text-[11px] leading-relaxed text-[#71717a]">
+          This only starts your player. It won&apos;t change playback for the room.
+        </p>
       </div>
     </div>
   );

--- a/packages/apps-sdk/src/apps/watch/web/components/WatchControls.tsx
+++ b/packages/apps-sdk/src/apps/watch/web/components/WatchControls.tsx
@@ -8,6 +8,8 @@ type WatchControlsProps = {
   playbackState: PlaybackState;
   currentTime: number;
   duration: number;
+  isLive: boolean;
+  isAtLiveEdge: boolean;
   muted: boolean;
   volume: number;
   readOnly: boolean;
@@ -25,6 +27,7 @@ type WatchControlsProps = {
   onPlay: () => void;
   onPause: () => void;
   onSeek: (seconds: number) => void;
+  onGoLive: () => void;
   onToggleMute: () => void;
   onVolumeChange: (value: number) => void;
 };
@@ -38,6 +41,8 @@ export function WatchControls({
   playbackState,
   currentTime,
   duration,
+  isLive,
+  isAtLiveEdge,
   muted,
   volume,
   readOnly,
@@ -53,6 +58,7 @@ export function WatchControls({
   onPlay,
   onPause,
   onSeek,
+  onGoLive,
   onToggleMute,
   onVolumeChange,
 }: WatchControlsProps) {
@@ -63,6 +69,7 @@ export function WatchControls({
   const max = duration > 0 ? duration : 0;
   const displayTime = scrubValue ?? currentTime;
   const clampedDisplay = max > 0 ? Math.min(displayTime, max) : displayTime;
+  const liveDelay = Math.max(0, max - clampedDisplay);
 
   return (
     <div className="flex items-center gap-2.5 py-2 pl-2.5 pr-2">
@@ -86,8 +93,12 @@ export function WatchControls({
         )}
       </button>
 
-      <span className="w-9 shrink-0 text-right text-[11px] tabular-nums text-[#e4e4e7]">
-        {formatTime(clampedDisplay)}
+      <span className="w-10 shrink-0 text-right text-[11px] tabular-nums text-[#e4e4e7]">
+        {isLive
+          ? isAtLiveEdge && scrubValue === null
+            ? "Live"
+            : `-${formatTime(liveDelay)}`
+          : formatTime(clampedDisplay)}
       </span>
 
       <Slider
@@ -106,9 +117,29 @@ export function WatchControls({
         }}
       />
 
-      <span className="w-9 shrink-0 text-[11px] tabular-nums text-[#71717a]">
-        {formatTime(max)}
-      </span>
+      {isLive ? (
+        <button
+          type="button"
+          onClick={onGoLive}
+          disabled={readOnly || isAtLiveEdge}
+          aria-label={isAtLiveEdge ? "At live edge" : "Go to live edge"}
+          className={`inline-flex h-7 shrink-0 items-center gap-1.5 rounded-full border px-2.5 text-[10px] font-semibold uppercase tracking-[0.08em] transition-colors ${
+            isAtLiveEdge
+              ? "cursor-default border-[#F95F4A]/35 bg-[#F95F4A]/10 text-[#ff8a78]"
+              : "cursor-pointer border-white/10 text-[#e4e4e7] hover:border-[#F95F4A]/35 hover:bg-[#F95F4A]/10 hover:text-[#ff8a78] disabled:cursor-not-allowed disabled:opacity-45"
+          }`}
+        >
+          <span
+            className="h-1.5 w-1.5 rounded-full"
+            style={{ backgroundColor: "#F95F4A" }}
+          />
+          {isAtLiveEdge ? "Live" : "Go live"}
+        </button>
+      ) : (
+        <span className="w-9 shrink-0 text-[11px] tabular-nums text-[#71717a]">
+          {formatTime(max)}
+        </span>
+      )}
 
       <div className="group/vol flex shrink-0 items-center">
         <button

--- a/packages/apps-sdk/src/apps/watch/web/components/WatchWebApp.tsx
+++ b/packages/apps-sdk/src/apps/watch/web/components/WatchWebApp.tsx
@@ -21,7 +21,12 @@ import {
   useWatchRequests,
   type WatchRequest,
 } from "../hooks/useWatchRequests";
-import { fetchVideoTitle, thumbnailUrl } from "../youtubeMeta";
+import {
+  fetchVideoMetadata,
+  fetchVideoTitle,
+  thumbnailUrl,
+  type WatchVideoMetadata,
+} from "../youtubeMeta";
 import { GestureOverlay } from "./GestureOverlay";
 import { HostPill } from "./HostPill";
 import { WatchControls } from "./WatchControls";
@@ -59,7 +64,36 @@ export function WatchWebApp() {
 
   const { videoId, videoTitle, queue } = useWatchDocState(doc);
 
-  const player = useSyncedPlayback({ doc, videoId, readOnly: isReadOnly });
+  // YouTube reports a growing finite duration for active broadcasts, so the
+  // player cannot identify live content from duration alone. Keep metadata
+  // keyed to its video to ensure a slow response never labels the next item.
+  const [videoMetadata, setVideoMetadata] =
+    useState<WatchVideoMetadata | null>(null);
+  useEffect(() => {
+    if (!videoId) {
+      setVideoMetadata(null);
+      return;
+    }
+    let cancelled = false;
+    setVideoMetadata(null);
+    void fetchVideoMetadata(videoId).then((metadata) => {
+      if (!cancelled && metadata?.videoId === videoId) {
+        setVideoMetadata(metadata);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [videoId]);
+  const liveHint =
+    videoMetadata?.videoId === videoId ? videoMetadata.isLive : null;
+
+  const player = useSyncedPlayback({
+    doc,
+    videoId,
+    readOnly: isReadOnly,
+    liveHint,
+  });
 
   // Start a video: play immediately when idle, append to the queue otherwise.
   // Playback starts instantly with no title; the title backfills into the doc
@@ -220,6 +254,7 @@ export function WatchWebApp() {
   // compare-and-swap lets exactly one writer win across the room.
   const videoOver =
     hasVideo &&
+    !player.isLive &&
     !isPlaying &&
     player.duration > 0 &&
     player.currentTime >= player.duration - 1.5;
@@ -399,13 +434,7 @@ export function WatchWebApp() {
       return;
     }
     pokeControls();
-    if (isReadOnly) return;
-    if (isPlaying) {
-      player.pause();
-    } else {
-      player.play();
-    }
-  }, [browsing, isPlaying, isReadOnly, player, pokeControls]);
+  }, [browsing, pokeControls]);
 
   return (
     <div
@@ -468,15 +497,13 @@ export function WatchWebApp() {
                 }
               />
               {/* Click shield: the iframe never receives input, so the hidden
-                  native UI can never inject intent. Tapping toggles play/pause,
-                  or returns from browse when in mini form. */}
+                  native UI can never inject intent. A stage tap only reveals
+                  controls; shared play/pause requires the explicit button. */}
               <button
                 type="button"
-                aria-label={
-                  browsing ? "Back to video" : isPlaying ? "Pause" : "Play"
-                }
+                aria-label={browsing ? "Back to video" : "Show playback controls"}
                 onClick={handleShieldClick}
-                className="absolute inset-0 m-0 cursor-pointer border-0 p-0"
+                className="absolute inset-0 m-0 cursor-default border-0 p-0"
                 style={{ backgroundColor: "transparent" }}
               />
               {browsing ? (
@@ -518,7 +545,6 @@ export function WatchWebApp() {
             <GestureOverlay
               need={player.gestureNeed}
               onResolve={player.resolveGesture}
-              videoId={videoId}
               title={videoTitle}
             />
           ) : null}
@@ -618,6 +644,8 @@ export function WatchWebApp() {
                 playbackState={player.playbackState}
                 currentTime={player.currentTime}
                 duration={player.duration}
+                isLive={player.isLive}
+                isAtLiveEdge={player.isAtLiveEdge}
                 muted={player.muted}
                 volume={player.volume}
                 readOnly={isReadOnly}
@@ -642,6 +670,7 @@ export function WatchWebApp() {
                 onPlay={player.play}
                 onPause={player.pause}
                 onSeek={player.seek}
+                onGoLive={player.goLive}
                 onToggleMute={player.toggleMute}
                 onVolumeChange={player.setVolume}
               />

--- a/packages/apps-sdk/src/apps/watch/web/hooks/useSyncedPlayback.ts
+++ b/packages/apps-sdk/src/apps/watch/web/hooks/useSyncedPlayback.ts
@@ -29,11 +29,6 @@ const END_GUARD_SECONDS = 0.75;
 // blocked autoplay and a user gesture is required.
 const AUTOPLAY_PROBE_MS = 1200;
 
-// A fresh setVideo record starts at zero before metadata has told the room
-// whether this is a broadcast. Zero is only inferred as "latest" for that one
-// untouched record; any later seek to zero remains a real seek.
-const INITIAL_LIVE_POSITION_SECONDS = 0.5;
-
 export type GestureNeed = "none" | "sound" | "sync";
 
 /**
@@ -326,7 +321,6 @@ export function useSyncedPlayback({
   isLiveRef.current = isLive;
   const [isAtLiveEdge, setIsAtLiveEdge] = useState(false);
   const initializedLiveForRef = useRef<string | null>(null);
-  const inferredLiveEdgeRecordKeyRef = useRef<string | null>(null);
   const [captionsAvailable, setCaptionsAvailable] = useState(false);
   const [captionsOn, setCaptionsOn] = useState(false);
   const [captionTracks, setCaptionTracks] = useState<WatchCaptionTrack[]>([]);
@@ -629,9 +623,7 @@ export function useSyncedPlayback({
       }
 
       const followsLiveEdge =
-        isLiveRef.current &&
-        (target.liveEdge ||
-          inferredLiveEdgeRecordKeyRef.current === anchor.key);
+        isLiveRef.current && target.liveEdge;
       const edge = followsLiveEdge
         ? readElementLiveEdge(element, elementDuration)
         : null;
@@ -731,18 +723,13 @@ export function useSyncedPlayback({
 
     const target = recordRef.current;
     initializedLiveForRef.current = currentVideo;
-    // An untouched setVideo record is the one safe legacy signal that zero
-    // means "start this broadcast" rather than an intentional rewind.
-    const startsAtLiveEdge =
-      target.liveEdge ||
-      target.positionSeconds <= INITIAL_LIVE_POSITION_SECONDS;
-    if (!startsAtLiveEdge) {
+    // Fresh video records carry explicit live-edge intent. Every user playback
+    // action clears it, including an intentional seek to the first half-second.
+    if (!target.liveEdge) {
       correctDrift(target);
       return;
     }
 
-    const targetKey = playbackKey(target);
-    inferredLiveEdgeRecordKeyRef.current = targetKey;
     applyPlaybackRate(target.rate);
     setCurrentTime(snapshot.liveEdge);
     try {
@@ -751,15 +738,7 @@ export function useSyncedPlayback({
       /* player will retry through drift correction */
     }
 
-    if (!readOnlyRef.current && !target.liveEdge) {
-      writePlayback(doc, {
-        state: target.state,
-        positionSeconds: snapshot.liveEdge,
-        rate: target.rate,
-        liveEdge: true,
-      });
-    }
-  }, [applyPlaybackRate, correctDrift, doc, syncMediaSnapshot]);
+  }, [applyPlaybackRate, correctDrift, syncMediaSnapshot]);
 
   // A new video started: allow it to advance the queue when it ends, clear any
   // stale error from the previous one, and let the fresh element correct
@@ -771,7 +750,6 @@ export function useSyncedPlayback({
     anchorRef.current = null;
     lastCorrectionRef.current = null;
     initializedLiveForRef.current = null;
-    inferredLiveEdgeRecordKeyRef.current = null;
     detectedLiveRef.current = null;
     isLiveRef.current = false;
     setDetectedLive(null);
@@ -897,7 +875,6 @@ export function useSyncedPlayback({
 
   const play = useCallback(() => {
     if (readOnlyRef.current) return;
-    inferredLiveEdgeRecordKeyRef.current = null;
     writePlayback(doc, {
       state: "playing",
       positionSeconds: readElementTime(),
@@ -908,7 +885,6 @@ export function useSyncedPlayback({
 
   const pause = useCallback(() => {
     if (readOnlyRef.current) return;
-    inferredLiveEdgeRecordKeyRef.current = null;
     writePlayback(doc, {
       state: "paused",
       positionSeconds: readElementTime(),
@@ -921,7 +897,6 @@ export function useSyncedPlayback({
     (seconds: number) => {
       if (readOnlyRef.current) return;
       const target = Math.max(0, seconds);
-      inferredLiveEdgeRecordKeyRef.current = null;
       applyPlaybackRate(recordRef.current.rate);
       const element = elementRef.current;
       if (element) {
@@ -949,7 +924,6 @@ export function useSyncedPlayback({
     const element = elementRef.current;
     if (!snapshot?.live || snapshot.liveEdge === null || !element) return;
 
-    inferredLiveEdgeRecordKeyRef.current = null;
     applyPlaybackRate(recordRef.current.rate);
     setCurrentTime(snapshot.liveEdge);
     try {

--- a/packages/apps-sdk/src/apps/watch/web/hooks/useSyncedPlayback.ts
+++ b/packages/apps-sdk/src/apps/watch/web/hooks/useSyncedPlayback.ts
@@ -8,10 +8,12 @@ import {
   writePlayback,
 } from "../../core/doc/index";
 import type { PlaybackRecord, PlaybackState } from "../../core/model/types";
-
-// If the local player drifts more than this from the extrapolated doc position,
-// we seek. 1.5s absorbs buffering jitter while keeping everyone visibly in sync.
-const DRIFT_THRESHOLD_SECONDS = 1.5;
+import {
+  LIVE_EDGE_TOLERANCE_SECONDS,
+  liveEdgeLag,
+  liveEdgeTime,
+  planPlaybackCorrection,
+} from "../playbackSync";
 
 // While the doc record has not changed, never hard-seek more often than this.
 // A genuinely stuck player still converges (the anchored expected position is
@@ -26,6 +28,11 @@ const END_GUARD_SECONDS = 0.75;
 // How long after asking for playback we wait before deciding the browser
 // blocked autoplay and a user gesture is required.
 const AUTOPLAY_PROBE_MS = 1200;
+
+// A fresh setVideo record starts at zero before metadata has told the room
+// whether this is a broadcast. Zero is only inferred as "latest" for that one
+// untouched record; any later seek to zero remains a real seek.
+const INITIAL_LIVE_POSITION_SECONDS = 0.5;
 
 export type GestureNeed = "none" | "sound" | "sync";
 
@@ -44,6 +51,8 @@ export type WatchMediaElement = Pick<
   | "play"
   | "pause"
   | "seeking"
+  | "seekable"
+  | "playbackRate"
   | "textTracks"
 >;
 
@@ -80,6 +89,10 @@ export type SyncedPlaybackHandle = {
   currentTime: number;
   duration: number;
   playbackState: PlaybackState;
+  /** True only while the current YouTube broadcast is actively live. */
+  isLive: boolean;
+  /** True when the local player is close enough to the moving live edge. */
+  isAtLiveEdge: boolean;
   /** Whether this video has caption tracks at all. */
   captionsAvailable: boolean;
   /** Whether a caption track is currently showing (local only). */
@@ -95,6 +108,7 @@ export type SyncedPlaybackHandle = {
   play: () => void;
   pause: () => void;
   seek: (seconds: number) => void;
+  goLive: () => void;
   toggleMute: () => void;
   setVolume: (value: number) => void;
   toggleCaptions: () => void;
@@ -121,11 +135,82 @@ type CaptionsApi = {
   loadModule?: (module: string) => void;
 };
 
+type YoutubeVideoData = {
+  isLive?: unknown;
+  isLiveContent?: unknown;
+  liveBroadcastContent?: unknown;
+};
+
+type YoutubeMediaApi = CaptionsApi & {
+  getVideoData?: () => YoutubeVideoData;
+  playerInfo?: { videoData?: YoutubeVideoData };
+};
+
 const captionsApiOf = (
   element: WatchMediaElement | null,
 ): CaptionsApi | null => {
-  const api = (element as unknown as { api?: CaptionsApi } | null)?.api;
+  const api = (element as unknown as { api?: YoutubeMediaApi } | null)?.api;
   return api && typeof api === "object" ? api : null;
+};
+
+/**
+ * Feature-detected fallback for deployments without YouTube Data API metadata.
+ * The public iframe wrapper exposes video data on current players, but the
+ * server-provided hint remains authoritative because this surface is not part
+ * of the HTMLMediaElement contract.
+ */
+const readApiLiveStatus = (
+  element: WatchMediaElement | null,
+): boolean | null => {
+  const api = (element as unknown as { api?: YoutubeMediaApi } | null)?.api;
+  if (!api || typeof api !== "object") return null;
+  let direct: YoutubeVideoData | null = null;
+  try {
+    direct = api.getVideoData?.() ?? null;
+  } catch {
+    direct = null;
+  }
+  const candidates = [direct, api.playerInfo?.videoData].filter(
+    (value): value is YoutubeVideoData => Boolean(value),
+  );
+  let sawExplicitFalse = false;
+  for (const data of candidates) {
+    if (
+      data.isLive === true ||
+      data.isLiveContent === true ||
+      data.liveBroadcastContent === "live"
+    ) {
+      return true;
+    }
+    if (
+      data.isLive === false ||
+      data.isLiveContent === false ||
+      data.liveBroadcastContent === "none"
+    ) {
+      sawExplicitFalse = true;
+    }
+  }
+  return sawExplicitFalse ? false : null;
+};
+
+const playbackKey = (record: PlaybackRecord): string =>
+  `${record.state}|${record.positionSeconds}|${record.rate}|${record.updatedAt}|${record.liveEdge}`;
+
+const readElementLiveEdge = (
+  element: WatchMediaElement,
+  duration: number,
+): number | null => {
+  try {
+    const ranges = element.seekable;
+    if (ranges && ranges.length > 0) {
+      const end = ranges.end(ranges.length - 1);
+      const edge = liveEdgeTime(end);
+      if (edge !== null) return edge;
+    }
+  } catch {
+    /* YouTube's media shim may not expose seekable ranges. */
+  }
+  return liveEdgeTime(duration);
 };
 
 type ApiCaptionState = {
@@ -186,6 +271,8 @@ type UseSyncedPlaybackArgs = {
   videoId: string | null;
   /** When true, actions author nothing; the player still follows the doc. */
   readOnly: boolean;
+  /** Authoritative server metadata when available; null uses player fallback. */
+  liveHint?: boolean | null;
 };
 
 /**
@@ -200,12 +287,15 @@ export function useSyncedPlayback({
   doc,
   videoId,
   readOnly,
+  liveHint = null,
 }: UseSyncedPlaybackArgs): SyncedPlaybackHandle {
   const elementRef = useRef<WatchMediaElement | null>(null);
   const readOnlyRef = useRef(readOnly);
   readOnlyRef.current = readOnly;
   const videoIdRef = useRef<string | null>(videoId);
   videoIdRef.current = videoId;
+  const liveHintRef = useRef<boolean | null>(liveHint);
+  liveHintRef.current = liveHint;
   // The last video this client advanced away from, so a duplicate ENDED event
   // cannot make the same client advance the queue twice.
   const advancedFromRef = useRef<string | null>(null);
@@ -213,6 +303,9 @@ export function useSyncedPlayback({
   const [record, setRecord] = useState<PlaybackRecord>(() => getPlayback(doc));
   const recordRef = useRef(record);
   recordRef.current = record;
+  const [effectiveRate, setEffectiveRate] = useState(record.rate);
+  const effectiveRateRef = useRef(effectiveRate);
+  effectiveRateRef.current = effectiveRate;
 
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -225,6 +318,15 @@ export function useSyncedPlayback({
   const [volume, setVolumeState] = useState(100);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
+  const [detectedLive, setDetectedLive] = useState<boolean | null>(null);
+  const detectedLiveRef = useRef<boolean | null>(detectedLive);
+  detectedLiveRef.current = detectedLive;
+  const isLive = liveHint ?? detectedLive ?? false;
+  const isLiveRef = useRef(isLive);
+  isLiveRef.current = isLive;
+  const [isAtLiveEdge, setIsAtLiveEdge] = useState(false);
+  const initializedLiveForRef = useRef<string | null>(null);
+  const inferredLiveEdgeRecordKeyRef = useRef<string | null>(null);
   const [captionsAvailable, setCaptionsAvailable] = useState(false);
   const [captionsOn, setCaptionsOn] = useState(false);
   const [captionTracks, setCaptionTracks] = useState<WatchCaptionTrack[]>([]);
@@ -393,6 +495,70 @@ export function useSyncedPlayback({
   }, []);
   applyCaptionFontSizeRef.current = applyCaptionFontSize;
 
+  const applyPlaybackRate = useCallback((nextRate: number) => {
+    if (!Number.isFinite(nextRate) || nextRate <= 0) return;
+    if (Math.abs(effectiveRateRef.current - nextRate) < 0.01) return;
+    effectiveRateRef.current = nextRate;
+    setEffectiveRate(nextRate);
+    const element = elementRef.current;
+    if (!element) return;
+    try {
+      // Apply immediately as well as declaratively through ReactPlayer.
+      element.playbackRate = nextRate;
+    } catch {
+      /* player may still be loading */
+    }
+  }, []);
+
+  type MediaSnapshot = {
+    current: number;
+    duration: number;
+    live: boolean;
+    liveEdge: number | null;
+  };
+
+  const syncMediaSnapshot = useCallback((): MediaSnapshot | null => {
+    const element = elementRef.current;
+    if (!element) return null;
+    let nextCurrent = 0;
+    let nextDuration = 0;
+    try {
+      nextCurrent = Number.isFinite(element.currentTime)
+        ? element.currentTime
+        : 0;
+      nextDuration = Number.isFinite(element.duration) ? element.duration : 0;
+    } catch {
+      return null;
+    }
+
+    const apiLive = readApiLiveStatus(element);
+    if (liveHintRef.current === null && apiLive !== null) {
+      detectedLiveRef.current = apiLive;
+      setDetectedLive((previous) =>
+        previous === apiLive ? previous : apiLive,
+      );
+    }
+    const liveNow =
+      liveHintRef.current ?? apiLive ?? detectedLiveRef.current ?? false;
+    isLiveRef.current = liveNow;
+    const edge = liveNow
+      ? readElementLiveEdge(element, nextDuration)
+      : null;
+    setCurrentTime(nextCurrent);
+    setDuration(nextDuration);
+    setIsAtLiveEdge(
+      liveNow && edge !== null
+        ? edge - nextCurrent <= LIVE_EDGE_TOLERANCE_SECONDS
+        : false,
+    );
+    return {
+      current: nextCurrent,
+      duration: nextDuration,
+      live: liveNow,
+      liveEdge: edge,
+    };
+  }, []);
+
   /* ---- Drift correction, hardened against restart loops. ----
      The doc's `updatedAt` is the WRITER'S wall clock. Extrapolating from it on
      every check means a writer whose clock runs ahead freezes everyone else's
@@ -414,7 +580,7 @@ export function useSyncedPlayback({
   const lastCorrectionRef = useRef<{ key: string; at: number } | null>(null);
 
   const anchorFor = useCallback((target: PlaybackRecord): PlaybackAnchor => {
-    const key = `${target.state}|${target.positionSeconds}|${target.rate}|${target.updatedAt}`;
+    const key = playbackKey(target);
     const existing = anchorRef.current;
     if (existing && existing.key === key) return existing;
     const now = Date.now();
@@ -433,18 +599,22 @@ export function useSyncedPlayback({
     return anchor;
   }, []);
 
-  // Seek the local player toward the doc when it has drifted too far.
+  // Reconcile toward the room without turning small drift into visible
+  // buffering. Explicit timeline jumps and large gaps still seek immediately;
+  // ordinary jitter gets a short, local-only playback-rate nudge.
   const correctDrift = useCallback(
     (target: PlaybackRecord) => {
       const element = elementRef.current;
       if (!element) return;
-      const anchor = anchorFor(target);
+      const previousAnchor = anchorRef.current;
       const now = Date.now();
-      const expected =
-        anchor.state === "playing"
-          ? anchor.position + ((now - anchor.at) / 1000) * anchor.rate
-          : anchor.position;
-      if (!Number.isFinite(expected)) return;
+      const previousExpected = previousAnchor
+        ? previousAnchor.state === "playing"
+          ? previousAnchor.position +
+            ((now - previousAnchor.at) / 1000) * previousAnchor.rate
+          : previousAnchor.position
+        : null;
+      const anchor = anchorFor(target);
 
       let current = 0;
       let elementDuration = Number.NaN;
@@ -458,30 +628,67 @@ export function useSyncedPlayback({
         return;
       }
 
-      // Live streams have no shared timeline to converge on; play/pause still
-      // follows the doc, but position is the stream's business.
-      if (elementDuration === Number.POSITIVE_INFINITY) return;
+      const followsLiveEdge =
+        isLiveRef.current &&
+        (target.liveEdge ||
+          inferredLiveEdgeRecordKeyRef.current === anchor.key);
+      const edge = followsLiveEdge
+        ? readElementLiveEdge(element, elementDuration)
+        : null;
+      const expected =
+        edge ??
+        (anchor.state === "playing"
+          ? anchor.position + ((now - anchor.at) / 1000) * anchor.rate
+          : anchor.position);
+      if (!Number.isFinite(expected)) return;
 
       let seekTarget = Math.max(0, expected);
-      if (Number.isFinite(elementDuration) && elementDuration > END_GUARD_SECONDS * 2) {
+      if (
+        !followsLiveEdge &&
+        Number.isFinite(elementDuration) &&
+        elementDuration > END_GUARD_SECONDS * 2
+      ) {
         seekTarget = Math.min(seekTarget, elementDuration - END_GUARD_SECONDS);
       }
-      if (Math.abs(current - seekTarget) <= DRIFT_THRESHOLD_SECONDS) return;
+      const recordChanged =
+        previousAnchor !== null && previousAnchor.key !== anchor.key;
+      const forceSeek =
+        recordChanged &&
+        (target.liveEdge ||
+          (previousExpected !== null &&
+            Math.abs(seekTarget - previousExpected) > 1.5));
+      const correction = planPlaybackCorrection({
+        current,
+        target: seekTarget,
+        state: anchor.state,
+        baseRate: anchor.rate,
+        forceSeek,
+      });
 
-      // Fresh intent (a new record) seeks immediately; repeat corrections for
-      // the SAME record are rate-limited so no failure mode can seek-loop.
+      if (correction.kind !== "seek") {
+        applyPlaybackRate(correction.rate);
+        return;
+      }
+      applyPlaybackRate(correction.rate);
+
+      // Repeat hard corrections for the SAME record are rate-limited so a
+      // pathological source cannot get stuck in a seek/buffer loop.
       const last = lastCorrectionRef.current;
-      if (last && last.key === anchor.key && now - last.at < CORRECTION_COOLDOWN_MS) {
+      if (
+        last &&
+        last.key === anchor.key &&
+        now - last.at < CORRECTION_COOLDOWN_MS
+      ) {
         return;
       }
       lastCorrectionRef.current = { key: anchor.key, at: now };
       try {
-        element.currentTime = seekTarget;
+        element.currentTime = correction.target;
       } catch {
         /* element not ready to seek yet */
       }
     },
-    [anchorFor],
+    [anchorFor, applyPlaybackRate],
   );
 
   // Follow the doc: mirror the record into state (which drives the `playing`
@@ -489,6 +696,8 @@ export function useSyncedPlayback({
   useEffect(() => {
     const sync = () => {
       const next = getPlayback(doc);
+      if (playbackKey(next) === playbackKey(recordRef.current)) return;
+      recordRef.current = next;
       setRecord(next);
       correctDrift(next);
     };
@@ -505,30 +714,79 @@ export function useSyncedPlayback({
   // runs even if the ready event was missed; every step is element-guarded.
   useEffect(() => {
     const interval = setInterval(() => {
-      const element = elementRef.current;
-      if (!element) return;
-      try {
-        setCurrentTime(element.currentTime ?? 0);
-      } catch {
-        /* ignore */
-      }
+      if (!syncMediaSnapshot()) return;
       correctDrift(recordRef.current);
       syncCaptionState();
     }, 1000);
     return () => clearInterval(interval);
-  }, [correctDrift, syncCaptionState]);
+  }, [correctDrift, syncCaptionState, syncMediaSnapshot]);
+
+  const initializeLivePlayback = useCallback(() => {
+    const currentVideo = videoIdRef.current;
+    if (!currentVideo || !isLiveRef.current) return;
+    const snapshot = syncMediaSnapshot();
+    const element = elementRef.current;
+    if (!snapshot?.live || snapshot.liveEdge === null || !element) return;
+    if (initializedLiveForRef.current === currentVideo) return;
+
+    const target = recordRef.current;
+    initializedLiveForRef.current = currentVideo;
+    // An untouched setVideo record is the one safe legacy signal that zero
+    // means "start this broadcast" rather than an intentional rewind.
+    const startsAtLiveEdge =
+      target.liveEdge ||
+      target.positionSeconds <= INITIAL_LIVE_POSITION_SECONDS;
+    if (!startsAtLiveEdge) {
+      correctDrift(target);
+      return;
+    }
+
+    const targetKey = playbackKey(target);
+    inferredLiveEdgeRecordKeyRef.current = targetKey;
+    applyPlaybackRate(target.rate);
+    setCurrentTime(snapshot.liveEdge);
+    try {
+      element.currentTime = snapshot.liveEdge;
+    } catch {
+      /* player will retry through drift correction */
+    }
+
+    if (!readOnlyRef.current && !target.liveEdge) {
+      writePlayback(doc, {
+        state: target.state,
+        positionSeconds: snapshot.liveEdge,
+        rate: target.rate,
+        liveEdge: true,
+      });
+    }
+  }, [applyPlaybackRate, correctDrift, doc, syncMediaSnapshot]);
 
   // A new video started: allow it to advance the queue when it ends, clear any
   // stale error from the previous one, and let the fresh element correct
   // immediately instead of inheriting the previous video's seek cooldown.
   useEffect(() => {
-    if (!videoId) return;
-    if (advancedFromRef.current !== videoId) {
+    if (videoId && advancedFromRef.current !== videoId) {
       advancedFromRef.current = null;
     }
+    anchorRef.current = null;
     lastCorrectionRef.current = null;
+    initializedLiveForRef.current = null;
+    inferredLiveEdgeRecordKeyRef.current = null;
+    detectedLiveRef.current = null;
+    isLiveRef.current = false;
+    setDetectedLive(null);
+    setIsAtLiveEdge(false);
+    setCurrentTime(0);
+    setDuration(0);
+    setReady(false);
+    setGestureNeed("none");
     setError(null);
   }, [videoId]);
+
+  useEffect(() => {
+    if (!ready || !isLive) return;
+    initializeLivePlayback();
+  }, [initializeLivePlayback, isLive, ready, videoId]);
 
   // Probe for blocked autoplay: if the room wants playback but the element is
   // still paused shortly after, a gesture is needed to start at all ("sync").
@@ -553,13 +811,20 @@ export function useSyncedPlayback({
   const onReady = useCallback(() => {
     setReady(true);
     setError(null);
+    syncMediaSnapshot();
     correctDrift(recordRef.current);
-  }, [correctDrift]);
+  }, [correctDrift, syncMediaSnapshot]);
 
   const onTimeUpdate = useCallback(
     (event: MediaEvent) => {
       const element = event.currentTarget;
       setCurrentTime(element.currentTime ?? 0);
+      if (isLiveRef.current) {
+        const lag = liveEdgeLag(element.currentTime, element.duration);
+        setIsAtLiveEdge(
+          lag !== null && lag <= LIVE_EDGE_TOLERANCE_SECONDS,
+        );
+      }
       if (recordRef.current.state === "playing") {
         correctDrift(recordRef.current);
       }
@@ -567,18 +832,19 @@ export function useSyncedPlayback({
     [correctDrift],
   );
 
-  const onDurationChange = useCallback((event: MediaEvent) => {
-    const value = event.currentTarget.duration;
-    setDuration(typeof value === "number" && Number.isFinite(value) ? value : 0);
-  }, []);
+  const onDurationChange = useCallback(() => {
+    syncMediaSnapshot();
+  }, [syncMediaSnapshot]);
 
   const onPlaying = useCallback(() => {
+    syncMediaSnapshot();
+    initializeLivePlayback();
     // Playback genuinely running: downgrade or clear the gesture prompt.
     setGestureNeed((prev) => {
       if (prev === "none") return prev;
       return mutedRef.current ? "sound" : "none";
     });
-  }, []);
+  }, [initializeLivePlayback, syncMediaSnapshot]);
 
   const onEnded = useCallback(() => {
     const ended = videoIdRef.current;
@@ -599,7 +865,12 @@ export function useSyncedPlayback({
     } catch {
       position = 0;
     }
-    writePlayback(doc, { state: "paused", positionSeconds: position, rate: 1 });
+    writePlayback(doc, {
+      state: "paused",
+      positionSeconds: position,
+      rate: 1,
+      liveEdge: false,
+    });
   }, [doc]);
 
   const onError = useCallback((event: MediaEvent) => {
@@ -626,19 +897,23 @@ export function useSyncedPlayback({
 
   const play = useCallback(() => {
     if (readOnlyRef.current) return;
+    inferredLiveEdgeRecordKeyRef.current = null;
     writePlayback(doc, {
       state: "playing",
       positionSeconds: readElementTime(),
       rate: recordRef.current.rate,
+      liveEdge: false,
     });
   }, [doc, readElementTime]);
 
   const pause = useCallback(() => {
     if (readOnlyRef.current) return;
+    inferredLiveEdgeRecordKeyRef.current = null;
     writePlayback(doc, {
       state: "paused",
       positionSeconds: readElementTime(),
       rate: recordRef.current.rate,
+      liveEdge: false,
     });
   }, [doc, readElementTime]);
 
@@ -646,6 +921,8 @@ export function useSyncedPlayback({
     (seconds: number) => {
       if (readOnlyRef.current) return;
       const target = Math.max(0, seconds);
+      inferredLiveEdgeRecordKeyRef.current = null;
+      applyPlaybackRate(recordRef.current.rate);
       const element = elementRef.current;
       if (element) {
         try {
@@ -655,14 +932,38 @@ export function useSyncedPlayback({
         }
       }
       setCurrentTime(target);
+      setIsAtLiveEdge(false);
       writePlayback(doc, {
         state: recordRef.current.state,
         positionSeconds: target,
         rate: recordRef.current.rate,
+        liveEdge: false,
       });
     },
-    [doc],
+    [applyPlaybackRate, doc],
   );
+
+  const goLive = useCallback(() => {
+    if (readOnlyRef.current || !isLiveRef.current) return;
+    const snapshot = syncMediaSnapshot();
+    const element = elementRef.current;
+    if (!snapshot?.live || snapshot.liveEdge === null || !element) return;
+
+    inferredLiveEdgeRecordKeyRef.current = null;
+    applyPlaybackRate(recordRef.current.rate);
+    setCurrentTime(snapshot.liveEdge);
+    try {
+      element.currentTime = snapshot.liveEdge;
+    } catch {
+      /* the new shared record will retry */
+    }
+    writePlayback(doc, {
+      state: "playing",
+      positionSeconds: snapshot.liveEdge,
+      rate: recordRef.current.rate,
+      liveEdge: true,
+    });
+  }, [applyPlaybackRate, doc, syncMediaSnapshot]);
 
   /* ---- Local mute / volume (never synced). ---- */
 
@@ -804,7 +1105,7 @@ export function useSyncedPlayback({
     playing: Boolean(videoId) && record.state === "playing",
     mutedProp: muted,
     volumeProp: volume / 100,
-    rate: record.rate,
+    rate: effectiveRate,
     onReady,
     onTimeUpdate,
     onDurationChange,
@@ -819,6 +1120,8 @@ export function useSyncedPlayback({
     currentTime,
     duration,
     playbackState: record.state,
+    isLive,
+    isAtLiveEdge,
     captionsAvailable,
     captionsOn,
     captionTracks,
@@ -827,6 +1130,7 @@ export function useSyncedPlayback({
     play,
     pause,
     seek,
+    goLive,
     toggleMute,
     setVolume,
     toggleCaptions,

--- a/packages/apps-sdk/src/apps/watch/web/playbackSync.ts
+++ b/packages/apps-sdk/src/apps/watch/web/playbackSync.ts
@@ -1,0 +1,63 @@
+import type { PlaybackState } from "../core/model/types";
+
+export const LIVE_EDGE_HEADROOM_SECONDS = 1.25;
+export const LIVE_EDGE_TOLERANCE_SECONDS = 4;
+
+const SETTLED_DRIFT_SECONDS = 0.45;
+const HARD_SEEK_DRIFT_SECONDS = 5;
+
+export type PlaybackCorrection =
+  | { kind: "settled"; rate: number }
+  | { kind: "rate"; rate: number }
+  | { kind: "seek"; rate: number; target: number };
+
+/**
+ * Keep small network/buffering drift invisible. Playing clients gently catch
+ * up (or ease back) and only seek when the gap is large or the room made an
+ * explicit timeline jump. Paused media can seek without causing a playback
+ * hiccup, so it converges directly.
+ */
+export const planPlaybackCorrection = (input: {
+  current: number;
+  target: number;
+  state: PlaybackState;
+  baseRate: number;
+  forceSeek?: boolean;
+}): PlaybackCorrection => {
+  const drift = input.target - input.current;
+  const absoluteDrift = Math.abs(drift);
+  if (absoluteDrift <= SETTLED_DRIFT_SECONDS) {
+    return { kind: "settled", rate: input.baseRate };
+  }
+  if (
+    input.forceSeek === true ||
+    input.state === "paused" ||
+    absoluteDrift >= HARD_SEEK_DRIFT_SECONDS
+  ) {
+    return { kind: "seek", rate: input.baseRate, target: input.target };
+  }
+
+  // YouTube exposes discrete rates; 0.75 and 1.25 are the nearest subtle,
+  // broadly-supported steps around normal playback.
+  return {
+    kind: "rate",
+    rate:
+      drift > 0
+        ? Math.min(2, input.baseRate * 1.25)
+        : Math.max(0.25, input.baseRate * 0.75),
+  };
+};
+
+export const liveEdgeTime = (duration: number): number | null => {
+  if (!Number.isFinite(duration) || duration <= 0) return null;
+  return Math.max(0, duration - LIVE_EDGE_HEADROOM_SECONDS);
+};
+
+export const liveEdgeLag = (
+  currentTime: number,
+  duration: number,
+): number | null => {
+  const edge = liveEdgeTime(duration);
+  if (edge === null || !Number.isFinite(currentTime)) return null;
+  return Math.max(0, edge - currentTime);
+};

--- a/packages/apps-sdk/src/apps/watch/web/youtubeMeta.ts
+++ b/packages/apps-sdk/src/apps/watch/web/youtubeMeta.ts
@@ -4,6 +4,7 @@
 // the UI falls back to the video id.
 
 const TITLE_FETCH_TIMEOUT_MS = 2_500;
+const METADATA_FETCH_TIMEOUT_MS = 3_000;
 
 /** Medium-quality 16:9 thumbnail for a video id. */
 export const thumbnailUrl = (videoId: string): string =>
@@ -17,6 +18,12 @@ export type WatchSearchResult = {
   durationSeconds: number | null;
   views: number | null;
   publishedAt: string | null;
+};
+
+export type WatchVideoMetadata = {
+  videoId: string;
+  title: string;
+  isLive: boolean;
 };
 
 /** 3661 -> "1:01:01", 754 -> "12:34". Null in, null out. */
@@ -136,6 +143,41 @@ export const fetchTrending = async (
     };
   } catch {
     return empty;
+  }
+};
+
+/**
+ * Resolve live status through the host's YouTube Data API proxy. Null means
+ * the proxy is unavailable; the player hook retains a feature-detected iframe
+ * fallback so playback still works without a configured API key.
+ */
+export const fetchVideoMetadata = async (
+  videoId: string,
+): Promise<WatchVideoMetadata | null> => {
+  if (typeof fetch !== "function" || !/^[A-Za-z0-9_-]{11}$/.test(videoId)) {
+    return null;
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), METADATA_FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(
+      `/api/youtube/video?id=${encodeURIComponent(videoId)}`,
+      { signal: controller.signal },
+    );
+    if (!response.ok) return null;
+    const payload = (await response.json()) as Partial<WatchVideoMetadata>;
+    if (
+      payload.videoId !== videoId ||
+      typeof payload.title !== "string" ||
+      typeof payload.isLive !== "boolean"
+    ) {
+      return null;
+    }
+    return payload as WatchVideoMetadata;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
   }
 };
 


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds live-aware YouTube watch playback. The main changes are:

- A YouTube video metadata API route with its own rate-limit binding.
- Live metadata fetching in the watch web app.
- Explicit `liveEdge` playback state in the shared watch document.
- Live-edge controls and drift correction for synced playback.
- Tests for live-edge intent and playback correction helpers.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I started the watch-live UI Next.js dev server and observed the attempted route load stall at compiling, indicating the route was blocked during development.
- I captured two Playwright screenshots showing the watch meeting route in a blocked/loading state before any UI interaction.
- I ran the watch-playback tests via vitest, and the log shows the command exited with code 0 and 3 tests passing.
- I reviewed the logs and artifacts to validate the loading blocker and the test outcomes.

<a href="https://app.greptile.com/trex/runs/13975175/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/youtube/video/route.ts | Adds the server-side YouTube metadata lookup used to identify live videos. |
| apps/web/src/app/api/youtube/rate-limit.ts | Adds the metadata limiter binding type used by the new video metadata route. |
| apps/web/wrangler.jsonc | Adds a dedicated Cloudflare rate-limit binding for YouTube metadata requests. |
| packages/apps-sdk/src/apps/watch/core/doc/index.ts | Stores explicit live-edge intent in the shared playback record. |
| packages/apps-sdk/src/apps/watch/web/hooks/useSyncedPlayback.ts | Adds live detection, live-edge initialization, local drift correction, and Go Live handling. |
| packages/apps-sdk/src/apps/watch/web/playbackSync.ts | Adds shared helpers for live-edge timing and playback correction planning. |

<sub>Reviews (2): Last reviewed commit: ["fix"](https://github.com/acm-vit/conclave/commit/68def443814f5fc36778eb575b53a51842094719) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43281015)</sub>

<!-- /greptile_comment -->