### PR TITLE
up

### DIFF
--- a/apps/conclave-skip/Sources/Conclave/Core/WebRTC/WebRTCClient.swift
+++ b/apps/conclave-skip/Sources/Conclave/Core/WebRTC/WebRTCClient.swift
@@ -150,6 +150,7 @@ final class WebRTCClient: NSObject, ObservableObject {
     }
 
     var consumers: [String: ConsumerInfo] = [:]
+    private var remoteProducerClosureGenerations: [String: Int] = [:]
     private var remoteConsumerPreferenceSignatures: [String: String] = [:]
     private var remoteConsumerLayerPreferenceUnsupportedIds: Set<String> = []
     private var remoteConsumerPreferenceInFlightIds: Set<String> = []
@@ -1442,6 +1443,8 @@ final class WebRTCClient: NSObject, ObservableObject {
         preferHighWebcamLayer: Bool = false,
         initialReceiveConnectionQuality: ConnectionQuality = .unknown
     ) async throws {
+        let consumeConfigurationGeneration = configurationGeneration
+        let producerClosureGeneration = remoteProducerClosureGenerations[producerId, default: 0]
         try await createReceiveTransportIfNeeded()
         guard let socket = socketManager,
               let rtpCaps = serverRtpCapabilities,
@@ -1513,6 +1516,13 @@ final class WebRTCClient: NSObject, ObservableObject {
             throw error
         }
 
+        guard configurationGeneration == consumeConfigurationGeneration,
+              remoteProducerClosureGenerations[producerId, default: 0] == producerClosureGeneration else {
+            consumer.close()
+            socket.closeConsumer(consumerId: response.id)
+            throw WebRTCError.staleConfiguration
+        }
+
         consumers[response.id] = ConsumerInfo(
             consumer: consumer,
             producerId: response.producerId,
@@ -1536,6 +1546,9 @@ final class WebRTCClient: NSObject, ObservableObject {
     }
 
     func closeConsumer(producerId: String, userId: String) {
+        if !producerId.isEmpty {
+            remoteProducerClosureGenerations[producerId, default: 0] += 1
+        }
         if producerId.isEmpty {
             let consumerIds = consumers
                 .filter { consumerMatchesUser($0.value, userId: userId) }
@@ -2860,6 +2873,7 @@ final class WebRTCClient: NSObject, ObservableObject {
             info.consumer.close()
         }
         consumers.removeAll()
+        remoteProducerClosureGenerations.removeAll()
         videoFreezeStats.removeAll()
         remoteConsumerPreferenceSignatures.removeAll()
         remoteConsumerLayerPreferenceUnsupportedIds.removeAll()

--- a/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift
+++ b/apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift
@@ -535,6 +535,7 @@ final class MeetingViewModel {
     private var pendingProducerContexts: [String: SocketEventContext] = [:]
     private var producerInfosById: [String: ProducerInfo] = [:]
     private var consumingProducerIds: Set<String> = []
+    private var deferredProducerConsumes: [String: PendingProducerRetryItem] = [:]
     private var pendingProducerRetryAttempts: [String: Int] = [:]
     private var remoteProducerCloseGraceTasks: [String: Task<Void, Never>] = [:]
     private var remoteProducerCloseGraceProducers: [String: ProducerInfo] = [:]
@@ -2447,6 +2448,7 @@ final class MeetingViewModel {
         cancelPendingMediaLifecycleWork()
         producerInfosById.removeAll()
         consumingProducerIds.removeAll()
+        deferredProducerConsumes.removeAll()
         clearAllParticipantConnectionStatusTimers()
 
         state.activeScreenShareUserId = nil
@@ -4991,6 +4993,7 @@ final class MeetingViewModel {
         pendingProducers.removeValue(forKey: notification.producerId)
         pendingProducerContexts.removeValue(forKey: notification.producerId)
         pendingProducerRetryAttempts.removeValue(forKey: notification.producerId)
+        deferredProducerConsumes.removeValue(forKey: notification.producerId)
         webRTCClient.closeConsumer(producerId: notification.producerId, userId: producerUserId ?? "")
 
         guard let producerUserId, !state.isLocalIdentityUserId(producerUserId) else { return }
@@ -6040,9 +6043,21 @@ final class MeetingViewModel {
         }
 
         guard consumingProducerIds.insert(producer.producerId).inserted else {
+            let deferredContext = context ?? SocketEventContext(
+                roomId: state.roomId,
+                joinAttemptId: joinAttemptId ?? activeJoinAttemptId,
+                lifecycleGeneration: meetingLifecycleGeneration
+            )
+            deferredProducerConsumes[producer.producerId] = PendingProducerRetryItem(
+                producer: producer,
+                context: deferredContext
+            )
             return
         }
-        defer { consumingProducerIds.remove(producer.producerId) }
+        defer {
+            consumingProducerIds.remove(producer.producerId)
+            scheduleDeferredProducerConsume(producerId: producer.producerId)
+        }
 
         do {
             try await webRTCClient.consumeProducer(
@@ -6065,6 +6080,10 @@ final class MeetingViewModel {
                     return
                 }
             }
+            guard isTrackedRemoteProducer(producer) else {
+                discardStaleConsumedProducer(producer)
+                return
+            }
             if MeetingState.isBrowserAudioUserId(producer.producerUserId) {
                 refreshBrowserAudioPresence()
                 applyBrowserAudioMuteState()
@@ -6084,8 +6103,26 @@ final class MeetingViewModel {
             } else {
                 guard isCurrentJoinAttempt(joinAttemptId) else { return }
             }
+            guard isTrackedRemoteProducer(producer) else { return }
             debugLog("[Meeting] Failed to consume producer \(producer.producerId): \(error)")
             queueProducerConsumeRetry(producer, context: context, joinAttemptId: joinAttemptId)
+        }
+    }
+
+    private func isTrackedRemoteProducer(_ producer: ProducerInfo) -> Bool {
+        guard let tracked = producerInfosById[producer.producerId] else { return false }
+        return tracked.producerUserId == producer.producerUserId
+            && tracked.kind == producer.kind
+            && tracked.type == producer.type
+    }
+
+    private func scheduleDeferredProducerConsume(producerId: String) {
+        guard let item = deferredProducerConsumes.removeValue(forKey: producerId) else { return }
+        Task { @MainActor [weak self] in
+            guard let self,
+                  self.isCurrentSocketEvent(item.context, roomId: item.producer.roomId),
+                  self.isTrackedRemoteProducer(item.producer) else { return }
+            await self.consumeRemoteProducer(item.producer, context: item.context)
         }
     }
 
@@ -6097,6 +6134,7 @@ final class MeetingViewModel {
         pendingProducers.removeValue(forKey: producer.producerId)
         pendingProducerContexts.removeValue(forKey: producer.producerId)
         pendingProducerRetryAttempts.removeValue(forKey: producer.producerId)
+        deferredProducerConsumes.removeValue(forKey: producer.producerId)
         if pendingProducers.isEmpty {
             pendingProducerRetryTask?.cancel()
             pendingProducerRetryTask = nil
@@ -6819,6 +6857,7 @@ final class MeetingViewModel {
         clearAllParticipantConnectionStatusTimers()
         producerInfosById.removeAll()
         consumingProducerIds.removeAll()
+        deferredProducerConsumes.removeAll()
         clearPendingPreAckRoomEvents()
         currentJoinInfo = nil
         currentRoomAliases.removeAll()

--- a/apps/conclave-skip/Sources/Conclave/Skip/WebRTCClient+Android.kt
+++ b/apps/conclave-skip/Sources/Conclave/Skip/WebRTCClient+Android.kt
@@ -142,6 +142,7 @@ internal class WebRTCClient : SendTransport.Listener, RecvTransport.Listener, Pr
     )
 
     private val consumers: MutableMap<String, ConsumerInfo> = mutableMapOf()
+    private val remoteProducerClosureGenerations: MutableMap<String, Int> = mutableMapOf()
     private val remoteConsumerPreferenceSignatures: MutableMap<String, String> = mutableMapOf()
     private val remoteConsumerLayerPreferenceUnsupportedIds: MutableSet<String> = mutableSetOf()
     private val remoteConsumerPreferenceInFlightIds: MutableSet<String> = mutableSetOf()
@@ -1309,6 +1310,8 @@ internal class WebRTCClient : SendTransport.Listener, RecvTransport.Listener, Pr
         preferHighWebcamLayer: Boolean = false,
         initialReceiveConnectionQuality: ConnectionQuality = ConnectionQuality.unknown,
     ) {
+        val consumeConfigurationGeneration = configurationGeneration
+        val producerClosureGeneration = remoteProducerClosureGenerations[producerId] ?: 0
         createReceiveTransportIfNeeded()
         val socket = socketManager ?: throw ErrorException("Socket not configured")
         val rtpCapsJson = socket.routerRtpCapabilitiesJson ?: throw ErrorException("RTP caps missing")
@@ -1371,6 +1374,15 @@ internal class WebRTCClient : SendTransport.Listener, RecvTransport.Listener, Pr
             throw error
         }
 
+        if (
+            configurationGeneration != consumeConfigurationGeneration ||
+            (remoteProducerClosureGenerations[producerId] ?: 0) != producerClosureGeneration
+        ) {
+            consumer.close()
+            socket.closeConsumer(response.id)
+            throw ErrorException("WebRTC session or remote producer changed while consumer was starting")
+        }
+
         consumers[response.id] = ConsumerInfo(
             consumer = consumer,
             producerId = response.producerId,
@@ -1393,6 +1405,10 @@ internal class WebRTCClient : SendTransport.Listener, RecvTransport.Listener, Pr
     }
 
     internal fun closeConsumer(producerId: String, userId: String) {
+        if (producerId.isNotEmpty()) {
+            remoteProducerClosureGenerations[producerId] =
+                (remoteProducerClosureGenerations[producerId] ?: 0) + 1
+        }
         if (producerId.isEmpty()) {
             val ids = consumers
                 .filterValues { consumerMatchesUser(it, userId) }
@@ -2459,6 +2475,7 @@ internal class WebRTCClient : SendTransport.Listener, RecvTransport.Listener, Pr
 
         consumers.values.forEach { it.consumer.close() }
         consumers.clear()
+        remoteProducerClosureGenerations.clear()
         videoFreezeStats.clear()
         remoteConsumerPreferenceSignatures.clear()
         remoteConsumerLayerPreferenceUnsupportedIds.clear()

--- a/apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift
+++ b/apps/conclave-skip/Tests/ConclaveTests/ConclaveTests.swift
@@ -7970,6 +7970,12 @@ final class ConclaveTests: XCTestCase {
         XCTAssertTrue(viewModelSource.contains(
             "guard consumingProducerIds.insert(producer.producerId).inserted else"
         ))
+        XCTAssertTrue(viewModelSource.contains(
+            "deferredProducerConsumes[producer.producerId] = PendingProducerRetryItem("
+        ))
+        XCTAssertTrue(viewModelSource.contains(
+            "scheduleDeferredProducerConsume(producerId: producer.producerId)"
+        ))
 
         let iosResume = try XCTUnwrap(iosWebRTCSource.range(of: "try await socket.resumeConsumer(\n                consumerId: response.id,"))
         let iosCommit = try XCTUnwrap(iosWebRTCSource.range(of: "consumers[response.id] = ConsumerInfo("))
@@ -7977,12 +7983,18 @@ final class ConclaveTests: XCTestCase {
         XCTAssertTrue(iosWebRTCSource.contains(
             "consumer.close()\n            socket.closeConsumer(consumerId: response.id)\n            throw error"
         ))
+        XCTAssertTrue(iosWebRTCSource.contains(
+            "remoteProducerClosureGenerations[producerId, default: 0] == producerClosureGeneration"
+        ))
 
         let androidResume = try XCTUnwrap(androidWebRTCSource.range(of: "socket.resumeConsumer(response.id, response.kind == \"video\")"))
         let androidCommit = try XCTUnwrap(androidWebRTCSource.range(of: "consumers[response.id] = ConsumerInfo("))
         XCTAssertLessThan(androidResume.lowerBound, androidCommit.lowerBound)
         XCTAssertTrue(androidWebRTCSource.contains(
             "consumer.close()\n            socket.closeConsumer(response.id)\n            throw error"
+        ))
+        XCTAssertTrue(androidWebRTCSource.contains(
+            "(remoteProducerClosureGenerations[producerId] ?: 0) != producerClosureGeneration"
         ))
     }
 

--- a/apps/web/src/app/api/unfurl/asset/route.ts
+++ b/apps/web/src/app/api/unfurl/asset/route.ts
@@ -1,0 +1,84 @@
+import { fetchUnfurlResource } from "../../../lib/unfurl-fetch";
+import { parseUnfurlableUrl } from "../../../lib/unfurl-html";
+import { takeUnfurlRateLimit } from "../../../lib/unfurl-rate-limit";
+import { readBoundedResponseBytes } from "../../../lib/unfurl-response";
+
+const FETCH_TIMEOUT_MS = 6_000;
+const MAX_ASSET_BYTES = 5 * 1024 * 1024;
+const ASSET_CACHE_CONTROL = "private, max-age=86400";
+const IMAGE_CONTENT_TYPE_PATTERN =
+  /^image\/(?:png|jpeg|gif|webp|avif|x-icon|vnd\.microsoft\.icon)\b/i;
+const USER_AGENT =
+  "Mozilla/5.0 (compatible; ConclaveLinkPreview/1.0; +https://conclave.acmvit.in)";
+
+const errorResponse = (status: number): Response =>
+  new Response(null, {
+    status,
+    headers: { "Cache-Control": "no-store" },
+  });
+
+export async function GET(request: Request) {
+  const requestedUrl = new URL(request.url).searchParams.get("url") ?? "";
+  const target = parseUnfurlableUrl(requestedUrl);
+  if (!target) return errorResponse(400);
+
+  const rateLimit = await takeUnfurlRateLimit(request);
+  if (!rateLimit.ok) return errorResponse(rateLimit.status);
+
+  let fetched: Awaited<ReturnType<typeof fetchUnfurlResource>>;
+  try {
+    fetched = await fetchUnfurlResource(target, {
+      headers: {
+        accept: "image/avif,image/webp,image/png,image/jpeg,image/gif,image/x-icon,*/*;q=0.1",
+        "user-agent": USER_AGENT,
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      cache: "no-store",
+    });
+  } catch {
+    return errorResponse(502);
+  }
+  if (!fetched) return errorResponse(400);
+
+  const { response } = fetched;
+  if (!response.ok) {
+    response.body?.cancel().catch(() => {});
+    return errorResponse(502);
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!IMAGE_CONTENT_TYPE_PATTERN.test(contentType)) {
+    response.body?.cancel().catch(() => {});
+    return errorResponse(415);
+  }
+
+  const declaredLength = Number.parseInt(
+    response.headers.get("content-length") ?? "",
+    10,
+  );
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_ASSET_BYTES) {
+    response.body?.cancel().catch(() => {});
+    return errorResponse(413);
+  }
+
+  let bytes: Uint8Array | null;
+  try {
+    bytes = await readBoundedResponseBytes(response, MAX_ASSET_BYTES);
+  } catch {
+    return errorResponse(502);
+  }
+  if (!bytes) return errorResponse(413);
+
+  const responseBody = Uint8Array.from(bytes).buffer;
+  const proxyResponse = new Response(responseBody, {
+    headers: {
+      "Cache-Control": ASSET_CACHE_CONTROL,
+      "Content-Length": String(bytes.byteLength),
+      "Content-Security-Policy": "default-src 'none'; sandbox",
+      "Content-Type": contentType,
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+
+  return proxyResponse;
+}

--- a/apps/web/src/app/api/unfurl/asset/route.ts
+++ b/apps/web/src/app/api/unfurl/asset/route.ts
@@ -1,13 +1,24 @@
 import { fetchUnfurlResource } from "../../../lib/unfurl-fetch";
 import { parseUnfurlableUrl } from "../../../lib/unfurl-html";
 import { takeUnfurlRateLimit } from "../../../lib/unfurl-rate-limit";
-import { readBoundedResponseBytes } from "../../../lib/unfurl-response";
+import {
+  boundedResponseStream,
+  readBoundedResponseBytes,
+} from "../../../lib/unfurl-response";
 
 const FETCH_TIMEOUT_MS = 6_000;
 const MAX_ASSET_BYTES = 5 * 1024 * 1024;
+// Streaming cap per response, not a file-size limit — backpressure means a
+// paused player stops the transfer, and seeks issue fresh range requests.
+const MAX_VIDEO_STREAM_BYTES = 256 * 1024 * 1024;
 const ASSET_CACHE_CONTROL = "private, max-age=86400";
 const IMAGE_CONTENT_TYPE_PATTERN =
   /^image\/(?:png|jpeg|gif|webp|avif|x-icon|vnd\.microsoft\.icon)\b/i;
+const VIDEO_CONTENT_TYPE_PATTERN = /^video\/mp4\b/i;
+// X's video CDN 403s hotlinked <video> requests, so tweet playback has to
+// round-trip through this proxy. Kept to an allowlist so the endpoint can't
+// be repurposed as a general video relay.
+const VIDEO_STREAM_HOSTS = new Set(["video.twimg.com"]);
 const USER_AGENT =
   "Mozilla/5.0 (compatible; ConclaveLinkPreview/1.0; +https://conclave.acmvit.in)";
 
@@ -25,28 +36,69 @@ export async function GET(request: Request) {
   const rateLimit = await takeUnfurlRateLimit(request);
   if (!rateLimit.ok) return errorResponse(rateLimit.status);
 
+  // <video> issues Range requests for playback and seeking; forward them so
+  // the upstream CDN can answer with 206s. Image loads never carry a range.
+  const rangeHeader = request.headers.get("range");
+
+  // The timeout must only bound the connection/headers phase: an
+  // AbortSignal.timeout would also sever a video body mid-stream at 6s.
+  const abortController = new AbortController();
+  const connectTimer = setTimeout(
+    () => abortController.abort(),
+    FETCH_TIMEOUT_MS,
+  );
   let fetched: Awaited<ReturnType<typeof fetchUnfurlResource>>;
   try {
     fetched = await fetchUnfurlResource(target, {
       headers: {
-        accept: "image/avif,image/webp,image/png,image/jpeg,image/gif,image/x-icon,*/*;q=0.1",
+        accept:
+          "image/avif,image/webp,image/png,image/jpeg,image/gif,image/x-icon,video/mp4,*/*;q=0.1",
         "user-agent": USER_AGENT,
+        ...(rangeHeader ? { range: rangeHeader } : {}),
       },
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      signal: abortController.signal,
       cache: "no-store",
     });
   } catch {
     return errorResponse(502);
+  } finally {
+    clearTimeout(connectTimer);
   }
   if (!fetched) return errorResponse(400);
 
-  const { response } = fetched;
+  const { response, finalUrl } = fetched;
   if (!response.ok) {
     response.body?.cancel().catch(() => {});
     return errorResponse(502);
   }
 
   const contentType = response.headers.get("content-type") ?? "";
+
+  if (VIDEO_CONTENT_TYPE_PATTERN.test(contentType)) {
+    if (!VIDEO_STREAM_HOSTS.has(finalUrl.hostname.toLowerCase())) {
+      response.body?.cancel().catch(() => {});
+      return errorResponse(415);
+    }
+    const headers: Record<string, string> = {
+      "Accept-Ranges": response.headers.get("accept-ranges") ?? "bytes",
+      "Cache-Control": ASSET_CACHE_CONTROL,
+      "Content-Security-Policy": "default-src 'none'; sandbox",
+      "Content-Type": contentType,
+      "X-Content-Type-Options": "nosniff",
+    };
+    const contentLength = response.headers.get("content-length");
+    if (contentLength) headers["Content-Length"] = contentLength;
+    const contentRange = response.headers.get("content-range");
+    if (contentRange) headers["Content-Range"] = contentRange;
+
+    return new Response(
+      response.body
+        ? boundedResponseStream(response.body, MAX_VIDEO_STREAM_BYTES)
+        : null,
+      { status: response.status === 206 ? 206 : 200, headers },
+    );
+  }
+
   if (!IMAGE_CONTENT_TYPE_PATTERN.test(contentType)) {
     response.body?.cancel().catch(() => {});
     return errorResponse(415);

--- a/apps/web/src/app/api/unfurl/route.ts
+++ b/apps/web/src/app/api/unfurl/route.ts
@@ -1,0 +1,326 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { NextResponse } from "next/server";
+import {
+  type ChatLinkPreview,
+  type UnfurlResponsePayload,
+  getYouTubeThumbnailUrl,
+  getYouTubeVideoId,
+} from "../../lib/link-embeds";
+import { parseUnfurlableUrl, parseUnfurlHtml } from "../../lib/unfurl-html";
+import { fetchTweetPreview, getTweetIdFromUrl } from "../../lib/unfurl-tweet";
+
+// Server-side link unfurler for chat embeds. The client hands us a URL from a
+// chat message; we fetch it (so participant IPs never reach the target site),
+// scrape Open Graph / Twitter-card metadata, and return a normalized preview.
+//
+// Production runs on Cloudflare Workers with `global_fetch_strictly_public`,
+// which hard-blocks fetches that resolve to private addresses. The hostname
+// checks in parseUnfurlableUrl are the equivalent guard for `next dev`.
+
+const FETCH_TIMEOUT_MS = 6_000;
+const MAX_HTML_BYTES = 512 * 1024;
+const USER_AGENT =
+  "Mozilla/5.0 (compatible; ConclaveLinkPreview/1.0; +https://conclave.acmvit.in)";
+
+// Found metadata is stable; misses retry sooner in case the page was flaky.
+const HIT_CACHE_CONTROL =
+  "public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400";
+const MISS_CACHE_CONTROL = "public, max-age=300, s-maxage=900";
+
+const RATE_LIMIT = 30;
+const RATE_WINDOW_MS = 60_000;
+
+type CloudflareRateLimitBinding = {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+};
+
+type LocalRateLimitBucket = { windowStartedAt: number; count: number };
+const localBuckets = new Map<string, LocalRateLimitBucket>();
+const MAX_LOCAL_BUCKETS = 1_000;
+
+const clientKey = (request: Request): string => {
+  const forwardedFor = request.headers
+    .get("x-forwarded-for")
+    ?.split(",")
+    .at(0)
+    ?.trim();
+  const candidate =
+    [
+      request.headers.get("cf-connecting-ip")?.trim(),
+      request.headers.get("x-real-ip")?.trim(),
+      forwardedFor,
+      request.headers.get("user-agent")?.trim(),
+    ].find((value): value is string => Boolean(value)) ?? "anonymous";
+  return candidate.slice(0, 128);
+};
+
+const takeLocalRateLimit = (key: string): boolean => {
+  const now = Date.now();
+  const bucket = localBuckets.get(key);
+  if (!bucket || now - bucket.windowStartedAt >= RATE_WINDOW_MS) {
+    localBuckets.set(key, { windowStartedAt: now, count: 1 });
+    while (localBuckets.size > MAX_LOCAL_BUCKETS) {
+      const oldest = localBuckets.keys().next().value;
+      if (oldest === undefined) break;
+      localBuckets.delete(oldest);
+    }
+    return true;
+  }
+  if (bucket.count >= RATE_LIMIT) return false;
+  bucket.count += 1;
+  return true;
+};
+
+type RateLimitOutcome = { ok: true } | { ok: false; status: 429 | 503 };
+
+const takeUnfurlRateLimit = async (request: Request): Promise<RateLimitOutcome> => {
+  const key = `unfurl:${clientKey(request)}`;
+
+  let limiter: CloudflareRateLimitBinding | null = null;
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    const binding = (env as { UNFURL_RATE_LIMITER?: CloudflareRateLimitBinding })
+      .UNFURL_RATE_LIMITER;
+    limiter = binding && typeof binding.limit === "function" ? binding : null;
+  } catch {
+    limiter = null;
+  }
+
+  if (limiter) {
+    try {
+      const { success } = await limiter.limit({ key });
+      return success ? { ok: true } : { ok: false, status: 429 };
+    } catch {
+      // Fall through to the fail-closed production branch below.
+    }
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    // An unfurler is an outbound-fetch proxy; never run it unmetered.
+    return { ok: false, status: 503 };
+  }
+
+  return takeLocalRateLimit(key) ? { ok: true } : { ok: false, status: 429 };
+};
+
+// Reads at most `maxBytes` of the body, stopping early once the document head
+// has closed — everything the parser wants lives there on real pages.
+const readHtmlPrefix = async (
+  response: Response,
+  maxBytes: number,
+): Promise<string> => {
+  const body = response.body;
+  if (!body) return "";
+  const reader = body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  let html = "";
+  let receivedBytes = 0;
+  try {
+    while (receivedBytes < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      receivedBytes += value.byteLength;
+      html += decoder.decode(value, { stream: true });
+      if (html.includes("</head")) break;
+    }
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+  return html + decoder.decode();
+};
+
+const IMAGE_CONTENT_TYPE_PATTERN =
+  /^image\/(?:png|jpeg|gif|webp|avif|svg\+xml)\b/i;
+
+// YouTube's watch pages are bot-gated and scrape to nothing; its public
+// oEmbed endpoint returns the title/author/thumbnail without an API key.
+const fetchYouTubePreview = async (
+  target: URL,
+  videoId: string,
+): Promise<ChatLinkPreview | null> => {
+  let parsed: unknown;
+  try {
+    const response = await fetch(
+      `https://www.youtube.com/oembed?url=${encodeURIComponent(target.href)}&format=json`,
+      {
+        headers: { accept: "application/json", "user-agent": USER_AGENT },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        cache: "no-store",
+      },
+    );
+    if (!response.ok) {
+      response.body?.cancel().catch(() => {});
+      return null;
+    }
+    parsed = await response.json();
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const payload = parsed as { title?: unknown; author_name?: unknown; thumbnail_url?: unknown };
+
+  const title = typeof payload.title === "string" ? payload.title : undefined;
+  if (!title) return null;
+  return {
+    url: target.href,
+    kind: "page",
+    siteName: "YouTube",
+    title,
+    description:
+      typeof payload.author_name === "string" ? payload.author_name : undefined,
+    imageUrl:
+      typeof payload.thumbnail_url === "string"
+        ? payload.thumbnail_url
+        : getYouTubeThumbnailUrl(videoId),
+    faviconUrl: "https://www.youtube.com/favicon.ico",
+    imageLayout: "large",
+  };
+};
+
+const fetchPreview = async (target: URL): Promise<ChatLinkPreview | null> => {
+  // Tweet links can't be scraped (X serves an empty JS shell); the
+  // syndication CDN returns the tweet with its media instead. On failure we
+  // still try the generic scrape below rather than giving up outright.
+  const tweetId = getTweetIdFromUrl(target);
+  if (tweetId) {
+    const tweetPreview = await fetchTweetPreview(tweetId, FETCH_TIMEOUT_MS);
+    if (tweetPreview) return tweetPreview;
+  }
+
+  const youTubeVideoId = getYouTubeVideoId(target.href);
+  if (youTubeVideoId) {
+    const youTubePreview = await fetchYouTubePreview(target, youTubeVideoId);
+    if (youTubePreview) return youTubePreview;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(target, {
+      headers: {
+        accept: "text/html,application/xhtml+xml;q=0.9,image/*;q=0.8,*/*;q=0.5",
+        "accept-language": "en",
+        "user-agent": USER_AGENT,
+      },
+      redirect: "follow",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      cache: "no-store",
+    });
+  } catch {
+    return null;
+  }
+
+  // Redirects may land anywhere; re-run the same safety checks on the final
+  // URL before touching the body or echoing it back to clients.
+  const finalUrl = parseUnfurlableUrl(response.url || target.href);
+  if (!finalUrl || !response.ok) {
+    response.body?.cancel().catch(() => {});
+    return null;
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (IMAGE_CONTENT_TYPE_PATTERN.test(contentType)) {
+    response.body?.cancel().catch(() => {});
+    return {
+      url: finalUrl.href,
+      kind: "image",
+      imageUrl: finalUrl.href,
+      siteName: finalUrl.hostname.replace(/^www\./, ""),
+    };
+  }
+
+  if (!/^(?:text\/html|application\/xhtml\+xml)\b/i.test(contentType)) {
+    response.body?.cancel().catch(() => {});
+    return null;
+  }
+
+  let html: string;
+  try {
+    html = await readHtmlPrefix(response, MAX_HTML_BYTES);
+  } catch {
+    return null;
+  }
+
+  const metadata = parseUnfurlHtml(html, finalUrl);
+  if (!metadata.title && !metadata.description && !metadata.imageUrl) {
+    return null;
+  }
+
+  return {
+    url: finalUrl.href,
+    kind: "page",
+    siteName: metadata.siteName ?? finalUrl.hostname.replace(/^www\./, ""),
+    title: metadata.title,
+    description: metadata.description,
+    imageUrl: metadata.imageUrl,
+    faviconUrl: metadata.faviconUrl,
+    imageLayout: metadata.imageLayout,
+  };
+};
+
+const previewResponse = (
+  payload: UnfurlResponsePayload,
+  init?: { status?: number; cacheControl?: string },
+): Response =>
+  NextResponse.json(payload, {
+    status: init?.status ?? 200,
+    headers: {
+      "Cache-Control":
+        init?.cacheControl ??
+        (payload.preview ? HIT_CACHE_CONTROL : MISS_CACHE_CONTROL),
+    },
+  });
+
+// workerd exposes the Cache API; `next dev` on Node does not. Cache hits are
+// shared across every participant who unfurls the same link and are served
+// before the rate limiter, so popular links stay cheap for everyone.
+const getEdgeCache = (): Cache | null =>
+  (globalThis as { caches?: { default?: Cache } }).caches?.default ?? null;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const target = parseUnfurlableUrl(searchParams.get("url") ?? "");
+  if (!target) {
+    return previewResponse(
+      { preview: null },
+      { status: 400, cacheControl: "no-store" },
+    );
+  }
+
+  const cacheKey = new Request(
+    new URL(
+      `/api/unfurl?url=${encodeURIComponent(target.href)}`,
+      request.url,
+    ).href,
+  );
+  const edgeCache = getEdgeCache();
+  if (edgeCache) {
+    try {
+      const cached = await edgeCache.match(cacheKey);
+      if (cached) return cached;
+    } catch {
+      // Cache API hiccups must never take down unfurling.
+    }
+  }
+
+  const rateLimit = await takeUnfurlRateLimit(request);
+  if (!rateLimit.ok) {
+    return previewResponse(
+      { preview: null },
+      { status: rateLimit.status, cacheControl: "no-store" },
+    );
+  }
+
+  const preview = await fetchPreview(target);
+  const response = previewResponse({ preview });
+
+  if (edgeCache) {
+    try {
+      await edgeCache.put(cacheKey, response.clone());
+    } catch {
+      // Same: caching is best-effort.
+    }
+  }
+
+  return response;
+}

--- a/apps/web/src/app/api/unfurl/route.ts
+++ b/apps/web/src/app/api/unfurl/route.ts
@@ -1,4 +1,3 @@
-import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { NextResponse } from "next/server";
 import {
   type ChatLinkPreview,
@@ -6,7 +5,11 @@ import {
   getYouTubeThumbnailUrl,
   getYouTubeVideoId,
 } from "../../lib/link-embeds";
+import { toUnfurlAssetUrl } from "../../lib/unfurl-assets";
+import { fetchUnfurlResource } from "../../lib/unfurl-fetch";
 import { parseUnfurlableUrl, parseUnfurlHtml } from "../../lib/unfurl-html";
+import { takeUnfurlRateLimit } from "../../lib/unfurl-rate-limit";
+import { readHtmlPrefix } from "../../lib/unfurl-response";
 import { fetchTweetPreview, getTweetIdFromUrl } from "../../lib/unfurl-tweet";
 
 // Server-side link unfurler for chat embeds. The client hands us a URL from a
@@ -24,110 +27,8 @@ const USER_AGENT =
 
 // Found metadata is stable; misses retry sooner in case the page was flaky.
 const HIT_CACHE_CONTROL =
-  "public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400";
-const MISS_CACHE_CONTROL = "public, max-age=300, s-maxage=900";
-
-const RATE_LIMIT = 30;
-const RATE_WINDOW_MS = 60_000;
-
-type CloudflareRateLimitBinding = {
-  limit(options: { key: string }): Promise<{ success: boolean }>;
-};
-
-type LocalRateLimitBucket = { windowStartedAt: number; count: number };
-const localBuckets = new Map<string, LocalRateLimitBucket>();
-const MAX_LOCAL_BUCKETS = 1_000;
-
-const clientKey = (request: Request): string => {
-  const forwardedFor = request.headers
-    .get("x-forwarded-for")
-    ?.split(",")
-    .at(0)
-    ?.trim();
-  const candidate =
-    [
-      request.headers.get("cf-connecting-ip")?.trim(),
-      request.headers.get("x-real-ip")?.trim(),
-      forwardedFor,
-      request.headers.get("user-agent")?.trim(),
-    ].find((value): value is string => Boolean(value)) ?? "anonymous";
-  return candidate.slice(0, 128);
-};
-
-const takeLocalRateLimit = (key: string): boolean => {
-  const now = Date.now();
-  const bucket = localBuckets.get(key);
-  if (!bucket || now - bucket.windowStartedAt >= RATE_WINDOW_MS) {
-    localBuckets.set(key, { windowStartedAt: now, count: 1 });
-    while (localBuckets.size > MAX_LOCAL_BUCKETS) {
-      const oldest = localBuckets.keys().next().value;
-      if (oldest === undefined) break;
-      localBuckets.delete(oldest);
-    }
-    return true;
-  }
-  if (bucket.count >= RATE_LIMIT) return false;
-  bucket.count += 1;
-  return true;
-};
-
-type RateLimitOutcome = { ok: true } | { ok: false; status: 429 | 503 };
-
-const takeUnfurlRateLimit = async (request: Request): Promise<RateLimitOutcome> => {
-  const key = `unfurl:${clientKey(request)}`;
-
-  let limiter: CloudflareRateLimitBinding | null = null;
-  try {
-    const { env } = await getCloudflareContext({ async: true });
-    const binding = (env as { UNFURL_RATE_LIMITER?: CloudflareRateLimitBinding })
-      .UNFURL_RATE_LIMITER;
-    limiter = binding && typeof binding.limit === "function" ? binding : null;
-  } catch {
-    limiter = null;
-  }
-
-  if (limiter) {
-    try {
-      const { success } = await limiter.limit({ key });
-      return success ? { ok: true } : { ok: false, status: 429 };
-    } catch {
-      // Fall through to the fail-closed production branch below.
-    }
-  }
-
-  if (process.env.NODE_ENV === "production") {
-    // An unfurler is an outbound-fetch proxy; never run it unmetered.
-    return { ok: false, status: 503 };
-  }
-
-  return takeLocalRateLimit(key) ? { ok: true } : { ok: false, status: 429 };
-};
-
-// Reads at most `maxBytes` of the body, stopping early once the document head
-// has closed — everything the parser wants lives there on real pages.
-const readHtmlPrefix = async (
-  response: Response,
-  maxBytes: number,
-): Promise<string> => {
-  const body = response.body;
-  if (!body) return "";
-  const reader = body.getReader();
-  const decoder = new TextDecoder("utf-8", { fatal: false });
-  let html = "";
-  let receivedBytes = 0;
-  try {
-    while (receivedBytes < maxBytes) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      receivedBytes += value.byteLength;
-      html += decoder.decode(value, { stream: true });
-      if (html.includes("</head")) break;
-    }
-  } finally {
-    reader.cancel().catch(() => {});
-  }
-  return html + decoder.decode();
-};
+  "private, max-age=3600, stale-while-revalidate=3600";
+const MISS_CACHE_CONTROL = "private, max-age=300";
 
 const IMAGE_CONTENT_TYPE_PATTERN =
   /^image\/(?:png|jpeg|gif|webp|avif|svg\+xml)\b/i;
@@ -168,11 +69,12 @@ const fetchYouTubePreview = async (
     title,
     description:
       typeof payload.author_name === "string" ? payload.author_name : undefined,
-    imageUrl:
+    imageUrl: toUnfurlAssetUrl(
       typeof payload.thumbnail_url === "string"
         ? payload.thumbnail_url
         : getYouTubeThumbnailUrl(videoId),
-    faviconUrl: "https://www.youtube.com/favicon.ico",
+    ),
+    faviconUrl: toUnfurlAssetUrl("https://www.youtube.com/favicon.ico"),
     imageLayout: "large",
   };
 };
@@ -193,26 +95,23 @@ const fetchPreview = async (target: URL): Promise<ChatLinkPreview | null> => {
     if (youTubePreview) return youTubePreview;
   }
 
-  let response: Response;
+  let fetched: Awaited<ReturnType<typeof fetchUnfurlResource>>;
   try {
-    response = await fetch(target, {
+    fetched = await fetchUnfurlResource(target, {
       headers: {
         accept: "text/html,application/xhtml+xml;q=0.9,image/*;q=0.8,*/*;q=0.5",
         "accept-language": "en",
         "user-agent": USER_AGENT,
       },
-      redirect: "follow",
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       cache: "no-store",
     });
   } catch {
     return null;
   }
-
-  // Redirects may land anywhere; re-run the same safety checks on the final
-  // URL before touching the body or echoing it back to clients.
-  const finalUrl = parseUnfurlableUrl(response.url || target.href);
-  if (!finalUrl || !response.ok) {
+  if (!fetched) return null;
+  const { response, finalUrl } = fetched;
+  if (!response.ok) {
     response.body?.cancel().catch(() => {});
     return null;
   }
@@ -224,7 +123,7 @@ const fetchPreview = async (target: URL): Promise<ChatLinkPreview | null> => {
     return {
       url: finalUrl.href,
       kind: "image",
-      imageUrl: finalUrl.href,
+      imageUrl: toUnfurlAssetUrl(finalUrl.href),
       siteName: finalUrl.hostname.replace(/^www\./, ""),
     };
   }
@@ -252,8 +151,8 @@ const fetchPreview = async (target: URL): Promise<ChatLinkPreview | null> => {
     siteName: metadata.siteName ?? finalUrl.hostname.replace(/^www\./, ""),
     title: metadata.title,
     description: metadata.description,
-    imageUrl: metadata.imageUrl,
-    faviconUrl: metadata.faviconUrl,
+    imageUrl: toUnfurlAssetUrl(metadata.imageUrl),
+    faviconUrl: toUnfurlAssetUrl(metadata.faviconUrl),
     imageLayout: metadata.imageLayout,
   };
 };
@@ -271,12 +170,6 @@ const previewResponse = (
     },
   });
 
-// workerd exposes the Cache API; `next dev` on Node does not. Cache hits are
-// shared across every participant who unfurls the same link and are served
-// before the rate limiter, so popular links stay cheap for everyone.
-const getEdgeCache = (): Cache | null =>
-  (globalThis as { caches?: { default?: Cache } }).caches?.default ?? null;
-
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const target = parseUnfurlableUrl(searchParams.get("url") ?? "");
@@ -285,22 +178,6 @@ export async function GET(request: Request) {
       { preview: null },
       { status: 400, cacheControl: "no-store" },
     );
-  }
-
-  const cacheKey = new Request(
-    new URL(
-      `/api/unfurl?url=${encodeURIComponent(target.href)}`,
-      request.url,
-    ).href,
-  );
-  const edgeCache = getEdgeCache();
-  if (edgeCache) {
-    try {
-      const cached = await edgeCache.match(cacheKey);
-      if (cached) return cached;
-    } catch {
-      // Cache API hiccups must never take down unfurling.
-    }
   }
 
   const rateLimit = await takeUnfurlRateLimit(request);
@@ -312,15 +189,5 @@ export async function GET(request: Request) {
   }
 
   const preview = await fetchPreview(target);
-  const response = previewResponse({ preview });
-
-  if (edgeCache) {
-    try {
-      await edgeCache.put(cacheKey, response.clone());
-    } catch {
-      // Same: caching is best-effort.
-    }
-  }
-
-  return response;
+  return previewResponse({ preview });
 }

--- a/apps/web/src/app/components/ChatLinkEmbedView.tsx
+++ b/apps/web/src/app/components/ChatLinkEmbedView.tsx
@@ -1,0 +1,541 @@
+"use client";
+
+import { Link as LinkIcon, Play, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  type ChatLinkPreview,
+  type ChatLinkTweetData,
+  type ChatLinkTweetMedia,
+  fetchChatLinkPreview,
+  getYouTubeEmbedUrl,
+  getYouTubeThumbnailUrl,
+  getYouTubeVideoId,
+} from "../lib/link-embeds";
+
+interface ChatLinkEmbedViewProps {
+  url: string;
+}
+
+// Sentinel for "unfurl in flight" so a null result ("no preview available")
+// can collapse the embed without a loading flash for links that never embed.
+const LOADING = Symbol("loading");
+
+const CARD_CLASS =
+  "block w-[280px] max-w-full overflow-hidden rounded-[16px] border border-white/10 bg-white/[0.04] transition-colors hover:border-white/20 hover:bg-white/[0.06]";
+
+function SiteRow({
+  preview,
+  fallbackHost,
+}: {
+  preview: ChatLinkPreview | null;
+  fallbackHost: string;
+}) {
+  const [faviconFailed, setFaviconFailed] = useState(false);
+  const siteName = preview?.siteName ?? fallbackHost;
+  if (!siteName) return null;
+
+  return (
+    <span className="flex min-w-0 items-center gap-1.5">
+      {preview?.faviconUrl && !faviconFailed ? (
+        <img
+          src={preview.faviconUrl}
+          alt=""
+          aria-hidden="true"
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          onError={() => setFaviconFailed(true)}
+          className="h-3.5 w-3.5 shrink-0 rounded-[3px] object-contain"
+        />
+      ) : null}
+      <span className="truncate text-[11px] text-[#a1a1aa]">{siteName}</span>
+    </span>
+  );
+}
+
+function YouTubeEmbed({
+  url,
+  videoId,
+  preview,
+}: {
+  url: string;
+  videoId: string;
+  preview: ChatLinkPreview | null;
+}) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [thumbnailFailed, setThumbnailFailed] = useState(false);
+  const title = preview?.title ?? "Watch on YouTube";
+  const thumbnailUrl = preview?.imageUrl ?? getYouTubeThumbnailUrl(videoId);
+
+  return (
+    <div className={CARD_CLASS}>
+      <a
+        href={preview?.url ?? url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block px-3 pb-2 pt-2.5"
+      >
+        <SiteRow preview={preview} fallbackHost="YouTube" />
+        <span className="mt-0.5 line-clamp-2 block text-[12.5px] font-medium leading-snug text-[#fafafa]">
+          {title}
+        </span>
+      </a>
+      <div className="relative aspect-video w-full bg-black/40">
+        {isPlaying ? (
+          <iframe
+            src={getYouTubeEmbedUrl(videoId)}
+            title={title}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+            className="absolute inset-0 h-full w-full border-0"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setIsPlaying(true)}
+            aria-label={`Play video: ${title}`}
+            className="group/play absolute inset-0 h-full w-full cursor-pointer"
+          >
+            {!thumbnailFailed ? (
+              <img
+                src={thumbnailUrl}
+                alt=""
+                aria-hidden="true"
+                loading="lazy"
+                referrerPolicy="no-referrer"
+                onError={() => setThumbnailFailed(true)}
+                className="absolute inset-0 h-full w-full object-cover"
+              />
+            ) : null}
+            <span className="absolute inset-0 flex items-center justify-center">
+              <span className="flex h-11 w-11 items-center justify-center rounded-full bg-[#F95F4A] text-white transition-transform group-hover/play:scale-105">
+                <Play size={18} strokeWidth={2} fill="currentColor" />
+              </span>
+            </span>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TweetPhotoCell({
+  media,
+  className = "",
+}: {
+  media: ChatLinkTweetMedia;
+  className?: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  if (failed) {
+    return <span className={`block h-full w-full bg-white/[0.04] ${className}`} />;
+  }
+  return (
+    <img
+      src={media.url}
+      alt="Tweet photo"
+      loading="lazy"
+      referrerPolicy="no-referrer"
+      onError={() => setFailed(true)}
+      className={`h-full w-full object-cover ${className}`}
+    />
+  );
+}
+
+// A tweet carries at most one video (or animated gif); gifs autoplay muted on
+// loop the way X renders them, real videos are click-to-play with controls.
+function TweetVideoView({
+  media,
+  label,
+}: {
+  media: ChatLinkTweetMedia;
+  label: string;
+}) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [posterFailed, setPosterFailed] = useState(false);
+  const aspectRatio =
+    media.width && media.height ? `${media.width} / ${media.height}` : "16 / 9";
+
+  if (media.kind === "gif") {
+    return (
+      <div
+        className="relative max-h-[320px] w-full bg-black/40"
+        style={{ aspectRatio }}
+      >
+        <video
+          src={media.videoUrl}
+          poster={media.url}
+          muted
+          loop
+          autoPlay
+          playsInline
+          preload="metadata"
+          aria-label={label}
+          className="absolute inset-0 h-full w-full object-contain"
+        />
+        <span className="absolute bottom-1.5 left-1.5 rounded bg-black/60 px-1 py-0.5 text-[10px] font-semibold leading-none text-white">
+          GIF
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative max-h-[320px] w-full bg-black/40"
+      style={{ aspectRatio }}
+    >
+      {isPlaying ? (
+        <video
+          src={media.videoUrl}
+          poster={media.url}
+          controls
+          autoPlay
+          playsInline
+          preload="metadata"
+          aria-label={label}
+          className="absolute inset-0 h-full w-full object-contain"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setIsPlaying(true)}
+          aria-label={`Play ${label}`}
+          className="group/play absolute inset-0 h-full w-full cursor-pointer"
+        >
+          {!posterFailed ? (
+            <img
+              src={media.url}
+              alt=""
+              aria-hidden="true"
+              loading="lazy"
+              referrerPolicy="no-referrer"
+              onError={() => setPosterFailed(true)}
+              className="absolute inset-0 h-full w-full object-cover"
+            />
+          ) : null}
+          <span className="absolute inset-0 flex items-center justify-center">
+            <span className="flex h-11 w-11 items-center justify-center rounded-full bg-[#F95F4A] text-white transition-transform group-hover/play:scale-105">
+              <Play size={18} strokeWidth={2} fill="currentColor" />
+            </span>
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function TweetPhotoGrid({ photos }: { photos: ChatLinkTweetMedia[] }) {
+  if (photos.length === 1) {
+    const [photo] = photos;
+    const aspectRatio =
+      photo.width && photo.height
+        ? `${photo.width} / ${photo.height}`
+        : undefined;
+    return (
+      <div
+        className={`w-full overflow-hidden bg-black/25 ${
+          aspectRatio ? "max-h-[240px]" : "h-[160px]"
+        }`}
+        style={aspectRatio ? { aspectRatio } : undefined}
+      >
+        <TweetPhotoCell media={photo} />
+      </div>
+    );
+  }
+  if (photos.length === 2) {
+    return (
+      <div className="grid h-[140px] grid-cols-2 gap-px bg-black/25">
+        {photos.map((photo) => (
+          <TweetPhotoCell key={photo.url} media={photo} />
+        ))}
+      </div>
+    );
+  }
+  if (photos.length === 3) {
+    return (
+      <div className="grid h-[186px] grid-cols-2 grid-rows-2 gap-px bg-black/25">
+        <TweetPhotoCell media={photos[0]} className="row-span-2" />
+        <TweetPhotoCell media={photos[1]} />
+        <TweetPhotoCell media={photos[2]} />
+      </div>
+    );
+  }
+  return (
+    <div className="grid h-[186px] grid-cols-2 grid-rows-2 gap-px bg-black/25">
+      {photos.slice(0, 4).map((photo) => (
+        <TweetPhotoCell key={photo.url} media={photo} />
+      ))}
+    </div>
+  );
+}
+
+function TweetEmbed({
+  preview,
+  tweet,
+}: {
+  preview: ChatLinkPreview;
+  tweet: ChatLinkTweetData;
+}) {
+  const [avatarFailed, setAvatarFailed] = useState(false);
+  const video = tweet.media.find(
+    (media) => media.kind === "video" || media.kind === "gif",
+  );
+  const photos = tweet.media.filter((media) => media.kind === "photo");
+  const timeLabel = tweet.createdAt
+    ? new Date(tweet.createdAt).toLocaleDateString([], {
+        month: "short",
+        day: "numeric",
+      })
+    : null;
+
+  return (
+    <div className={CARD_CLASS}>
+      <a
+        href={preview.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block px-3 pb-2 pt-2.5"
+      >
+        <span className="flex min-w-0 items-center gap-1.5">
+          {tweet.authorAvatarUrl && !avatarFailed ? (
+            <img
+              src={tweet.authorAvatarUrl}
+              alt=""
+              aria-hidden="true"
+              loading="lazy"
+              referrerPolicy="no-referrer"
+              onError={() => setAvatarFailed(true)}
+              className="h-5 w-5 shrink-0 rounded-full bg-black/25 object-cover"
+            />
+          ) : null}
+          <span className="truncate text-[12.5px] font-medium text-[#fafafa]">
+            {tweet.authorName}
+          </span>
+          <span className="min-w-0 shrink-[2] truncate text-[11px] text-[#a1a1aa]">
+            @{tweet.authorHandle}
+            {timeLabel ? ` · ${timeLabel}` : ""}
+          </span>
+        </span>
+        {tweet.text ? (
+          <span className="mt-1 line-clamp-5 block whitespace-pre-wrap text-[12.5px] leading-snug text-[#fafafa]/90">
+            {tweet.text}
+          </span>
+        ) : null}
+      </a>
+      {video ? (
+        <TweetVideoView
+          media={video}
+          label={`video from @${tweet.authorHandle}`}
+        />
+      ) : photos.length > 0 ? (
+        <a
+          href={preview.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block"
+        >
+          <TweetPhotoGrid photos={photos} />
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+function ImageEmbed({ preview }: { preview: ChatLinkPreview }) {
+  const [failed, setFailed] = useState(false);
+  if (failed || !preview.imageUrl) return null;
+
+  return (
+    <a
+      href={preview.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block max-w-full overflow-hidden rounded-[16px] border border-white/10 bg-black/25"
+    >
+      <img
+        src={preview.imageUrl}
+        alt="Linked image"
+        loading="lazy"
+        referrerPolicy="no-referrer"
+        onError={() => setFailed(true)}
+        className="block max-h-56 w-auto max-w-full object-contain"
+      />
+    </a>
+  );
+}
+
+function PageEmbed({ preview }: { preview: ChatLinkPreview }) {
+  const [imageFailed, setImageFailed] = useState(false);
+  const showImage = Boolean(preview.imageUrl) && !imageFailed;
+  const isLargeImage = showImage && preview.imageLayout === "large";
+  const isThumbImage = showImage && !isLargeImage;
+
+  return (
+    <a
+      href={preview.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`${CARD_CLASS} px-3 py-2.5`}
+    >
+      <span className="flex items-start gap-2.5">
+        <span className="min-w-0 flex-1">
+          <SiteRow preview={preview} fallbackHost="" />
+          {preview.title ? (
+            <span className="mt-0.5 line-clamp-2 block text-[12.5px] font-medium leading-snug text-[#fafafa]">
+              {preview.title}
+            </span>
+          ) : null}
+          {preview.description ? (
+            <span className="mt-0.5 line-clamp-2 block text-[12px] leading-snug text-[#a1a1aa]">
+              {preview.description}
+            </span>
+          ) : null}
+        </span>
+        {isThumbImage ? (
+          <img
+            src={preview.imageUrl}
+            alt=""
+            aria-hidden="true"
+            loading="lazy"
+            referrerPolicy="no-referrer"
+            onError={() => setImageFailed(true)}
+            className="h-14 w-14 shrink-0 rounded-lg bg-black/25 object-cover"
+          />
+        ) : null}
+      </span>
+      {isLargeImage ? (
+        <img
+          src={preview.imageUrl}
+          alt=""
+          aria-hidden="true"
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          onError={() => setImageFailed(true)}
+          className="mt-2 max-h-[150px] w-full rounded-lg bg-black/25 object-cover"
+        />
+      ) : null}
+    </a>
+  );
+}
+
+/**
+ * Compact preview above the composer for the first link in the draft, with a
+ * dismiss control. Dismissing tells the send path to set `suppressEmbeds`, so
+ * the message renders without embed cards for everyone.
+ */
+export function ChatComposerLinkPreview({
+  url,
+  onDismiss,
+}: {
+  url: string;
+  onDismiss: () => void;
+}) {
+  const [preview, setPreview] = useState<
+    ChatLinkPreview | null | typeof LOADING
+  >(LOADING);
+  const [thumbFailed, setThumbFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setPreview(LOADING);
+    setThumbFailed(false);
+    void fetchChatLinkPreview(url).then((result) => {
+      if (!cancelled) setPreview(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (preview === LOADING) return null;
+
+  const videoId = getYouTubeVideoId(url);
+  // No card would render on the sent message either — nothing to dismiss.
+  if (!preview && !videoId) return null;
+
+  const thumbnailUrl =
+    preview?.imageUrl ?? (videoId ? getYouTubeThumbnailUrl(videoId) : undefined);
+  let host = "";
+  try {
+    host = new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    host = "";
+  }
+  const siteName = preview?.siteName ?? (videoId ? "YouTube" : host);
+  const title = preview?.title ?? (videoId ? "Watch on YouTube" : url);
+
+  return (
+    <div className="mb-2 flex items-center gap-2.5 rounded-xl border border-white/10 bg-white/[0.04] p-2 pr-1.5">
+      {thumbnailUrl && !thumbFailed ? (
+        <img
+          src={thumbnailUrl}
+          alt=""
+          aria-hidden="true"
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          onError={() => setThumbFailed(true)}
+          className="h-10 w-10 shrink-0 rounded-lg bg-black/25 object-cover"
+        />
+      ) : (
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white/[0.06] text-[#a1a1aa]">
+          <LinkIcon size={16} strokeWidth={1.75} />
+        </span>
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-[11px] text-[#a1a1aa]">
+          Link preview{siteName ? ` · ${siteName}` : ""}
+        </p>
+        <p className="truncate text-[12.5px] font-medium text-[#fafafa]">
+          {title}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Remove link preview"
+        title="Send without link preview"
+        className="shrink-0 self-center rounded-md p-1 text-[#a1a1aa] transition-colors hover:bg-white/[0.08] hover:text-[#fafafa]"
+      >
+        <X size={14} strokeWidth={2} />
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Rich preview card for a link in a chat message. Renders nothing while the
+ * unfurl is in flight and stays empty when the URL yields no metadata, so
+ * messages never show broken or placeholder cards.
+ */
+export default function ChatLinkEmbedView({ url }: ChatLinkEmbedViewProps) {
+  const [preview, setPreview] = useState<
+    ChatLinkPreview | null | typeof LOADING
+  >(LOADING);
+
+  useEffect(() => {
+    let cancelled = false;
+    setPreview(LOADING);
+    void fetchChatLinkPreview(url).then((result) => {
+      if (!cancelled) setPreview(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (preview === LOADING) return null;
+
+  // YouTube links get an inline click-to-play player even when the page
+  // scrape came back empty — the thumbnail is derivable from the video id.
+  const videoId = getYouTubeVideoId(url);
+  if (videoId) {
+    return <YouTubeEmbed url={url} videoId={videoId} preview={preview} />;
+  }
+
+  if (!preview) return null;
+  if (preview.kind === "tweet" && preview.tweet) {
+    return <TweetEmbed preview={preview} tweet={preview.tweet} />;
+  }
+  if (preview.kind === "image") return <ImageEmbed preview={preview} />;
+  return <PageEmbed preview={preview} />;
+}

--- a/apps/web/src/app/components/ChatLinkEmbedView.tsx
+++ b/apps/web/src/app/components/ChatLinkEmbedView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Link as LinkIcon, Play, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   type ChatLinkPreview,
   type ChatLinkTweetData,
@@ -152,8 +152,21 @@ function TweetVideoView({
 }) {
   const [isPlaying, setIsPlaying] = useState(false);
   const [posterFailed, setPosterFailed] = useState(false);
+  const hasAutoStartedRef = useRef(false);
   const aspectRatio =
     media.width && media.height ? `${media.width} / ${media.height}` : "16 / 9";
+
+  // Kick playback off inside the click's user-activation window (the swap
+  // commits synchronously for discrete events) instead of trusting the
+  // autoplay attribute; retry muted if unmuted playback is denied.
+  const startPlayback = (video: HTMLVideoElement | null) => {
+    if (!video || hasAutoStartedRef.current) return;
+    hasAutoStartedRef.current = true;
+    video.play().catch(() => {
+      video.muted = true;
+      video.play().catch(() => {});
+    });
+  };
 
   if (media.kind === "gif") {
     return (
@@ -186,6 +199,7 @@ function TweetVideoView({
     >
       {isPlaying ? (
         <video
+          ref={startPlayback}
           src={media.videoUrl}
           poster={media.url}
           controls

--- a/apps/web/src/app/components/ChatPanel.tsx
+++ b/apps/web/src/app/components/ChatPanel.tsx
@@ -14,7 +14,12 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Avatar } from "@conclave/ui-tokens/web";
 import type { ConclaveAssistantApiKeyPromptState } from "../hooks/useMeetChat";
-import type { ChatGifAttachment, ChatMessage, ChatReplyPreview } from "../lib/types";
+import type {
+  ChatGifAttachment,
+  ChatMessage,
+  ChatReplyPreview,
+  SendChatMessageOptions,
+} from "../lib/types";
 import { getActionText, getCommandSuggestions } from "../lib/chat-commands";
 import {
   CHAT_IMAGE_ACCEPT,
@@ -36,6 +41,7 @@ import {
   CONCLAVE_MENTION_TOKEN,
   isConclaveAssistantModel,
 } from "../lib/conclave-assistant";
+import { extractEmbedUrls } from "../lib/link-embeds";
 import { formatDisplayName, getChatMessageSegments } from "../lib/utils";
 import {
   Conversation,
@@ -44,6 +50,9 @@ import {
 } from "./ai-elements/conversation";
 import ChatGifAttachmentView from "./ChatGifAttachmentView";
 import ChatImageAttachmentView from "./ChatImageAttachmentView";
+import ChatLinkEmbedView, {
+  ChatComposerLinkPreview,
+} from "./ChatLinkEmbedView";
 import ConclaveMessage from "./ConclaveMessage";
 import GifPicker from "./GifPicker";
 
@@ -59,7 +68,7 @@ interface ChatPanelProps {
   messages: ChatMessage[];
   chatInput: string;
   onInputChange: (value: string) => void;
-  onSend: (content: string) => void;
+  onSend: (content: string, options?: SendChatMessageOptions) => void;
   onSendGif: (gif: ChatGifAttachment) => void;
   onSendImage: (
     file: File,
@@ -150,6 +159,13 @@ function ChatPanel({
   const [highlightedMessageId, setHighlightedMessageId] = useState<
     string | null
   >(null);
+  // First embeddable URL of the draft (debounced) drives the composer-side
+  // link preview; dismissing it remembers the URL so the preview stays away
+  // while that same link is in the draft, and the send carries the flag.
+  const [composerEmbedUrl, setComposerEmbedUrl] = useState<string | null>(null);
+  const [dismissedEmbedUrl, setDismissedEmbedUrl] = useState<string | null>(
+    null,
+  );
   const isChatDisabled = isChatLocked && !isAdmin;
   const isImagePickerDisabled =
     isChatDisabled || !areImageAttachmentsEnabled || isImageUploading;
@@ -334,6 +350,28 @@ function ChatPanel({
     textarea.style.height = `${Math.min(textarea.scrollHeight, 112)}px`;
   }, [chatInput]);
 
+  useEffect(() => {
+    const [firstUrl] = extractEmbedUrls(chatInput, 1);
+    if (!firstUrl) {
+      setComposerEmbedUrl(null);
+      return;
+    }
+    // Debounced so half-typed URLs don't hit the unfurl endpoint on every
+    // keystroke; pasted links settle within one tick.
+    const handle = window.setTimeout(() => setComposerEmbedUrl(firstUrl), 450);
+    return () => window.clearTimeout(handle);
+  }, [chatInput]);
+
+  useEffect(() => {
+    if (
+      dismissedEmbedUrl &&
+      composerEmbedUrl &&
+      composerEmbedUrl !== dismissedEmbedUrl
+    ) {
+      setDismissedEmbedUrl(null);
+    }
+  }, [composerEmbedUrl, dismissedEmbedUrl]);
+
   const clearPendingImage = useCallback(() => {
     if (pendingImageUrlRef.current) {
       URL.revokeObjectURL(pendingImageUrlRef.current);
@@ -437,13 +475,19 @@ function ChatPanel({
         if (sent) {
           clearPendingImage();
           onInputChange("");
+          setDismissedEmbedUrl(null);
         } else {
           setImageUploadError("Couldn’t send this image. Try again.");
         }
         return;
       }
-      onSend(chatInput);
+      // Recomputed from the draft (not the debounced state) so a fast
+      // paste-and-enter can't race the composer preview.
+      const [firstUrl] = extractEmbedUrls(chatInput, 1);
+      const suppressEmbeds = Boolean(firstUrl) && firstUrl === dismissedEmbedUrl;
+      onSend(chatInput, suppressEmbeds ? { suppressEmbeds: true } : undefined);
       onInputChange("");
+      setDismissedEmbedUrl(null);
     }
   };
 
@@ -451,6 +495,7 @@ function ChatPanel({
     if (isChatDisabled) return;
     onSendGif(gif);
     onInputChange("");
+    setDismissedEmbedUrl(null);
   };
 
   const applyMentionSuggestion = (index: number) => {
@@ -754,6 +799,11 @@ function ChatPanel({
                   ? "You"
                   : formatDisplayName(msg.replyTo.displayName));
 
+              const embedUrls =
+                msg.gif || msg.image || msg.suppressEmbeds
+                  ? []
+                  : extractEmbedUrls(msg.content);
+
               const nestedReplyQuote = msg.replyTo ? (
                 <button
                   type="button"
@@ -911,6 +961,17 @@ function ChatPanel({
                       </div>
                       {replyButton}
                     </div>
+                    {embedUrls.length > 0 ? (
+                      <div
+                        className={`mt-1 flex w-full min-w-0 flex-col gap-1 ${
+                          isOwn ? "items-end" : "items-start"
+                        }`}
+                      >
+                        {embedUrls.map((embedUrl) => (
+                          <ChatLinkEmbedView key={embedUrl} url={embedUrl} />
+                        ))}
+                      </div>
+                    ) : null}
                   </div>
                 </div>
               );
@@ -1185,6 +1246,15 @@ function ChatPanel({
               </button>
             </div>
           )}
+          {composerEmbedUrl &&
+          dismissedEmbedUrl !== composerEmbedUrl &&
+          !pendingImage &&
+          !isChatDisabled ? (
+            <ChatComposerLinkPreview
+              url={composerEmbedUrl}
+              onDismiss={() => setDismissedEmbedUrl(composerEmbedUrl)}
+            />
+          ) : null}
           {pendingImage && !isChatDisabled ? (
             <div className="mb-2 overflow-hidden rounded-xl border border-white/10 bg-white/[0.04]">
               <div className="flex items-center gap-3 p-2">

--- a/apps/web/src/app/components/ControlsBar.tsx
+++ b/apps/web/src/app/components/ControlsBar.tsx
@@ -309,6 +309,14 @@ function ActivityDock({
   const FaceIcon = face?.d.icon ?? Shapes;
   const faceLabel = face ? face.d.label : "Activities";
   const faceActive = face?.d.variant === "active";
+  const handleFaceClick = () => {
+    if (face?.d.onPress) {
+      setOpen(false);
+      face.d.onPress();
+      return;
+    }
+    toggleFromFace();
+  };
 
   return (
     <div className="flex items-center rounded-full bg-white/[0.05] p-1">
@@ -343,7 +351,7 @@ function ActivityDock({
                 title={faceLabel}
                 aria-expanded={open}
                 aria-controls={trayId}
-                onClick={toggleFromFace}
+                onClick={handleFaceClick}
                 className="relative inline-flex h-10 w-10 items-center justify-center rounded-full transition-[background-color,color] duration-[120ms] hover:bg-white/[0.08] hover:!text-[#fafafa]"
                 style={{ color: faceActive ? color.accent : color.textMuted }}
               >

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -59,6 +59,7 @@ import type {
   Participant,
   ReconnectRecoveryStatus,
   ReactionOption,
+  SendChatMessageOptions,
   WebinarConfigSnapshot,
   WebinarLinkResponse,
   WebinarUpdateRequest,
@@ -209,7 +210,7 @@ interface MeetsMainContentProps {
   chatMessages: ChatMessage[];
   chatInput: string;
   setChatInput: Dispatch<SetStateAction<string>>;
-  sendChat: (content: string) => void;
+  sendChat: (content: string, options?: SendChatMessageOptions) => void;
   sendChatGif: (gif: ChatGifAttachment) => void;
   sendChatImage: (
     file: File,
@@ -1322,9 +1323,12 @@ export default function MeetsMainContent({
   useEffect(() => {
     sendChatRef.current = sendChat;
   }, [sendChat]);
-  const handleSendChat = useCallback((content: string) => {
-    sendChatRef.current(content);
-  }, []);
+  const handleSendChat = useCallback(
+    (content: string, options?: SendChatMessageOptions) => {
+      sendChatRef.current(content, options);
+    },
+    [],
+  );
   const sendChatGifRef = useRef(sendChatGif);
   useEffect(() => {
     sendChatGifRef.current = sendChatGif;

--- a/apps/web/src/app/hooks/useMeetChat.ts
+++ b/apps/web/src/app/hooks/useMeetChat.ts
@@ -7,6 +7,7 @@ import type {
   ChatImageAttachment,
   ChatMessage,
   ChatReplyPreview,
+  SendChatMessageOptions,
 } from "../lib/types";
 import {
   createLocalChatMessage,
@@ -515,6 +516,7 @@ export function useMeetChat({
       gif?: ChatGifAttachment,
       replyTo?: ChatReplyPreview,
       image?: ChatImageAttachment,
+      suppressEmbeds?: boolean,
     ): ChatMessage =>
       normalizeChatMessage({
         id: `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -525,6 +527,7 @@ export function useMeetChat({
         ...(gif ? { gif } : {}),
         ...(image ? { image } : {}),
         ...(replyTo ? { replyTo } : {}),
+        ...(suppressEmbeds ? { suppressEmbeds: true } : {}),
       }).message,
     [currentUserDisplayName, currentUserId],
   );
@@ -563,6 +566,7 @@ export function useMeetChat({
       gif?: ChatGifAttachment,
       replyTo?: ChatReplyPreview,
       image?: ChatImageAttachment,
+      suppressEmbeds?: boolean,
     ): Promise<ChatMessage | null> => {
       const socket = socketRef.current;
       const trimmedContent = content.trim();
@@ -578,6 +582,7 @@ export function useMeetChat({
         gif,
         replyTo,
         image,
+        suppressEmbeds,
       );
       setChatMessages((prev) => [...prev, optimisticMessage]);
 
@@ -592,6 +597,7 @@ export function useMeetChat({
             ...(isTtsMessage && outgoingTtsVoiceToken
               ? { ttsVoiceToken: outgoingTtsVoiceToken }
               : {}),
+            ...(suppressEmbeds ? { suppressEmbeds: true } : {}),
           },
           (
             response:
@@ -668,7 +674,7 @@ export function useMeetChat({
   }, []);
 
   const sendChat = useCallback(
-    (content: string) => {
+    (content: string, options?: SendChatMessageOptions) => {
       if (isObserverMode) return;
       if (isChatLocked && !isAdmin) {
         appendLocalMessage("Chat is locked by the host.");
@@ -677,9 +683,16 @@ export function useMeetChat({
       const trimmed = content.trim();
       if (!trimmed) return;
 
+      const suppressEmbeds = options?.suppressEmbeds === true;
       const conclaveQuestion = parseConclaveMention(trimmed);
       if (conclaveQuestion !== null) {
-        void sendChatInternal(trimmed).then((message) => {
+        void sendChatInternal(
+          trimmed,
+          undefined,
+          undefined,
+          undefined,
+          suppressEmbeds,
+        ).then((message) => {
           if (message) {
             askConclave(conclaveQuestion, message.id);
           }
@@ -777,7 +790,13 @@ export function useMeetChat({
 
       const activeReply = replyTarget ?? undefined;
       if (activeReply) setReplyTarget(null);
-      void sendChatInternal(trimmed, undefined, activeReply);
+      void sendChatInternal(
+        trimmed,
+        undefined,
+        activeReply,
+        undefined,
+        suppressEmbeds,
+      );
     },
     [
       isObserverMode,

--- a/apps/web/src/app/lib/link-embeds.ts
+++ b/apps/web/src/app/lib/link-embeds.ts
@@ -133,10 +133,15 @@ export function fetchChatLinkPreview(url: string): Promise<ChatLinkPreview | nul
   if (!pending) {
     pending = (async (): Promise<ChatLinkPreview | null> => {
       const response = await fetch(`/api/unfurl?url=${encodeURIComponent(url)}`);
-      if (!response.ok) return null;
+      if (!response.ok) {
+        throw new Error(`Unfurl failed with ${response.status}`);
+      }
       const payload = (await response.json()) as UnfurlResponsePayload;
       return payload?.preview ?? null;
-    })().catch(() => null);
+    })().catch(() => {
+      previewCache.delete(url);
+      return null;
+    });
     previewCache.set(url, pending);
   }
   return pending;

--- a/apps/web/src/app/lib/link-embeds.ts
+++ b/apps/web/src/app/lib/link-embeds.ts
@@ -1,0 +1,143 @@
+// Client-side plumbing for chat link embeds: which URLs in a message deserve
+// a preview card, YouTube detection for the inline player, and a session-wide
+// cache in front of /api/unfurl so every message, remount, and duplicate link
+// costs at most one request.
+
+export type ChatLinkPreviewKind = "page" | "image" | "tweet";
+
+export interface ChatLinkTweetMedia {
+  kind: "photo" | "video" | "gif";
+  /** Photo URL, or the poster frame for videos and gifs. */
+  url: string;
+  /** Direct mp4 for videos and gifs. */
+  videoUrl?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface ChatLinkTweetData {
+  authorName: string;
+  /** Without the leading @. */
+  authorHandle: string;
+  authorAvatarUrl?: string;
+  text: string;
+  media: ChatLinkTweetMedia[];
+  createdAt?: number;
+}
+
+export interface ChatLinkPreview {
+  /** Final URL after redirects — what the embed card links to. */
+  url: string;
+  kind: ChatLinkPreviewKind;
+  siteName?: string;
+  title?: string;
+  description?: string;
+  imageUrl?: string;
+  faviconUrl?: string;
+  imageLayout?: "large" | "thumb";
+  /** Present when kind is "tweet"; clients without tweet support can fall
+   * back to the generic title/description/imageUrl fields above. */
+  tweet?: ChatLinkTweetData;
+}
+
+export interface UnfurlResponsePayload {
+  preview: ChatLinkPreview | null;
+}
+
+export const MAX_EMBEDS_PER_MESSAGE = 2;
+
+// Only unfurl links the sender typed explicitly as links ("https://…" or
+// "www.…"). Bare domains like "vercel.com" still linkify in the message text
+// but don't embed — mid-sentence mentions would otherwise spam cards.
+const EMBED_URL_PATTERN = /(?:https?:\/\/|www\.)[^\s<>]+/gi;
+
+/**
+ * Returns the embeddable URLs of a chat message, deduped and capped. Wrapping
+ * a link in angle brackets ("<https://…>") suppresses its embed, mirroring
+ * the convention chat power users expect.
+ */
+export function extractEmbedUrls(
+  content: string,
+  max: number = MAX_EMBEDS_PER_MESSAGE,
+): string[] {
+  const urls: string[] = [];
+  const seen = new Set<string>();
+
+  for (const match of content.matchAll(EMBED_URL_PATTERN)) {
+    if (urls.length >= max) break;
+    const index = match.index ?? -1;
+    if (index < 0) continue;
+
+    // Same trailing-punctuation trim as the message linkifier, so the embed
+    // fetches exactly the URL the text renders as a link.
+    const trimmed = match[0].replace(/[),.!?;:]+$/, "");
+    if (!trimmed || trimmed.includes("@")) continue;
+
+    const followingChar = content[index + match[0].length];
+    if (content[index - 1] === "<" && followingChar === ">") continue;
+
+    const href = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+    let normalized: string;
+    try {
+      normalized = new URL(href).href;
+    } catch {
+      continue;
+    }
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    urls.push(normalized);
+  }
+
+  return urls;
+}
+
+const YOUTUBE_VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+
+/** Extracts a YouTube video id from watch/shorts/live/embed/youtu.be URLs. */
+export function getYouTubeVideoId(rawUrl: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  const host = url.hostname.toLowerCase().replace(/^www\./, "");
+  let candidate: string | undefined;
+
+  if (host === "youtu.be") {
+    candidate = url.pathname.split("/")[1];
+  } else if (host === "youtube.com" || host === "m.youtube.com" || host === "music.youtube.com") {
+    const [, first, second] = url.pathname.split("/");
+    if (first === "watch") {
+      candidate = url.searchParams.get("v") ?? undefined;
+    } else if (first === "shorts" || first === "live" || first === "embed") {
+      candidate = second;
+    }
+  }
+
+  return candidate && YOUTUBE_VIDEO_ID_PATTERN.test(candidate) ? candidate : null;
+}
+
+export const getYouTubeThumbnailUrl = (videoId: string): string =>
+  `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+
+export const getYouTubeEmbedUrl = (videoId: string): string =>
+  `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`;
+
+// Resolved previews (including nulls — "this URL has no card") are kept for
+// the whole session; chat history remounts constantly and must not refetch.
+const previewCache = new Map<string, Promise<ChatLinkPreview | null>>();
+
+export function fetchChatLinkPreview(url: string): Promise<ChatLinkPreview | null> {
+  let pending = previewCache.get(url);
+  if (!pending) {
+    pending = (async (): Promise<ChatLinkPreview | null> => {
+      const response = await fetch(`/api/unfurl?url=${encodeURIComponent(url)}`);
+      if (!response.ok) return null;
+      const payload = (await response.json()) as UnfurlResponsePayload;
+      return payload?.preview ?? null;
+    })().catch(() => null);
+    previewCache.set(url, pending);
+  }
+  return pending;
+}

--- a/apps/web/src/app/lib/unfurl-assets.ts
+++ b/apps/web/src/app/lib/unfurl-assets.ts
@@ -1,0 +1,10 @@
+import { parseUnfurlableUrl } from "./unfurl-html";
+
+export const toUnfurlAssetUrl = (
+  candidate: string | undefined,
+): string | undefined => {
+  const target = parseUnfurlableUrl(candidate ?? "");
+  return target
+    ? `/api/unfurl/asset?url=${encodeURIComponent(target.href)}`
+    : undefined;
+};

--- a/apps/web/src/app/lib/unfurl-fetch.ts
+++ b/apps/web/src/app/lib/unfurl-fetch.ts
@@ -1,0 +1,48 @@
+import { parseUnfurlableUrl } from "./unfurl-html";
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const MAX_REDIRECTS = 5;
+
+export interface UnfurlFetchResult {
+  response: Response;
+  finalUrl: URL;
+}
+
+/**
+ * Fetches a public unfurl resource without letting the runtime follow an
+ * unvalidated redirect. Every Location is resolved and checked before the
+ * next request, which keeps next dev from following public URLs onto the LAN.
+ */
+export async function fetchUnfurlResource(
+  target: URL,
+  init: RequestInit = {},
+  fetcher: typeof fetch = fetch,
+): Promise<UnfurlFetchResult | null> {
+  let currentUrl = parseUnfurlableUrl(target.href);
+  if (!currentUrl) return null;
+
+  let redirectCount = 0;
+  while (true) {
+    const response = await fetcher(currentUrl, {
+      ...init,
+      redirect: "manual",
+    });
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      return { response, finalUrl: currentUrl };
+    }
+
+    const location = response.headers.get("location");
+    response.body?.cancel().catch(() => {});
+    if (!location || redirectCount >= MAX_REDIRECTS) return null;
+
+    let redirectUrl: URL;
+    try {
+      redirectUrl = new URL(location, currentUrl);
+    } catch {
+      return null;
+    }
+    currentUrl = parseUnfurlableUrl(redirectUrl.href);
+    if (!currentUrl) return null;
+    redirectCount += 1;
+  }
+}

--- a/apps/web/src/app/lib/unfurl-html.ts
+++ b/apps/web/src/app/lib/unfurl-html.ts
@@ -1,0 +1,250 @@
+// Pure helpers for the /api/unfurl route: hostname safety checks and a
+// tolerant Open Graph / Twitter-card scraper. Everything here is plain string
+// work so it runs identically in Node (next dev), workerd (production), and
+// vitest.
+
+export interface UnfurlPageMetadata {
+  title?: string;
+  description?: string;
+  siteName?: string;
+  imageUrl?: string;
+  faviconUrl?: string;
+  /** How the embed card should present the image: hero or side thumbnail. */
+  imageLayout?: "large" | "thumb";
+}
+
+const MAX_TITLE_LENGTH = 200;
+const MAX_DESCRIPTION_LENGTH = 400;
+const MAX_SITE_NAME_LENGTH = 80;
+const MAX_URL_LENGTH = 2048;
+
+// Hosts that must never be fetched server-side. Production additionally runs
+// with Cloudflare's `global_fetch_strictly_public` flag, which blocks private
+// address resolution outright; this list keeps `next dev` (plain Node fetch)
+// from being used as a LAN probe and gives both runtimes fast, uniform errors.
+const BLOCKED_HOST_SUFFIXES = [
+  ".localhost",
+  ".local",
+  ".internal",
+  ".intranet",
+  ".home.arpa",
+  ".onion",
+];
+
+const isPrivateIpv4 = (hostname: string): boolean => {
+  const match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!match) return false;
+  const octets = match.slice(1).map((part) => Number.parseInt(part, 10));
+  if (octets.some((octet) => !Number.isFinite(octet) || octet > 255)) {
+    // Not a real IPv4 literal; treat it as a hostname instead.
+    return false;
+  }
+  const [a, b] = octets;
+  if (a === 0 || a === 10 || a === 127) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64/10
+  if (a === 169 && b === 254) return true; // link-local + cloud metadata
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 192 && b === 0) return true; // 192.0.0/24 + 192.0.2/24 test range
+  if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking
+  if (a >= 224) return true; // multicast + reserved + broadcast
+  return false;
+};
+
+/**
+ * Returns true when a hostname must not be unfurled: loopback, private and
+ * special-use IPv4 ranges, every IPv6 literal (shared links are never raw
+ * IPv6, and the ranges are fiddly to classify), single-label intranet names,
+ * and reserved DNS suffixes. Expects a hostname as produced by `new URL()`,
+ * which canonicalizes integer/octal/hex IPv4 forms to dotted quads.
+ */
+export function isForbiddenUnfurlHost(rawHostname: string): boolean {
+  const hostname = rawHostname.toLowerCase().replace(/\.+$/, "");
+  if (!hostname) return true;
+  if (hostname.startsWith("[") || hostname.includes(":")) return true;
+  if (hostname === "localhost") return true;
+  if (!hostname.includes(".")) return true;
+  if (BLOCKED_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix))) {
+    return true;
+  }
+  return isPrivateIpv4(hostname);
+}
+
+/**
+ * Parses and validates a URL that the unfurler is allowed to touch — http(s)
+ * only, no embedded credentials, sane length, public-looking host. Returns
+ * null when the candidate fails any check.
+ */
+export function parseUnfurlableUrl(candidate: string): URL | null {
+  if (!candidate || candidate.length > MAX_URL_LENGTH) return null;
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  if (url.username || url.password) return null;
+  if (isForbiddenUnfurlHost(url.hostname)) return null;
+  return url;
+}
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+  mdash: "—",
+  ndash: "–",
+  hellip: "…",
+  rsquo: "’",
+  lsquo: "‘",
+  rdquo: "”",
+  ldquo: "“",
+};
+
+export function decodeHtmlEntities(value: string): string {
+  return value.replace(
+    /&(?:#x([0-9a-f]+)|#(\d+)|([a-z]+));/gi,
+    (whole, hex: string | undefined, dec: string | undefined, named: string | undefined) => {
+      const codePoint = hex
+        ? Number.parseInt(hex, 16)
+        : dec
+          ? Number.parseInt(dec, 10)
+          : null;
+      if (codePoint !== null) {
+        if (!Number.isFinite(codePoint) || codePoint <= 0 || codePoint > 0x10ffff) {
+          return whole;
+        }
+        try {
+          return String.fromCodePoint(codePoint);
+        } catch {
+          return whole;
+        }
+      }
+      const replacement = named ? NAMED_ENTITIES[named.toLowerCase()] : undefined;
+      return replacement ?? whole;
+    },
+  );
+}
+
+const cleanText = (value: string, maxLength: number): string | undefined => {
+  const text = decodeHtmlEntities(value).replace(/\s+/g, " ").trim();
+  if (!text) return undefined;
+  return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+};
+
+// Resolves a scraped URL (possibly relative or protocol-relative) against the
+// page URL and re-applies the public-host rules, so a page can't point the
+// viewer's browser at file:, javascript:, or LAN addresses.
+const resolveSafeUrl = (candidate: string, base: URL): string | undefined => {
+  const raw = decodeHtmlEntities(candidate).trim();
+  if (!raw) return undefined;
+  let resolved: URL;
+  try {
+    resolved = new URL(raw, base);
+  } catch {
+    return undefined;
+  }
+  if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
+    return undefined;
+  }
+  if (resolved.username || resolved.password) return undefined;
+  if (isForbiddenUnfurlHost(resolved.hostname)) return undefined;
+  return resolved.href.length > MAX_URL_LENGTH ? undefined : resolved.href;
+};
+
+// Pulls attributes out of a single tag's source. Handles double-quoted,
+// single-quoted, and bare values, any attribute order, and uppercase names.
+const parseTagAttributes = (tagSource: string): Map<string, string> => {
+  const attributes = new Map<string, string>();
+  const pattern = /([a-zA-Z][a-zA-Z0-9:_-]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'<>`]+))/g;
+  for (const match of tagSource.matchAll(pattern)) {
+    const name = match[1].toLowerCase();
+    if (!attributes.has(name)) {
+      attributes.set(name, match[2] ?? match[3] ?? match[4] ?? "");
+    }
+  }
+  return attributes;
+};
+
+/**
+ * Extracts embed metadata from an HTML document (or its truncated prefix).
+ * Tolerates attribute-order and quoting variance rather than parsing a full
+ * DOM — meta/link/title tags are effectively line-oriented in real pages.
+ */
+export function parseUnfurlHtml(html: string, pageUrl: URL): UnfurlPageMetadata {
+  const meta = new Map<string, string>();
+  for (const match of html.matchAll(/<meta\b[^>]*>/gi)) {
+    const attributes = parseTagAttributes(match[0]);
+    const key = (attributes.get("property") ?? attributes.get("name"))?.toLowerCase();
+    const content = attributes.get("content");
+    if (!key || content === undefined || meta.has(key)) continue;
+    meta.set(key, content);
+  }
+
+  const pick = (...keys: string[]): string | undefined => {
+    for (const key of keys) {
+      const value = meta.get(key);
+      if (value !== undefined && value.trim()) return value;
+    }
+    return undefined;
+  };
+
+  const titleTag = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1];
+  const title = cleanText(
+    pick("og:title", "twitter:title") ?? titleTag ?? "",
+    MAX_TITLE_LENGTH,
+  );
+  const description = cleanText(
+    pick("og:description", "twitter:description", "description") ?? "",
+    MAX_DESCRIPTION_LENGTH,
+  );
+  const siteName = cleanText(
+    pick("og:site_name", "application-name") ?? "",
+    MAX_SITE_NAME_LENGTH,
+  );
+
+  const imageCandidate = pick(
+    "og:image:secure_url",
+    "og:image",
+    "og:image:url",
+    "twitter:image",
+    "twitter:image:src",
+  );
+  const imageUrl = imageCandidate
+    ? resolveSafeUrl(imageCandidate, pageUrl)
+    : undefined;
+
+  let faviconUrl: string | undefined;
+  for (const match of html.matchAll(/<link\b[^>]*>/gi)) {
+    const attributes = parseTagAttributes(match[0]);
+    const rel = attributes.get("rel")?.toLowerCase() ?? "";
+    if (!/(^|\s)(icon|shortcut icon|apple-touch-icon)(\s|$)/.test(rel)) continue;
+    const href = attributes.get("href");
+    if (!href) continue;
+    const resolved = resolveSafeUrl(href, pageUrl);
+    if (resolved) {
+      faviconUrl = resolved;
+      break;
+    }
+  }
+  if (!faviconUrl) {
+    faviconUrl = `${pageUrl.origin}/favicon.ico`;
+  }
+
+  let imageLayout: UnfurlPageMetadata["imageLayout"];
+  if (imageUrl) {
+    const twitterCard = pick("twitter:card")?.trim().toLowerCase();
+    const imageWidth = Number.parseInt(pick("og:image:width") ?? "", 10);
+    const isLarge =
+      twitterCard === "summary_large_image" ||
+      Boolean(pick("og:video", "og:video:url", "og:video:secure_url")) ||
+      (Number.isFinite(imageWidth) && imageWidth >= 600);
+    imageLayout = isLarge ? "large" : "thumb";
+  }
+
+  return { title, description, siteName, imageUrl, faviconUrl, imageLayout };
+}

--- a/apps/web/src/app/lib/unfurl-rate-limit.ts
+++ b/apps/web/src/app/lib/unfurl-rate-limit.ts
@@ -1,0 +1,81 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+const RATE_LIMIT = 30;
+const RATE_WINDOW_MS = 60_000;
+const MAX_LOCAL_BUCKETS = 1_000;
+
+type CloudflareRateLimitBinding = {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+};
+
+type LocalRateLimitBucket = { windowStartedAt: number; count: number };
+const localBuckets = new Map<string, LocalRateLimitBucket>();
+
+const clientKey = (request: Request): string => {
+  const forwardedFor = request.headers
+    .get("x-forwarded-for")
+    ?.split(",")
+    .at(0)
+    ?.trim();
+  const candidate =
+    [
+      request.headers.get("cf-connecting-ip")?.trim(),
+      request.headers.get("x-real-ip")?.trim(),
+      forwardedFor,
+      request.headers.get("user-agent")?.trim(),
+    ].find((value): value is string => Boolean(value)) ?? "anonymous";
+  return candidate.slice(0, 128);
+};
+
+const takeLocalRateLimit = (key: string): boolean => {
+  const now = Date.now();
+  const bucket = localBuckets.get(key);
+  if (!bucket || now - bucket.windowStartedAt >= RATE_WINDOW_MS) {
+    localBuckets.set(key, { windowStartedAt: now, count: 1 });
+    while (localBuckets.size > MAX_LOCAL_BUCKETS) {
+      const oldest = localBuckets.keys().next().value;
+      if (oldest === undefined) break;
+      localBuckets.delete(oldest);
+    }
+    return true;
+  }
+  if (bucket.count >= RATE_LIMIT) return false;
+  bucket.count += 1;
+  return true;
+};
+
+export type UnfurlRateLimitOutcome =
+  | { ok: true }
+  | { ok: false; status: 429 | 503 };
+
+export async function takeUnfurlRateLimit(
+  request: Request,
+): Promise<UnfurlRateLimitOutcome> {
+  const key = `unfurl:${clientKey(request)}`;
+
+  let limiter: CloudflareRateLimitBinding | null = null;
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    const binding = (env as { UNFURL_RATE_LIMITER?: CloudflareRateLimitBinding })
+      .UNFURL_RATE_LIMITER;
+    limiter = binding && typeof binding.limit === "function" ? binding : null;
+  } catch {
+    limiter = null;
+  }
+
+  if (limiter) {
+    try {
+      const { success } = await limiter.limit({ key });
+      return success ? { ok: true } : { ok: false, status: 429 };
+    } catch {
+      // Fall through to the fail-closed production branch below.
+    }
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    // An unfurler is an outbound-fetch proxy; never run it unmetered.
+    return { ok: false, status: 503 };
+  }
+
+  return takeLocalRateLimit(key) ? { ok: true } : { ok: false, status: 429 };
+}

--- a/apps/web/src/app/lib/unfurl-response.ts
+++ b/apps/web/src/app/lib/unfurl-response.ts
@@ -1,0 +1,58 @@
+// Reads at most `maxBytes` of the body, stopping early once the document head
+// has closed — everything the parser wants lives there on real pages.
+export const readHtmlPrefix = async (
+  response: Response,
+  maxBytes: number,
+): Promise<string> => {
+  const body = response.body;
+  if (!body) return "";
+  const reader = body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  let html = "";
+  let receivedBytes = 0;
+  try {
+    while (receivedBytes < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const remainingBytes = maxBytes - receivedBytes;
+      const chunk = value.subarray(0, remainingBytes);
+      receivedBytes += chunk.byteLength;
+      html += decoder.decode(chunk, { stream: true });
+      if (html.includes("</head")) break;
+    }
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+  return html + decoder.decode();
+};
+
+/** Buffers a response only when its complete body fits within `maxBytes`. */
+export const readBoundedResponseBytes = async (
+  response: Response,
+  maxBytes: number,
+): Promise<Uint8Array | null> => {
+  const body = response.body;
+  if (!body) return new Uint8Array();
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value.byteLength > maxBytes - receivedBytes) return null;
+      chunks.push(value);
+      receivedBytes += value.byteLength;
+    }
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+
+  const result = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+};

--- a/apps/web/src/app/lib/unfurl-response.ts
+++ b/apps/web/src/app/lib/unfurl-response.ts
@@ -26,6 +26,30 @@ export const readHtmlPrefix = async (
   return html + decoder.decode();
 };
 
+/**
+ * Passes a body through unchanged, erroring the stream once `maxBytes` have
+ * flowed. Used for media too large to buffer — backpressure means only what
+ * the client actually consumes is transferred.
+ */
+export const boundedResponseStream = (
+  body: ReadableStream<Uint8Array>,
+  maxBytes: number,
+): ReadableStream<Uint8Array> => {
+  let receivedBytes = 0;
+  return body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        receivedBytes += chunk.byteLength;
+        if (receivedBytes > maxBytes) {
+          controller.error(new Error("unfurl asset exceeded byte limit"));
+          return;
+        }
+        controller.enqueue(chunk);
+      },
+    }),
+  );
+};
+
 /** Buffers a response only when its complete body fits within `maxBytes`. */
 export const readBoundedResponseBytes = async (
   response: Response,

--- a/apps/web/src/app/lib/unfurl-tweet.ts
+++ b/apps/web/src/app/lib/unfurl-tweet.ts
@@ -1,0 +1,343 @@
+// Tweet unfurling for the /api/unfurl route. X/Twitter pages are a JS shell
+// with no Open Graph tags for generic scrapers, so tweet links go through the
+// public syndication CDN (the same unauthenticated endpoint react-tweet and
+// the official embed widget use). It returns tweet text, author, photos, and
+// mp4 variants — everything the chat card needs to show real media. Any
+// failure falls back to the generic HTML scrape, which degrades to no embed.
+
+import type {
+  ChatLinkPreview,
+  ChatLinkTweetData,
+  ChatLinkTweetMedia,
+} from "./link-embeds";
+
+const TWEET_HOSTS = new Set([
+  "twitter.com",
+  "www.twitter.com",
+  "mobile.twitter.com",
+  "m.twitter.com",
+  "x.com",
+  "www.x.com",
+  "mobile.x.com",
+]);
+
+const TWEET_ID_PATTERN = /^\d{1,25}$/;
+const MAX_TWEET_TEXT_LENGTH = 500;
+const MAX_TWEET_MEDIA = 4;
+
+/** Extracts the tweet id from …/status/<id> URLs (incl. /i/web/status). */
+export function getTweetIdFromUrl(url: URL): string | null {
+  if (!TWEET_HOSTS.has(url.hostname.toLowerCase())) return null;
+  const segments = url.pathname.split("/").filter(Boolean);
+  const statusIndex = segments.findIndex(
+    (segment) => segment === "status" || segment === "statuses",
+  );
+  if (statusIndex === -1) return null;
+  const id = segments[statusIndex + 1] ?? "";
+  return TWEET_ID_PATTERN.test(id) ? id : null;
+}
+
+// The syndication endpoint requires a token derived from the tweet id; this
+// is the exact formula the official widget computes client-side.
+export function getSyndicationToken(tweetId: string): string {
+  return ((Number(tweetId) / 1e15) * Math.PI)
+    .toString(36)
+    .replace(/(0+|\.)/g, "");
+}
+
+const SYNDICATION_FEATURES = [
+  "tfw_timeline_list:",
+  "tfw_follower_count_sunset:true",
+  "tfw_tweet_edit_backend:on",
+  "tfw_refsrc_session:on",
+  "tfw_fosnr_soft_interventions_enabled:on",
+  "tfw_show_birdwatch_pivots_enabled:on",
+  "tfw_show_business_verified_badge:on",
+  "tfw_duplicate_scribes_to_settings:on",
+  "tfw_use_profile_image_shape_enabled:on",
+  "tfw_show_blue_verified_badge:on",
+  "tfw_legacy_timeline_sunset:true",
+  "tfw_show_gov_verified_badge:on",
+  "tfw_show_business_affiliate_badge:on",
+  "tfw_tweet_edit_frontend:on",
+].join(";");
+
+export function getSyndicationUrl(tweetId: string): string {
+  const url = new URL("https://cdn.syndication.twimg.com/tweet-result");
+  url.searchParams.set("id", tweetId);
+  url.searchParams.set("lang", "en");
+  url.searchParams.set("features", SYNDICATION_FEATURES);
+  url.searchParams.set("token", getSyndicationToken(tweetId));
+  return url.href;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+
+const asString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim() ? value : null;
+
+const asMediaUrl = (value: unknown): string | null => {
+  const raw = asString(value);
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    return url.protocol === "https:" ? url.href : null;
+  } catch {
+    return null;
+  }
+};
+
+const asDimension = (value: unknown): number | undefined => {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.round(value);
+};
+
+// Photos render at card width; ask pbs.twimg.com for the "small" rendition
+// instead of the multi-megabyte original.
+const smallPhotoUrl = (url: string): string =>
+  `${url}${url.includes("?") ? "&" : "?"}name=small`;
+
+interface RawVideoVariant {
+  bitrate?: unknown;
+  content_type?: unknown;
+  url?: unknown;
+}
+
+// Chat cards are ~280px wide; the middle mp4 rendition is plenty.
+const pickMp4Variant = (variants: unknown): string | null => {
+  if (!Array.isArray(variants)) return null;
+  const mp4s = variants
+    .map((variant) => variant as RawVideoVariant)
+    .filter((variant) => asString(variant.content_type) === "video/mp4")
+    .map((variant) => ({
+      bitrate: typeof variant.bitrate === "number" ? variant.bitrate : 0,
+      url: asMediaUrl(variant.url),
+    }))
+    .filter((variant): variant is { bitrate: number; url: string } =>
+      Boolean(variant.url),
+    )
+    .sort((left, right) => left.bitrate - right.bitrate);
+  if (mp4s.length === 0) return null;
+  return mp4s[Math.floor(mp4s.length / 2)].url;
+};
+
+const parseMediaDetails = (value: unknown): ChatLinkTweetMedia[] => {
+  if (!Array.isArray(value)) return [];
+  const media: ChatLinkTweetMedia[] = [];
+
+  for (const entry of value) {
+    if (media.length >= MAX_TWEET_MEDIA) break;
+    const detail = asRecord(entry);
+    if (!detail) continue;
+    const type = asString(detail.type);
+    const stillUrl = asMediaUrl(detail.media_url_https);
+    if (!stillUrl) continue;
+    const originalInfo = asRecord(detail.original_info);
+    const width = asDimension(originalInfo?.width);
+    const height = asDimension(originalInfo?.height);
+
+    if (type === "photo") {
+      media.push({ kind: "photo", url: smallPhotoUrl(stillUrl), width, height });
+      continue;
+    }
+    if (type === "video" || type === "animated_gif") {
+      const videoInfo = asRecord(detail.video_info);
+      const videoUrl = pickMp4Variant(videoInfo?.variants);
+      if (!videoUrl) continue;
+      const aspect = Array.isArray(videoInfo?.aspect_ratio)
+        ? (videoInfo.aspect_ratio as unknown[])
+        : [];
+      media.push({
+        kind: type === "video" ? "video" : "gif",
+        url: stillUrl,
+        videoUrl,
+        width: asDimension(aspect[0]) ?? width,
+        height: asDimension(aspect[1]) ?? height,
+      });
+    }
+  }
+
+  return media;
+};
+
+// Older payload shape: `photos` + `video` at the top level. Used only when
+// `mediaDetails` is absent.
+const parseLegacyMedia = (tweet: Record<string, unknown>): ChatLinkTweetMedia[] => {
+  const media: ChatLinkTweetMedia[] = [];
+
+  if (Array.isArray(tweet.photos)) {
+    for (const entry of tweet.photos) {
+      if (media.length >= MAX_TWEET_MEDIA) break;
+      const photo = asRecord(entry);
+      const url = asMediaUrl(photo?.url);
+      if (!url) continue;
+      media.push({
+        kind: "photo",
+        url: smallPhotoUrl(url),
+        width: asDimension(photo?.width),
+        height: asDimension(photo?.height),
+      });
+    }
+  }
+
+  const video = asRecord(tweet.video);
+  if (video) {
+    const poster = asMediaUrl(video.poster);
+    const variants = Array.isArray(video.variants)
+      ? video.variants.map((variant) => {
+          const record = asRecord(variant);
+          return {
+            content_type: record?.type,
+            url: record?.src,
+          };
+        })
+      : [];
+    const videoUrl = pickMp4Variant(variants);
+    if (poster && videoUrl) {
+      const aspect = Array.isArray(video.aspectRatio)
+        ? (video.aspectRatio as unknown[])
+        : [];
+      media.push({
+        kind: "video",
+        url: poster,
+        videoUrl,
+        width: asDimension(aspect[0]),
+        height: asDimension(aspect[1]),
+      });
+    }
+  }
+
+  return media;
+};
+
+interface RawUrlEntity {
+  url?: unknown;
+  display_url?: unknown;
+}
+
+const cleanTweetText = (tweet: Record<string, unknown>): string => {
+  const rawText = asString(tweet.text) ?? "";
+  // Ranges are in Unicode code points; slice accordingly so emoji-heavy
+  // tweets don't get cut mid-surrogate.
+  const codePoints = Array.from(rawText);
+  const range = Array.isArray(tweet.display_text_range)
+    ? (tweet.display_text_range as unknown[])
+    : null;
+  const start =
+    typeof range?.[0] === "number" && range[0] >= 0 ? range[0] : 0;
+  const end =
+    typeof range?.[1] === "number" && range[1] <= codePoints.length
+      ? range[1]
+      : codePoints.length;
+  let text = codePoints.slice(start, end).join("");
+
+  // Swap remaining t.co wrappers for their human-readable display form.
+  const entities = asRecord(tweet.entities);
+  if (Array.isArray(entities?.urls)) {
+    for (const entry of entities.urls) {
+      const urlEntity = entry as RawUrlEntity;
+      const shortUrl = asString(urlEntity.url);
+      const displayUrl = asString(urlEntity.display_url);
+      if (shortUrl && displayUrl) {
+        text = text.replaceAll(shortUrl, displayUrl);
+      }
+    }
+  }
+  // Trailing media t.co links (present when display_text_range is absent).
+  // Tweets from the http era wrap media as http://t.co/…, hence https?.
+  text = text.replace(/(?:\s*https?:\/\/t\.co\/\w+)+\s*$/, "");
+
+  text = text.trim();
+  return text.length > MAX_TWEET_TEXT_LENGTH
+    ? `${text.slice(0, MAX_TWEET_TEXT_LENGTH - 1)}…`
+    : text;
+};
+
+/**
+ * Maps a syndication `tweet-result` payload onto a chat link preview.
+ * Returns null for tombstones (deleted/protected) and unrecognized shapes.
+ */
+export function parseTweetResult(
+  payload: unknown,
+  requestedId: string,
+): ChatLinkPreview | null {
+  const tweet = asRecord(payload);
+  if (!tweet) return null;
+  const typename = asString(tweet.__typename);
+  if (typename && typename !== "Tweet") return null;
+
+  const user = asRecord(tweet.user);
+  const authorName = asString(user?.name);
+  const authorHandle = asString(user?.screen_name);
+  if (!authorName || !authorHandle) return null;
+
+  const media =
+    "mediaDetails" in tweet
+      ? parseMediaDetails(tweet.mediaDetails)
+      : parseLegacyMedia(tweet);
+  const text = cleanTweetText(tweet);
+  if (!text && media.length === 0) return null;
+
+  const tweetId = asString(tweet.id_str) ?? requestedId;
+  const canonicalUrl = `https://x.com/${authorHandle}/status/${tweetId}`;
+  const avatarUrl = asMediaUrl(user?.profile_image_url_https) ?? undefined;
+  const createdAt = asString(tweet.created_at);
+  const createdAtMs = createdAt ? Date.parse(createdAt) : Number.NaN;
+
+  const data: ChatLinkTweetData = {
+    authorName,
+    authorHandle,
+    ...(avatarUrl ? { authorAvatarUrl: avatarUrl } : {}),
+    text,
+    media,
+    ...(Number.isFinite(createdAtMs) ? { createdAt: createdAtMs } : {}),
+  };
+
+  const firstMedia = media[0];
+  return {
+    url: canonicalUrl,
+    kind: "tweet",
+    siteName: "X",
+    title: `${authorName} (@${authorHandle})`,
+    description: text || undefined,
+    imageUrl: firstMedia?.url ?? avatarUrl,
+    faviconUrl: "https://abs.twimg.com/favicons/twitter.3.ico",
+    imageLayout: firstMedia ? "large" : "thumb",
+    tweet: data,
+  };
+}
+
+/** Fetches and parses a tweet; null means "use the generic unfurl path". */
+export async function fetchTweetPreview(
+  tweetId: string,
+  timeoutMs: number,
+): Promise<ChatLinkPreview | null> {
+  let response: Response;
+  try {
+    response = await fetch(getSyndicationUrl(tweetId), {
+      headers: {
+        accept: "application/json",
+        "user-agent":
+          "Mozilla/5.0 (compatible; ConclaveLinkPreview/1.0; +https://conclave.acmvit.in)",
+      },
+      signal: AbortSignal.timeout(timeoutMs),
+      cache: "no-store",
+    });
+  } catch {
+    return null;
+  }
+  if (!response.ok) {
+    response.body?.cancel().catch(() => {});
+    return null;
+  }
+  try {
+    return parseTweetResult(await response.json(), tweetId);
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/app/lib/unfurl-tweet.ts
+++ b/apps/web/src/app/lib/unfurl-tweet.ts
@@ -10,6 +10,7 @@ import type {
   ChatLinkTweetData,
   ChatLinkTweetMedia,
 } from "./link-embeds";
+import { toUnfurlAssetUrl } from "./unfurl-assets";
 
 const TWEET_HOSTS = new Set([
   "twitter.com",
@@ -142,19 +143,25 @@ const parseMediaDetails = (value: unknown): ChatLinkTweetMedia[] => {
     const height = asDimension(originalInfo?.height);
 
     if (type === "photo") {
-      media.push({ kind: "photo", url: smallPhotoUrl(stillUrl), width, height });
+      // Everything the embed renders goes through /api/unfurl/asset: images
+      // for privacy, and video because video.twimg.com 403s hotlinking.
+      const photoUrl = toUnfurlAssetUrl(smallPhotoUrl(stillUrl));
+      if (photoUrl) {
+        media.push({ kind: "photo", url: photoUrl, width, height });
+      }
       continue;
     }
     if (type === "video" || type === "animated_gif") {
       const videoInfo = asRecord(detail.video_info);
-      const videoUrl = pickMp4Variant(videoInfo?.variants);
-      if (!videoUrl) continue;
+      const posterUrl = toUnfurlAssetUrl(stillUrl);
+      const videoUrl = toUnfurlAssetUrl(pickMp4Variant(videoInfo?.variants) ?? "");
+      if (!posterUrl || !videoUrl) continue;
       const aspect = Array.isArray(videoInfo?.aspect_ratio)
         ? (videoInfo.aspect_ratio as unknown[])
         : [];
       media.push({
         kind: type === "video" ? "video" : "gif",
-        url: stillUrl,
+        url: posterUrl,
         videoUrl,
         width: asDimension(aspect[0]) ?? width,
         height: asDimension(aspect[1]) ?? height,
@@ -176,9 +183,11 @@ const parseLegacyMedia = (tweet: Record<string, unknown>): ChatLinkTweetMedia[] 
       const photo = asRecord(entry);
       const url = asMediaUrl(photo?.url);
       if (!url) continue;
+      const photoUrl = toUnfurlAssetUrl(smallPhotoUrl(url));
+      if (!photoUrl) continue;
       media.push({
         kind: "photo",
-        url: smallPhotoUrl(url),
+        url: photoUrl,
         width: asDimension(photo?.width),
         height: asDimension(photo?.height),
       });
@@ -197,14 +206,15 @@ const parseLegacyMedia = (tweet: Record<string, unknown>): ChatLinkTweetMedia[] 
           };
         })
       : [];
-    const videoUrl = pickMp4Variant(variants);
-    if (poster && videoUrl) {
+    const posterUrl = toUnfurlAssetUrl(poster ?? "");
+    const videoUrl = toUnfurlAssetUrl(pickMp4Variant(variants) ?? "");
+    if (posterUrl && videoUrl) {
       const aspect = Array.isArray(video.aspectRatio)
         ? (video.aspectRatio as unknown[])
         : [];
       media.push({
         kind: "video",
-        url: poster,
+        url: posterUrl,
         videoUrl,
         width: asDimension(aspect[0]),
         height: asDimension(aspect[1]),
@@ -285,7 +295,9 @@ export function parseTweetResult(
 
   const tweetId = asString(tweet.id_str) ?? requestedId;
   const canonicalUrl = `https://x.com/${authorHandle}/status/${tweetId}`;
-  const avatarUrl = asMediaUrl(user?.profile_image_url_https) ?? undefined;
+  const avatarUrl = toUnfurlAssetUrl(
+    asMediaUrl(user?.profile_image_url_https) ?? "",
+  );
   const createdAt = asString(tweet.created_at);
   const createdAtMs = createdAt ? Date.parse(createdAt) : Number.NaN;
 
@@ -306,7 +318,7 @@ export function parseTweetResult(
     title: `${authorName} (@${authorHandle})`,
     description: text || undefined,
     imageUrl: firstMedia?.url ?? avatarUrl,
-    faviconUrl: "https://abs.twimg.com/favicons/twitter.3.ico",
+    faviconUrl: toUnfurlAssetUrl("https://abs.twimg.com/favicons/twitter.3.ico"),
     imageLayout: firstMedia ? "large" : "thumb",
     tweet: data,
   };

--- a/apps/web/test/chat-link-embeds.test.ts
+++ b/apps/web/test/chat-link-embeds.test.ts
@@ -10,6 +10,7 @@ import {
   parseUnfurlHtml,
   parseUnfurlableUrl,
 } from "../src/app/lib/unfurl-html";
+import { boundedResponseStream } from "../src/app/lib/unfurl-response";
 import {
   getSyndicationToken,
   getTweetIdFromUrl,
@@ -313,6 +314,11 @@ describe("getSyndicationToken", () => {
   });
 });
 
+// Tweet media round-trips through the asset proxy: images for privacy, video
+// because video.twimg.com 403s hotlinked playback.
+const assetUrl = (raw: string): string =>
+  `/api/unfurl/asset?url=${encodeURIComponent(raw)}`;
+
 describe("parseTweetResult", () => {
   const visibleText = "Hi 👋 see https://t.co/abc";
   const fixture = {
@@ -391,14 +397,16 @@ describe("parseTweetResult", () => {
     const [photo, video] = preview?.tweet?.media ?? [];
     expect(photo).toEqual({
       kind: "photo",
-      url: "https://pbs.twimg.com/media/AAA.jpg?name=small",
+      url: assetUrl("https://pbs.twimg.com/media/AAA.jpg?name=small"),
       width: 1200,
       height: 800,
     });
     // Middle bitrate mp4: chat cards don't need the 2 Mbps rendition.
     expect(video?.kind).toBe("video");
-    expect(video?.videoUrl).toBe("https://video.twimg.com/mid.mp4");
-    expect(video?.url).toBe("https://pbs.twimg.com/ext_tw_video_thumb/BBB.jpg");
+    expect(video?.videoUrl).toBe(assetUrl("https://video.twimg.com/mid.mp4"));
+    expect(video?.url).toBe(
+      assetUrl("https://pbs.twimg.com/ext_tw_video_thumb/BBB.jpg"),
+    );
     expect(video?.width).toBe(16);
     expect(video?.height).toBe(9);
   });
@@ -432,7 +440,7 @@ describe("parseTweetResult", () => {
     expect(preview?.tweet?.text).toBe("look at this");
     expect(preview?.tweet?.media[0]?.kind).toBe("gif");
     expect(preview?.tweet?.media[0]?.videoUrl).toBe(
-      "https://video.twimg.com/tweet_video/CCC.mp4",
+      assetUrl("https://video.twimg.com/tweet_video/CCC.mp4"),
     );
   });
 
@@ -459,10 +467,10 @@ describe("parseTweetResult", () => {
     );
     expect(preview?.tweet?.media).toHaveLength(2);
     expect(preview?.tweet?.media[0]?.url).toBe(
-      "https://pbs.twimg.com/media/DDD.jpg?name=small",
+      assetUrl("https://pbs.twimg.com/media/DDD.jpg?name=small"),
     );
     expect(preview?.tweet?.media[1]?.videoUrl).toBe(
-      "https://video.twimg.com/EEE.mp4",
+      assetUrl("https://video.twimg.com/EEE.mp4"),
     );
   });
 
@@ -476,5 +484,39 @@ describe("parseTweetResult", () => {
         "1",
       ),
     ).toBeNull();
+  });
+});
+
+describe("boundedResponseStream", () => {
+  const collect = async (stream: ReadableStream<Uint8Array>) => {
+    const reader = stream.getReader();
+    const chunks: number[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value.byteLength);
+    }
+    return chunks;
+  };
+
+  const sourceOf = (...sizes: number[]) =>
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const size of sizes) controller.enqueue(new Uint8Array(size));
+        controller.close();
+      },
+    });
+
+  it("passes chunks through under the cap", async () => {
+    const chunks = await collect(
+      boundedResponseStream(sourceOf(10, 20, 30), 100),
+    );
+    expect(chunks).toEqual([10, 20, 30]);
+  });
+
+  it("errors the stream once the cap is exceeded", async () => {
+    await expect(
+      collect(boundedResponseStream(sourceOf(60, 60), 100)),
+    ).rejects.toThrow();
   });
 });

--- a/apps/web/test/chat-link-embeds.test.ts
+++ b/apps/web/test/chat-link-embeds.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   extractEmbedUrls,
+  fetchChatLinkPreview,
   getYouTubeVideoId,
 } from "../src/app/lib/link-embeds";
 import {
@@ -16,6 +17,10 @@ import {
 } from "../src/app/lib/unfurl-tweet";
 
 const PAGE_URL = new URL("https://blog.example.com/posts/hello");
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("extractEmbedUrls", () => {
   it("embeds explicit https and www links only", () => {
@@ -70,6 +75,36 @@ describe("getYouTubeVideoId", () => {
     expect(getYouTubeVideoId("https://www.youtube.com/watch?v=short")).toBeNull();
     expect(getYouTubeVideoId("https://notyoutube.com/watch?v=dQw4w9WgXcQ")).toBeNull();
     expect(getYouTubeVideoId("not a url")).toBeNull();
+  });
+});
+
+describe("fetchChatLinkPreview", () => {
+  it("retries a URL after a transient unfurl failure", async () => {
+    const preview = {
+      url: "https://retry.example.com/article",
+      title: "Recovered preview",
+    };
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(Response.json({ preview }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchChatLinkPreview(preview.url)).resolves.toBeNull();
+    await expect(fetchChatLinkPreview(preview.url)).resolves.toEqual(preview);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches a successful response with no preview", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(Response.json({ preview: null }));
+    vi.stubGlobal("fetch", fetchMock);
+    const url = "https://no-preview.example.com/article";
+
+    await expect(fetchChatLinkPreview(url)).resolves.toBeNull();
+    await expect(fetchChatLinkPreview(url)).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/test/chat-link-embeds.test.ts
+++ b/apps/web/test/chat-link-embeds.test.ts
@@ -1,0 +1,445 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractEmbedUrls,
+  getYouTubeVideoId,
+} from "../src/app/lib/link-embeds";
+import {
+  decodeHtmlEntities,
+  isForbiddenUnfurlHost,
+  parseUnfurlHtml,
+  parseUnfurlableUrl,
+} from "../src/app/lib/unfurl-html";
+import {
+  getSyndicationToken,
+  getTweetIdFromUrl,
+  parseTweetResult,
+} from "../src/app/lib/unfurl-tweet";
+
+const PAGE_URL = new URL("https://blog.example.com/posts/hello");
+
+describe("extractEmbedUrls", () => {
+  it("embeds explicit https and www links only", () => {
+    const urls = extractEmbedUrls(
+      "see https://example.com/a and www.example.org/b but not example.net",
+    );
+    expect(urls).toEqual([
+      "https://example.com/a",
+      "https://www.example.org/b",
+    ]);
+  });
+
+  it("trims trailing punctuation like the linkifier", () => {
+    expect(extractEmbedUrls("read https://example.com/docs.")).toEqual([
+      "https://example.com/docs",
+    ]);
+  });
+
+  it("skips links wrapped in angle brackets", () => {
+    expect(extractEmbedUrls("quiet <https://example.com> link")).toEqual([]);
+    expect(
+      extractEmbedUrls("<https://a.example.com> https://b.example.com"),
+    ).toEqual(["https://b.example.com/"]);
+  });
+
+  it("dedupes repeated links and caps the count", () => {
+    const urls = extractEmbedUrls(
+      "https://a.example.com https://a.example.com https://b.example.com https://c.example.com",
+    );
+    expect(urls).toEqual(["https://a.example.com/", "https://b.example.com/"]);
+  });
+
+  it("ignores email-looking matches", () => {
+    expect(extractEmbedUrls("mail me at www.someone@example.com")).toEqual([]);
+  });
+});
+
+describe("getYouTubeVideoId", () => {
+  it.each([
+    ["https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+    ["https://youtu.be/dQw4w9WgXcQ?t=10", "dQw4w9WgXcQ"],
+    ["https://youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+    ["https://m.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+    ["https://www.youtube.com/live/dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+    ["https://www.youtube.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ"],
+  ])("extracts the id from %s", (url, id) => {
+    expect(getYouTubeVideoId(url)).toBe(id);
+  });
+
+  it("rejects non-video and non-youtube urls", () => {
+    expect(getYouTubeVideoId("https://www.youtube.com/@somechannel")).toBeNull();
+    expect(getYouTubeVideoId("https://www.youtube.com/watch?v=short")).toBeNull();
+    expect(getYouTubeVideoId("https://notyoutube.com/watch?v=dQw4w9WgXcQ")).toBeNull();
+    expect(getYouTubeVideoId("not a url")).toBeNull();
+  });
+});
+
+describe("isForbiddenUnfurlHost", () => {
+  it.each([
+    "localhost",
+    "intranet",
+    "router.local",
+    "service.internal",
+    "printer.home.arpa",
+    "hidden.onion",
+    "127.0.0.1",
+    "10.1.2.3",
+    "172.16.0.1",
+    "172.31.255.255",
+    "192.168.1.1",
+    "169.254.169.254",
+    "100.64.0.1",
+    "0.0.0.0",
+    "224.0.0.1",
+    "255.255.255.255",
+    "[::1]",
+    "[fd00::1]",
+  ])("blocks %s", (host) => {
+    expect(isForbiddenUnfurlHost(host)).toBe(true);
+  });
+
+  it.each([
+    "example.com",
+    "www.example.com",
+    "8.8.8.8",
+    "172.32.0.1",
+    "100.128.0.1",
+    "my.local.example.com",
+  ])("allows %s", (host) => {
+    expect(isForbiddenUnfurlHost(host)).toBe(false);
+  });
+});
+
+describe("parseUnfurlableUrl", () => {
+  it("accepts plain public http(s) urls", () => {
+    expect(parseUnfurlableUrl("https://example.com/a?b=c")?.href).toBe(
+      "https://example.com/a?b=c",
+    );
+    expect(parseUnfurlableUrl("http://example.com/")?.href).toBe(
+      "http://example.com/",
+    );
+  });
+
+  it("rejects other protocols, credentials, and bad input", () => {
+    expect(parseUnfurlableUrl("ftp://example.com/")).toBeNull();
+    expect(parseUnfurlableUrl("javascript:alert(1)")).toBeNull();
+    expect(parseUnfurlableUrl("https://user:pass@example.com/")).toBeNull();
+    expect(parseUnfurlableUrl("")).toBeNull();
+    expect(parseUnfurlableUrl("not a url")).toBeNull();
+    expect(parseUnfurlableUrl(`https://example.com/${"a".repeat(2100)}`)).toBeNull();
+  });
+
+  it("catches integer hosts that canonicalize to private addresses", () => {
+    // WHATWG URL parsing turns http://2130706433/ into http://127.0.0.1/.
+    expect(parseUnfurlableUrl("http://2130706433/")).toBeNull();
+    expect(parseUnfurlableUrl("http://0x7f000001/")).toBeNull();
+  });
+});
+
+describe("decodeHtmlEntities", () => {
+  it("decodes named, decimal, and hex entities", () => {
+    expect(decodeHtmlEntities("Tom &amp; Jerry&#39;s &#x1F600;")).toBe(
+      "Tom & Jerry's 😀",
+    );
+  });
+
+  it("leaves invalid escapes alone", () => {
+    expect(decodeHtmlEntities("&notreal; &#xZZ; 100% &")).toBe(
+      "&notreal; &#xZZ; 100% &",
+    );
+  });
+});
+
+describe("parseUnfurlHtml", () => {
+  it("reads open graph metadata regardless of quoting and attribute order", () => {
+    const html = `
+      <html><head>
+        <meta property="og:title" content="Hello &amp; Welcome">
+        <meta content='A tiny&#39;s description' property='og:description'>
+        <meta property="og:site_name" content="Example Blog"/>
+        <meta property="og:image" content="https://cdn.example.com/hero.png">
+      </head><body></body></html>`;
+    const parsed = parseUnfurlHtml(html, PAGE_URL);
+    expect(parsed.title).toBe("Hello & Welcome");
+    expect(parsed.description).toBe("A tiny's description");
+    expect(parsed.siteName).toBe("Example Blog");
+    expect(parsed.imageUrl).toBe("https://cdn.example.com/hero.png");
+  });
+
+  it("falls back to twitter tags, meta description, and the title tag", () => {
+    const html = `
+      <head>
+        <title> Fallback   Title </title>
+        <meta name="description" content="Plain description">
+        <meta name="twitter:image" content="/relative/image.jpg">
+      </head>`;
+    const parsed = parseUnfurlHtml(html, PAGE_URL);
+    expect(parsed.title).toBe("Fallback Title");
+    expect(parsed.description).toBe("Plain description");
+    expect(parsed.imageUrl).toBe("https://blog.example.com/relative/image.jpg");
+  });
+
+  it("resolves protocol-relative images and rejects unsafe image urls", () => {
+    const protocolRelative = parseUnfurlHtml(
+      `<meta property="og:image" content="//cdn.example.com/pic.png">`,
+      PAGE_URL,
+    );
+    expect(protocolRelative.imageUrl).toBe("https://cdn.example.com/pic.png");
+
+    const unsafe = parseUnfurlHtml(
+      `<meta property="og:title" content="x">
+       <meta property="og:image" content="javascript:alert(1)">`,
+      PAGE_URL,
+    );
+    expect(unsafe.imageUrl).toBeUndefined();
+
+    const privateHost = parseUnfurlHtml(
+      `<meta property="og:image" content="http://192.168.1.5/cam.jpg">`,
+      PAGE_URL,
+    );
+    expect(privateHost.imageUrl).toBeUndefined();
+  });
+
+  it("finds favicons and falls back to /favicon.ico", () => {
+    const withIcon = parseUnfurlHtml(
+      `<link rel="shortcut icon" href="/assets/icon.png">`,
+      PAGE_URL,
+    );
+    expect(withIcon.faviconUrl).toBe("https://blog.example.com/assets/icon.png");
+
+    const withoutIcon = parseUnfurlHtml(`<title>x</title>`, PAGE_URL);
+    expect(withoutIcon.faviconUrl).toBe("https://blog.example.com/favicon.ico");
+  });
+
+  it("classifies image layout from twitter card and og image width", () => {
+    const large = parseUnfurlHtml(
+      `<meta name="twitter:card" content="summary_large_image">
+       <meta property="og:image" content="https://cdn.example.com/a.png">`,
+      PAGE_URL,
+    );
+    expect(large.imageLayout).toBe("large");
+
+    const wide = parseUnfurlHtml(
+      `<meta property="og:image" content="https://cdn.example.com/a.png">
+       <meta property="og:image:width" content="1200">`,
+      PAGE_URL,
+    );
+    expect(wide.imageLayout).toBe("large");
+
+    const small = parseUnfurlHtml(
+      `<meta property="og:image" content="https://cdn.example.com/a.png">`,
+      PAGE_URL,
+    );
+    expect(small.imageLayout).toBe("thumb");
+
+    const none = parseUnfurlHtml(`<title>x</title>`, PAGE_URL);
+    expect(none.imageLayout).toBeUndefined();
+  });
+
+  it("keeps the first occurrence of duplicated meta keys and caps lengths", () => {
+    const html = `
+      <meta property="og:title" content="First">
+      <meta property="og:title" content="Second">
+      <meta property="og:description" content="${"d".repeat(600)}">`;
+    const parsed = parseUnfurlHtml(html, PAGE_URL);
+    expect(parsed.title).toBe("First");
+    expect(parsed.description?.length).toBe(400);
+    expect(parsed.description?.endsWith("…")).toBe(true);
+  });
+});
+
+describe("getTweetIdFromUrl", () => {
+  const url = (value: string) => new URL(value);
+
+  it.each([
+    ["https://x.com/janedoe/status/1234567890123456789", "1234567890123456789"],
+    ["https://twitter.com/janedoe/status/123?s=20&t=abc", "123"],
+    ["https://mobile.twitter.com/janedoe/statuses/123", "123"],
+    ["https://x.com/i/web/status/123", "123"],
+  ])("extracts the id from %s", (href, id) => {
+    expect(getTweetIdFromUrl(url(href))).toBe(id);
+  });
+
+  it("rejects non-status and non-twitter urls", () => {
+    expect(getTweetIdFromUrl(url("https://x.com/janedoe"))).toBeNull();
+    expect(getTweetIdFromUrl(url("https://x.com/janedoe/status/12a3"))).toBeNull();
+    expect(getTweetIdFromUrl(url("https://x.com/janedoe/status/"))).toBeNull();
+    expect(
+      getTweetIdFromUrl(url("https://example.com/janedoe/status/123")),
+    ).toBeNull();
+  });
+});
+
+describe("getSyndicationToken", () => {
+  it("produces the widget token shape (base36, no zeros or dots)", () => {
+    const token = getSyndicationToken("1629307668568633344");
+    expect(token).toMatch(/^[1-9a-z]+$/);
+    expect(getSyndicationToken("1629307668568633344")).toBe(token);
+    expect(getSyndicationToken("20")).toMatch(/^[1-9a-z]+$/);
+  });
+});
+
+describe("parseTweetResult", () => {
+  const visibleText = "Hi 👋 see https://t.co/abc";
+  const fixture = {
+    __typename: "Tweet",
+    id_str: "1234567890123456789",
+    created_at: "2026-01-02T03:04:05.000Z",
+    text: `${visibleText} https://t.co/media1`,
+    display_text_range: [0, Array.from(visibleText).length],
+    entities: {
+      urls: [
+        {
+          url: "https://t.co/abc",
+          expanded_url: "https://example.com/page",
+          display_url: "example.com/page",
+        },
+      ],
+      media: [{ url: "https://t.co/media1" }],
+    },
+    user: {
+      name: "Jane Doe",
+      screen_name: "janedoe",
+      profile_image_url_https:
+        "https://pbs.twimg.com/profile_images/1/x_normal.jpg",
+    },
+    mediaDetails: [
+      {
+        type: "photo",
+        media_url_https: "https://pbs.twimg.com/media/AAA.jpg",
+        original_info: { width: 1200, height: 800 },
+      },
+      {
+        type: "video",
+        media_url_https: "https://pbs.twimg.com/ext_tw_video_thumb/BBB.jpg",
+        video_info: {
+          aspect_ratio: [16, 9],
+          variants: [
+            {
+              bitrate: 256000,
+              content_type: "video/mp4",
+              url: "https://video.twimg.com/low.mp4",
+            },
+            {
+              content_type: "application/x-mpegURL",
+              url: "https://video.twimg.com/playlist.m3u8",
+            },
+            {
+              bitrate: 2176000,
+              content_type: "video/mp4",
+              url: "https://video.twimg.com/high.mp4",
+            },
+            {
+              bitrate: 832000,
+              content_type: "video/mp4",
+              url: "https://video.twimg.com/mid.mp4",
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  it("maps a media tweet onto the preview shape", () => {
+    const preview = parseTweetResult(fixture, "1234567890123456789");
+    expect(preview).not.toBeNull();
+    expect(preview?.kind).toBe("tweet");
+    expect(preview?.url).toBe("https://x.com/janedoe/status/1234567890123456789");
+    expect(preview?.title).toBe("Jane Doe (@janedoe)");
+    expect(preview?.siteName).toBe("X");
+    expect(preview?.imageLayout).toBe("large");
+    expect(preview?.tweet?.authorHandle).toBe("janedoe");
+    expect(preview?.tweet?.text).toBe("Hi 👋 see example.com/page");
+    expect(preview?.tweet?.createdAt).toBe(
+      Date.parse("2026-01-02T03:04:05.000Z"),
+    );
+
+    const [photo, video] = preview?.tweet?.media ?? [];
+    expect(photo).toEqual({
+      kind: "photo",
+      url: "https://pbs.twimg.com/media/AAA.jpg?name=small",
+      width: 1200,
+      height: 800,
+    });
+    // Middle bitrate mp4: chat cards don't need the 2 Mbps rendition.
+    expect(video?.kind).toBe("video");
+    expect(video?.videoUrl).toBe("https://video.twimg.com/mid.mp4");
+    expect(video?.url).toBe("https://pbs.twimg.com/ext_tw_video_thumb/BBB.jpg");
+    expect(video?.width).toBe(16);
+    expect(video?.height).toBe(9);
+  });
+
+  it("classifies animated gifs and strips trailing media links without ranges", () => {
+    const preview = parseTweetResult(
+      {
+        ...fixture,
+        text: "look at this https://t.co/media1",
+        display_text_range: undefined,
+        entities: { media: [{ url: "https://t.co/media1" }] },
+        mediaDetails: [
+          {
+            type: "animated_gif",
+            media_url_https: "https://pbs.twimg.com/tweet_video_thumb/CCC.jpg",
+            video_info: {
+              aspect_ratio: [4, 3],
+              variants: [
+                {
+                  bitrate: 0,
+                  content_type: "video/mp4",
+                  url: "https://video.twimg.com/tweet_video/CCC.mp4",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      "42",
+    );
+    expect(preview?.tweet?.text).toBe("look at this");
+    expect(preview?.tweet?.media[0]?.kind).toBe("gif");
+    expect(preview?.tweet?.media[0]?.videoUrl).toBe(
+      "https://video.twimg.com/tweet_video/CCC.mp4",
+    );
+  });
+
+  it("supports the legacy photos/video payload shape", () => {
+    const preview = parseTweetResult(
+      {
+        __typename: "Tweet",
+        id_str: "7",
+        text: "legacy",
+        user: { name: "Jane", screen_name: "jane" },
+        photos: [
+          { url: "https://pbs.twimg.com/media/DDD.jpg", width: 800, height: 600 },
+        ],
+        video: {
+          poster: "https://pbs.twimg.com/EEE.jpg",
+          aspectRatio: [1, 1],
+          variants: [
+            { type: "video/mp4", src: "https://video.twimg.com/EEE.mp4" },
+            { type: "application/x-mpegURL", src: "https://video.twimg.com/EEE.m3u8" },
+          ],
+        },
+      },
+      "7",
+    );
+    expect(preview?.tweet?.media).toHaveLength(2);
+    expect(preview?.tweet?.media[0]?.url).toBe(
+      "https://pbs.twimg.com/media/DDD.jpg?name=small",
+    );
+    expect(preview?.tweet?.media[1]?.videoUrl).toBe(
+      "https://video.twimg.com/EEE.mp4",
+    );
+  });
+
+  it("returns null for tombstones and malformed payloads", () => {
+    expect(parseTweetResult({ __typename: "TweetTombstone" }, "1")).toBeNull();
+    expect(parseTweetResult(null, "1")).toBeNull();
+    expect(parseTweetResult({ text: "no user" }, "1")).toBeNull();
+    expect(
+      parseTweetResult(
+        { __typename: "Tweet", user: { name: "x", screen_name: "y" } },
+        "1",
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/web/test/unfurl-assets.test.ts
+++ b/apps/web/test/unfurl-assets.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { toUnfurlAssetUrl } from "../src/app/lib/unfurl-assets";
+
+describe("toUnfurlAssetUrl", () => {
+  it("rewrites a public remote asset through the same-origin proxy", () => {
+    expect(toUnfurlAssetUrl("https://cdn.example.com/image.png?a=1&b=2")).toBe(
+      "/api/unfurl/asset?url=https%3A%2F%2Fcdn.example.com%2Fimage.png%3Fa%3D1%26b%3D2",
+    );
+  });
+
+  it("does not create proxy URLs for private or non-http targets", () => {
+    expect(toUnfurlAssetUrl("http://127.0.0.1/private.png")).toBeUndefined();
+    expect(toUnfurlAssetUrl("data:image/png;base64,abc")).toBeUndefined();
+    expect(toUnfurlAssetUrl(undefined)).toBeUndefined();
+  });
+});

--- a/apps/web/test/unfurl-fetch.test.ts
+++ b/apps/web/test/unfurl-fetch.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchUnfurlResource } from "../src/app/lib/unfurl-fetch";
+
+describe("fetchUnfurlResource", () => {
+  it("rejects a redirect to a private host before fetching it", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(null, {
+          status: 302,
+          headers: { location: "http://127.0.0.1:3000/admin" },
+        }),
+      );
+
+    const result = await fetchUnfurlResource(
+      new URL("https://public.example.com/start"),
+      {},
+      fetcher,
+    );
+
+    expect(result).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates and follows relative public redirects manually", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 301,
+          headers: { location: "/final" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const result = await fetchUnfurlResource(
+      new URL("https://public.example.com/start"),
+      {},
+      fetcher,
+    );
+
+    expect(result?.finalUrl.href).toBe("https://public.example.com/final");
+    expect(await result?.response.text()).toBe("ok");
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher.mock.calls[0]?.[1]).toMatchObject({ redirect: "manual" });
+    expect(fetcher.mock.calls[1]?.[0].toString()).toBe(
+      "https://public.example.com/final",
+    );
+  });
+
+  it("stops redirect loops after the configured hop limit", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const current = new URL(input.toString());
+      const hop = Number.parseInt(current.searchParams.get("hop") ?? "0", 10);
+      return new Response(null, {
+        status: 302,
+        headers: { location: `/?hop=${hop + 1}` },
+      });
+    });
+
+    const result = await fetchUnfurlResource(
+      new URL("https://public.example.com/?hop=0"),
+      {},
+      fetcher,
+    );
+
+    expect(result).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(6);
+  });
+});

--- a/apps/web/test/unfurl-response.test.ts
+++ b/apps/web/test/unfurl-response.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  readBoundedResponseBytes,
+  readHtmlPrefix,
+} from "../src/app/lib/unfurl-response";
+
+const responseFromChunks = (...chunks: Uint8Array[]): Response =>
+  new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    }),
+  );
+
+describe("readHtmlPrefix", () => {
+  it("does not decode bytes beyond the configured limit", async () => {
+    const body = new TextEncoder().encode(`${"a".repeat(64)}SECRET`);
+
+    const html = await readHtmlPrefix(responseFromChunks(body), 64);
+
+    expect(html).toBe("a".repeat(64));
+    expect(html).not.toContain("SECRET");
+  });
+
+  it("applies the limit across multiple chunks", async () => {
+    const encoder = new TextEncoder();
+
+    const html = await readHtmlPrefix(
+      responseFromChunks(
+        encoder.encode("a".repeat(40)),
+        encoder.encode(`${"b".repeat(40)}SECRET`),
+      ),
+      64,
+    );
+
+    expect(html).toBe(`${"a".repeat(40)}${"b".repeat(24)}`);
+  });
+});
+
+describe("readBoundedResponseBytes", () => {
+  it("returns the complete body when it fits", async () => {
+    const encoder = new TextEncoder();
+    const bytes = await readBoundedResponseBytes(
+      responseFromChunks(encoder.encode("first"), encoder.encode("second")),
+      11,
+    );
+
+    expect(new TextDecoder().decode(bytes)).toBe("firstsecond");
+  });
+
+  it("rejects a body as soon as it exceeds the limit", async () => {
+    const bytes = await readBoundedResponseBytes(
+      responseFromChunks(new Uint8Array(65)),
+      64,
+    );
+
+    expect(bytes).toBeNull();
+  });
+});

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -52,6 +52,14 @@
         "limit": 30,
         "period": 60
       }
+    },
+    {
+      "name": "UNFURL_RATE_LIMITER",
+      "namespace_id": "2004",
+      "simple": {
+        "limit": 30,
+        "period": 60
+      }
     }
   ],
   "r2_buckets": [

--- a/packages/meeting-core/src/types.ts
+++ b/packages/meeting-core/src/types.ts
@@ -52,6 +52,12 @@ export interface ChatMessage {
   replyTo?: ChatReplyPreview;
   /** Encrypted capability for the sender's consented cloned TTS voice. */
   ttsVoiceToken?: string;
+  /** Sender dismissed the link preview; clients must not render embeds. */
+  suppressEmbeds?: boolean;
+}
+
+export interface SendChatMessageOptions {
+  suppressEmbeds?: boolean;
 }
 
 export interface ChatReplyPreview {

--- a/packages/sfu/server/games/aiContent.ts
+++ b/packages/sfu/server/games/aiContent.ts
@@ -20,13 +20,22 @@ type GeneratedContentRequest<T> = {
 
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/g;
 const MAX_GENERATED_TEXT_LENGTH = 240;
-const CURRENT_TOPIC_TIMEOUT_MS = 60_000;
-const CURRENT_TOPIC_PATTERN =
-  /\b(latest|recent|current|news|today|this week|this month|this year|breaking|new)\b/i;
+const WEB_SEARCH_REQUEST_TIMEOUT_MS = 60_000;
 const GAME_AI_WEB_SEARCH_TOOL: WebSearchTool = {
   type: "web_search",
   search_context_size: sfuConfig.gameAi.webSearchContextSize,
 };
+
+const GAME_CONTENT_SYSTEM_INSTRUCTIONS = [
+  "You create high-quality party-game content for people playing together in a live video meeting.",
+  "Follow the requested game, topic, task instructions, and response schema exactly. Return only content that belongs in the schema; do not add commentary, citations, URLs, source lists, or extra fields unless the schema explicitly requests them.",
+  "Interpret the topic according to the user's likely intent and the mechanics of the named game. Make every item immediately understandable, playable, distinct from the other items, and concise enough to read aloud or display in a compact game interface.",
+  "Prefer concrete, vivid, broadly recognizable ideas over vague wording. Preserve useful variety across difficulty, framing, subject, and answer shape without drifting away from the requested topic.",
+  "Avoid duplicates, near-duplicates, answer leakage, ambiguous wording, impossible tasks, trick questions that depend on unstated assumptions, and content that requires participants to reveal private or sensitive information.",
+  "The audience may be mixed in age, background, culture, and familiarity with the topic. Keep the content welcoming and suitable for a general social setting. Do not generate hateful, harassing, sexually explicit, graphically violent, dangerous, humiliating, or targeted personal content.",
+  "When factual claims matter, favor accuracy over novelty. Do not fabricate events, people, quotations, statistics, titles, or other details. If reliable specificity is unavailable, use a sounder and more timeless alternative that still fits the topic.",
+  "Treat the supplied output schema as a strict contract. Satisfy every required field, respect all stated limits and types, and ensure the complete response is valid JSON matching that schema.",
+].join("\n");
 
 export const GAME_CONTENT_TOPIC_OPTION: GameOptionSpec = {
   id: "topic",
@@ -99,25 +108,26 @@ export const generateStructuredGameContent = async <T>({
   const cleanTopic = sanitizeTopic(topic);
   if (!cleanTopic || !sfuConfig.gameAi.enabled) return null;
 
-  const currentDate = new Date().toISOString().slice(0, 10);
-  const needsCurrentContext = CURRENT_TOPIC_PATTERN.test(cleanTopic);
+  const now = new Date();
+  const currentDate = now.toISOString().slice(0, 10);
+  const currentDay = new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    timeZone: "UTC",
+  }).format(now);
   const systemInstructions = [
-    "Generate concise, safe party-game content for a live video meeting.",
-    `Current date: ${currentDate}.`,
+    GAME_CONTENT_SYSTEM_INSTRUCTIONS,
     sfuConfig.gameAi.webSearchEnabled
-      ? "Web search is available. Use current web information whenever the topic asks for latest, recent, current, or news-based content."
-      : "Do not invent time-sensitive facts when current information is unavailable.",
-  ].join(" ");
+      ? [
+          "You have access to web search. Decide for yourself whether searching would materially improve the accuracy, freshness, specificity, relevance, or safety of the requested game content.",
+          "Search whenever it is useful, including when the request depends on information you are not confident is correct or complete. Do not search when the task can be answered reliably without it.",
+          "When you search, use the retrieved information to produce the requested game content, reconcile conflicting or uncertain details conservatively, and never invent unsupported facts.",
+        ].join("\n")
+      : "Web search is unavailable. Do not imply that uncertain or time-sensitive information has been verified; prefer reliable, timeless alternatives when necessary.",
+    `Current date and day (UTC): ${currentDate}, ${currentDay}.`,
+  ].join("\n\n");
   const input = [
     `Game: ${gameName}`,
     `Topic: ${cleanTopic}`,
-    needsCurrentContext
-      ? [
-          "This is a current-news topic. Use fresh web context before answering.",
-          "Prefer recent, verifiable developments over evergreen facts.",
-          "Do not use outdated examples unless the topic asks for historical context.",
-        ].join(" ")
-      : null,
     instructions,
     "Keep text short, original, and appropriate for a mixed group.",
   ]
@@ -131,7 +141,7 @@ export const generateStructuredGameContent = async <T>({
       schemaName,
       schema,
       maxOutputTokens ?? sfuConfig.gameAi.maxOutputTokens,
-      resolveRequestTimeoutMs(needsCurrentContext),
+      resolveRequestTimeoutMs(),
     );
     if (payload == null) {
       Logger.warn(`[Games AI] ${gameName} returned an empty structured response`);
@@ -185,11 +195,11 @@ const runOpenAiJson = async (
   return parseStrictJson(response.output_text);
 };
 
-const resolveRequestTimeoutMs = (needsCurrentContext: boolean): number => {
-  if (!needsCurrentContext || !sfuConfig.gameAi.webSearchEnabled) {
+const resolveRequestTimeoutMs = (): number => {
+  if (!sfuConfig.gameAi.webSearchEnabled) {
     return sfuConfig.gameAi.timeoutMs;
   }
-  return Math.max(sfuConfig.gameAi.timeoutMs, CURRENT_TOPIC_TIMEOUT_MS);
+  return Math.max(sfuConfig.gameAi.timeoutMs, WEB_SEARCH_REQUEST_TIMEOUT_MS);
 };
 
 const parseStrictJson = (value: string): unknown | null => {

--- a/packages/sfu/server/socket/handlers/chatHandlers.ts
+++ b/packages/sfu/server/socket/handlers/chatHandlers.ts
@@ -896,6 +896,7 @@ export const registerChatHandlers = (context: ConnectionContext): void => {
           ...(isTtsMessage
             ? { ttsVoiceToken: normalizeTtsVoiceToken(data.ttsVoiceToken) }
             : {}),
+          ...(data.suppressEmbeds === true ? { suppressEmbeds: true } : {}),
           isDirect: Boolean(dmTarget),
           dmTargetUserId: dmTarget?.userId,
           dmTargetDisplayName: dmTarget?.displayName,

--- a/packages/sfu/test/game-ai-content.test.ts
+++ b/packages/sfu/test/game-ai-content.test.ts
@@ -62,7 +62,7 @@ describe("game AI content", () => {
     openAiConstructor.mockClear();
   });
 
-  it("uses the centrally configured OpenAI Responses contract", async () => {
+  it("lets the model decide when to use web search", async () => {
     createResponse.mockResolvedValue({
       output_text: JSON.stringify({ prompts: ["Moon bases"] }),
     });
@@ -95,7 +95,13 @@ describe("game AI content", () => {
     }
     expect(requestInput).toContain("Topic: latest space news");
     expect(requestInstructions).toContain(
-      "Generate concise, safe party-game content",
+      "You create high-quality party-game content",
+    );
+    expect(requestInstructions).toContain(
+      "Decide for yourself whether searching would materially improve",
+    );
+    expect(requestInstructions).toMatch(
+      /Current date and day \(UTC\): \d{4}-\d{2}-\d{2}, [A-Za-z]+\.$/,
     );
     expect(requestRecord).toMatchObject({
       model: "gpt-5.6-luna",
@@ -112,6 +118,29 @@ describe("game AI content", () => {
       },
       tools: [{ type: "web_search", search_context_size: "low" }],
     });
+    expect(request).not.toHaveProperty("tool_choice");
+    expect(requestOptions).toEqual({ timeout: 60_000 });
+  });
+
+  it("offers the same optional web search for evergreen topics", async () => {
+    createResponse.mockResolvedValue({
+      output_text: JSON.stringify({ prompts: ["Draw a moon base"] }),
+    });
+
+    await generateStructuredGameContent({
+      gameName: "Quick Draw",
+      topic: "space",
+      instructions: "Create one prompt.",
+      schemaName: "quick_draw_prompts",
+      schema,
+      parse: (payload) => payload,
+    });
+
+    const [request, requestOptions] = createResponse.mock.calls[0];
+    expect(request).not.toHaveProperty("tool_choice");
+    expect(request).toHaveProperty("tools", [
+      { type: "web_search", search_context_size: "low" },
+    ]);
     expect(requestOptions).toEqual({ timeout: 60_000 });
   });
 

--- a/packages/sfu/types.ts
+++ b/packages/sfu/types.ts
@@ -632,6 +632,8 @@ export interface ChatMessage {
   replyTo?: ChatReplyPreview;
   /** Encrypted capability for the sender's consented cloned TTS voice. */
   ttsVoiceToken?: string;
+  /** Sender dismissed the link preview; clients must not render embeds. */
+  suppressEmbeds?: boolean;
 }
 
 export interface ChatReplyPreview {
@@ -683,6 +685,7 @@ export interface SendChatData {
   image?: Pick<ChatImageAttachment, "id">;
   replyTo?: ChatReplyPreview;
   ttsVoiceToken?: string;
+  suppressEmbeds?: boolean;
 }
 
 export interface ChatMessageNotification extends ChatMessage {}


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds rich link previews to meeting chat and improves remote media lifecycle handling. The main changes are:

- Server-side URL unfurling with bounded HTML and asset responses.
- Preview cards for pages, images, YouTube videos, and tweets.
- Composer controls for suppressing link embeds.
- Chat message schema updates across web, meeting core, and SFU.
- Stale consumer detection and deferred producer consumption on iOS and Android.
- Tests for link parsing, response limits, AI content, and media lifecycle behavior.

<h3>Confidence Score: 4/5</h3>

This is close, but the remaining negative-cache bug should be fixed before merging.

- The HTML byte cap now applies before oversized chunks are decoded.
- Direct request and JSON failures are removed from the client cache.
- Temporary failures returned by the API as successful null responses still suppress previews for the full browser session.

apps/web/src/app/lib/link-embeds.ts and apps/web/src/app/api/unfurl/route.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/lib/link-embeds.ts | Adds URL extraction, YouTube helpers, and shared preview caching, but temporary null responses can remain cached for the browser session. |
| apps/web/src/app/api/unfurl/route.ts | Adds server-side preview fetching and normalization for generic pages, images, YouTube, and tweets. |
| apps/web/src/app/lib/unfurl-response.ts | Adds bounded readers for HTML, buffered assets, and streamed media. |
| apps/conclave-skip/Sources/Conclave/Features/Meeting/MeetingViewModel.swift | Adds deferred producer consumption and stale producer checks during asynchronous media setup. |
| apps/conclave-skip/Sources/Conclave/Core/WebRTC/WebRTCClient.swift | Adds generation tracking to reject consumers created after a producer or session becomes stale. |
| apps/conclave-skip/Sources/Conclave/Skip/WebRTCClient+Android.kt | Mirrors stale consumer generation checks in the Android WebRTC client. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Flib%2Flink-embeds.ts%3A140%0A**Transient%20null%20stays%20cached**%0A%0AThe%20server%20converts%20upstream%20timeouts%2C%20fetch%20failures%2C%20and%20body-read%20failures%20into%20a%20successful%20%60200%60%20response%20with%20%60preview%3A%20null%60.%20That%20response%20resolves%20normally%20here%2C%20so%20the%20catch%20handler%20does%20not%20remove%20it%20from%20%60previewCache%60.%20If%20the%20origin%20later%20recovers%2C%20every%20preview%20for%20this%20URL%20remains%20empty%20until%20the%20browser%20session%20ends.%20Negative%20results%20need%20a%20bounded%20lifetime%20or%20a%20response%20signal%20that%20distinguishes%20temporary%20failures%20from%20confirmed%20misses.%0A%0A&repo=acm-vit%2Fconclave&pr=188&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Flib%2Flink-embeds.ts%3A140%0A**Transient%20null%20stays%20cached**%0A%0AThe%20server%20converts%20upstream%20timeouts%2C%20fetch%20failures%2C%20and%20body-read%20failures%20into%20a%20successful%20%60200%60%20response%20with%20%60preview%3A%20null%60.%20That%20response%20resolves%20normally%20here%2C%20so%20the%20catch%20handler%20does%20not%20remove%20it%20from%20%60previewCache%60.%20If%20the%20origin%20later%20recovers%2C%20every%20preview%20for%20this%20URL%20remains%20empty%20until%20the%20browser%20session%20ends.%20Negative%20results%20need%20a%20bounded%20lifetime%20or%20a%20response%20signal%20that%20distinguishes%20temporary%20failures%20from%20confirmed%20misses.%0A%0A&repo=acm-vit%2Fconclave&pr=188&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fapp%2Flib%2Flink-embeds.ts%3A140%0A**Transient%20null%20stays%20cached**%0A%0AThe%20server%20converts%20upstream%20timeouts%2C%20fetch%20failures%2C%20and%20body-read%20failures%20into%20a%20successful%20%60200%60%20response%20with%20%60preview%3A%20null%60.%20That%20response%20resolves%20normally%20here%2C%20so%20the%20catch%20handler%20does%20not%20remove%20it%20from%20%60previewCache%60.%20If%20the%20origin%20later%20recovers%2C%20every%20preview%20for%20this%20URL%20remains%20empty%20until%20the%20browser%20session%20ends.%20Negative%20results%20need%20a%20bounded%20lifetime%20or%20a%20response%20signal%20that%20distinguishes%20temporary%20failures%20from%20confirmed%20misses.%0A%0A&pr=188&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["feat: enhance video playback handling in..."](https://github.com/acm-vit/conclave/commit/a7327096391f97be1a8e5b4d8882b13f4a9440ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43590003)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->