### PR TITLE
feat(meet): add tags mom versioning and room music

### DIFF
--- a/apps/web/src/app/api/conclave/mom/finalize/route.ts
+++ b/apps/web/src/app/api/conclave/mom/finalize/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const MAX_MOM_BYTES = 512 * 1024;
+
+const sanitizePathSegment = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+
+export async function POST(request: Request) {
+  const token = process.env.MOM_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
+  const repository = process.env.MOM_GITHUB_REPOSITORY;
+  const branch = process.env.MOM_GITHUB_BRANCH || "main";
+  const basePath = process.env.MOM_GITHUB_BASE_PATH || "meeting-minutes";
+
+  if (!token || !repository) {
+    return NextResponse.json(
+      {
+        error:
+          "MoM versioning is not configured. Set MOM_GITHUB_TOKEN and MOM_GITHUB_REPOSITORY.",
+      },
+      { status: 501 },
+    );
+  }
+
+  const body = (await request.json().catch(() => null)) as {
+    roomId?: unknown;
+    markdown?: unknown;
+    title?: unknown;
+  } | null;
+
+  const roomId = typeof body?.roomId === "string" ? body.roomId.trim() : "";
+  const markdown =
+    typeof body?.markdown === "string" ? body.markdown.trim() : "";
+  if (!roomId || !markdown) {
+    return NextResponse.json(
+      { error: "roomId and markdown are required." },
+      { status: 400 },
+    );
+  }
+
+  if (Buffer.byteLength(markdown, "utf8") > MAX_MOM_BYTES) {
+    return NextResponse.json(
+      { error: "MoM is too large to version." },
+      { status: 413 },
+    );
+  }
+
+  const safeRoomId = sanitizePathSegment(roomId) || "meeting";
+  const date = new Date().toISOString().slice(0, 10);
+  const fileName = `${date}-${safeRoomId}.md`;
+  const path = `${basePath.replace(/^\/+|\/+$/g, "")}/${fileName}`;
+  const apiBase = `https://api.github.com/repos/${repository}/contents/${encodeURIComponent(path).replace(/%2F/g, "/")}`;
+
+  const lookup = await fetch(`${apiBase}?ref=${encodeURIComponent(branch)}`, {
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "x-github-api-version": "2022-11-28",
+    },
+  });
+  const existing = lookup.ok
+    ? ((await lookup.json()) as { sha?: string; html_url?: string })
+    : null;
+
+  const response = await fetch(apiBase, {
+    method: "PUT",
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "x-github-api-version": "2022-11-28",
+    },
+    body: JSON.stringify({
+      message: `docs(mom): finalize minutes for ${roomId}`,
+      content: Buffer.from(markdown, "utf8").toString("base64"),
+      branch,
+      ...(existing?.sha ? { sha: existing.sha } : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    return NextResponse.json(
+      { error: "Failed to version MoM.", detail: text.slice(0, 500) },
+      { status: response.status },
+    );
+  }
+
+  const result = (await response.json()) as {
+    content?: { html_url?: string; path?: string };
+    commit?: { html_url?: string; sha?: string };
+  };
+
+  return NextResponse.json({
+    success: true,
+    path: result.content?.path ?? path,
+    url: result.content?.html_url ?? existing?.html_url ?? null,
+    commitUrl: result.commit?.html_url ?? null,
+    commitSha: result.commit?.sha ?? null,
+  });
+}

--- a/apps/web/src/app/components/MeetSettingsPanel.tsx
+++ b/apps/web/src/app/components/MeetSettingsPanel.tsx
@@ -25,6 +25,7 @@ import type {
   WebinarConfigSnapshot,
   WebinarLinkResponse,
   WebinarUpdateRequest,
+  MeetingMusicPermission,
 } from "../lib/types";
 
 const DEFAULT_WEBINAR_CAP = 500;
@@ -65,6 +66,8 @@ interface MeetSettingsPanelProps {
   onToggleImageAttachments?: () => void;
   isReactionsDisabled: boolean;
   onToggleReactionsDisabled?: () => void;
+  musicPermission: MeetingMusicPermission;
+  onSetMusicPermission?: (permission: MeetingMusicPermission) => void;
   meetingRequiresInviteCode: boolean;
   onGetMeetingConfig?: () => Promise<MeetingConfigSnapshot | null>;
   onUpdateMeetingConfig?: (
@@ -456,6 +459,8 @@ export default function MeetSettingsPanel({
   onToggleImageAttachments,
   isReactionsDisabled,
   onToggleReactionsDisabled,
+  musicPermission,
+  onSetMusicPermission,
   meetingRequiresInviteCode,
   onGetMeetingConfig,
   onUpdateMeetingConfig,
@@ -721,6 +726,51 @@ export default function MeetSettingsPanel({
             onClick={onToggleReactionsDisabled}
             disabled={!onToggleReactionsDisabled}
           />
+
+          <div className="px-4 py-2.5">
+            <div className="mb-2 flex items-center gap-3">
+              <Volume2
+                size={ICON_SIZE}
+                strokeWidth={ICON_STROKE}
+                className="shrink-0"
+                style={{
+                  color:
+                    musicPermission === "off"
+                      ? ICON_OFF
+                      : TONE_ACCENT.success,
+                }}
+              />
+              <span className="min-w-0 flex-1 truncate text-[14px] font-normal text-[#fafafa]">
+                Room music
+              </span>
+            </div>
+            <div className="grid grid-cols-3 gap-1 rounded-[10px] border border-white/[0.10] bg-black/20 p-1">
+              {(["off", "admin", "everyone"] as const).map((permission) => {
+                const active = musicPermission === permission;
+                const label =
+                  permission === "off"
+                    ? "Off"
+                    : permission === "admin"
+                      ? "Hosts"
+                      : "Everyone";
+                return (
+                  <button
+                    key={permission}
+                    type="button"
+                    onClick={() => onSetMusicPermission?.(permission)}
+                    disabled={!onSetMusicPermission}
+                    className={`h-8 rounded-[8px] text-[12px] font-semibold transition-colors ${
+                      active
+                        ? "bg-[#F95F4A] text-white"
+                        : "text-[#a1a1aa] hover:bg-white/[0.06] hover:text-[#fafafa]"
+                    } disabled:cursor-not-allowed disabled:opacity-50`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
 
           <Separator />
 

--- a/apps/web/src/app/components/MeetingMusicPlayer.tsx
+++ b/apps/web/src/app/components/MeetingMusicPlayer.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { Pause, Play, Volume2, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { MeetingMusicState } from "../lib/types";
+
+interface MeetingMusicPlayerProps {
+  state: MeetingMusicState;
+  isAdmin: boolean;
+  activeSpeakerId: string | null;
+  currentUserId: string;
+  onStop?: () => void;
+}
+
+export default function MeetingMusicPlayer({
+  state,
+  isAdmin,
+  activeSpeakerId,
+  currentUserId,
+  onStop,
+}: MeetingMusicPlayerProps) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [needsGesture, setNeedsGesture] = useState(false);
+  const track = state.track;
+  const shouldDuck = Boolean(
+    track && activeSpeakerId && activeSpeakerId !== currentUserId,
+  );
+  const volume = shouldDuck ? 0.35 : 0.82;
+  const requestedBy = track?.requestedByDisplayName || "Someone";
+  const title = track?.title || "";
+  const canPlay = Boolean(track?.url);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio || !track) {
+      setIsPlaying(false);
+      setNeedsGesture(false);
+      return;
+    }
+    audio.volume = volume;
+  }, [track, volume]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio || !track?.url) return;
+    setNeedsGesture(false);
+    void audio.play().then(
+      () => setIsPlaying(true),
+      () => {
+        setIsPlaying(false);
+        setNeedsGesture(true);
+      },
+    );
+  }, [track?.id, track?.url]);
+
+  const status = useMemo(() => {
+    if (!track) return null;
+    if (needsGesture) return "Tap to start";
+    return shouldDuck ? "Ducked while someone speaks" : "Playing for everyone";
+  }, [needsGesture, shouldDuck, track]);
+
+  if (!track || state.permission === "off") {
+    return null;
+  }
+
+  const togglePlayback = () => {
+    const audio = audioRef.current;
+    if (!audio || !canPlay) return;
+    if (audio.paused) {
+      void audio.play().then(
+        () => {
+          setIsPlaying(true);
+          setNeedsGesture(false);
+        },
+        () => setNeedsGesture(true),
+      );
+      return;
+    }
+    audio.pause();
+    setIsPlaying(false);
+  };
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-16 z-[68] flex justify-center px-4">
+      <div className="pointer-events-auto flex max-w-[min(560px,100%)] items-center gap-3 rounded-xl border border-[#F95F4A]/30 bg-[#18181b]/95 px-3 py-2 shadow-2xl shadow-black/30 backdrop-blur">
+        <audio
+          ref={audioRef}
+          src={track.url}
+          preload="auto"
+          loop
+          onPlay={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
+        />
+        <button
+          type="button"
+          onClick={togglePlayback}
+          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[#F95F4A] text-white transition-colors hover:bg-[#f24b35]"
+          aria-label={isPlaying ? "Pause room music" : "Play room music"}
+          title={isPlaying ? "Pause room music" : "Play room music"}
+        >
+          {isPlaying ? <Pause size={16} /> : <Play size={16} />}
+        </button>
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <Volume2 size={14} className="shrink-0 text-[#F95F4A]" />
+            <p className="truncate text-[13px] font-semibold text-[#fafafa]">
+              {title}
+            </p>
+          </div>
+          <p className="truncate text-[11.5px] text-[#a1a1aa]">
+            {status} by {requestedBy}
+          </p>
+        </div>
+        {isAdmin && onStop ? (
+          <button
+            type="button"
+            onClick={onStop}
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[#a1a1aa] transition-colors hover:bg-white/[0.06] hover:text-[#fafafa]"
+            aria-label="Stop room music"
+            title="Stop room music"
+          >
+            <X size={16} />
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -23,6 +23,7 @@ import BrowserLayout from "./BrowserLayout";
 import MeetingAppLayout from "./MeetingAppLayout";
 import ScreenShareAudioPlayers from "./ScreenShareAudioPlayers";
 import SystemAudioPlayers from "./SystemAudioPlayers";
+import MeetingMusicPlayer from "./MeetingMusicPlayer";
 import ParticipantVideo from "./ParticipantVideo";
 import ToastQueue from "./ToastQueue";
 import TranscriptPanel from "./TranscriptPanel";
@@ -55,6 +56,7 @@ import type {
   ConnectionState,
   MeetError,
   MeetingConfigSnapshot,
+  MeetingMusicState,
   MeetingUpdateRequest,
   Participant,
   ReconnectRecoveryStatus,
@@ -282,6 +284,8 @@ interface MeetsMainContentProps {
   isDmEnabled: boolean;
   areImageAttachmentsEnabled: boolean;
   isReactionsDisabled: boolean;
+  musicState: MeetingMusicState;
+  availableParticipantTags: string[];
   meetingRequiresInviteCode: boolean;
   webinarConfig?: WebinarConfigSnapshot | null;
   webinarRole?: "attendee" | "participant" | "host" | null;
@@ -526,6 +530,8 @@ export default function MeetsMainContent({
   isDmEnabled,
   areImageAttachmentsEnabled,
   isReactionsDisabled,
+  musicState,
+  availableParticipantTags,
   meetingRequiresInviteCode,
   webinarConfig,
   webinarRole,
@@ -1394,6 +1400,31 @@ export default function MeetsMainContent({
     );
   }, [socket, isReactionsDisabled]);
 
+  const handleSetMusicPermission = useCallback(
+    (permission: MeetingMusicState["permission"]) => {
+      if (!socket) return;
+      socket.emit(
+        "setMusicPermission",
+        { permission },
+        (res: { error?: string }) => {
+          if (res?.error) {
+            console.error("Failed to update music permission:", res.error);
+          }
+        },
+      );
+    },
+    [socket],
+  );
+
+  const handleStopMusic = useCallback(() => {
+    if (!socket) return;
+    socket.emit("music:stop", {}, (res: { error?: string }) => {
+      if (res?.error) {
+        console.error("Failed to stop music:", res.error);
+      }
+    });
+  }, [socket]);
+
   const handleToggleChat = useCallback(() => {
     if (!isChatOpen) {
       if (isParticipantsOpen) {
@@ -2231,6 +2262,16 @@ export default function MeetsMainContent({
         </div>
       )}
 
+      {isJoined && !isWebinarAttendee && (
+        <MeetingMusicPlayer
+          state={musicState}
+          isAdmin={isAdmin}
+          activeSpeakerId={activeSpeakerId}
+          currentUserId={currentUserId}
+          onStop={handleStopMusic}
+        />
+      )}
+
       {isJoined &&
         (isWebinarAttendee ? (
           <div className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-black/30 px-4 py-3">
@@ -2337,6 +2378,7 @@ export default function MeetsMainContent({
           onPendingUserStale={handlePendingUserStale}
           hostUserId={hostUserId}
           hostUserIds={hostUserIds}
+          availableTags={availableParticipantTags}
         />
       )}
 
@@ -2359,6 +2401,8 @@ export default function MeetsMainContent({
             onToggleImageAttachments={handleToggleImageAttachments}
             isReactionsDisabled={isReactionsDisabled}
             onToggleReactionsDisabled={handleToggleReactionsDisabled}
+            musicPermission={musicState.permission}
+            onSetMusicPermission={handleSetMusicPermission}
             meetingRequiresInviteCode={meetingRequiresInviteCode}
             onGetMeetingConfig={onGetMeetingConfig}
             onUpdateMeetingConfig={onUpdateMeetingConfig}

--- a/apps/web/src/app/components/ParticipantsPanel.tsx
+++ b/apps/web/src/app/components/ParticipantsPanel.tsx
@@ -33,6 +33,7 @@ interface ParticipantsPanelProps {
   };
   hostUserId?: string | null;
   hostUserIds?: string[];
+  availableTags?: string[];
 }
 
 const ICON = 18;
@@ -65,6 +66,7 @@ function ParticipantsPanel({
   localState,
   hostUserId,
   hostUserIds,
+  availableTags = ["host", "jc", "sc", "boards", "guest"],
 }: ParticipantsPanelProps & {
   socket: Socket | null;
   isAdmin?: boolean | null;
@@ -90,6 +92,7 @@ function ParticipantsPanel({
           isCameraOff: localState.isCameraOff,
           isVideoAdaptivelyPaused: false,
           isHandRaised: localState.isHandRaised,
+          tags: [],
         }
       : null;
   const displayParticipants = localParticipant
@@ -107,6 +110,7 @@ function ParticipantsPanel({
   const [pendingKickUserId, setPendingKickUserId] = useState<string | null>(null);
   const [removingUserId, setRemovingUserId] = useState<string | null>(null);
   const [isAdmittingAll, setIsAdmittingAll] = useState(false);
+  const [removingTag, setRemovingTag] = useState<string | null>(null);
   const [hostActionError, setHostActionError] = useState<string | null>(null);
   const effectiveHostUserId = hostUserId ?? (isAdmin ? currentUserId : null);
   const effectiveHostUserIds = new Set<string>(
@@ -232,6 +236,43 @@ function ParticipantsPanel({
     );
   };
 
+  const handleToggleTag = (targetUserId: string, tag: string) => {
+    if (!socket || !isAdmin) return;
+    const participant = participants.get(targetUserId);
+    const current = new Set(participant?.tags ?? []);
+    if (current.has(tag)) {
+      current.delete(tag);
+    } else {
+      current.add(tag);
+    }
+    setHostActionError(null);
+    socket.emit(
+      "setParticipantTags",
+      { userId: targetUserId, tags: Array.from(current) },
+      (res: { success?: boolean; error?: string }) => {
+        if (res?.error || !res?.success) {
+          setHostActionError(res?.error || "Failed to update tags.");
+        }
+      },
+    );
+  };
+
+  const handleRemoveByTag = (tag: string) => {
+    if (!socket || !isAdmin || removingTag) return;
+    setHostActionError(null);
+    setRemovingTag(tag);
+    socket.emit(
+      "removeUsersByTag",
+      { tag },
+      (res: { success?: boolean; error?: string; removedCount?: number }) => {
+        setRemovingTag(null);
+        if (res?.error || !res?.success) {
+          setHostActionError(res?.error || "Failed to remove tagged members.");
+        }
+      },
+    );
+  };
+
   useEffect(() => {
     if (
       expandedUserId &&
@@ -317,6 +358,24 @@ function ParticipantsPanel({
               <span>Stop video</span>
             </button>
           </div>
+          {availableTags.length > 0 && (
+            <div className="mt-2.5 flex flex-wrap gap-1.5">
+              {availableTags
+                .filter((tag) => tag !== "host" && tag !== "guest")
+                .map((tag) => (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => handleRemoveByTag(tag)}
+                    disabled={removingTag === tag}
+                    className="rounded-md border border-[#F95F4A]/25 bg-[#F95F4A]/10 px-2 py-1 text-[11.5px] font-semibold text-[#F95F4A] transition-colors hover:bg-[#F95F4A]/15 disabled:opacity-50"
+                    title={`Remove all members tagged @${tag}`}
+                  >
+                    {removingTag === tag ? "Removing" : `Remove @${tag}`}
+                  </button>
+                ))}
+            </div>
+          )}
         </section>
       )}
 
@@ -483,6 +542,25 @@ function ParticipantsPanel({
                       </span>
                     )}
                   </div>
+                  {((participant.tags ?? []).length > 0 || isHost) && (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {Array.from(
+                        new Set([
+                          ...(isHost ? ["host"] : []),
+                          ...(participant.tags ?? []),
+                        ]),
+                      )
+                        .sort()
+                        .map((tag) => (
+                          <span
+                            key={tag}
+                            className="rounded-md bg-white/[0.06] px-1.5 py-0.5 text-[10.5px] font-semibold text-[#a1a1aa]"
+                          >
+                            @{tag}
+                          </span>
+                        ))}
+                    </div>
+                  )}
                 </div>
 
                 <div className="flex shrink-0 items-center gap-2.5">
@@ -545,7 +623,29 @@ function ParticipantsPanel({
                   className="mx-2 mb-1 mt-0.5 rounded-lg border border-white/10 bg-black/20 px-3 py-2.5"
                 >
                   {isAdmin && !isMe && (
-                    <div className="flex flex-wrap gap-1.5">
+                    <div className="space-y-2">
+                      <div className="flex flex-wrap gap-1.5">
+                        {availableTags
+                          .filter((tag) => tag !== "host" && tag !== "guest")
+                          .map((tag) => {
+                            const active = Boolean(participant.tags?.includes(tag));
+                            return (
+                              <button
+                                key={tag}
+                                type="button"
+                                onClick={() => handleToggleTag(participant.userId, tag)}
+                                className={`rounded-md border px-2 py-1 text-[11.5px] font-semibold transition-colors ${
+                                  active
+                                    ? "border-[#F95F4A]/35 bg-[#F95F4A]/15 text-[#F95F4A]"
+                                    : "border-white/10 bg-white/[0.04] text-[#a1a1aa] hover:bg-white/[0.07] hover:text-[#fafafa]"
+                                }`}
+                              >
+                                @{tag}
+                              </button>
+                            );
+                          })}
+                      </div>
+                      <div className="flex flex-wrap gap-1.5">
                       {canPromoteParticipant && (
                         <>
                           {isPendingPromotion ? (
@@ -674,6 +774,7 @@ function ParticipantsPanel({
                           </button>
                         );
                       })() : null}
+                      </div>
                     </div>
                   )}
                 </div>

--- a/apps/web/src/app/components/TranscriptPanel.tsx
+++ b/apps/web/src/app/components/TranscriptPanel.tsx
@@ -21,7 +21,7 @@ import {
   Tag,
   X,
 } from "lucide-react";
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import type {
   MeetingTranscriptController,
   TranscriptQaMessage,
@@ -975,6 +975,14 @@ export default function TranscriptPanel({
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">(
     "idle",
   );
+  const [finalizeState, setFinalizeState] = useState<
+    | { status: "idle" }
+    | { status: "saving" }
+    | { status: "saved"; url: string | null }
+    | { status: "failed"; error: string }
+    | { status: "aborted" }
+  >({ status: "idle" });
+  const finalizeTokenRef = useRef(0);
   const session = transcript.session;
   const hasExportContent =
     transcript.allSegments.length > 0 || hasMinutesContent(transcript.minutes);
@@ -1016,6 +1024,41 @@ export default function TranscriptPanel({
       `conclave-${session.roomId}-transcript.md`,
       transcript.exportMarkdown(),
     );
+  };
+
+  const handleFinalizeMom = async () => {
+    if (!canExport || finalizeState.status === "saving") return;
+    const token = finalizeTokenRef.current + 1;
+    finalizeTokenRef.current = token;
+    setFinalizeState({ status: "saving" });
+    try {
+      const response = await fetch("/api/conclave/mom/finalize", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          roomId: session.roomId,
+          title: `Meeting Minutes - ${session.roomId}`,
+          markdown: transcript.exportMarkdown(),
+        }),
+      });
+      const result = (await response.json().catch(() => null)) as
+        | { success?: boolean; url?: string | null; error?: string }
+        | null;
+      if (!response.ok || !result?.success) {
+        throw new Error(result?.error || "Failed to finalize MoM.");
+      }
+      if (finalizeTokenRef.current === token) {
+        setFinalizeState({ status: "saved", url: result.url ?? null });
+      }
+    } catch (error) {
+      if (finalizeTokenRef.current === token) {
+        setFinalizeState({
+          status: "failed",
+          error:
+            error instanceof Error ? error.message : "Failed to finalize MoM.",
+        });
+      }
+    }
   };
 
   return (
@@ -1191,7 +1234,44 @@ export default function TranscriptPanel({
             )}
           </div>
 
-          <div className="flex shrink-0 items-center gap-2 border-t border-white/10 bg-[#18181b] px-3 py-3">
+          <div className="shrink-0 border-t border-white/10 bg-[#18181b] px-3 py-3">
+            {finalizeState.status !== "idle" ? (
+              <div className="mb-2 flex items-center justify-between gap-2 rounded-lg border border-white/10 bg-white/[0.03] px-2.5 py-2 text-[11.5px] text-[#a1a1aa]">
+                <span className="min-w-0 truncate">
+                  {finalizeState.status === "saving"
+                    ? "Finalizing MoM..."
+                    : finalizeState.status === "saved"
+                      ? finalizeState.url
+                        ? "MoM versioned in GitHub"
+                        : "MoM versioned"
+                      : finalizeState.status === "aborted"
+                        ? "MoM finalization aborted"
+                        : finalizeState.error}
+                </span>
+                {finalizeState.status === "saved" && finalizeState.url ? (
+                  <a
+                    href={finalizeState.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="shrink-0 text-[#F95F4A] hover:text-[#ff8a78]"
+                  >
+                    Open
+                  </a>
+                ) : finalizeState.status === "saving" ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      finalizeTokenRef.current += 1;
+                      setFinalizeState({ status: "aborted" });
+                    }}
+                    className="shrink-0 text-[#F95F4A] hover:text-[#ff8a78]"
+                  >
+                    Abort
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+            <div className="flex items-center gap-2">
             <button
               onClick={handleCopy}
               disabled={!canExport}
@@ -1212,6 +1292,19 @@ export default function TranscriptPanel({
               <Download size={14} strokeWidth={1.8} />
               Export
             </button>
+            <button
+              onClick={handleFinalizeMom}
+              disabled={!canExport || finalizeState.status === "saving"}
+              className="inline-flex h-9 flex-1 items-center justify-center gap-2 rounded-lg border border-[#F95F4A]/35 bg-[#F95F4A]/10 px-3 text-[12px] font-semibold text-[#F95F4A] transition-colors hover:bg-[#F95F4A]/15 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {finalizeState.status === "saving" ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <CheckCircle2 size={14} strokeWidth={1.8} />
+              )}
+              Finalize
+            </button>
+            </div>
           </div>
         </>
       ) : (

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -33,6 +33,7 @@ import type {
   MeetError,
   Producer,
   MeetingConfigSnapshot,
+  MeetingMusicState,
   MeetingUpdateRequest,
   ParticipantConnectionStatus,
   ProducerInfo,
@@ -740,6 +741,8 @@ interface UseMeetSocketOptions {
   setIsDmEnabled: (value: boolean) => void;
   setAreImageAttachmentsEnabled: (value: boolean) => void;
   setIsReactionsDisabled: (value: boolean) => void;
+  setMusicState: React.Dispatch<React.SetStateAction<MeetingMusicState>>;
+  setAvailableParticipantTags: React.Dispatch<React.SetStateAction<string[]>>;
   setActiveScreenShareId: (value: string | null) => void;
   setActiveSpeakerId: React.Dispatch<React.SetStateAction<string | null>>;
   setServerActiveSpeakerAvailable: (value: boolean) => void;
@@ -842,6 +845,8 @@ export function useMeetSocket({
   setIsDmEnabled,
   setAreImageAttachmentsEnabled,
   setIsReactionsDisabled,
+  setMusicState,
+  setAvailableParticipantTags,
   setActiveScreenShareId,
   setActiveSpeakerId,
   setServerActiveSpeakerAvailable,
@@ -4649,6 +4654,16 @@ export function useMeetSocket({
                 response.areImageAttachmentsEnabled ?? true,
               );
               setIsReactionsDisabled(response.isReactionsDisabled ?? false);
+              setMusicState(
+                response.musicState ?? {
+                  permission: "off",
+                  slowModeMs: 30_000,
+                  track: null,
+                },
+              );
+              if (Array.isArray(response.availableTags)) {
+                setAvailableParticipantTags(response.availableTags);
+              }
               resolve("waiting");
               return;
             }
@@ -4672,6 +4687,26 @@ export function useMeetSocket({
                 response.areImageAttachmentsEnabled ?? true,
               );
               setIsReactionsDisabled(response.isReactionsDisabled ?? false);
+              setMusicState(
+                response.musicState ?? {
+                  permission: "off",
+                  slowModeMs: 30_000,
+                  track: null,
+                },
+              );
+              if (Array.isArray(response.availableTags)) {
+                setAvailableParticipantTags(response.availableTags);
+              }
+              if (Array.isArray(response.participantTags)) {
+                for (const entry of response.participantTags) {
+                  if (!entry?.userId || !Array.isArray(entry.tags)) continue;
+                  dispatchParticipants({
+                    type: "UPDATE_TAGS",
+                    userId: entry.userId,
+                    tags: entry.tags,
+                  });
+                }
+              }
               if (
                 Object.prototype.hasOwnProperty.call(response, "activeSpeakerId")
               ) {
@@ -4827,6 +4862,11 @@ export function useMeetSocket({
       setIsTtsDisabled,
       setIsChatLocked,
       setIsDmEnabled,
+      setAreImageAttachmentsEnabled,
+      setIsReactionsDisabled,
+      setMusicState,
+      setAvailableParticipantTags,
+      dispatchParticipants,
     ],
   );
 
@@ -6197,6 +6237,45 @@ export function useMeetSocket({
                 if (!isRoomEvent(eventRoomId)) return;
                 console.info("[Meets] Room reactions disabled changed:", disabled);
                 setIsReactionsDisabled(disabled);
+              },
+            );
+
+            socket.on(
+              "musicStateChanged",
+              ({
+                state,
+                roomId: eventRoomId,
+              }: {
+                state?: MeetingMusicState;
+                roomId?: string;
+              }) => {
+                if (!isRoomEvent(eventRoomId) || !state) return;
+                setMusicState(state);
+              },
+            );
+
+            socket.on(
+              "participantTagsChanged",
+              ({
+                userId: taggedUserId,
+                tags,
+                availableTags,
+                roomId: eventRoomId,
+              }: {
+                userId?: string;
+                tags?: string[];
+                availableTags?: string[];
+                roomId?: string;
+              }) => {
+                if (!isRoomEvent(eventRoomId) || !taggedUserId) return;
+                dispatchParticipants({
+                  type: "UPDATE_TAGS",
+                  userId: taggedUserId,
+                  tags: Array.isArray(tags) ? tags : [],
+                });
+                if (Array.isArray(availableTags)) {
+                  setAvailableParticipantTags(availableTags);
+                }
               },
             );
 

--- a/apps/web/src/app/hooks/useMeetState.ts
+++ b/apps/web/src/app/hooks/useMeetState.ts
@@ -7,6 +7,7 @@ import type {
   AdminNoticeNotification,
   ConnectionState,
   MeetError,
+  MeetingMusicState,
   Participant,
   WebinarConfigSnapshot,
 } from "../lib/types";
@@ -74,6 +75,14 @@ export function useMeetState({ initialRoomId }: UseMeetStateOptions) {
   );
   const [adminNotice, setAdminNotice] =
     useState<AdminNoticeNotification | null>(null);
+  const [musicState, setMusicState] = useState<MeetingMusicState>({
+    permission: "off",
+    slowModeMs: 30_000,
+    track: null,
+  });
+  const [availableParticipantTags, setAvailableParticipantTags] = useState<
+    string[]
+  >(["host", "jc", "sc", "boards", "guest"]);
 
   return {
     connectionState,
@@ -142,5 +151,9 @@ export function useMeetState({ initialRoomId }: UseMeetStateOptions) {
     setServerRestartNotice,
     adminNotice,
     setAdminNotice,
+    musicState,
+    setMusicState,
+    availableParticipantTags,
+    setAvailableParticipantTags,
   };
 }

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -589,6 +589,10 @@ export default function MeetsClient({
     setServerRestartNotice,
     adminNotice,
     setAdminNotice,
+    musicState,
+    setMusicState,
+    availableParticipantTags,
+    setAvailableParticipantTags,
   } = useMeetState({ initialRoomId });
 
   const [serverActiveSpeakerAvailable, setServerActiveSpeakerAvailable] =
@@ -2253,6 +2257,8 @@ export default function MeetsClient({
     setIsDmEnabled,
     setAreImageAttachmentsEnabled,
     setIsReactionsDisabled,
+    setMusicState,
+    setAvailableParticipantTags,
     setActiveScreenShareId,
     setActiveSpeakerId,
     setServerActiveSpeakerAvailable,
@@ -3207,6 +3213,8 @@ export default function MeetsClient({
         isDmEnabled={isDmEnabled}
         areImageAttachmentsEnabled={areImageAttachmentsEnabled}
         isReactionsDisabled={isReactionsDisabled}
+        musicState={musicState}
+        availableParticipantTags={availableParticipantTags}
         onToggleLock={() => {
           if (canModerateMeeting) void socket.toggleRoomLock(!isRoomLocked);
         }}

--- a/packages/meeting-core/src/chat-commands.ts
+++ b/packages/meeting-core/src/chat-commands.ts
@@ -11,6 +11,7 @@ export type ChatCommandId =
   | "mute"
   | "unmute"
   | "camera"
+  | "play"
   | "leave"
   | "clear";
 
@@ -92,6 +93,13 @@ export const CHAT_COMMANDS: ChatCommand[] = [
     description: "Control your camera",
     usage: "/camera on|off|toggle",
     insertText: "/camera ",
+  },
+  {
+    id: "play",
+    label: "play",
+    description: "Play music for the room",
+    usage: "/play <url or search>",
+    insertText: "/play ",
   },
   {
     id: "leave",

--- a/packages/meeting-core/src/participant-reducer.ts
+++ b/packages/meeting-core/src/participant-reducer.ts
@@ -45,6 +45,7 @@ export type ParticipantAction =
       userId: string;
       status: ParticipantConnectionStatus | null;
     }
+  | { type: "UPDATE_TAGS"; userId: string; tags: string[] }
   | { type: "CLEAR_ALL" };
 
 // A brand-new entry has no producers, so it cannot be sending media: it starts
@@ -243,6 +244,22 @@ export function participantReducer(
       return withParticipant(state, action.userId, {
         ...(participant || createEmptyParticipant(action.userId)),
         isHandRaised: action.raised,
+      });
+    }
+    case "UPDATE_TAGS": {
+      const participant = state.get(action.userId);
+      if (!participant) return state;
+      const tags = action.tags.slice().sort();
+      const current = participant.tags ?? [];
+      if (
+        current.length === tags.length &&
+        current.every((tag, index) => tag === tags[index])
+      ) {
+        return state;
+      }
+      return withParticipant(state, action.userId, {
+        ...participant,
+        tags,
       });
     }
     case "UPDATE_CONNECTION_STATUS": {

--- a/packages/meeting-core/src/sfu-events.ts
+++ b/packages/meeting-core/src/sfu-events.ts
@@ -68,6 +68,10 @@ export const SFU_EVENTS = {
     getTtsDisabledStatus: "getTtsDisabledStatus",
     setReactionsDisabled: "setReactionsDisabled",
     getReactionsDisabledStatus: "getReactionsDisabledStatus",
+    setMusicPermission: "setMusicPermission",
+    stopMusic: "music:stop",
+    setParticipantTags: "setParticipantTags",
+    removeUsersByTag: "removeUsersByTag",
     admitUser: "admitUser",
     rejectUser: "rejectUser",
     kickUser: "kickUser",
@@ -188,6 +192,8 @@ export const SFU_EVENTS = {
     imageAttachmentsStateChanged: "imageAttachmentsStateChanged",
     ttsDisabledChanged: "ttsDisabledChanged",
     reactionsDisabledChanged: "reactionsDisabledChanged",
+    musicStateChanged: "musicStateChanged",
+    participantTagsChanged: "participantTagsChanged",
 
     // Session lifecycle / disruptive
     kicked: "kicked",

--- a/packages/meeting-core/src/types.ts
+++ b/packages/meeting-core/src/types.ts
@@ -54,6 +54,24 @@ export interface ChatMessage {
   ttsVoiceToken?: string;
 }
 
+export type MeetingMusicPermission = "off" | "admin" | "everyone";
+
+export interface MeetingMusicTrack {
+  id: string;
+  query: string;
+  title: string;
+  url: string;
+  requestedByUserId: string;
+  requestedByDisplayName: string;
+  startedAt: number;
+}
+
+export interface MeetingMusicState {
+  permission: MeetingMusicPermission;
+  slowModeMs: number;
+  track: MeetingMusicTrack | null;
+}
+
 export interface ChatReplyPreview {
   id: string;
   userId: string;
@@ -210,6 +228,7 @@ export interface Participant {
   isCameraOff: boolean;
   isVideoAdaptivelyPaused: boolean;
   isHandRaised: boolean;
+  tags?: string[];
   isLeaving?: boolean;
   connectionStatus?: ParticipantConnectionStatus;
 }
@@ -252,6 +271,9 @@ export interface JoinRoomResponse {
   isDmEnabled?: boolean;
   areImageAttachmentsEnabled?: boolean;
   isReactionsDisabled?: boolean;
+  musicState?: MeetingMusicState;
+  participantTags?: { userId: string; tags: string[] }[];
+  availableTags?: string[];
   meetingRequiresInviteCode?: boolean;
   webinarRole?: "attendee" | "participant" | "host";
   isWebinarEnabled?: boolean;

--- a/packages/sfu/config/classes/Room.ts
+++ b/packages/sfu/config/classes/Room.ts
@@ -18,6 +18,9 @@ import * as Y from "yjs";
 import type {
   ActiveSpeakerChangedNotification,
   ChatMessage,
+  MeetingMusicPermission,
+  MeetingMusicState,
+  MeetingMusicTrack,
   ProducerInfo,
   VideoQuality,
 } from "../../types.js";
@@ -81,6 +84,8 @@ export const CHAT_IMAGE_ORPHAN_TTL_MS = 2 * 60 * 1000;
 const MAX_CHAT_IMAGE_ROOM_BYTES = 64 * 1024 * 1024;
 const MAX_CHAT_IMAGE_USER_BYTES = 24 * 1024 * 1024;
 const MAX_INVITE_CODE_LENGTH = 256;
+const DEFAULT_ROOM_TAGS = ["host", "jc", "sc", "boards", "guest"];
+const MUSIC_SLOW_MODE_MS = 30_000;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
 
 const normalizeInviteCode = (value: unknown): string => {
@@ -96,6 +101,18 @@ const normalizeInviteCode = (value: unknown): string => {
     return "";
   }
   return normalized;
+};
+
+const normalizeParticipantTag = (value: unknown): string => {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const normalized = value
+    .trim()
+    .replace(/^@+/, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "");
+  return normalized.length > 0 && normalized.length <= 24 ? normalized : "";
 };
 
 const getAwarenessStateUserId = (state: unknown): string | null => {
@@ -176,6 +193,12 @@ export class Room {
   private _areImageAttachmentsEnabled: boolean = true;
   private _reactionsDisabled: boolean = false;
   private _meetingInviteCodeHash: string | null = null;
+  private _musicPermission: MeetingMusicPermission = "off";
+  private _currentMusicTrack: MeetingMusicTrack | null = null;
+  public readonly musicSlowModeMs = MUSIC_SLOW_MODE_MS;
+  public lastMusicRequestByUserId: Map<string, number> = new Map();
+  private availableParticipantTags: Set<string> = new Set(DEFAULT_ROOM_TAGS);
+  private participantTagsByUserId: Map<string, Set<string>> = new Map();
   public appsState: { activeAppId: string | null; locked: boolean } = {
     activeAppId: null,
     locked: false,
@@ -310,6 +333,8 @@ export class Room {
     const departingUserKey = this.userKeysById.get(clientId);
     this.userKeysById.delete(clientId);
     this.handRaisedByUserId.delete(clientId);
+    this.participantTagsByUserId.delete(clientId);
+    this.lastMusicRequestByUserId.delete(clientId);
     // Drop the cached display name once NO live client still shares this userKey
     // (a user may be joined from two tabs under one key). Without this,
     // displayNamesByKey is only cleared on full room teardown, so a long-lived
@@ -926,6 +951,85 @@ export class Room {
 
   setImageAttachmentsEnabled(enabled: boolean): void {
     this._areImageAttachmentsEnabled = enabled;
+  }
+
+  get musicPermission(): MeetingMusicPermission {
+    return this._musicPermission;
+  }
+
+  setMusicPermission(permission: MeetingMusicPermission): void {
+    this._musicPermission = permission;
+    if (permission === "off") {
+      this._currentMusicTrack = null;
+      this.lastMusicRequestByUserId.clear();
+    }
+  }
+
+  get currentMusicTrack(): MeetingMusicTrack | null {
+    return this._currentMusicTrack;
+  }
+
+  setCurrentMusicTrack(track: MeetingMusicTrack | null): void {
+    this._currentMusicTrack = track;
+  }
+
+  getMusicState(): MeetingMusicState {
+    return {
+      permission: this._musicPermission,
+      slowModeMs: this.musicSlowModeMs,
+      track: this._currentMusicTrack,
+    };
+  }
+
+  getAvailableParticipantTags(): string[] {
+    return Array.from(this.availableParticipantTags).sort();
+  }
+
+  setAvailableParticipantTags(tags: string[]): string[] {
+    const normalized = new Set<string>();
+    for (const tag of tags) {
+      const clean = normalizeParticipantTag(tag);
+      if (clean) normalized.add(clean);
+    }
+    for (const tag of DEFAULT_ROOM_TAGS) {
+      normalized.add(tag);
+    }
+    this.availableParticipantTags = normalized;
+    return this.getAvailableParticipantTags();
+  }
+
+  getParticipantTags(userId: string): string[] {
+    const tags = this.participantTagsByUserId.get(userId);
+    return tags ? Array.from(tags).sort() : [];
+  }
+
+  getParticipantTagsSnapshot(): { userId: string; tags: string[] }[] {
+    return Array.from(this.clients.keys()).map((userId) => ({
+      userId,
+      tags: this.getParticipantTags(userId),
+    }));
+  }
+
+  setParticipantTags(userId: string, tags: string[]): string[] {
+    const normalized = new Set<string>();
+    for (const tag of tags) {
+      const clean = normalizeParticipantTag(tag);
+      if (!clean) continue;
+      this.availableParticipantTags.add(clean);
+      normalized.add(clean);
+    }
+    if (normalized.size === 0) {
+      this.participantTagsByUserId.delete(userId);
+      return [];
+    }
+    this.participantTagsByUserId.set(userId, normalized);
+    return Array.from(normalized).sort();
+  }
+
+  hasParticipantTag(userId: string, tag: string): boolean {
+    const clean = normalizeParticipantTag(tag);
+    if (!clean) return false;
+    return this.participantTagsByUserId.get(userId)?.has(clean) ?? false;
   }
 
   addChatImageAsset(
@@ -1550,6 +1654,11 @@ export class Room {
     this.userKeysById.clear();
     this.adminUserKeys.clear();
     this.displayNamesByKey.clear();
+    this.participantTagsByUserId.clear();
+    this.availableParticipantTags = new Set(DEFAULT_ROOM_TAGS);
+    this.lastMusicRequestByUserId.clear();
+    this._musicPermission = "off";
+    this._currentMusicTrack = null;
     this.blockedUsers.clear();
     this.webinarActiveSpeakerUserId = null;
     this.webinarDominantSpeakerUserId = null;

--- a/packages/sfu/server/admin/controlPlane.ts
+++ b/packages/sfu/server/admin/controlPlane.ts
@@ -26,6 +26,7 @@ type ParticipantSnapshot = {
   userKey: string | null;
   displayName: string;
   role: ParticipantRole;
+  tags: string[];
   mode: Client["mode"];
   socketId: string;
   muted: boolean;
@@ -71,7 +72,13 @@ export type RoomSnapshot = {
     dmEnabled: boolean;
     imageAttachmentsEnabled: boolean;
     reactionsDisabled: boolean;
+    musicPermission: ReturnType<Room["getMusicState"]>["permission"];
+    musicSlowModeMs: number;
     requiresMeetingInviteCode: boolean;
+  };
+  music: ReturnType<Room["getMusicState"]>;
+  tags: {
+    available: string[];
   };
   access: {
     allowedUserKeys: string[];
@@ -146,6 +153,7 @@ export type RoomPolicyUpdate = {
   dmEnabled?: boolean;
   imageAttachmentsEnabled?: boolean;
   reactionsDisabled?: boolean;
+  musicPermission?: ReturnType<Room["getMusicState"]>["permission"];
 };
 
 type ProducerInfo = ReturnType<Client["getProducerInfos"]>[number];
@@ -275,11 +283,17 @@ const toParticipantSnapshot = (
     (producer) =>
       producer.kind === "video" && producer.type === "webcam" && !producer.paused,
   );
+  const role = toParticipantRole(room, client);
+  const tags = new Set(room.getParticipantTags(client.id));
+  if (role === "host" || role === "admin") tags.add("host");
+  const userKey = room.userKeysById.get(client.id) ?? null;
+  if (isGuestUserKey(userKey)) tags.add("guest");
   return {
     userId: client.id,
-    userKey: room.userKeysById.get(client.id) ?? null,
+    userKey,
     displayName: toDisplayName(room, client.id),
-    role: toParticipantRole(room, client),
+    role,
+    tags: Array.from(tags).sort(),
     mode: client.mode,
     socketId: client.socket.id,
     muted: !hasLiveAudio,
@@ -345,7 +359,13 @@ export const toRoomSnapshot = (room: Room): RoomSnapshot => {
       dmEnabled: room.isDmEnabled,
       imageAttachmentsEnabled: room.areImageAttachmentsEnabled,
       reactionsDisabled: room.isReactionsDisabled,
+      musicPermission: room.getMusicState().permission,
+      musicSlowModeMs: room.musicSlowModeMs,
       requiresMeetingInviteCode: room.requiresMeetingInviteCode,
+    },
+    music: room.getMusicState(),
+    tags: {
+      available: room.getAvailableParticipantTags(),
     },
     access: {
       allowedUserKeys: Array.from(room.allowedUsers.values()).sort(),
@@ -748,6 +768,20 @@ export const applyRoomPolicyUpdate = (
     io.to(room.channelId).emit("reactionsDisabledChanged", {
       disabled: update.reactionsDisabled,
       roomId: room.id,
+    });
+  }
+
+  if (
+    (update.musicPermission === "off" ||
+      update.musicPermission === "admin" ||
+      update.musicPermission === "everyone") &&
+    update.musicPermission !== room.musicPermission
+  ) {
+    room.setMusicPermission(update.musicPermission);
+    changed.musicPermission = update.musicPermission;
+    io.to(room.channelId).emit("musicStateChanged", {
+      roomId: room.id,
+      state: room.getMusicState(),
     });
   }
 

--- a/packages/sfu/server/socket/handlers/adminHandlers.ts
+++ b/packages/sfu/server/socket/handlers/adminHandlers.ts
@@ -1421,6 +1421,122 @@ export const registerAdminHandlers = (
   });
 
   socket.on(
+    "setMusicPermission",
+    (
+      data: { permission?: "off" | "admin" | "everyone" },
+      cb,
+    ) => {
+      const guard = ensureAdminRoom(context);
+      if ("error" in guard) {
+        respond(cb, guard);
+        return;
+      }
+      const permission = data?.permission;
+      if (
+        permission !== "off" &&
+        permission !== "admin" &&
+        permission !== "everyone"
+      ) {
+        respond(cb, { error: "Invalid music permission" });
+        return;
+      }
+
+      const update = applyRoomPolicyUpdate(io, guard.room, {
+        musicPermission: permission,
+      });
+      Logger.info(
+        `Room ${guard.room.id} music permission changed to ${permission} by admin`,
+      );
+      respond(cb, {
+        success: true,
+        state: guard.room.getMusicState(),
+        changed: update.changed,
+      });
+    },
+  );
+
+  socket.on("music:stop", (_data, cb) => {
+    const guard = ensureAdminRoom(context);
+    if ("error" in guard) {
+      respond(cb, guard);
+      return;
+    }
+    guard.room.setCurrentMusicTrack(null);
+    io.to(guard.room.channelId).emit("musicStateChanged", {
+      roomId: guard.room.id,
+      state: guard.room.getMusicState(),
+    });
+    respond(cb, { success: true, state: guard.room.getMusicState() });
+  });
+
+  socket.on(
+    "setParticipantTags",
+    (data: { userId?: string; tags?: string[] }, cb) => {
+      const guard = ensureAdminRoom(context);
+      if ("error" in guard) {
+        respond(cb, guard);
+        return;
+      }
+      const targetId = normalizeUserId(data?.userId);
+      if (!targetId || !guard.room.getClient(targetId)) {
+        respond(cb, { error: "User not found" });
+        return;
+      }
+      const tags = Array.isArray(data?.tags) ? data.tags : [];
+      const nextTags = guard.room.setParticipantTags(targetId, tags);
+      io.to(guard.room.channelId).emit("participantTagsChanged", {
+        roomId: guard.room.id,
+        userId: targetId,
+        tags: nextTags,
+        availableTags: guard.room.getAvailableParticipantTags(),
+      });
+      respond(cb, {
+        success: true,
+        userId: targetId,
+        tags: nextTags,
+        availableTags: guard.room.getAvailableParticipantTags(),
+      });
+    },
+  );
+
+  socket.on(
+    "removeUsersByTag",
+    (data: { tag?: string; includeAdmins?: boolean }, cb) => {
+      const guard = ensureAdminRoom(context);
+      if ("error" in guard) {
+        respond(cb, guard);
+        return;
+      }
+      const tag = typeof data?.tag === "string" ? data.tag.trim().replace(/^@+/, "") : "";
+      if (!tag) {
+        respond(cb, { error: "Tag is required" });
+        return;
+      }
+      const removedUserIds: string[] = [];
+      const participants = Array.from(guard.room.clients.values());
+      for (const client of participants) {
+        if (client.id === guard.adminId) continue;
+        const isAdminTarget = client instanceof Admin;
+        if (isAdminTarget && !data?.includeAdmins) continue;
+        if (!guard.room.hasParticipantTag(client.id, tag)) continue;
+        const kicked = kickClient(guard.room, client.id, `Removed by @${tag}`, {
+          io,
+          state,
+        });
+        if (kicked) {
+          removedUserIds.push(client.id);
+        }
+      }
+      respond(cb, {
+        success: true,
+        tag,
+        removedCount: removedUserIds.length,
+        removedUserIds,
+      });
+    },
+  );
+
+  socket.on(
     "admin:setPolicies",
     (
       data: {

--- a/packages/sfu/server/socket/handlers/chatHandlers.ts
+++ b/packages/sfu/server/socket/handlers/chatHandlers.ts
@@ -5,6 +5,7 @@ import type {
   ChatImageAttachment,
   ChatMessage,
   ChatReplyPreview,
+  MeetingMusicTrack,
   SendChatData,
 } from "../../../types.js";
 import { Admin } from "../../../config/classes/Admin.js";
@@ -59,6 +60,9 @@ const MAX_TTS_VOICE_TOKEN_LENGTH = 2048;
 const TTS_VOICE_TOKEN_PATTERN = /^[A-Za-z0-9._~-]+$/;
 const KLIPY_MEDIA_HOSTS = new Set(["static.klipy.com"]);
 const KLIPY_PAGE_HOSTS = new Set(["klipy.com", "www.klipy.com"]);
+const MUSIC_DIRECT_URL_PATTERN = /^https?:\/\/\S+$/i;
+const MUSIC_PIPED_API_BASE =
+  process.env.MUSIC_PIPED_API_BASE?.trim().replace(/\/+$/, "") || "";
 
 const fallbackDisplayNameFromUserId = (userId: string): string =>
   userId.split("#")[0]?.split("@")[0] || userId;
@@ -77,6 +81,101 @@ const normalizeTtsVoiceToken = (value: unknown): string | undefined => {
     return undefined;
   }
   return token;
+};
+
+const isAllowedMusicUrl = (value: string): boolean => {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+};
+
+const resolveMusicTrack = async (options: {
+  query: string;
+  userId: string;
+  displayName: string;
+}): Promise<MeetingMusicTrack | { error: string }> => {
+  const query = options.query.trim();
+  if (!query) {
+    return { error: "Usage: /play <url or search>" };
+  }
+  if (query.length > 240) {
+    return { error: "Music query is too long." };
+  }
+
+  if (MUSIC_DIRECT_URL_PATTERN.test(query)) {
+    if (!isAllowedMusicUrl(query)) {
+      return { error: "Use a valid http or https music URL." };
+    }
+    return {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      query,
+      title: query,
+      url: query,
+      requestedByUserId: options.userId,
+      requestedByDisplayName: options.displayName,
+      startedAt: Date.now(),
+    };
+  }
+
+  if (!MUSIC_PIPED_API_BASE) {
+    return {
+      error:
+        "Music search is not configured. Ask the host to play a direct audio URL or set MUSIC_PIPED_API_BASE.",
+    };
+  }
+
+  try {
+    const searchUrl = `${MUSIC_PIPED_API_BASE}/search?q=${encodeURIComponent(query)}&filter=music_songs`;
+    const searchResponse = await fetch(searchUrl, {
+      headers: { accept: "application/json" },
+    });
+    if (!searchResponse.ok) {
+      return { error: "Music search failed." };
+    }
+    const results = (await searchResponse.json()) as unknown;
+    const list = Array.isArray(results) ? results : [];
+    const first = list.find(
+      (item) =>
+        item &&
+        typeof item === "object" &&
+        typeof (item as { url?: unknown }).url === "string",
+    ) as { url?: string; title?: string; name?: string } | undefined;
+    const videoPath = first?.url;
+    if (!videoPath) {
+      return { error: "No music result found." };
+    }
+    const streamResponse = await fetch(`${MUSIC_PIPED_API_BASE}/streams/${videoPath.replace(/^\/watch\?v=/, "")}`, {
+      headers: { accept: "application/json" },
+    });
+    if (!streamResponse.ok) {
+      return { error: "Music stream lookup failed." };
+    }
+    const streamData = (await streamResponse.json()) as {
+      title?: string;
+      audioStreams?: Array<{ url?: string; bitrate?: number }>;
+    };
+    const stream = streamData.audioStreams
+      ?.filter((entry) => typeof entry.url === "string" && isAllowedMusicUrl(entry.url))
+      .sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0))[0];
+    if (!stream?.url) {
+      return { error: "No playable audio stream found." };
+    }
+    return {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      query,
+      title: streamData.title || first.title || first.name || query,
+      url: stream.url,
+      requestedByUserId: options.userId,
+      requestedByDisplayName: options.displayName,
+      startedAt: Date.now(),
+    };
+  } catch (error) {
+    Logger.warn("Music resolver failed", error);
+    return { error: "Music resolver is unavailable." };
+  }
 };
 
 const normalizeHttpsUrl = (
@@ -667,6 +766,7 @@ const resolveDirectMessageTarget = (
 
 export const registerChatHandlers = (context: ConnectionContext): void => {
   const { socket } = context;
+  const { io } = context;
 
   socket.on(
     "chat:imageUploadAuthorize",
@@ -739,6 +839,7 @@ export const registerChatHandlers = (context: ConnectionContext): void => {
           | { error: string },
       ) => void,
     ) => {
+      void (async () => {
       try {
         if (!context.currentClient || !context.currentRoom) {
           respond(callback, { error: "Not in a room" });
@@ -884,6 +985,57 @@ export const registerChatHandlers = (context: ConnectionContext): void => {
           sender.id.split("#")[0]?.split("@")[0] ||
           "Anonymous";
 
+        const playMatch = messageContent.match(/^\/play(?:\s+([\s\S]+))?$/i);
+        if (playMatch) {
+          const permission = room.musicPermission;
+          if (permission === "off") {
+            rejectMessage("Room music is disabled by the host.");
+            return;
+          }
+          if (permission === "admin" && !(sender instanceof Admin)) {
+            rejectMessage("Only hosts can play music in this room.");
+            return;
+          }
+          if (permission === "everyone" && !(sender instanceof Admin)) {
+            const lastPlayedAt = room.lastMusicRequestByUserId.get(sender.id) ?? 0;
+            const retryInMs =
+              room.musicSlowModeMs - Math.max(0, Date.now() - lastPlayedAt);
+            if (retryInMs > 0) {
+              rejectMessage(
+                `Music slow mode is on. Try again in ${Math.ceil(retryInMs / 1000)}s.`,
+              );
+              return;
+            }
+          }
+          const resolved = await resolveMusicTrack({
+            query: playMatch[1] ?? "",
+            userId: sender.id,
+            displayName,
+          });
+          if ("error" in resolved) {
+            rejectMessage(resolved.error);
+            return;
+          }
+          room.setCurrentMusicTrack(resolved);
+          room.lastMusicRequestByUserId.set(sender.id, Date.now());
+          io.to(room.channelId).emit("musicStateChanged", {
+            roomId: room.id,
+            state: room.getMusicState(),
+          });
+
+          const message: ChatMessage = {
+            id: `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+            userId: sender.id,
+            displayName,
+            content: `Music: ${displayName} played ${resolved.title}`,
+            timestamp: Date.now(),
+          };
+          socket.to(room.channelId).emit("chatMessage", message);
+          room.recordChatMessage(message);
+          respond(callback, { success: true, message });
+          return;
+        }
+
         const message: ChatMessage = {
           id: `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
           userId: sender.id,
@@ -921,6 +1073,7 @@ export const registerChatHandlers = (context: ConnectionContext): void => {
       } catch (error) {
         respond(callback, { error: (error as Error).message });
       }
+      })();
     },
   );
 

--- a/packages/sfu/server/socket/handlers/joinRoom.ts
+++ b/packages/sfu/server/socket/handlers/joinRoom.ts
@@ -950,6 +950,9 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           areImageAttachmentsEnabled:
             context.currentRoom.areImageAttachmentsEnabled,
           isReactionsDisabled: context.currentRoom.isReactionsDisabled,
+          musicState: context.currentRoom.getMusicState(),
+          participantTags: context.currentRoom.getParticipantTagsSnapshot(),
+          availableTags: context.currentRoom.getAvailableParticipantTags(),
           meetingRequiresInviteCode: context.currentRoom.requiresMeetingInviteCode,
           webinarRole: context.currentClient.isWebinarAttendee
             ? "attendee"

--- a/packages/sfu/types.ts
+++ b/packages/sfu/types.ts
@@ -634,6 +634,24 @@ export interface ChatMessage {
   ttsVoiceToken?: string;
 }
 
+export type MeetingMusicPermission = "off" | "admin" | "everyone";
+
+export interface MeetingMusicTrack {
+  id: string;
+  query: string;
+  title: string;
+  url: string;
+  requestedByUserId: string;
+  requestedByDisplayName: string;
+  startedAt: number;
+}
+
+export interface MeetingMusicState {
+  permission: MeetingMusicPermission;
+  slowModeMs: number;
+  track: MeetingMusicTrack | null;
+}
+
 export interface ChatReplyPreview {
   id: string;
   userId: string;


### PR DESCRIPTION
## Summary
- add room participant tags with host-side tag assignment and bulk removal by tag
- add room music permissions, `/play` handling, slow mode, shared music playback, and speech ducking to 35%
- add MoM finalization from the transcript panel with GitHub Markdown versioning via server-side env config

## Configuration
- `MUSIC_PIPED_API_BASE` enables open-source Piped-compatible music search; direct audio URLs work without it
- `MOM_GITHUB_TOKEN`/`GITHUB_TOKEN`, `MOM_GITHUB_REPOSITORY`, optional `MOM_GITHUB_BRANCH`, and optional `MOM_GITHUB_BASE_PATH` enable MoM commits

## Verification
- `git diff --check --cached` passed
- `eslint` passed for modified shared/SFU files
- Web lint/typecheck could not complete because `pnpm install` repeatedly timed out fetching registry packages (`dashjs`, `next`, `@next/swc-win32-x64-msvc`), leaving `eslint-plugin-react-hooks` unavailable locally

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds participant groups, shared room music, and GitHub-backed meeting minutes. The main changes are:

- Host-managed participant tags and bulk removal by tag.
- Room music permissions, `/play` resolution, slow mode, playback, and speech ducking.
- Transcript finalization into versioned Markdown files on GitHub.
- Realtime protocol and room-state updates for music and tags.

<h3>Confidence Score: 2/5</h3>

The repository-write authorization and arbitrary playback URL paths need fixes before merging.

The MoM route lets reachable callers write with a shared GitHub credential. Music URLs can trigger requests from every participant browser without a host boundary. Pending lookups can restore music after it is disabled. Tag synchronization can lose initial or rejoined participant assignments.

apps/web/src/app/api/conclave/mom/finalize/route.ts, packages/sfu/server/socket/handlers/chatHandlers.ts, apps/web/src/app/hooks/useMeetSocket.ts, packages/sfu/config/classes/Room.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted a repository write authorization test using a focused Vitest harness that posts without Cookie, Authorization, session, or room-host headers and mocks GitHub lookup and PUT requests; the run timed out before a durable execution log could be produced.
- T-Rex attempted to abort a running TranscriptPanel reproduction; the run reached the maximum execution steps and navigation timed out, and while a focused harness and delayed-response script were created, no contradictory-state capture was produced.
- T-Rex generated a narrow TypeScript reproduction harness for a playback URL with no host, but no runtime command was executed and no real execution evidence was captured.
- Reproduced the initial tag snapshot dropped scenario using a focused executable join snapshot ordering test; UPDATE\_TAGS ran while the existing peer was absent and left participant state unchanged, and the final ADD\_PARTICIPANT created the peer but the tags were undefined instead of including the moderator tag.
- Reproduced the Disconnect Erases Assigned Tags scenario using a Room lifecycle harness; before disconnect the participant snapshot contained the assigned tag and was targeted by moderation, but after grace expiration and rejoin the same identity rejoined with no restored tags and was omitted from tag-based moderation targets.

<a href="https://app.greptile.com/trex/runs/14129820/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/conclave/mom/finalize/route.ts | Adds GitHub-backed MoM versioning without server-side caller or room authorization. |
| apps/web/src/app/components/TranscriptPanel.tsx | Adds MoM finalization controls, but Abort does not cancel the remote write. |
| packages/sfu/server/socket/handlers/chatHandlers.ts | Adds asynchronous music resolution with unrestricted playback hosts and a stale-permission race. |
| apps/web/src/app/hooks/useMeetSocket.ts | Adds music and tag synchronization, but initial tag updates can precede participant creation. |
| packages/sfu/config/classes/Room.ts | Adds room music and tag state while tying tag lifetime to the participant connection. |
| packages/sfu/server/socket/handlers/adminHandlers.ts | Adds guarded host actions for music policy, tag assignment, and bulk removal. |
| apps/web/src/app/components/MeetingMusicPlayer.tsx | Adds shared audio playback and speech ducking using the server-provided track URL. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant Web
  participant SFU
  participant Peers
  participant MoM as MoM API
  participant GitHub

  User->>SFU: /play URL or search
  SFU->>SFU: Check permission
  SFU->>SFU: Resolve track asynchronously
  SFU->>Peers: musicStateChanged
  Peers->>Peers: Load audio URL

  User->>Web: Finalize minutes
  Web->>MoM: POST roomId and Markdown
  MoM->>GitHub: Read current file SHA
  MoM->>GitHub: Commit Markdown
  GitHub-->>Web: Commit result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant Web
  participant SFU
  participant Peers
  participant MoM as MoM API
  participant GitHub

  User->>SFU: /play URL or search
  SFU->>SFU: Check permission
  SFU->>SFU: Resolve track asynchronously
  SFU->>Peers: musicStateChanged
  Peers->>Peers: Load audio URL

  User->>Web: Finalize minutes
  Web->>MoM: POST roomId and Markdown
  MoM->>GitHub: Read current file SHA
  MoM->>GitHub: Commit Markdown
  GitHub-->>Web: Commit result
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22codex%2Ftags-mom-music-system%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ftags-mom-music-system%22.%0A%0AFix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Aapps%2Fweb%2Fsrc%2Fapp%2Fapi%2Fconclave%2Fmom%2Ffinalize%2Froute.ts%3A21-25%0A**Repository%20Write%20Lacks%20Authorization**%0A%0AThis%20public%20handler%20accepts%20caller-supplied%20%60roomId%60%20and%20Markdown%2C%20then%20writes%20them%20with%20the%20server's%20GitHub%20token%20without%20checking%20a%20session%20or%20room-host%20role.%20Any%20caller%20who%20can%20reach%20the%20route%20can%20create%20or%20replace%20that%20day's%20minutes%20for%20another%20room.%0A%0A%23%23%23%20Issue%202%20of%206%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FTranscriptPanel.tsx%3A1262-1265%0A**Abort%20Leaves%20Commit%20Running**%0A%0AThis%20action%20only%20invalidates%20the%20local%20completion%20token%3B%20it%20never%20cancels%20the%20in-flight%20request.%20If%20GitHub%20completes%20the%20write%20afterward%2C%20the%20UI%20reports%20that%20finalization%20was%20aborted%20even%20though%20the%20minutes%20were%20committed.%0A%0A%23%23%23%20Issue%203%20of%206%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FchatHandlers.ts%3A111-120%0A**Playback%20URL%20Has%20No%20Host%20Boundary**%0A%0AA%20direct%20%60%2Fplay%60%20request%20accepts%20any%20HTTP%20or%20HTTPS%20URL%20and%20broadcasts%20it%20as%20an%20audio%20source%20to%20every%20participant.%20When%20room%20music%20is%20enabled%2C%20a%20participant%20can%20make%20attendees'%20browsers%20request%20private-network%20or%20state-changing%20endpoints%3B%20direct%20and%20resolved%20stream%20URLs%20need%20a%20compulsory%20default-deny%20host%20and%20network%20policy.%0A%0A%23%23%23%20Issue%204%20of%206%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FchatHandlers.ts%3A1010-1019%0A**Pending%20Search%20Revives%20Disabled%20Music**%0A%0APermission%20is%20checked%20before%20the%20awaited%20lookup%20but%20not%20before%20the%20resulting%20track%20is%20committed.%20If%20a%20host%20turns%20music%20off%20while%20lookup%20is%20pending%2C%20this%20continuation%20installs%20and%20broadcasts%20the%20track%20after%20the%20off%20transition%2C%20so%20music%20can%20start%20despite%20the%20current%20room%20policy.%0A%0A%23%23%23%20Issue%205%20of%206%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%3A4700-4708%0A**Initial%20Tag%20Snapshot%20Is%20Dropped**%0A%0AThe%20join%20snapshot%20dispatches%20%60UPDATE_TAGS%60%20before%20existing%20peers%20are%20guaranteed%20to%20have%20participant%20entries.%20Because%20the%20reducer%20ignores%20updates%20for%20missing%20users%2C%20a%20newly%20joined%20client%20can%20permanently%20omit%20existing%20participants'%20tags%20until%20another%20tag%20change%20is%20broadcast.%0A%0A%23%23%23%20Issue%206%20of%206%0Apackages%2Fsfu%2Fconfig%2Fclasses%2FRoom.ts%3A336%0A**Disconnect%20Erases%20Assigned%20Tags**%0A%0AOnce%20the%20disconnect%20grace%20period%20expires%2C%20this%20deletes%20every%20host-assigned%20tag%20for%20the%20participant.%20If%20the%20same%20member%20rejoins%20later%2C%20the%20server%20has%20no%20identity-keyed%20assignment%20to%20restore%2C%20so%20tag-based%20moderation%20silently%20omits%20that%20member.%0A%0A&repo=acm-vit%2Fconclave&pr=189&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Aapps%2Fweb%2Fsrc%2Fapp%2Fapi%2Fconclave%2Fmom%2Ffinalize%2Froute.ts%3A21-25%0A**Repository%20Write%20Lacks%20Authorization**%0A%0AThis%20public%20handler%20accepts%20caller-supplied%20%60roomId%60%20and%20Markdown%2C%20then%20writes%20them%20with%20the%20server's%20GitHub%20token%20without%20checking%20a%20session%20or%20room-host%20role.%20Any%20caller%20who%20can%20reach%20the%20route%20can%20create%20or%20replace%20that%20day's%20minutes%20for%20another%20room.%0A%0A%23%23%23%20Issue%202%20of%206%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FTranscriptPanel.tsx%3A1262-1265%0A**Abort%20Leaves%20Commit%20Running**%0A%0AThis%20action%20only%20invalidates%20the%20local%20completion%20token%3B%20it%20never%20cancels%20the%20in-flight%20request.%20If%20GitHub%20completes%20the%20write%20afterward%2C%20the%20UI%20reports%20that%20finalization%20was%20aborted%20even%20though%20the%20minutes%20were%20committed.%0A%0A%23%23%23%20Issue%203%20of%206%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FchatHandlers.ts%3A111-120%0A**Playback%20URL%20Has%20No%20Host%20Boundary**%0A%0AA%20direct%20%60%2Fplay%60%20request%20accepts%20any%20HTTP%20or%20HTTPS%20URL%20and%20broadcasts%20it%20as%20an%20audio%20source%20to%20every%20participant.%20When%20room%20music%20is%20enabled%2C%20a%20participant%20can%20make%20attendees'%20browsers%20request%20private-network%20or%20state-changing%20endpoints%3B%20direct%20and%20resolved%20stream%20URLs%20need%20a%20compulsory%20default-deny%20host%20and%20network%20policy.%0A%0A%23%23%23%20Issue%204%20of%206%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FchatHandlers.ts%3A1010-1019%0A**Pending%20Search%20Revives%20Disabled%20Music**%0A%0APermission%20is%20checked%20before%20the%20awaited%20lookup%20but%20not%20before%20the%20resulting%20track%20is%20committed.%20If%20a%20host%20turns%20music%20off%20while%20lookup%20is%20pending%2C%20this%20continuation%20installs%20and%20broadcasts%20the%20track%20after%20the%20off%20transition%2C%20so%20music%20can%20start%20despite%20the%20current%20room%20policy.%0A%0A%23%23%23%20Issue%205%20of%206%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%3A4700-4708%0A**Initial%20Tag%20Snapshot%20Is%20Dropped**%0A%0AThe%20join%20snapshot%20dispatches%20%60UPDATE_TAGS%60%20before%20existing%20peers%20are%20guaranteed%20to%20have%20participant%20entries.%20Because%20the%20reducer%20ignores%20updates%20for%20missing%20users%2C%20a%20newly%20joined%20client%20can%20permanently%20omit%20existing%20participants'%20tags%20until%20another%20tag%20change%20is%20broadcast.%0A%0A%23%23%23%20Issue%206%20of%206%0Apackages%2Fsfu%2Fconfig%2Fclasses%2FRoom.ts%3A336%0A**Disconnect%20Erases%20Assigned%20Tags**%0A%0AOnce%20the%20disconnect%20grace%20period%20expires%2C%20this%20deletes%20every%20host-assigned%20tag%20for%20the%20participant.%20If%20the%20same%20member%20rejoins%20later%2C%20the%20server%20has%20no%20identity-keyed%20assignment%20to%20restore%2C%20so%20tag-based%20moderation%20silently%20omits%20that%20member.%0A%0A&repo=acm-vit%2Fconclave&pr=189&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Aapps%2Fweb%2Fsrc%2Fapp%2Fapi%2Fconclave%2Fmom%2Ffinalize%2Froute.ts%3A21-25%0A**Repository%20Write%20Lacks%20Authorization**%0A%0AThis%20public%20handler%20accepts%20caller-supplied%20%60roomId%60%20and%20Markdown%2C%20then%20writes%20them%20with%20the%20server's%20GitHub%20token%20without%20checking%20a%20session%20or%20room-host%20role.%20Any%20caller%20who%20can%20reach%20the%20route%20can%20create%20or%20replace%20that%20day's%20minutes%20for%20another%20room.%0A%0A%23%23%23%20Issue%202%20of%206%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FTranscriptPanel.tsx%3A1262-1265%0A**Abort%20Leaves%20Commit%20Running**%0A%0AThis%20action%20only%20invalidates%20the%20local%20completion%20token%3B%20it%20never%20cancels%20the%20in-flight%20request.%20If%20GitHub%20completes%20the%20write%20afterward%2C%20the%20UI%20reports%20that%20finalization%20was%20aborted%20even%20though%20the%20minutes%20were%20committed.%0A%0A%23%23%23%20Issue%203%20of%206%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FchatHandlers.ts%3A111-120%0A**Playback%20URL%20Has%20No%20Host%20Boundary**%0A%0AA%20direct%20%60%2Fplay%60%20request%20accepts%20any%20HTTP%20or%20HTTPS%20URL%20and%20broadcasts%20it%20as%20an%20audio%20source%20to%20every%20participant.%20When%20room%20music%20is%20enabled%2C%20a%20participant%20can%20make%20attendees'%20browsers%20request%20private-network%20or%20state-changing%20endpoints%3B%20direct%20and%20resolved%20stream%20URLs%20need%20a%20compulsory%20default-deny%20host%20and%20network%20policy.%0A%0A%23%23%23%20Issue%204%20of%206%0Apackages%2Fsfu%2Fserver%2Fsocket%2Fhandlers%2FchatHandlers.ts%3A1010-1019%0A**Pending%20Search%20Revives%20Disabled%20Music**%0A%0APermission%20is%20checked%20before%20the%20awaited%20lookup%20but%20not%20before%20the%20resulting%20track%20is%20committed.%20If%20a%20host%20turns%20music%20off%20while%20lookup%20is%20pending%2C%20this%20continuation%20installs%20and%20broadcasts%20the%20track%20after%20the%20off%20transition%2C%20so%20music%20can%20start%20despite%20the%20current%20room%20policy.%0A%0A%23%23%23%20Issue%205%20of%206%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetSocket.ts%3A4700-4708%0A**Initial%20Tag%20Snapshot%20Is%20Dropped**%0A%0AThe%20join%20snapshot%20dispatches%20%60UPDATE_TAGS%60%20before%20existing%20peers%20are%20guaranteed%20to%20have%20participant%20entries.%20Because%20the%20reducer%20ignores%20updates%20for%20missing%20users%2C%20a%20newly%20joined%20client%20can%20permanently%20omit%20existing%20participants'%20tags%20until%20another%20tag%20change%20is%20broadcast.%0A%0A%23%23%23%20Issue%206%20of%206%0Apackages%2Fsfu%2Fconfig%2Fclasses%2FRoom.ts%3A336%0A**Disconnect%20Erases%20Assigned%20Tags**%0A%0AOnce%20the%20disconnect%20grace%20period%20expires%2C%20this%20deletes%20every%20host-assigned%20tag%20for%20the%20participant.%20If%20the%20same%20member%20rejoins%20later%2C%20the%20server%20has%20no%20identity-keyed%20assignment%20to%20restore%2C%20so%20tag-based%20moderation%20silently%20omits%20that%20member.%0A%0A&pr=189&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(meet): add tags mom versioning and ..."](https://github.com/acm-vit/conclave/commit/113afd62aa1ee096501d97259371f9a7013ed2e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43590065)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->