### PR TITLE
Staging

### DIFF
--- a/apps/web/src/app/components/ChatPanel.tsx
+++ b/apps/web/src/app/components/ChatPanel.tsx
@@ -22,6 +22,7 @@ import {
   CHAT_IMAGE_TYPE_MESSAGE,
   MAX_CHAT_IMAGE_BYTES,
   chatImageCaption,
+  findClipboardImageFile,
   formatChatImageSize,
   isSupportedChatImageType,
 } from "../lib/chat-images";
@@ -153,7 +154,7 @@ function ChatPanel({
   const isImagePickerDisabled =
     isChatDisabled || !areImageAttachmentsEnabled || isImageUploading;
   const imagePickerLabel = areImageAttachmentsEnabled
-    ? "Attach image"
+    ? "Attach or paste image"
     : "Image attachments disabled by host";
   const selectedAssistantModel =
     CONCLAVE_ASSISTANT_BYOK_MODELS.find(
@@ -364,29 +365,53 @@ function ChatPanel({
     pendingImage,
   ]);
 
+  const stageImage = useCallback(
+    (file: File): boolean => {
+      setImageUploadError(null);
+      if (!areImageAttachmentsEnabled) {
+        setImageUploadError("Image attachments are disabled by the host.");
+        return false;
+      }
+      if (isImageUploading) {
+        setImageUploadError("Wait for the current image to finish uploading.");
+        return false;
+      }
+      if (!isSupportedChatImageType(file.type)) {
+        setImageUploadError(CHAT_IMAGE_TYPE_MESSAGE);
+        return false;
+      }
+      if (file.size <= 0 || file.size > MAX_CHAT_IMAGE_BYTES) {
+        setImageUploadError(CHAT_IMAGE_SIZE_MESSAGE);
+        return false;
+      }
+      if (pendingImageUrlRef.current) {
+        URL.revokeObjectURL(pendingImageUrlRef.current);
+      }
+      const previewUrl = URL.createObjectURL(file);
+      pendingImageUrlRef.current = previewUrl;
+      setPendingImage({ file, previewUrl });
+      setImageUploadProgress(0);
+      textareaRef.current?.focus();
+      return true;
+    },
+    [areImageAttachmentsEnabled, isImageUploading],
+  );
+
   const handleImageSelected = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
-    setImageUploadError(null);
-    if (!isSupportedChatImageType(file.type)) {
-      setImageUploadError(CHAT_IMAGE_TYPE_MESSAGE);
-      event.target.value = "";
-      return;
-    }
-    if (file.size > MAX_CHAT_IMAGE_BYTES) {
-      setImageUploadError(CHAT_IMAGE_SIZE_MESSAGE);
-      event.target.value = "";
-      return;
-    }
-    if (pendingImageUrlRef.current) {
-      URL.revokeObjectURL(pendingImageUrlRef.current);
-    }
-    const previewUrl = URL.createObjectURL(file);
-    pendingImageUrlRef.current = previewUrl;
-    setPendingImage({ file, previewUrl });
-    setImageUploadProgress(0);
-    textareaRef.current?.focus();
+    if (!stageImage(file)) event.target.value = "";
   };
+
+  const handlePaste = useCallback(
+    (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const file = findClipboardImageFile(event.clipboardData);
+      if (!file) return;
+      event.preventDefault();
+      stageImage(file);
+    },
+    [stageImage],
+  );
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -621,8 +646,8 @@ function ChatPanel({
                       No messages yet
                     </p>
                     <p className="text-[12.5px] leading-relaxed text-[#a1a1aa]">
-                      Be the first to say something. Drop a GIF, share a link, or
-                      just say hi.
+                      Be the first to say something. Paste an image, drop a GIF,
+                      share a link, or just say hi.
                     </p>
                   </div>
                   {assistantEnabled && !isChatDisabled ? (
@@ -1229,6 +1254,7 @@ function ChatPanel({
               value={chatInput}
               onChange={(e) => onInputChange(e.target.value)}
               onKeyDown={handleKeyDown}
+              onPaste={handlePaste}
               placeholder={
                 isChatLocked && !isAdmin
                     ? "Chat locked by host"

--- a/apps/web/src/app/components/ControlsBar.tsx
+++ b/apps/web/src/app/components/ControlsBar.tsx
@@ -147,7 +147,7 @@ function DockStatusDot({ dot }: { dot: DockDot }) {
   );
 }
 
-function DockItem({ entry, tabIndex }: { entry: DockEntry; tabIndex?: number }) {
+function DockItem({ entry }: { entry: DockEntry }) {
   const { d, dot } = entry;
   const Icon = d.icon;
   const active = d.variant === "active";
@@ -162,7 +162,6 @@ function DockItem({ entry, tabIndex }: { entry: DockEntry; tabIndex?: number }) 
         onClick={d.onPress}
         aria-label={d.label}
         title={d.label}
-        tabIndex={tabIndex}
         className={
           "relative inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full " +
           "transition-[background-color,color] duration-[120ms] " +
@@ -194,34 +193,67 @@ function DockDivider() {
   );
 }
 
+/** A labeled row inside the activities flyout: icon, name, and the same
+ * status-dot language as the dock (dot = live in the room). */
+function DockFlyoutRow({
+  entry,
+  onActivate,
+}: {
+  entry: DockEntry;
+  onActivate: () => void;
+}) {
+  const { d, dot } = entry;
+  const Icon = d.icon;
+  const active = d.variant === "active";
+  return (
+    <button
+      type="button"
+      aria-label={d.label}
+      onClick={onActivate}
+      className="flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left text-[14px] font-medium transition-[background-color] duration-[120ms] hover:bg-white/[0.06]"
+      style={{ color: active ? color.accent : color.text }}
+    >
+      <Icon size={MENU_ICON} strokeWidth={STROKE} className="shrink-0" />
+      <span className="flex-1">{d.label}</span>
+      {dot ? (
+        <span
+          aria-hidden
+          className={
+            "h-2 w-2 shrink-0 rounded-full " + (dot.pulse ? "animate-pulse" : "")
+          }
+          style={{ backgroundColor: dot.color }}
+        />
+      ) : null}
+    </button>
+  );
+}
+
 /**
  * The right-rail dock. Panel toggles are grouped by intent instead of lined up
  * as six equal icons: the people panels (participants, chat) stay put, the
- * activity panels (games, apps, transcript) fold into a single slot that fans
- * open on hover or tap, and the host shield anchors its own segment. When
- * something is live in the room — game running, app open, transcript recording
- * — the folded slot morphs into that activity's icon with a status dot, so one
- * click returns to it without any "LIVE" chrome.
+ * activity panels (games, apps, transcript) share a single slot, and the host
+ * shield anchors its own segment. The slot opens a small flyout above the bar
+ * (hover, tap, or keyboard), so the pill never changes width and the bar never
+ * shifts. When something is live in the room — game running, app open,
+ * transcript recording — the slot wears that activity's icon with a status
+ * dot, so one click returns to it without any "LIVE" chrome.
  */
 function ActivityDock({
   core,
   activities,
   promoted,
   host,
-  forceOpen = false,
 }: {
   core: DockEntry[];
   activities: DockEntry[];
-  /** The activity owning the folded slot's face right now (live beats open). */
+  /** The activity owning the shared slot's face right now (live beats open). */
   promoted?: DockEntry | null;
   host?: DockEntry | null;
-  forceOpen?: boolean;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [open, setOpen] = useState(false);
   const segmentRef = useRef<HTMLDivElement>(null);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const trayId = useId();
-  const open = expanded || forceOpen;
   const collapsible = activities.length > 1;
 
   const cancelClose = useCallback(() => {
@@ -232,10 +264,10 @@ function ActivityDock({
   }, []);
   useEffect(() => cancelClose, [cancelClose]);
 
-  // A short grace period keeps the tray from snapping shut when the pointer
-  // clips the segment edge on its way to an icon. Only *keyboard* focus pins
-  // the tray open — a mouse click also focuses the button it hit, and honoring
-  // that would leave the tray stuck open after every click.
+  // A short grace period keeps the flyout from snapping shut when the pointer
+  // crosses the gap between the face and the flyout. Only *keyboard* focus
+  // pins it open — a mouse click also focuses the button it hit, and honoring
+  // that would leave the flyout stuck open after every click.
   const scheduleClose = () => {
     cancelClose();
     closeTimer.current = setTimeout(() => {
@@ -249,19 +281,23 @@ function ActivityDock({
       ) {
         return;
       }
-      setExpanded(false);
+      setOpen(false);
     }, 160);
   };
 
-  const openTray = () => {
+  const openFlyout = () => {
     cancelClose();
-    setExpanded(true);
+    setOpen(true);
   };
 
-  // Touch/keyboard path: hover never fired, so the face itself unfolds the
-  // tray and hands focus to the first activity.
-  const openTrayFromFace = () => {
-    openTray();
+  // Tap/keyboard path: hover never fired, so the face itself toggles the
+  // flyout and hands focus to the first activity row.
+  const toggleFromFace = () => {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    openFlyout();
     requestAnimationFrame(() => {
       segmentRef.current
         ?.querySelector<HTMLButtonElement>("[data-tray] button")
@@ -285,63 +321,67 @@ function ActivityDock({
           {collapsible ? (
             <div
               ref={segmentRef}
-              className="flex items-center"
-              onMouseEnter={openTray}
+              className="relative flex items-center"
+              onMouseEnter={openFlyout}
               onMouseLeave={scheduleClose}
               onBlurCapture={(event) => {
                 if (!event.currentTarget.contains(event.relatedTarget)) {
-                  setExpanded(false);
+                  setOpen(false);
+                }
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Escape" && open) {
+                  event.stopPropagation();
+                  setOpen(false);
+                  segmentRef.current?.querySelector("button")?.focus();
                 }
               }}
             >
-              <div
-                aria-hidden={open}
-                className="overflow-hidden transition-[width,opacity] duration-[120ms] ease-out"
-                style={{
-                  width: open ? 0 : 40,
-                  opacity: open ? 0 : 1,
-                  pointerEvents: open ? "none" : "auto",
-                }}
+              <button
+                type="button"
+                aria-label={faceLabel}
+                title={faceLabel}
+                aria-expanded={open}
+                aria-controls={trayId}
+                onClick={toggleFromFace}
+                className="relative inline-flex h-10 w-10 items-center justify-center rounded-full transition-[background-color,color] duration-[120ms] hover:bg-white/[0.08] hover:!text-[#fafafa]"
+                style={{ color: faceActive ? color.accent : color.textMuted }}
               >
-                <button
-                  type="button"
-                  aria-label={faceLabel}
-                  title={faceLabel}
-                  aria-expanded={open}
-                  aria-controls={trayId}
-                  tabIndex={open ? -1 : 0}
-                  onClick={openTrayFromFace}
-                  className="relative inline-flex h-10 w-10 items-center justify-center rounded-full transition-[background-color,color] duration-[120ms] hover:bg-white/[0.08] hover:!text-[#fafafa]"
-                  style={{ color: faceActive ? color.accent : color.textMuted }}
+                {/* Keyed so a promotion change pops the new face in. */}
+                <span
+                  key={face?.d.id ?? "activities"}
+                  className="inline-flex animate-[acm-pop-in_150ms_cubic-bezier(0.22,1,0.36,1)_both]"
                 >
-                  {/* Keyed so a promotion change pops the new face in. */}
-                  <span
-                    key={face?.d.id ?? "activities"}
-                    className="inline-flex animate-[acm-pop-in_150ms_cubic-bezier(0.22,1,0.36,1)_both]"
-                  >
-                    <FaceIcon size={ICON} strokeWidth={STROKE} />
-                  </span>
-                  {face?.dot ? <DockStatusDot dot={face.dot} /> : null}
-                </button>
-              </div>
-              <div id={trayId} data-tray className="flex items-center">
-                {activities.map((entry, index) => (
+                  <FaceIcon size={ICON} strokeWidth={STROKE} />
+                </span>
+                {face?.dot ? <DockStatusDot dot={face.dot} /> : null}
+              </button>
+              {open && (
+                // pb-2 bridges the gap so hover stays continuous between the
+                // face and the flyout (same trick as the leave button's menu).
+                <div className="absolute bottom-full right-0 z-50 pb-2">
                   <div
-                    key={entry.d.id}
-                    aria-hidden={!open}
-                    className="overflow-hidden transition-[width,opacity] duration-[120ms] ease-out"
+                    id={trayId}
+                    data-tray
+                    className={popoverPanelClass + " w-44"}
                     style={{
-                      width: open ? 40 : 0,
-                      opacity: open ? 1 : 0,
-                      pointerEvents: open ? "auto" : "none",
-                      // Ripple outward on open only; fold back as one.
-                      transitionDelay: open ? `${index * 30}ms` : "0ms",
+                      backgroundColor: color.surfaceRaised,
+                      borderColor: color.border,
                     }}
                   >
-                    <DockItem entry={entry} tabIndex={open ? 0 : -1} />
+                    {activities.map((entry) => (
+                      <DockFlyoutRow
+                        key={entry.d.id}
+                        entry={entry}
+                        onActivate={() => {
+                          setOpen(false);
+                          entry.d.onPress?.();
+                        }}
+                      />
+                    ))}
                   </div>
-                ))}
-              </div>
+                </div>
+              )}
             </div>
           ) : (
             activities.map((entry) => (
@@ -379,7 +419,7 @@ function WatchTogetherTip({
         description={"You can now watch YouTube together on Conclave."}
         width="w-[16.5rem]"
         className="!left-auto right-0 !translate-x-0"
-        arrowLeft="calc(100% - 7.5rem)"
+        arrowLeft="calc(100% - 5rem)"
         onDismiss={onDismiss}
         visual={
           /* A living watch party: the room's real avatars orbit the
@@ -741,12 +781,6 @@ function ControlsBar(props: ControlsBarProps) {
     (watchTip.visible ||
       (gamesTip.visible && !props.isGamesOpen && !props.hasActiveGame) ||
       (gifsTip.visible && !props.isChatOpen));
-  // Tips that point at a folded activity hold the tray open so their target
-  // is actually visible.
-  const dockTrayForced =
-    panelCoachmarkVisible &&
-    (watchTip.visible ||
-      (gamesTip.visible && !props.isGamesOpen && !props.hasActiveGame));
 
   // Side-panel toggles regroup into the activity dock: people panels stay
   // always-visible, activity panels fold into one adaptive slot, and the host
@@ -839,9 +873,9 @@ function ControlsBar(props: ControlsBarProps) {
 
   return (
     <div className="relative flex w-full items-center gap-2 px-4 py-3 sm:grid sm:grid-cols-[1fr_auto_1fr]">
-      {/* Equal side columns keep center controls from overlapping side content
-          at sm+; below that the tag is dropped and the center group grows to
-          fill the row (flex-1) so the bar can't overlap itself. */}
+      {/* Equal side columns keep the center controls truly centered; the dock
+          never grows sideways (activities open as a flyout above it), so the
+          columns cannot collide and the bar never shifts. */}
       <div className="flex min-w-0 shrink-0 items-center justify-self-start">
         {!compact && <MeetingInfoTag roomId={roomId} />}
       </div>
@@ -1183,7 +1217,7 @@ function ControlsBar(props: ControlsBarProps) {
         />
       </div>
 
-      <div className="flex min-w-0 shrink-0 items-center justify-self-end gap-0.5">
+      <div className="flex min-w-0 shrink-0 items-center justify-self-end">
         {dockVisible && (
           <div className="relative flex pr-[max(0.5rem,env(safe-area-inset-right))]">
             <ActivityDock
@@ -1191,7 +1225,6 @@ function ControlsBar(props: ControlsBarProps) {
               activities={dockActivities}
               promoted={promotedEntry}
               host={hostEntry}
-              forceOpen={dockTrayForced}
             />
             {panelCoachmarkVisible && watchTip.visible ? (
               <WatchTogetherTip

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -1513,11 +1513,14 @@ export default function MeetsMainContent({
     ? { paddingRight: `calc(1rem + ${dockedPanelReserve}px)` }
     : undefined;
   // When docked panels eat into the stage, the full controls bar (clock +
-  // center + side cluster) gets cramped. Fold it to its compact layout once the
-  // remaining width is tight so it stays comfortable instead of squeezing.
+  // center + side cluster) gets cramped. Degrade in two steps: first demote
+  // the least-used center controls (hand, screen share) into More so the bar
+  // keeps air, then fold to the compact layout once the stage is truly tight.
   const stageWidth = viewportWidth - dockedPanelReserve;
   const isControlsBarTight = !isMobile && isJoined && stageWidth < 900;
   const useCompactControls = isMobile || isControlsBarTight;
+  const useSlimControls =
+    !useCompactControls && isJoined && !isMobile && stageWidth < 1080;
   const isRecoveringMeeting = isJoined && connectionState !== "joined";
   const isTerminalMeetingError =
     Boolean(meetError) && meetError?.recoverable === false;
@@ -1609,6 +1612,7 @@ export default function MeetsMainContent({
   // search and run.
   const controlsBarProps: ControlsBarProps = {
     compact: useCompactControls,
+    slim: useSlimControls,
     coachAvatars,
     roomId,
     isMuted,

--- a/apps/web/src/app/components/command-palette-actions.ts
+++ b/apps/web/src/app/components/command-palette-actions.ts
@@ -175,8 +175,8 @@ export function buildPaletteActions(
 ): PaletteAction[] {
   const actions: PaletteAction[] = [];
   // Force the full desktop config so side-panel toggles and hand/screen-share
-  // rows are present even when the visible bar is compact.
-  const config = buildControlsConfig({ ...p, compact: false });
+  // rows are present even when the visible bar is compact or slimmed.
+  const config = buildControlsConfig({ ...p, compact: false, slim: false });
 
   for (const d of config.center) {
     if (!d.onPress) continue;

--- a/apps/web/src/app/components/controls-config.ts
+++ b/apps/web/src/app/components/controls-config.ts
@@ -42,6 +42,10 @@ export interface ControlsBarProps {
   /** Phone-width layout: fold screen-share/reactions into the More menu so the
    * core mic/camera/More/leave row fits without wrapping. */
   compact?: boolean;
+  /** Tight-stage layout (docked panels eating width): demote the least-used
+   * center controls (raise hand, screen share) into the More menu so the bar
+   * keeps breathing room instead of crowding. Ignored when compact is set. */
+  slim?: boolean;
   /** Room members (self first) for the watch-together coachmark vignette. */
   coachAvatars?: { id: string; name: string }[];
   roomId?: string;
@@ -341,6 +345,27 @@ export function buildControlsConfig(p: ControlsBarProps): ControlsConfig {
     // Phone-width bar: keep the core row to mic/cam/More/leave, fold
     // side controls, hand raise, and screen-share into the More menu instead
     // of squeezing them into separate rails.
+    overflow.push({
+      id: handDescriptor.id,
+      icon: handDescriptor.icon,
+      label: handDescriptor.label,
+      hotkey: handDescriptor.hotkey,
+      active: handDescriptor.variant === "active",
+      disabled: handDescriptor.disabled,
+      onPress: handDescriptor.onPress,
+    });
+    overflow.push({
+      id: "screen-share",
+      icon: screenShareDescriptor.icon,
+      label: screenShareDescriptor.label,
+      hotkey: screenShareDescriptor.hotkey,
+      active: p.isScreenSharing,
+      disabled: screenShareDescriptor.disabled,
+      onPress: screenShareDescriptor.onPress,
+    });
+  } else if (p.slim) {
+    // Tight stage: keep mic/camera/reactions/More/leave in the bar and demote
+    // the two least-used center controls to the top of the More menu.
     overflow.push({
       id: handDescriptor.id,
       icon: handDescriptor.icon,

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -88,6 +88,11 @@ import {
   selectScreenSharePublishNetworkProfile,
 } from "../lib/screen-share-network-profile";
 import { getBrowserNetworkSnapshot } from "../lib/network-information";
+import {
+  getConsumerResumeEffectiveAttempt,
+  isConsumerResumeSettlementCurrent,
+  type ConsumerResumeRetryState,
+} from "../lib/consumer-resume-retry";
 import type {
   ConsumerTelemetrySnapshot,
   MeetRefs,
@@ -884,11 +889,11 @@ export function useMeetSocket({
   const consumeRetryAttemptsRef = useRef<Map<string, number>>(new Map());
   // One retry chain per producer for acked resumeConsumer delivery; a lost
   // resume means one silent speaker for this attendee only (#177). The entry
-  // keeps the attempt count so overlapping triggers (sync tick, unmute event)
-  // adopt the running chain's progress instead of resetting it — otherwise
-  // the escalation to a full re-consume could be starved forever.
+  // owns a specific consumer generation and keeps its attempt count, so stale
+  // acknowledgements from a displaced consumer cannot cancel the replacement
+  // consumer's chain while overlapping triggers still adopt current progress.
   const consumerResumeRetryStateRef = useRef<
-    Map<string, { timeoutId: number | null; attempt: number }>
+    Map<string, ConsumerResumeRetryState>
   >(new Map());
   const videoStallRecoveryTimeoutsRef = useRef<Map<string, number>>(new Map());
   const participantConnectionStatusTimeoutsRef = useRef<Map<string, number>>(
@@ -2091,14 +2096,23 @@ export function useMeetSocket({
     [],
   );
 
-  const clearConsumerResumeRetry = useCallback((producerId: string) => {
-    const entry = consumerResumeRetryStateRef.current.get(producerId);
-    if (!entry) return;
-    if (entry.timeoutId != null) {
-      window.clearTimeout(entry.timeoutId);
-    }
-    consumerResumeRetryStateRef.current.delete(producerId);
-  }, []);
+  const clearConsumerResumeRetry = useCallback(
+    (producerId: string, expectedConsumerId?: string) => {
+      const entry = consumerResumeRetryStateRef.current.get(producerId);
+      if (!entry) return;
+      if (
+        expectedConsumerId !== undefined &&
+        entry.consumerId !== expectedConsumerId
+      ) {
+        return;
+      }
+      if (entry.timeoutId != null) {
+        window.clearTimeout(entry.timeoutId);
+      }
+      consumerResumeRetryStateRef.current.delete(producerId);
+    },
+    [],
+  );
 
   // resumeConsumer used to be fire-and-forget: a single dropped request (rate
   // limit, disconnect blip, lost ack) left the server-side consumer paused
@@ -2128,14 +2142,23 @@ export function useMeetSocket({
       if (existingRetryState?.timeoutId != null) {
         window.clearTimeout(existingRetryState.timeoutId);
       }
-      const effectiveAttempt = Math.max(
+      const effectiveAttempt = getConsumerResumeEffectiveAttempt(
+        existingRetryState,
+        consumerId,
         attempt,
-        existingRetryState?.attempt ?? 0,
       );
       consumerResumeRetryStateRef.current.set(producerId, {
+        consumerId,
         timeoutId: null,
         attempt: effectiveAttempt,
       });
+
+      const ownsCurrentResumeState = () =>
+        isConsumerResumeSettlementCurrent(
+          consumersRef.current.get(producerId)?.id,
+          consumerResumeRetryStateRef.current.get(producerId),
+          consumerId,
+        );
 
       const buildProducerInfoForRecovery = (): ProducerInfo | null => {
         const entry = producerMapRef.current.get(producerId);
@@ -2149,9 +2172,10 @@ export function useMeetSocket({
       };
 
       const scheduleRetry = (reason: string) => {
+        if (!ownsCurrentResumeState()) return;
         const nextAttempt = effectiveAttempt + 1;
         if (nextAttempt >= RESUME_CONSUMER_MAX_ATTEMPTS) {
-          clearConsumerResumeRetry(producerId);
+          clearConsumerResumeRetry(producerId, consumerId);
           console.warn(
             `[Meets] resumeConsumer retries exhausted for producer ${producerId}: ${reason}`,
           );
@@ -2169,15 +2193,24 @@ export function useMeetSocket({
           }
           return;
         }
-        clearConsumerResumeRetry(producerId);
+        clearConsumerResumeRetry(producerId, consumerId);
         const timeoutId = window.setTimeout(() => {
           const entry = consumerResumeRetryStateRef.current.get(producerId);
-          if (entry) {
-            entry.timeoutId = null;
+          if (
+            !entry ||
+            !isConsumerResumeSettlementCurrent(
+              consumersRef.current.get(producerId)?.id,
+              entry,
+              consumerId,
+            )
+          ) {
+            return;
           }
+          entry.timeoutId = null;
           resumeConsumerReliablyRef.current(producerId, options, nextAttempt);
         }, getResumeConsumerRetryDelayMs(effectiveAttempt));
         consumerResumeRetryStateRef.current.set(producerId, {
+          consumerId,
           timeoutId,
           attempt: nextAttempt,
         });
@@ -2196,6 +2229,7 @@ export function useMeetSocket({
         },
         (response?: { success?: boolean; error?: string; code?: string }) => {
           if (!settleResume()) return;
+          if (!ownsCurrentResumeState()) return;
           const error =
             response && typeof response.error === "string"
               ? response.error
@@ -2211,7 +2245,7 @@ export function useMeetSocket({
             if (code === "not_found") {
               // The server no longer tracks this consumer (displaced or torn
               // down); retrying the resume can never succeed. Re-consume.
-              clearConsumerResumeRetry(producerId);
+              clearConsumerResumeRetry(producerId, consumerId);
               const producerInfo = buildProducerInfoForRecovery();
               if (producerInfo) {
                 void recoverStaleConsumerRef.current(
@@ -2224,7 +2258,7 @@ export function useMeetSocket({
             scheduleRetry(code ?? error);
             return;
           }
-          clearConsumerResumeRetry(producerId);
+          clearConsumerResumeRetry(producerId, consumerId);
           if (effectiveAttempt > 0) {
             telemetry.capture("meet_consumer_resume_recovered", {
               kind: consumer.kind,

--- a/apps/web/src/app/lib/chat-images.ts
+++ b/apps/web/src/app/lib/chat-images.ts
@@ -20,8 +20,33 @@ export const CHAT_IMAGE_MODERATION_BLOCKED_CODE =
 export const CHAT_IMAGE_MODERATION_BLOCKED_MESSAGE =
   "Image not sent. Our safety check flagged it as potentially harmful. Only you can see this notice.";
 
+type ClipboardImageData = {
+  items: ArrayLike<
+    Pick<DataTransferItem, "getAsFile" | "kind" | "type">
+  >;
+  files: ArrayLike<File>;
+};
+
 export function isSupportedChatImageType(mimeType: string): boolean {
   return (CHAT_IMAGE_MIME_TYPES as readonly string[]).includes(mimeType);
+}
+
+export function findClipboardImageFile(
+  clipboardData: ClipboardImageData,
+): File | null {
+  for (let index = 0; index < clipboardData.items.length; index += 1) {
+    const item = clipboardData.items[index];
+    if (item?.kind !== "file" || !item.type.startsWith("image/")) continue;
+    const file = item.getAsFile();
+    if (file) return file;
+  }
+
+  for (let index = 0; index < clipboardData.files.length; index += 1) {
+    const file = clipboardData.files[index];
+    if (file?.type.startsWith("image/")) return file;
+  }
+
+  return null;
 }
 
 export function formatChatImageSize(bytes: number): string {

--- a/apps/web/src/app/lib/consumer-resume-retry.ts
+++ b/apps/web/src/app/lib/consumer-resume-retry.ts
@@ -1,0 +1,22 @@
+export type ConsumerResumeRetryState = {
+  consumerId: string;
+  timeoutId: number | null;
+  attempt: number;
+};
+
+export const getConsumerResumeEffectiveAttempt = (
+  state: ConsumerResumeRetryState | undefined,
+  consumerId: string,
+  requestedAttempt: number,
+): number =>
+  state?.consumerId === consumerId
+    ? Math.max(requestedAttempt, state.attempt)
+    : requestedAttempt;
+
+export const isConsumerResumeSettlementCurrent = (
+  activeConsumerId: string | null | undefined,
+  state: ConsumerResumeRetryState | undefined,
+  settledConsumerId: string,
+): boolean =>
+  activeConsumerId === settledConsumerId &&
+  state?.consumerId === settledConsumerId;

--- a/apps/web/src/app/lib/webcam-codec.ts
+++ b/apps/web/src/app/lib/webcam-codec.ts
@@ -917,8 +917,22 @@ export async function produceScreenShareTrack({
     }
 
     console.warn(
-      "[Meets] Preferred screen-share codec failed, retrying router default codec:",
+      "[Meets] Preferred screen-share codec with temporal scalability failed, retrying the same codec without scalability mode:",
       primaryError,
+    );
+  }
+
+  try {
+    return await transport.produce(
+      buildOptions(
+        withoutScreenShareScalabilityMode(encoding),
+        preferredCodec,
+      ),
+    );
+  } catch (preferredCodecError) {
+    console.warn(
+      "[Meets] Preferred screen-share codec failed without temporal scalability, retrying router default codec:",
+      preferredCodecError,
     );
   }
 

--- a/apps/web/test/chat-images.test.ts
+++ b/apps/web/test/chat-images.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { findClipboardImageFile } from "../src/app/lib/chat-images";
+
+const emptyFiles: ArrayLike<File> = { length: 0 };
+
+describe("chat image clipboard handling", () => {
+  it("returns the first pasted image file", () => {
+    const image = { name: "clipboard.png", type: "image/png" } as File;
+    const getAsFile = vi.fn(() => image);
+
+    const result = findClipboardImageFile({
+      items: {
+        0: { kind: "string", type: "text/plain", getAsFile: () => null },
+        1: { kind: "file", type: "image/png", getAsFile },
+        length: 2,
+      },
+      files: emptyFiles,
+    });
+
+    expect(result).toBe(image);
+    expect(getAsFile).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to clipboard files and ignores non-images", () => {
+    const textFile = { name: "notes.txt", type: "text/plain" } as File;
+    const image = { name: "clipboard.webp", type: "image/webp" } as File;
+
+    expect(
+      findClipboardImageFile({
+        items: { length: 0 },
+        files: { 0: textFile, 1: image, length: 2 },
+      }),
+    ).toBe(image);
+  });
+
+  it("leaves ordinary text-only clipboard data alone", () => {
+    expect(
+      findClipboardImageFile({
+        items: {
+          0: { kind: "string", type: "text/plain", getAsFile: () => null },
+          length: 1,
+        },
+        files: emptyFiles,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/test/consumer-resume-retry.test.ts
+++ b/apps/web/test/consumer-resume-retry.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  getConsumerResumeEffectiveAttempt,
+  isConsumerResumeSettlementCurrent,
+  type ConsumerResumeRetryState,
+} from "../src/app/lib/consumer-resume-retry";
+
+const retryState = (
+  consumerId: string,
+  attempt = 2,
+): ConsumerResumeRetryState => ({
+  consumerId,
+  timeoutId: 1,
+  attempt,
+});
+
+describe("consumer resume retry ownership", () => {
+  it("does not carry retry attempts across a replacement consumer", () => {
+    expect(
+      getConsumerResumeEffectiveAttempt(
+        retryState("old-consumer", 5),
+        "new-consumer",
+        0,
+      ),
+    ).toBe(0);
+  });
+
+  it("preserves progress for overlapping retries of the same consumer", () => {
+    expect(
+      getConsumerResumeEffectiveAttempt(
+        retryState("consumer", 3),
+        "consumer",
+        1,
+      ),
+    ).toBe(3);
+  });
+
+  it("rejects a stale settlement after the producer gets a new consumer", () => {
+    expect(
+      isConsumerResumeSettlementCurrent(
+        "new-consumer",
+        retryState("new-consumer"),
+        "old-consumer",
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts a settlement only for the active retry owner", () => {
+    expect(
+      isConsumerResumeSettlementCurrent(
+        "consumer",
+        retryState("consumer"),
+        "consumer",
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/web/test/webcam-codec.test.ts
+++ b/apps/web/test/webcam-codec.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from "vitest";
-import type { RtpCodecCapability } from "mediasoup-client/types";
-import { getPreferredScreenShareCodec } from "../src/app/lib/webcam-codec";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  Producer,
+  RtpCodecCapability,
+  Transport,
+} from "mediasoup-client/types";
+import {
+  getPreferredScreenShareCodec,
+  produceScreenShareTrack,
+} from "../src/app/lib/webcam-codec";
 
 type ScreenShareCodecDevice = Parameters<
   typeof getPreferredScreenShareCodec
@@ -14,6 +21,10 @@ const videoCodec = (
   mimeType,
   preferredPayloadType,
   clockRate: 90000,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("getPreferredScreenShareCodec", () => {
@@ -43,5 +54,38 @@ describe("getPreferredScreenShareCodec", () => {
     const codec = getPreferredScreenShareCodec(device);
 
     expect(codec?.mimeType).toBe("video/VP9");
+  });
+
+  it("keeps the preferred codec when only temporal scalability is rejected", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const preferredCodec = videoCodec("video/VP8", 102);
+    const producer = {} as Producer;
+    const produce = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("unsupported scalability mode"))
+      .mockResolvedValueOnce(producer);
+    const transport = { produce } as unknown as Transport;
+    const track = {
+      getSettings: () => ({ width: 1920, height: 1080 }),
+    } as MediaStreamTrack;
+
+    await expect(
+      produceScreenShareTrack({
+        transport,
+        track,
+        networkProfile: "good",
+        preferredCodec,
+      }),
+    ).resolves.toBe(producer);
+
+    expect(produce).toHaveBeenCalledTimes(2);
+    const firstOptions = produce.mock.calls[0]?.[0];
+    const secondOptions = produce.mock.calls[1]?.[0];
+    expect(firstOptions?.codec).toBe(preferredCodec);
+    expect(secondOptions?.codec).toBe(preferredCodec);
+    expect(firstOptions?.encodings?.[0]).toHaveProperty("scalabilityMode");
+    expect(secondOptions?.encodings?.[0]).not.toHaveProperty(
+      "scalabilityMode",
+    );
   });
 });


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR expands meeting controls, media recovery, and chat image handling. The main changes are:

- Clipboard image staging in chat.
- A fixed-width activity flyout and slim desktop controls.
- Consumer-generation checks for resume retries.
- An extra screen-share codec fallback without temporal scalability.

<h3>Confidence Score: 4/5</h3>

The clipboard paste path needs a contained fix before merging.

A rejected clipboard image can suppress valid text from the same paste. The consumer retry and screen-share fallback changes preserve their expected recovery paths.

apps/web/src/app/components/ChatPanel.tsx

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to start the real ChatPanel browser harness, but the server startup timed out and a stale process on port 3100 returned HTTP 500.
- The remaining work is to restart the harness on a clean port, run the prepared Playwright mixed text-and-image paste scenario, and capture the requested video, poster frame, and command transcript.
- The meeting-controls-01-before.log and meeting-controls-02-after.log were inspected to confirm baseline harness failure and the subsequent timeout and server state.
- The meeting-controls-capture.mjs Playwright script was reviewed to map the interaction sequence that could not be reached.

<a href="https://app.greptile.com/trex/runs/14117658/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/components/ChatPanel.tsx | Adds shared image staging and clipboard handling, but rejected images currently suppress accompanying clipboard text. |
| apps/web/src/app/components/ControlsBar.tsx | Replaces the expanding activity tray with a fixed-width flyout and updates its focus handling. |
| apps/web/src/app/components/controls-config.ts | Adds a slim layout that moves hand and screen-share controls into the overflow menu. |
| apps/web/src/app/hooks/useMeetSocket.ts | Scopes consumer resume retry state and settlements to the active consumer generation. |
| apps/web/src/app/lib/consumer-resume-retry.ts | Adds helpers for preserving retry progress and rejecting stale consumer settlements. |
| apps/web/src/app/lib/webcam-codec.ts | Retries the preferred screen-share codec without temporal scalability before using the router default. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant U as User
participant C as Chat textarea
participant S as Image staging
U->>C: Paste text and image
C->>S: Try to stage image
alt Image accepted
    S-->>C: true
    C-->>U: Show image preview
else Image rejected
    S-->>C: false
    C-->>U: Preserve normal text paste
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant U as User
participant C as Chat textarea
participant S as Image staging
U->>C: Paste text and image
C->>S: Try to stage image
alt Image accepted
    S-->>C: true
    C-->>U: Show image preview
else Image rejected
    S-->>C: false
    C-->>U: Preserve normal text paste
end
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FChatPanel.tsx%3A408-411%0A**Rejected%20Image%20Suppresses%20Text%20Paste**%0A%0AWhen%20clipboard%20data%20contains%20both%20text%20and%20an%20image%2C%20this%20prevents%20the%20entire%20paste%20before%20confirming%20that%20the%20image%20can%20be%20staged.%20If%20attachments%20are%20disabled%2C%20an%20upload%20is%20active%2C%20or%20the%20image%20fails%20validation%2C%20%60stageImage%60%20rejects%20it%20and%20the%20accompanying%20text%20is%20also%20lost.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20file%20%3D%20findClipboardImageFile%28event.clipboardData%29%3B%0A%20%20%20%20%20%20if%20%28!file%29%20return%3B%0A%20%20%20%20%20%20if%20%28stageImage%28file%29%29%20event.preventDefault%28%29%3B%0A%60%60%60%0A%0A&repo=acm-vit%2Fconclave&pr=187&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FChatPanel.tsx%3A408-411%0A**Rejected%20Image%20Suppresses%20Text%20Paste**%0A%0AWhen%20clipboard%20data%20contains%20both%20text%20and%20an%20image%2C%20this%20prevents%20the%20entire%20paste%20before%20confirming%20that%20the%20image%20can%20be%20staged.%20If%20attachments%20are%20disabled%2C%20an%20upload%20is%20active%2C%20or%20the%20image%20fails%20validation%2C%20%60stageImage%60%20rejects%20it%20and%20the%20accompanying%20text%20is%20also%20lost.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20file%20%3D%20findClipboardImageFile%28event.clipboardData%29%3B%0A%20%20%20%20%20%20if%20%28!file%29%20return%3B%0A%20%20%20%20%20%20if%20%28stageImage%28file%29%29%20event.preventDefault%28%29%3B%0A%60%60%60%0A%0A&repo=acm-vit%2Fconclave&pr=187&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FChatPanel.tsx%3A408-411%0A**Rejected%20Image%20Suppresses%20Text%20Paste**%0A%0AWhen%20clipboard%20data%20contains%20both%20text%20and%20an%20image%2C%20this%20prevents%20the%20entire%20paste%20before%20confirming%20that%20the%20image%20can%20be%20staged.%20If%20attachments%20are%20disabled%2C%20an%20upload%20is%20active%2C%20or%20the%20image%20fails%20validation%2C%20%60stageImage%60%20rejects%20it%20and%20the%20accompanying%20text%20is%20also%20lost.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20file%20%3D%20findClipboardImageFile%28event.clipboardData%29%3B%0A%20%20%20%20%20%20if%20%28!file%29%20return%3B%0A%20%20%20%20%20%20if%20%28stageImage%28file%29%29%20event.preventDefault%28%29%3B%0A%60%60%60%0A%0A&pr=187&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: add clipboard image handling and i..."](https://github.com/acm-vit/conclave/commit/4e098c6a444d06b3591f9b175bd8f7d1682c4a4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43566644)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->