### PR TITLE
add

### DIFF
--- a/apps/web/src/app/api/tts/voices/route.ts
+++ b/apps/web/src/app/api/tts/voices/route.ts
@@ -48,9 +48,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     durationSeconds > MAX_VOICE_SAMPLE_SECONDS
   ) {
     return errorResponse(
-      new Error(
-        `Record between ${MIN_VOICE_SAMPLE_SECONDS} and ${MAX_VOICE_SAMPLE_SECONDS} seconds.`,
-      ),
+      new Error("The voice sample must be about 1 to 2 minutes long."),
       400,
     );
   }

--- a/apps/web/src/app/components/ChatPanel.tsx
+++ b/apps/web/src/app/components/ChatPanel.tsx
@@ -1,17 +1,27 @@
 "use client";
 
 import {
+  AudioLines,
   Check,
   ChevronDown,
   ExternalLink,
   Image as ImageIcon,
   Lock,
   Paperclip,
+  Play,
   Reply,
   Send,
+  Square,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { Avatar } from "@conclave/ui-tokens/web";
 import type { ConclaveAssistantApiKeyPromptState } from "../hooks/useMeetChat";
 import type {
@@ -20,7 +30,12 @@ import type {
   ChatReplyPreview,
   SendChatMessageOptions,
 } from "../lib/types";
-import { getActionText, getCommandSuggestions } from "../lib/chat-commands";
+import {
+  getActionText,
+  getCommandSuggestions,
+  getTtsMessageText,
+  TTS_MAX_TEXT_LENGTH,
+} from "../lib/chat-commands";
 import {
   CHAT_IMAGE_ACCEPT,
   CHAT_IMAGE_SIZE_MESSAGE,
@@ -96,6 +111,12 @@ interface ChatPanelProps {
   replyTarget?: ChatReplyPreview | null;
   onReply?: (message: ChatMessage) => void;
   onCancelReply?: () => void;
+  /** Chat message id currently being spoken aloud by the TTS engine. */
+  activeTtsMessageId?: string | null;
+  onReplayTtsMessage?: (message: ChatMessage) => void;
+  onStopTts?: () => void;
+  hasClonedTtsVoice?: boolean;
+  isTtsDisabled?: boolean;
 }
 
 type LocalRenderChatMessage = ChatMessage & {
@@ -104,6 +125,91 @@ type LocalRenderChatMessage = ChatMessage & {
 
 const getMessageRenderKey = (message: ChatMessage): string =>
   (message as LocalRenderChatMessage).clientRenderKey ?? message.id;
+
+function TtsEqualizer() {
+  return (
+    <span aria-hidden="true" className="flex h-3 items-center gap-[2.5px]">
+      {[0, 1, 2, 3].map((bar) => (
+        <span
+          key={bar}
+          className="web-chat-tts-eq-bar h-full w-[2.5px] rounded-full bg-current"
+        />
+      ))}
+    </span>
+  );
+}
+
+function TtsMessageBody({
+  message,
+  isOwn,
+  isSpeaking,
+  onReplay,
+  onStop,
+  renderContent,
+}: {
+  message: ChatMessage;
+  isOwn: boolean;
+  isSpeaking: boolean;
+  onReplay?: (message: ChatMessage) => void;
+  onStop?: () => void;
+  renderContent: (content: string) => ReactNode;
+}) {
+  const headerTone = isOwn ? "text-white/75" : "text-[#a1a1aa]";
+  const controlTone = isOwn
+    ? "bg-white/[0.16] text-white hover:bg-white/[0.26]"
+    : "bg-white/[0.08] text-[#fafafa] hover:bg-white/[0.14]";
+  const control = isSpeaking && onStop ? (
+    <button
+      type="button"
+      onClick={onStop}
+      aria-label="Stop speaking"
+      title="Stop speaking"
+      className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full transition-colors ${controlTone}`}
+    >
+      <Square size={9} fill="currentColor" strokeWidth={0} />
+    </button>
+  ) : onReplay ? (
+    <button
+      type="button"
+      onClick={() => onReplay(message)}
+      aria-label="Play voice message"
+      title="Play again (only you will hear it)"
+      className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full transition-colors ${controlTone}`}
+    >
+      <Play size={10} fill="currentColor" strokeWidth={0} className="translate-x-[0.5px]" />
+    </button>
+  ) : (
+    <span
+      aria-hidden="true"
+      className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full ${
+        isOwn ? "bg-white/[0.16] text-white" : "bg-white/[0.08] text-[#fafafa]"
+      }`}
+    >
+      <AudioLines size={12} strokeWidth={2} />
+    </span>
+  );
+
+  return (
+    <div className="px-3.5 pb-2 pt-2.5">
+      <div className={`flex items-center gap-2 ${headerTone}`}>
+        {control}
+        <span className="text-[10px] font-semibold uppercase tracking-[0.09em]">
+          {isSpeaking ? "Speaking" : "Voice message"}
+        </span>
+        {isSpeaking ? <TtsEqualizer /> : null}
+      </div>
+      <div
+        className={`mt-1.5 text-[13.5px] leading-relaxed [overflow-wrap:anywhere] whitespace-pre-wrap ${
+          isOwn
+            ? "selection:bg-white/25 selection:text-white"
+            : "selection:bg-[#F95F4A]/40 selection:text-white"
+        }`}
+      >
+        {renderContent(getTtsMessageText(message.content))}
+      </div>
+    </div>
+  );
+}
 
 function ChatPanel({
   messages,
@@ -131,6 +237,11 @@ function ChatPanel({
   replyTarget = null,
   onReply,
   onCancelReply,
+  activeTtsMessageId = null,
+  onReplayTtsMessage,
+  onStopTts,
+  hasClonedTtsVoice = false,
+  isTtsDisabled = false,
 }: ChatPanelProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const imageInputRef = useRef<HTMLInputElement>(null);
@@ -195,6 +306,14 @@ function ChatPanel({
     !isChatDisabled && chatInput.startsWith("/") && commandSuggestions.length > 0;
   const isPickingCommand =
     showCommandSuggestions && !chatInput.slice(1).includes(" ");
+
+  // Live hint while composing a /tts message: voice used + character budget.
+  const ttsComposer = useMemo(() => {
+    const match = chatInput.match(/^\/tts(?:\s+([\s\S]*))?$/i);
+    if (!match || match[1] === undefined) return null;
+    const length = match[1].trim().length;
+    return { length, overLimit: length > TTS_MAX_TEXT_LENGTH };
+  }, [chatInput]);
 
   const mentionContext = useMemo(() => {
     if (isChatDisabled || !isDmEnabled) return null;
@@ -454,6 +573,9 @@ function ChatPanel({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (isChatDisabled || isImageUploading) return;
+    // Keep the draft: the hint bar above the composer explains why the
+    // message can't go out yet (over the limit or host-disabled).
+    if (ttsComposer && (ttsComposer.overLimit || isTtsDisabled)) return;
     if (chatInput.trim() || pendingImage) {
       setIsSendAnimating(true);
       if (sendAnimationTimeoutRef.current !== null) {
@@ -947,6 +1069,19 @@ function ChatPanel({
                             image={msg.image}
                             caption={chatImageCaption(msg.content, msg.image)}
                           />
+                        ) : msg.isTts ? (
+                          <TtsMessageBody
+                            message={msg}
+                            isOwn={isOwn}
+                            isSpeaking={activeTtsMessageId === msg.id}
+                            onReplay={
+                              onReplayTtsMessage && !isTtsDisabled
+                                ? onReplayTtsMessage
+                                : undefined
+                            }
+                            onStop={onStopTts}
+                            renderContent={renderMessageContent}
+                          />
                         ) : (
                           <div
                             className={`px-3.5 py-2 text-[13.5px] leading-relaxed [overflow-wrap:anywhere] whitespace-pre-wrap ${
@@ -1299,6 +1434,39 @@ function ChatPanel({
               {imageUploadError}
             </p>
           ) : null}
+          {ttsComposer && !isChatDisabled ? (
+            <div className="mb-2 flex items-center gap-2 rounded-xl bg-white/[0.04] px-2.5 py-1.5">
+              <AudioLines
+                size={13}
+                strokeWidth={2}
+                className="shrink-0 text-[#F95F4A]"
+              />
+              <p className="min-w-0 flex-1 truncate text-[11.5px] text-[#a1a1aa]">
+                {isTtsDisabled
+                  ? "TTS is disabled by the host in this room."
+                  : (
+                    <>
+                      Spoken aloud to everyone
+                      <span className="text-[#a1a1aa]/60">
+                        {" · "}
+                        {hasClonedTtsVoice ? "your voice" : "system voice"}
+                      </span>
+                    </>
+                  )}
+              </p>
+              {!isTtsDisabled ? (
+                <span
+                  className={`shrink-0 text-[11px] tabular-nums ${
+                    ttsComposer.overLimit
+                      ? "font-semibold text-[#f97066]"
+                      : "text-[#a1a1aa]/70"
+                  }`}
+                >
+                  {ttsComposer.length} / {TTS_MAX_TEXT_LENGTH}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
           <div className="flex items-end gap-2 rounded-2xl border border-white/10 bg-white/[0.04] py-2 pl-3 pr-2 transition-colors focus-within:border-white/20 focus-within:bg-white/[0.055]">
             <input
               ref={imageInputRef}
@@ -1340,7 +1508,8 @@ function ChatPanel({
               disabled={
                 isChatDisabled ||
                 isImageUploading ||
-                (!chatInput.trim() && !pendingImage)
+                (!chatInput.trim() && !pendingImage) ||
+                Boolean(ttsComposer && (ttsComposer.overLimit || isTtsDisabled))
               }
               aria-label="Send message"
               title="Send message"

--- a/apps/web/src/app/components/ControlsBar.tsx
+++ b/apps/web/src/app/components/ControlsBar.tsx
@@ -243,14 +243,21 @@ function ActivityDock({
   activities,
   promoted,
   host,
+  onFlyoutOpenChange,
 }: {
   core: DockEntry[];
   activities: DockEntry[];
   /** The activity owning the shared slot's face right now (live beats open). */
   promoted?: DockEntry | null;
   host?: DockEntry | null;
+  /** Lets the bar hide dock coachmarks while the flyout is up — both float in
+   * the same spot above the dock, and the flyout must win. */
+  onFlyoutOpenChange?: (open: boolean) => void;
 }) {
   const [open, setOpen] = useState(false);
+  useEffect(() => {
+    onFlyoutOpenChange?.(open);
+  }, [open, onFlyoutOpenChange]);
   const segmentRef = useRef<HTMLDivElement>(null);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const trayId = useId();
@@ -290,13 +297,7 @@ function ActivityDock({
     setOpen(true);
   };
 
-  // Tap/keyboard path: hover never fired, so the face itself toggles the
-  // flyout and hands focus to the first activity row.
-  const toggleFromFace = () => {
-    if (open) {
-      setOpen(false);
-      return;
-    }
+  const openFlyoutWithFocus = () => {
     openFlyout();
     requestAnimationFrame(() => {
       segmentRef.current
@@ -309,13 +310,25 @@ function ActivityDock({
   const FaceIcon = face?.d.icon ?? Shapes;
   const faceLabel = face ? face.d.label : "Activities";
   const faceActive = face?.d.variant === "active";
+
+  // Clicking the face does what its icon promises: with a promoted activity
+  // it toggles that panel directly (the flyout is a hover reveal on pointer
+  // devices). Only the idle face — or any tap on a no-hover device, where the
+  // flyout is the sole way to reach the activities — toggles the flyout.
   const handleFaceClick = () => {
-    if (face?.d.onPress) {
+    const hoverCapable =
+      typeof window !== "undefined" &&
+      window.matchMedia("(hover: hover)").matches;
+    if (face && hoverCapable) {
       setOpen(false);
-      face.d.onPress();
+      face.d.onPress?.();
       return;
     }
-    toggleFromFace();
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    openFlyoutWithFocus();
   };
 
   return (
@@ -781,10 +794,12 @@ function ControlsBar(props: ControlsBarProps) {
           props.transcriptStatus === "error"
         ? "attention"
         : null;
+  const [dockFlyoutOpen, setDockFlyoutOpen] = useState(false);
   const panelCoachmarkVisible =
     !moreOpen &&
     !reactionsOpen &&
     !browserOpen &&
+    !dockFlyoutOpen &&
     !filtersTip.visible &&
     (watchTip.visible ||
       (gamesTip.visible && !props.isGamesOpen && !props.hasActiveGame) ||
@@ -831,11 +846,13 @@ function ControlsBar(props: ControlsBarProps) {
           ...transcriptItem,
           variant: props.isTranscriptOpen ? "active" : "default",
         },
+        // One dot language across the dock: the lone coral accent. A pulse —
+        // not a different hue — marks the needs-attention state.
         dot:
           transcriptClusterStatus === "live"
-            ? { color: "#32d583" }
+            ? { color: color.accent }
             : transcriptClusterStatus === "attention"
-              ? { color: "#f97066", pulse: true }
+              ? { color: color.accent, pulse: true }
               : null,
       }
     : null;
@@ -1233,6 +1250,7 @@ function ControlsBar(props: ControlsBarProps) {
               activities={dockActivities}
               promoted={promotedEntry}
               host={hostEntry}
+              onFlyoutOpenChange={setDockFlyoutOpen}
             />
             {panelCoachmarkVisible && watchTip.visible ? (
               <WatchTogetherTip

--- a/apps/web/src/app/components/DeviceSettingsPanel.tsx
+++ b/apps/web/src/app/components/DeviceSettingsPanel.tsx
@@ -839,7 +839,7 @@ export default function DeviceSettingsPanel({
               </button>
             </Section>
 
-            <Section label="Text to speech">
+            <Section label="Voice messages">
               <TtsVoiceSettings
                 systemVoices={ttsSystemVoices}
                 selectedSystemVoiceUri={selectedTtsSystemVoiceUri}
@@ -850,6 +850,7 @@ export default function DeviceSettingsPanel({
                 getRecordingStream={micTest.getRecordingStream}
                 canCloneVoice={canCloneTtsVoice}
                 ownerName={ttsVoiceOwnerName}
+                audioOutputDeviceId={selectedAudioOutputDeviceId}
               />
             </Section>
           </div>

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -222,6 +222,11 @@ interface MeetsMainContentProps {
   replyTarget: ChatReplyPreview | null;
   onReplyToMessage: (message: ChatMessage) => void;
   onCancelReply: () => void;
+  /** Chat message id currently being spoken by the TTS engine. */
+  activeTtsMessageId?: string | null;
+  onReplayTtsMessage?: (message: ChatMessage) => void;
+  onStopTts?: () => void;
+  hasClonedTtsVoice?: boolean;
   assistantApiKeyPrompt: ConclaveAssistantApiKeyPromptState;
   onSubmitAssistantApiKey: (
     apiKey: string,
@@ -474,6 +479,10 @@ export default function MeetsMainContent({
   replyTarget,
   onReplyToMessage,
   onCancelReply,
+  activeTtsMessageId,
+  onReplayTtsMessage,
+  onStopTts,
+  hasClonedTtsVoice,
   assistantApiKeyPrompt,
   onSubmitAssistantApiKey,
   onCancelAssistantApiKey,
@@ -2307,6 +2316,11 @@ export default function MeetsMainContent({
           replyTarget={replyTarget}
           onReply={onReplyToMessage}
           onCancelReply={onCancelReply}
+          activeTtsMessageId={activeTtsMessageId}
+          onReplayTtsMessage={onReplayTtsMessage}
+          onStopTts={onStopTts}
+          hasClonedTtsVoice={hasClonedTtsVoice}
+          isTtsDisabled={isTtsDisabled}
           assistantApiKeyPrompt={assistantApiKeyPrompt}
           onSubmitAssistantApiKey={onSubmitAssistantApiKey}
           onCancelAssistantApiKey={onCancelAssistantApiKey}

--- a/apps/web/src/app/components/TtsVoiceSettings.tsx
+++ b/apps/web/src/app/components/TtsVoiceSettings.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import {
-  AudioWaveform,
+  AudioLines,
   Check,
   LoaderCircle,
-  Mic2,
-  ShieldCheck,
+  Mic,
+  Pause,
+  Play,
+  RotateCcw,
   Square,
   Trash2,
 } from "lucide-react";
@@ -16,13 +18,43 @@ import type {
   TtsSystemVoiceOption,
 } from "../hooks/useMeetTts";
 
-const MIN_RECORDING_SECONDS = 10;
-const MAX_RECORDING_SECONDS = 20;
+// The voice provider's instant-clone guidance: 1 to 2 minutes of clean,
+// consistent audio gives the best likeness; short samples clone poorly.
+const MIN_RECORDING_SECONDS = 60;
+const MAX_RECORDING_SECONDS = 120;
 const ICON_STROKE = 1.75;
 const SAMPLE_SCRIPT =
-  "Hi, this is my voice. I’m creating a personal voice for Conclave so my text-to-speech messages sound like me. The quick brown fox jumps over the lazy dog.";
+  "Hi, this is my voice. I am recording a short sample so my spoken chat " +
+  "messages in Conclave sound like me. When I send a message out loud, this " +
+  "is the voice everyone in the meeting will hear, so I want it to sound " +
+  "natural, steady, and clear. I am speaking the way I normally talk in a " +
+  "call: relaxed, at a comfortable pace, without rushing. A few varied lines " +
+  "help the clone. The quick brown fox jumps over the lazy dog. Pack my box " +
+  "with five dozen liquor jugs. Sphinx of black quartz, judge my vow. One, " +
+  "two, three, four, five, six, seven, eight, nine, ten. In a meeting I " +
+  "might say: can everyone see my screen, let us take a look at the " +
+  "dashboard, or I will follow up right after the call. I will keep reading " +
+  "in this same tone until the timer fills, because a longer, consistent " +
+  "sample makes my voice sound more like me.";
 
-type EnrollmentPhase = "idle" | "recording" | "uploading" | "deleting";
+const formatClock = (totalSeconds: number): string => {
+  const seconds = Math.max(0, Math.ceil(totalSeconds));
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
+};
+const CLONE_PREVIEW_TEXT =
+  "Hey everyone, this is how my chat messages sound when I send them as speech.";
+const SYSTEM_PREVIEW_TEXT =
+  "This is the standard voice used for spoken chat messages.";
+
+type EnrollmentPhase =
+  | "idle"
+  | "recording"
+  | "review"
+  | "uploading"
+  | "deleting";
+
+type PreviewPhase = "idle" | "loading" | "playing";
 
 const pickRecorderMimeType = (): string | undefined => {
   if (typeof MediaRecorder === "undefined") return undefined;
@@ -43,6 +75,109 @@ const readError = async (response: Response, fallback: string): Promise<string> 
   }
 };
 
+const attachSink = async (
+  audio: HTMLAudioElement,
+  outputDeviceId?: string,
+): Promise<void> => {
+  const sinkCapable = audio as HTMLAudioElement & {
+    setSinkId?: (sinkId: string) => Promise<void>;
+  };
+  if (outputDeviceId && sinkCapable.setSinkId) {
+    await sinkCapable.setSinkId(outputDeviceId).catch(() => {});
+  }
+};
+
+/**
+ * Scrolling level-history waveform for the active recording, fed by its own
+ * analyser so it tracks exactly what the recorder hears.
+ */
+function LiveWaveform({ stream }: { stream: MediaStream | null }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !stream) return;
+    const AudioContextCtor =
+      window.AudioContext ??
+      (window as Window & { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext;
+    if (!AudioContextCtor) return;
+
+    const audioContext = new AudioContextCtor();
+    let source: MediaStreamAudioSourceNode;
+    try {
+      source = audioContext.createMediaStreamSource(stream);
+    } catch {
+      void audioContext.close().catch(() => {});
+      return;
+    }
+    const analyser = audioContext.createAnalyser();
+    analyser.fftSize = 1024;
+    source.connect(analyser);
+
+    const data = new Uint8Array(analyser.fftSize);
+    const history: number[] = [];
+    let frame = 0;
+
+    const draw = () => {
+      frame = requestAnimationFrame(draw);
+      analyser.getByteTimeDomainData(data);
+      let sum = 0;
+      for (let i = 0; i < data.length; i += 1) {
+        const value = (data[i] - 128) / 128;
+        sum += value * value;
+      }
+      const level = Math.min(1, Math.sqrt(sum / data.length) * 3.2);
+
+      const context = canvas.getContext("2d");
+      if (!context) return;
+      const dpr = window.devicePixelRatio || 1;
+      const width = canvas.clientWidth * dpr;
+      const height = canvas.clientHeight * dpr;
+      if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width;
+        canvas.height = height;
+      }
+
+      const barWidth = 3 * dpr;
+      const gap = 2 * dpr;
+      const maxBars = Math.max(8, Math.floor(width / (barWidth + gap)));
+      history.push(level);
+      while (history.length > maxBars) history.shift();
+
+      context.clearRect(0, 0, width, height);
+      context.fillStyle = "#F95F4A";
+      const mid = height / 2;
+      for (let index = 0; index < history.length; index += 1) {
+        const x = width - (history.length - index) * (barWidth + gap);
+        const barHeight = Math.max(
+          2 * dpr,
+          history[index] ** 0.8 * (height - 4 * dpr),
+        );
+        context.fillRect(x, mid - barHeight / 2, barWidth, barHeight);
+      }
+    };
+    draw();
+
+    return () => {
+      cancelAnimationFrame(frame);
+      try {
+        source.disconnect();
+      } catch {}
+      void audioContext.close().catch(() => {});
+    };
+  }, [stream]);
+
+  return <canvas ref={canvasRef} aria-hidden="true" className="h-10 w-full" />;
+}
+
+interface RecordingReview {
+  blob: Blob;
+  url: string;
+  mimeType: string;
+  durationSeconds: number;
+}
+
 interface TtsVoiceSettingsProps {
   systemVoices: TtsSystemVoiceOption[];
   selectedSystemVoiceUri?: string | null;
@@ -53,6 +188,7 @@ interface TtsVoiceSettingsProps {
   getRecordingStream: () => MediaStream | null;
   canCloneVoice: boolean;
   ownerName: string;
+  audioOutputDeviceId?: string;
 }
 
 export default function TtsVoiceSettings({
@@ -65,17 +201,37 @@ export default function TtsVoiceSettings({
   getRecordingStream,
   canCloneVoice,
   ownerName,
+  audioOutputDeviceId,
 }: TtsVoiceSettingsProps) {
   const [phase, setPhase] = useState<EnrollmentPhase>("idle");
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [hasConsent, setHasConsent] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [review, setReview] = useState<RecordingReview | null>(null);
+  const [recordingStream, setRecordingStream] = useState<MediaStream | null>(
+    null,
+  );
+  const [isReviewPlaying, setIsReviewPlaying] = useState(false);
+  const [reviewProgress, setReviewProgress] = useState(0);
+  const [clonePreviewPhase, setClonePreviewPhase] =
+    useState<PreviewPhase>("idle");
+  const [isSystemPreviewPlaying, setIsSystemPreviewPlaying] = useState(false);
+
   const recorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const startedAtRef = useRef(0);
   const intervalRef = useRef<number | null>(null);
   const timeoutRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
+  const reviewAudioRef = useRef<HTMLAudioElement | null>(null);
+  const reviewUrlRef = useRef<string | null>(null);
+  const previewAudioRef = useRef<HTMLAudioElement | null>(null);
+  const previewAbortRef = useRef<AbortController | null>(null);
+  const previewUrlRef = useRef<string | null>(null);
+  // True only while a system-voice preview this component started is live.
+  // Guards the global speechSynthesis.cancel() so closing settings never
+  // cuts off an unrelated /tts message being spoken in the meeting.
+  const ownsSystemPreviewRef = useRef(false);
 
   const clearTimers = useCallback(() => {
     if (intervalRef.current !== null) window.clearInterval(intervalRef.current);
@@ -84,48 +240,57 @@ export default function TtsVoiceSettings({
     timeoutRef.current = null;
   }, []);
 
-  const uploadRecording = useCallback(async (
-    chunks: Blob[],
-    mimeType: string,
-    durationSeconds: number,
-  ) => {
-    if (durationSeconds < MIN_RECORDING_SECONDS) {
-      setPhase("idle");
-      setError(`Keep speaking for at least ${MIN_RECORDING_SECONDS} seconds.`);
-      return;
+  const stopReviewPlayback = useCallback(() => {
+    const audio = reviewAudioRef.current;
+    reviewAudioRef.current = null;
+    if (audio) {
+      audio.onended = null;
+      audio.ontimeupdate = null;
+      audio.onerror = null;
+      audio.pause();
+      audio.src = "";
     }
-    setPhase("uploading");
-    setError(null);
-    const blob = new Blob(chunks, { type: mimeType || "audio/webm" });
-    const extension = mimeType.includes("mp4") ? "m4a" : "webm";
-    const formData = new FormData();
-    formData.append("audio", blob, `voice-sample.${extension}`);
-    formData.append("durationSeconds", durationSeconds.toFixed(2));
-    formData.append("consent", "true");
-    formData.append("name", ownerName);
+    setIsReviewPlaying(false);
+    setReviewProgress(0);
+  }, []);
 
-    try {
-      const response = await fetch("/api/tts/voices", {
-        method: "POST",
-        body: formData,
-      });
-      if (!response.ok) {
-        throw new Error(await readError(response, "Could not create your voice."));
-      }
-      const body = (await response.json()) as { token?: string; name?: string };
-      if (!body.token || !body.name) throw new Error("Voice creation was incomplete.");
-      onClonedVoiceChange?.({ token: body.token, name: body.name });
-      if (mountedRef.current) setPhase("idle");
-    } catch (uploadError) {
-      if (!mountedRef.current) return;
-      setPhase("idle");
-      setError(
-        uploadError instanceof Error
-          ? uploadError.message
-          : "Could not create your voice.",
-      );
+  const discardReview = useCallback(() => {
+    stopReviewPlayback();
+    if (reviewUrlRef.current) {
+      URL.revokeObjectURL(reviewUrlRef.current);
+      reviewUrlRef.current = null;
     }
-  }, [onClonedVoiceChange, ownerName]);
+    setReview(null);
+  }, [stopReviewPlayback]);
+
+  const stopClonePreview = useCallback(() => {
+    previewAbortRef.current?.abort();
+    previewAbortRef.current = null;
+    const audio = previewAudioRef.current;
+    previewAudioRef.current = null;
+    if (audio) {
+      audio.onended = null;
+      audio.onerror = null;
+      audio.pause();
+      audio.src = "";
+    }
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
+    setClonePreviewPhase("idle");
+  }, []);
+
+  const stopSystemPreview = useCallback(() => {
+    if (!ownsSystemPreviewRef.current) return;
+    ownsSystemPreviewRef.current = false;
+    if (typeof window !== "undefined" && "speechSynthesis" in window) {
+      try {
+        window.speechSynthesis.cancel();
+      } catch {}
+    }
+    setIsSystemPreviewPlaying(false);
+  }, []);
 
   const finishRecording = useCallback(() => {
     clearTimers();
@@ -135,6 +300,7 @@ export default function TtsVoiceSettings({
       recorder.stop();
     } catch {
       recorderRef.current = null;
+      setRecordingStream(null);
       setPhase("idle");
       setError("The recording could not be completed.");
     }
@@ -142,13 +308,10 @@ export default function TtsVoiceSettings({
 
   const startRecording = useCallback(() => {
     setError(null);
-    if (!hasConsent) {
-      setError("Confirm that this is your voice before recording.");
-      return;
-    }
+    discardReview();
     const stream = getRecordingStream();
     if (!stream?.getAudioTracks().some((track) => track.readyState === "live")) {
-      setError("Wait for the microphone test to start, then try again.");
+      setError("Wait for the microphone test above to start, then try again.");
       return;
     }
     if (typeof MediaRecorder === "undefined") {
@@ -171,11 +334,30 @@ export default function TtsVoiceSettings({
     };
     recorder.onstop = () => {
       recorderRef.current = null;
+      if (!mountedRef.current) return;
+      setRecordingStream(null);
       const duration = Math.min(
         MAX_RECORDING_SECONDS,
         (Date.now() - startedAtRef.current) / 1000,
       );
-      void uploadRecording(chunksRef.current, recorder.mimeType || mimeType || "", duration);
+      const recordedType = recorder.mimeType || mimeType || "audio/webm";
+      if (duration < MIN_RECORDING_SECONDS) {
+        setPhase("idle");
+        setError(
+          `Keep speaking for at least ${formatClock(MIN_RECORDING_SECONDS)} so the clone has enough to learn from.`,
+        );
+        return;
+      }
+      const blob = new Blob(chunksRef.current, { type: recordedType });
+      if (!blob.size) {
+        setPhase("idle");
+        setError("Nothing was recorded. Check your microphone and try again.");
+        return;
+      }
+      const url = URL.createObjectURL(blob);
+      reviewUrlRef.current = url;
+      setReview({ blob, url, mimeType: recordedType, durationSeconds: duration });
+      setPhase("review");
     };
     recorderRef.current = recorder;
     startedAtRef.current = Date.now();
@@ -189,6 +371,7 @@ export default function TtsVoiceSettings({
       setError("Voice recording could not start.");
       return;
     }
+    setRecordingStream(stream);
 
     intervalRef.current = window.setInterval(() => {
       setElapsedSeconds(
@@ -196,10 +379,118 @@ export default function TtsVoiceSettings({
       );
     }, 100);
     timeoutRef.current = window.setTimeout(finishRecording, MAX_RECORDING_SECONDS * 1000);
-  }, [finishRecording, getRecordingStream, hasConsent, uploadRecording]);
+  }, [discardReview, finishRecording, getRecordingStream]);
+
+  const reRecord = useCallback(() => {
+    setError(null);
+    discardReview();
+    setPhase("idle");
+  }, [discardReview]);
+
+  const toggleReviewPlayback = useCallback(async () => {
+    if (!review) return;
+    if (isReviewPlaying) {
+      stopReviewPlayback();
+      return;
+    }
+    stopClonePreview();
+    stopSystemPreview();
+    const audio = new Audio(review.url);
+    reviewAudioRef.current = audio;
+    await attachSink(audio, audioOutputDeviceId);
+    // A second click or unmount while the sink attached wins ownership.
+    if (!mountedRef.current || reviewAudioRef.current !== audio) {
+      audio.pause();
+      return;
+    }
+    audio.ontimeupdate = () => {
+      if (reviewAudioRef.current !== audio || !review.durationSeconds) return;
+      setReviewProgress(
+        Math.min(1, audio.currentTime / review.durationSeconds),
+      );
+    };
+    audio.onended = () => {
+      if (reviewAudioRef.current === audio) stopReviewPlayback();
+    };
+    audio.onerror = () => {
+      if (reviewAudioRef.current !== audio) return;
+      stopReviewPlayback();
+      setError("The recording could not be played back.");
+    };
+    try {
+      await audio.play();
+      if (!mountedRef.current || reviewAudioRef.current !== audio) {
+        audio.pause();
+        return;
+      }
+      setIsReviewPlaying(true);
+    } catch {
+      if (reviewAudioRef.current !== audio) return;
+      stopReviewPlayback();
+      setError("The recording could not be played back.");
+    }
+  }, [
+    audioOutputDeviceId,
+    isReviewPlaying,
+    review,
+    stopClonePreview,
+    stopReviewPlayback,
+    stopSystemPreview,
+  ]);
+
+  const createVoice = useCallback(async () => {
+    if (!review || phase !== "review") return;
+    if (!hasConsent) {
+      setError("Confirm that this is your voice before creating it.");
+      return;
+    }
+    stopReviewPlayback();
+    setPhase("uploading");
+    setError(null);
+    const extension = review.mimeType.includes("mp4") ? "m4a" : "webm";
+    const formData = new FormData();
+    formData.append("audio", review.blob, `voice-sample.${extension}`);
+    formData.append("durationSeconds", review.durationSeconds.toFixed(2));
+    formData.append("consent", "true");
+    formData.append("name", ownerName);
+
+    try {
+      const response = await fetch("/api/tts/voices", {
+        method: "POST",
+        body: formData,
+      });
+      if (!response.ok) {
+        throw new Error(await readError(response, "Could not create your voice."));
+      }
+      const body = (await response.json()) as { token?: string; name?: string };
+      if (!body.token || !body.name) throw new Error("Voice creation was incomplete.");
+      onClonedVoiceChange?.({ token: body.token, name: body.name });
+      if (mountedRef.current) {
+        discardReview();
+        setPhase("idle");
+      }
+    } catch (uploadError) {
+      if (!mountedRef.current) return;
+      setPhase("review");
+      setError(
+        uploadError instanceof Error
+          ? uploadError.message
+          : "Could not create your voice.",
+      );
+    }
+  }, [
+    discardReview,
+    hasConsent,
+    onClonedVoiceChange,
+    ownerName,
+    phase,
+    review,
+    stopReviewPlayback,
+  ]);
 
   const deleteVoice = useCallback(async () => {
     if (!clonedVoice || phase !== "idle") return;
+    stopClonePreview();
     setPhase("deleting");
     setError(null);
     try {
@@ -221,7 +512,119 @@ export default function TtsVoiceSettings({
           : "Could not delete your voice.",
       );
     }
-  }, [clonedVoice, onClonedVoiceClear, phase]);
+  }, [clonedVoice, onClonedVoiceClear, phase, stopClonePreview]);
+
+  const toggleClonePreview = useCallback(async () => {
+    if (!clonedVoice) return;
+    if (clonePreviewPhase !== "idle") {
+      stopClonePreview();
+      return;
+    }
+    stopReviewPlayback();
+    stopSystemPreview();
+    setError(null);
+    setClonePreviewPhase("loading");
+    const controller = new AbortController();
+    previewAbortRef.current = controller;
+    try {
+      const response = await fetch("/api/tts/speech", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          token: clonedVoice.token,
+          text: CLONE_PREVIEW_TEXT,
+        }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(await readError(response, "The preview is unavailable."));
+      }
+      const blob = await response.blob();
+      if (controller.signal.aborted || !mountedRef.current) return;
+      const url = URL.createObjectURL(blob);
+      previewUrlRef.current = url;
+      const audio = new Audio(url);
+      previewAudioRef.current = audio;
+      await attachSink(audio, audioOutputDeviceId);
+      if (controller.signal.aborted || previewAudioRef.current !== audio) {
+        audio.pause();
+        return;
+      }
+      audio.onended = () => {
+        if (previewAudioRef.current === audio) stopClonePreview();
+      };
+      audio.onerror = () => {
+        if (previewAudioRef.current === audio) stopClonePreview();
+      };
+      await audio.play();
+      if (controller.signal.aborted || previewAudioRef.current !== audio) {
+        audio.pause();
+        return;
+      }
+      if (mountedRef.current) setClonePreviewPhase("playing");
+    } catch (previewError) {
+      if (controller.signal.aborted || !mountedRef.current) return;
+      stopClonePreview();
+      setError(
+        previewError instanceof Error
+          ? previewError.message
+          : "The preview is unavailable.",
+      );
+    }
+  }, [
+    audioOutputDeviceId,
+    clonePreviewPhase,
+    clonedVoice,
+    stopClonePreview,
+    stopReviewPlayback,
+    stopSystemPreview,
+  ]);
+
+  const toggleSystemPreview = useCallback(() => {
+    if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
+    if (isSystemPreviewPlaying) {
+      stopSystemPreview();
+      return;
+    }
+    stopReviewPlayback();
+    stopClonePreview();
+    try {
+      const synth = window.speechSynthesis;
+      // Preempt anything already speaking so that from here on the only
+      // utterance in flight is ours; stop/unmount cancel is then always safe.
+      // A live meeting message recovers through its own error handler.
+      synth.cancel();
+      const utterance = new SpeechSynthesisUtterance(SYSTEM_PREVIEW_TEXT);
+      const chosen = synth
+        .getVoices()
+        .find((voice) => voice.voiceURI === selectedSystemVoiceUri);
+      if (chosen) {
+        utterance.voice = chosen;
+        utterance.lang = chosen.lang;
+      }
+      utterance.rate = 0.97;
+      utterance.onend = () => {
+        ownsSystemPreviewRef.current = false;
+        if (mountedRef.current) setIsSystemPreviewPlaying(false);
+      };
+      utterance.onerror = () => {
+        ownsSystemPreviewRef.current = false;
+        if (mountedRef.current) setIsSystemPreviewPlaying(false);
+      };
+      synth.speak(utterance);
+      ownsSystemPreviewRef.current = true;
+      setIsSystemPreviewPlaying(true);
+    } catch {
+      ownsSystemPreviewRef.current = false;
+      setIsSystemPreviewPlaying(false);
+    }
+  }, [
+    isSystemPreviewPlaying,
+    selectedSystemVoiceUri,
+    stopClonePreview,
+    stopReviewPlayback,
+    stopSystemPreview,
+  ]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -239,177 +642,354 @@ export default function TtsVoiceSettings({
           } catch {}
         }
       }
+      const reviewAudio = reviewAudioRef.current;
+      reviewAudioRef.current = null;
+      if (reviewAudio) {
+        reviewAudio.onended = null;
+        reviewAudio.ontimeupdate = null;
+        reviewAudio.onerror = null;
+        reviewAudio.pause();
+      }
+      if (reviewUrlRef.current) {
+        URL.revokeObjectURL(reviewUrlRef.current);
+        reviewUrlRef.current = null;
+      }
+      previewAbortRef.current?.abort();
+      const previewAudio = previewAudioRef.current;
+      previewAudioRef.current = null;
+      if (previewAudio) {
+        previewAudio.onended = null;
+        previewAudio.onerror = null;
+        previewAudio.pause();
+      }
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+        previewUrlRef.current = null;
+      }
+      // Only cancels a preview this component started; a live /tts message
+      // in the meeting keeps speaking.
+      if (
+        ownsSystemPreviewRef.current &&
+        typeof window !== "undefined" &&
+        "speechSynthesis" in window
+      ) {
+        ownsSystemPreviewRef.current = false;
+        try {
+          window.speechSynthesis.cancel();
+        } catch {}
+      }
     };
   }, [clearTimers]);
 
   const recordedEnough = elapsedSeconds >= MIN_RECORDING_SECONDS;
-  const progress = Math.min(100, (elapsedSeconds / MAX_RECORDING_SECONDS) * 100);
+  const recordingProgress = Math.min(
+    100,
+    (elapsedSeconds / MAX_RECORDING_SECONDS) * 100,
+  );
+
+  const outlinePill =
+    "inline-flex items-center justify-center gap-2 rounded-full border px-4 py-2 text-[12.5px] font-medium transition-colors duration-[120ms] hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-40";
 
   return (
     <div className="space-y-3">
+      <div
+        className="rounded-xl border p-3"
+        style={{ borderColor: color.border, backgroundColor: color.bgAlt }}
+      >
+        {clonedVoice ? (
+          <>
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[12px]" style={{ color: color.textMuted }}>
+                Your voice
+              </p>
+              <span className="inline-flex items-center gap-1 text-[11px] text-[#32d583]">
+                <Check size={12} strokeWidth={2} /> Ready
+              </span>
+            </div>
+            <p className="mt-1 truncate text-[13px]" style={{ color: color.text }}>
+              {clonedVoice.name}
+            </p>
+            <div className="mt-2.5 flex items-center gap-2">
+              <button
+                type="button"
+                data-testid="tts-clone-preview"
+                onClick={() => void toggleClonePreview()}
+                disabled={phase !== "idle"}
+                className={`${outlinePill} flex-1`}
+                style={{ borderColor: color.borderStrong, color: color.text }}
+              >
+                {clonePreviewPhase === "loading" ? (
+                  <LoaderCircle
+                    size={14}
+                    strokeWidth={ICON_STROKE}
+                    className="animate-spin text-[#F95F4A]"
+                  />
+                ) : clonePreviewPhase === "playing" ? (
+                  <Square size={12} strokeWidth={ICON_STROKE} />
+                ) : (
+                  <Play size={14} strokeWidth={ICON_STROKE} />
+                )}
+                {clonePreviewPhase === "playing"
+                  ? "Stop"
+                  : clonePreviewPhase === "loading"
+                    ? "Preparing"
+                    : "Hear my voice"}
+              </button>
+              <button
+                type="button"
+                onClick={() => void deleteVoice()}
+                disabled={phase !== "idle"}
+                aria-label="Delete my voice"
+                title="Delete my voice"
+                className="inline-flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-full border text-[#f97066] transition-colors duration-[120ms] hover:bg-[#f97066]/10 disabled:cursor-not-allowed disabled:opacity-40"
+                style={{ borderColor: color.borderStrong }}
+              >
+                {phase === "deleting" ? (
+                  <LoaderCircle size={14} className="animate-spin" />
+                ) : (
+                  <Trash2 size={14} strokeWidth={ICON_STROKE} />
+                )}
+              </button>
+            </div>
+            <p
+              className="mt-1.5 text-[11px] leading-snug"
+              style={{ color: color.textFaint }}
+            >
+              Plays for everyone when you send /tts in chat.
+            </p>
+          </>
+        ) : !canCloneVoice ? (
+          <>
+            <p className="text-[12px]" style={{ color: color.textMuted }}>
+              Your voice
+            </p>
+            <p
+              className="mt-1 text-[12px] leading-relaxed"
+              style={{ color: color.textFaint }}
+            >
+              Sign in with an email account to create a personal voice for
+              /tts messages. Until then, messages use the standard voice
+              below.
+            </p>
+          </>
+        ) : phase === "review" || phase === "uploading" ? (
+          <>
+            <p className="mb-2 text-[12px]" style={{ color: color.textMuted }}>
+              Listen back before creating your voice
+            </p>
+            <div className="flex items-center gap-2.5">
+              <button
+                type="button"
+                data-testid="tts-review-playback"
+                onClick={() => void toggleReviewPlayback()}
+                disabled={phase === "uploading"}
+                aria-label={isReviewPlaying ? "Pause recording" : "Play recording"}
+                className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border transition-colors duration-[120ms] hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-40"
+                style={{ borderColor: color.borderStrong, color: color.text }}
+              >
+                {isReviewPlaying ? (
+                  <Pause size={14} strokeWidth={ICON_STROKE} />
+                ) : (
+                  <Play size={14} strokeWidth={ICON_STROKE} className="translate-x-[1px]" />
+                )}
+              </button>
+              <div className="h-1 min-w-0 flex-1 overflow-hidden rounded-full bg-white/10">
+                <div
+                  className="h-full bg-[#F95F4A] transition-[width] duration-150"
+                  style={{ width: `${reviewProgress * 100}%` }}
+                />
+              </div>
+              <span
+                className="shrink-0 text-[11.5px] tabular-nums"
+                style={{ color: color.textMuted }}
+              >
+                {review ? formatClock(review.durationSeconds) : ""}
+              </span>
+            </div>
+
+            <label
+              className="mt-3 flex cursor-pointer items-start gap-2.5 text-[11.5px] leading-relaxed"
+              style={{ color: color.textMuted }}
+            >
+              <input
+                type="checkbox"
+                checked={hasConsent}
+                onChange={(event) => setHasConsent(event.target.checked)}
+                disabled={phase === "uploading"}
+                className="mt-0.5 h-3.5 w-3.5 accent-[#F95F4A]"
+              />
+              <span>
+                This is my voice. I consent to creating a clone of it and
+                understand meeting participants may hear it.
+              </span>
+            </label>
+
+            <div className="mt-3 flex items-center gap-2">
+              <button
+                type="button"
+                data-testid="tts-create-voice"
+                onClick={() => void createVoice()}
+                disabled={phase === "uploading" || !hasConsent}
+                className="inline-flex flex-1 items-center justify-center gap-2 rounded-full bg-[#F95F4A] px-4 py-2 text-[12.5px] font-semibold text-white transition-[filter] duration-[120ms] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {phase === "uploading" ? (
+                  <LoaderCircle size={14} className="animate-spin" />
+                ) : (
+                  <Check size={14} strokeWidth={2} />
+                )}
+                {phase === "uploading" ? "Creating" : "Create my voice"}
+              </button>
+              <button
+                type="button"
+                onClick={reRecord}
+                disabled={phase === "uploading"}
+                className={`${outlinePill} shrink-0`}
+                style={{ borderColor: color.borderStrong, color: color.text }}
+              >
+                <RotateCcw size={13} strokeWidth={ICON_STROKE} />
+                Redo
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="mb-2 text-[12px]" style={{ color: color.textMuted }}>
+              {phase === "recording"
+                ? "Read this naturally"
+                : "Create your voice for /tts messages"}
+            </p>
+            <p className="devicesettings-scroll max-h-44 overflow-y-auto pr-1 text-[12.5px] leading-relaxed text-[#fafafa]/85">
+              {SAMPLE_SCRIPT}
+            </p>
+
+            {phase === "recording" ? (
+              <div className="mt-3">
+                <div className="mb-1 flex items-center justify-between text-[11.5px]">
+                  <span className="inline-flex items-center gap-1.5 text-[#f97066]">
+                    <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[#f97066]" />
+                    Recording
+                  </span>
+                  <span className="tabular-nums" style={{ color: color.textMuted }}>
+                    {formatClock(elapsedSeconds)} / {formatClock(MAX_RECORDING_SECONDS)}
+                  </span>
+                </div>
+                <LiveWaveform stream={recordingStream} />
+                <div className="mt-1 h-1 overflow-hidden rounded-full bg-white/10">
+                  <div
+                    className="h-full bg-[#F95F4A] transition-[width] duration-100"
+                    style={{ width: `${recordingProgress}%` }}
+                  />
+                </div>
+              </div>
+            ) : null}
+
+            <button
+              type="button"
+              data-testid="tts-record"
+              onClick={phase === "recording" ? finishRecording : startRecording}
+              disabled={phase === "recording" && !recordedEnough}
+              className={`${outlinePill} mt-3 w-full`}
+              style={{ borderColor: color.borderStrong, color: color.text }}
+            >
+              {phase === "recording" ? (
+                <Square size={12} strokeWidth={ICON_STROKE} />
+              ) : (
+                <Mic size={14} strokeWidth={ICON_STROKE} />
+              )}
+              {phase === "recording"
+                ? recordedEnough
+                  ? "Stop recording"
+                  : `Keep speaking (${formatClock(MIN_RECORDING_SECONDS - elapsedSeconds)} left)`
+                : "Record my voice"}
+            </button>
+            {phase !== "recording" ? (
+              <p
+                className="mt-1.5 text-[11px] leading-snug"
+                style={{ color: color.textFaint }}
+              >
+                Takes 1 to 2 minutes in a quiet room, speaking steadily at your
+                normal pace. The clone copies exactly what it hears. You can
+                listen back before anything is created.
+              </p>
+            ) : (
+              <p
+                className="mt-1.5 text-[11px] leading-snug"
+                style={{ color: color.textFaint }}
+              >
+                If you finish the script early, read it again in the same tone.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+
       <div>
         <label
           htmlFor="tts-system-voice"
           className="mb-1.5 block text-[12px]"
           style={{ color: color.textMuted }}
         >
-          Fallback voice you hear
+          Standard voice
         </label>
-        <select
-          id="tts-system-voice"
-          value={selectedSystemVoiceUri || ""}
-          onChange={(event) => onSystemVoiceChange?.(event.target.value || null)}
-          disabled={!onSystemVoiceChange || !systemVoices.length}
-          className="h-10 w-full rounded-xl border border-white/10 bg-white/[0.03] px-3 text-[13px] text-[#fafafa] focus:border-[#F95F4A]/60 focus:outline-none disabled:opacity-50"
-        >
-          <option value="" className="bg-[#18181b]">Automatic</option>
-          {systemVoices.map((voice) => (
-            <option
-              key={voice.voiceURI}
-              value={voice.voiceURI}
-              className="bg-[#18181b]"
+        <div className="flex items-center gap-2">
+          <div className="relative min-w-0 flex-1">
+            <AudioLines
+              size={15}
+              strokeWidth={ICON_STROKE}
+              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[#fafafa]/45"
+            />
+            <select
+              id="tts-system-voice"
+              value={selectedSystemVoiceUri || ""}
+              onChange={(event) => onSystemVoiceChange?.(event.target.value || null)}
+              disabled={!onSystemVoiceChange || !systemVoices.length}
+              className="h-10 w-full cursor-pointer appearance-none rounded-xl border border-white/10 bg-white/[0.03] pl-9 pr-3 text-[13px] text-[#fafafa] transition-colors duration-[120ms] hover:bg-white/[0.05] focus:border-[#F95F4A]/60 focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
             >
-              {voice.name} · {voice.lang}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div
-        className="overflow-hidden rounded-xl border"
-        style={{ borderColor: color.borderStrong, backgroundColor: color.bgAlt }}
-      >
-        <div className="flex items-start gap-3 p-3">
-          <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[#F95F4A]/30 bg-[#F95F4A]/10 text-[#F95F4A]">
-            <AudioWaveform size={16} strokeWidth={ICON_STROKE} />
-          </span>
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-[13px] font-semibold">My message voice</p>
-              {clonedVoice ? (
-                <span className="inline-flex items-center gap-1 text-[11px] text-[#32d583]">
-                  <Check size={12} strokeWidth={2} /> Ready
-                </span>
-              ) : null}
-            </div>
-            <p className="mt-1 text-[11.5px] leading-relaxed" style={{ color: color.textMuted }}>
-              Your clone is used only when you send <code>/tts</code>. Other web
-              participants hear it; unsupported clients use their system voice.
-            </p>
-          </div>
-        </div>
-
-        {clonedVoice ? (
-          <div className="flex items-center justify-between gap-3 border-t border-white/10 px-3 py-2.5">
-            <span className="min-w-0 truncate text-[12px]" style={{ color: color.textMuted }}>
-              {clonedVoice.name}
-            </span>
-            <button
-              type="button"
-              onClick={() => void deleteVoice()}
-              disabled={phase !== "idle"}
-              className="inline-flex shrink-0 items-center gap-1.5 rounded-lg px-2 py-1.5 text-[12px] text-[#f97066] transition-colors hover:bg-[#f97066]/10 disabled:opacity-50"
-            >
-              {phase === "deleting" ? (
-                <LoaderCircle size={13} className="animate-spin" />
-              ) : (
-                <Trash2 size={13} strokeWidth={ICON_STROKE} />
-              )}
-              Delete
-            </button>
-          </div>
-        ) : (
-          <div className="border-t border-white/10 p-3">
-            {!canCloneVoice ? (
-              <p className="text-[12px] leading-relaxed" style={{ color: color.textMuted }}>
-                Sign in with an email account to create and manage a voice clone.
-              </p>
-            ) : (
-              <>
-                <div className="rounded-lg border border-white/10 bg-black/15 p-2.5">
-                  <p className="text-[10.5px] font-medium uppercase tracking-[0.08em]" style={{ color: color.textFaint }}>
-                    Read this naturally
-                  </p>
-                  <p className="mt-1.5 text-[12px] leading-relaxed text-[#fafafa]/85">
-                    {SAMPLE_SCRIPT}
-                  </p>
-                </div>
-
-                {phase === "recording" ? (
-                  <div className="mt-3">
-                    <div className="mb-1.5 flex items-center justify-between text-[11.5px]">
-                      <span className="inline-flex items-center gap-1.5 text-[#f97066]">
-                        <span className="h-1.5 w-1.5 rounded-full bg-[#f97066] animate-pulse" />
-                        Recording
-                      </span>
-                      <span className="tabular-nums" style={{ color: color.textMuted }}>
-                        {elapsedSeconds.toFixed(1)} / {MAX_RECORDING_SECONDS}s
-                      </span>
-                    </div>
-                    <div className="h-1 overflow-hidden rounded-full bg-white/10">
-                      <div
-                        className="h-full bg-[#F95F4A] transition-[width] duration-100"
-                        style={{ width: `${progress}%` }}
-                      />
-                    </div>
-                  </div>
-                ) : null}
-
-                <label className="mt-3 flex cursor-pointer items-start gap-2.5 text-[11.5px] leading-relaxed" style={{ color: color.textMuted }}>
-                  <input
-                    type="checkbox"
-                    checked={hasConsent}
-                    onChange={(event) => setHasConsent(event.target.checked)}
-                    disabled={phase !== "idle"}
-                    className="mt-0.5 h-3.5 w-3.5 accent-[#F95F4A]"
-                  />
-                  <span>
-                    I confirm this is my voice, I consent to creating a clone, and
-                    I understand meeting participants may hear it.
-                  </span>
-                </label>
-
-                <button
-                  type="button"
-                  onClick={phase === "recording" ? finishRecording : startRecording}
-                  disabled={
-                    phase === "uploading" ||
-                    phase === "deleting" ||
-                    (phase === "recording" && !recordedEnough)
-                  }
-                  className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-full bg-[#F95F4A] px-4 py-2 text-[12.5px] font-semibold text-white transition-[filter] hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
+              <option value="" className="bg-[#18181b]">Automatic</option>
+              {systemVoices.map((voice) => (
+                <option
+                  key={voice.voiceURI}
+                  value={voice.voiceURI}
+                  className="bg-[#18181b]"
                 >
-                  {phase === "uploading" ? (
-                    <LoaderCircle size={14} className="animate-spin" />
-                  ) : phase === "recording" ? (
-                    <Square size={13} fill="currentColor" />
-                  ) : (
-                    <Mic2 size={15} strokeWidth={ICON_STROKE} />
-                  )}
-                  {phase === "uploading"
-                    ? "Creating voice…"
-                    : phase === "recording"
-                      ? recordedEnough
-                        ? "Stop and create voice"
-                        : `Keep speaking · ${Math.ceil(MIN_RECORDING_SECONDS - elapsedSeconds)}s`
-                      : "Record 10–20 seconds"}
-                </button>
-
-                <div className="mt-2 flex items-start gap-1.5 text-[10.5px] leading-relaxed" style={{ color: color.textFaint }}>
-                  <ShieldCheck size={13} strokeWidth={ICON_STROKE} className="mt-0.5 shrink-0" />
-                  <span>
-                    The sample is sent securely to the configured voice provider.
-                    One to two minutes of clean audio gives better fidelity than a quick clone.
-                  </span>
-                </div>
-              </>
-            )}
+                  {voice.name} · {voice.lang}
+                </option>
+              ))}
+            </select>
           </div>
-        )}
+          <button
+            type="button"
+            data-testid="tts-system-preview"
+            onClick={toggleSystemPreview}
+            disabled={!systemVoices.length}
+            aria-label={
+              isSystemPreviewPlaying
+                ? "Stop voice preview"
+                : "Preview the standard voice"
+            }
+            title={isSystemPreviewPlaying ? "Stop preview" : "Preview this voice"}
+            className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.03] text-[#fafafa] transition-colors duration-[120ms] hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {isSystemPreviewPlaying ? (
+              <Square size={13} strokeWidth={ICON_STROKE} />
+            ) : (
+              <Play size={14} strokeWidth={ICON_STROKE} className="translate-x-[1px]" />
+            )}
+          </button>
+        </div>
+        <p
+          className="mt-1 px-1 text-[11px] leading-snug"
+          style={{ color: color.textFaint }}
+        >
+          You hear this for speakers without a personal voice.
+        </p>
       </div>
 
       {error ? (
-        <div className="rounded-xl border border-[#f97066]/30 bg-[#f97066]/10 px-3 py-2 text-[11.5px] leading-relaxed text-[#fda29b]">
+        <div
+          role="alert"
+          className="rounded-xl border border-[#F95F4A]/30 bg-[#F95F4A]/[0.14] px-3 py-2 text-[12px] leading-snug"
+        >
           {error}
         </div>
       ) : null}

--- a/apps/web/src/app/components/controls-config.ts
+++ b/apps/web/src/app/components/controls-config.ts
@@ -261,7 +261,9 @@ export function buildControlsConfig(p: ControlsBarProps): ControlsConfig {
     sideControls.push({
       id: "transcript",
       icon: FileText,
-      label: p.isTranscriptLive ? "Live transcript" : "Transcript",
+      // Label stays put; live state is signalled by the status dot/tint, not
+      // by renaming the control under the user.
+      label: "Transcript",
       showTooltipWithoutHotkey: true,
       variant:
         p.isTranscriptOpen || p.isTranscriptLive ? "active" : "default",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -678,6 +678,42 @@ select:focus {
   animation: web-chat-highlight-flash 900ms ease-out both;
 }
 
+/* Equalizer bars shown on a TTS voice message while it is being spoken. */
+@keyframes web-chat-tts-eq {
+  0%,
+  100% {
+    transform: scaleY(0.3);
+  }
+
+  50% {
+    transform: scaleY(1);
+  }
+}
+
+.web-chat-tts-eq-bar {
+  transform-origin: center;
+  animation: web-chat-tts-eq 0.85s ease-in-out infinite;
+}
+
+.web-chat-tts-eq-bar:nth-child(2) {
+  animation-delay: 0.14s;
+}
+
+.web-chat-tts-eq-bar:nth-child(3) {
+  animation-delay: 0.28s;
+}
+
+.web-chat-tts-eq-bar:nth-child(4) {
+  animation-delay: 0.42s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .web-chat-tts-eq-bar {
+    animation: none;
+    transform: scaleY(0.75);
+  }
+}
+
 /* Smooth height+fade collapse for Radix Collapsible surfaces (Conclave AI
    reasoning / chain-of-thought). Radix exposes the measured content height as
    --radix-collapsible-content-height, which lets us animate from/to 0. */

--- a/apps/web/src/app/hooks/useMeetChat.ts
+++ b/apps/web/src/app/hooks/useMeetChat.ts
@@ -15,6 +15,7 @@ import {
   getHelpText,
   normalizeChatMessage,
   parseChatCommand,
+  TTS_MAX_TEXT_LENGTH,
 } from "../lib/chat-commands";
 import {
   CHAT_IMAGE_MODERATION_BLOCKED_CODE,
@@ -90,6 +91,7 @@ interface UseMeetChatOptions {
     displayName: string;
     text: string;
     ttsVoiceToken?: string;
+    messageId?: string;
   }) => void;
   outgoingTtsVoiceToken?: string;
   isTtsDisabled?: boolean;
@@ -639,6 +641,7 @@ export function useMeetChat({
                   displayName: message.displayName,
                   text: ttsText,
                   ttsVoiceToken: message.ttsVoiceToken,
+                  messageId: message.id,
                 });
               }
               resolve(message);
@@ -723,6 +726,12 @@ export function useMeetChat({
           }
           if (!args) {
             appendLocalMessage("Usage: /tts <text>");
+            return;
+          }
+          if (args.length > TTS_MAX_TEXT_LENGTH) {
+            appendLocalMessage(
+              `TTS messages are limited to ${TTS_MAX_TEXT_LENGTH} characters. Yours is ${args.length}.`,
+            );
             return;
           }
           void sendChatInternal(`/tts ${args}`);

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -784,6 +784,7 @@ interface UseMeetSocketOptions {
     displayName: string;
     text: string;
     ttsVoiceToken?: string;
+    messageId?: string;
   }) => void;
   prewarm?: {
     Device: typeof import("mediasoup-client").Device | null;
@@ -5794,6 +5795,7 @@ export function useMeetSocket({
                   displayName: normalized.displayName,
                   text: ttsText,
                   ttsVoiceToken: normalized.ttsVoiceToken,
+                  messageId: normalized.id,
                 });
               }
               if (!chat.isChatOpenRef.current) {

--- a/apps/web/src/app/hooks/useMeetTts.ts
+++ b/apps/web/src/app/hooks/useMeetTts.ts
@@ -3,11 +3,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { clampMeetVolume, DEFAULT_MEET_VOLUME } from "../lib/meet-volume";
 
-interface TtsPayload {
+export interface TtsPayload {
   userId: string;
   displayName: string;
   text: string;
   ttsVoiceToken?: string;
+  /** Chat message id, when the payload came from a chat message. */
+  messageId?: string;
 }
 
 export interface TtsSystemVoiceOption {
@@ -23,6 +25,23 @@ export interface ClonedTtsVoice {
 
 const TTS_RATE = 0.94;
 const TTS_PITCH = 1;
+/** Queued messages beyond this are dropped oldest-first. */
+const MAX_QUEUED_TTS = 6;
+/** Gap between queued messages so back-to-back TTS doesn't run together. */
+const QUEUE_ADVANCE_DELAY_MS = 250;
+/** Give up on cloned-speech generation after this and use the system voice. */
+const CLONED_GENERATION_TIMEOUT_MS = 15000;
+/** Post-playback grace before the stuck-playback failsafe fires. */
+const FAILSAFE_GRACE_MS = 8000;
+
+/** Speech budget for playbacks whose real duration is unknown. */
+const estimateSpeechMs = (text: string): number => {
+  const words = text.split(/\s+/).filter(Boolean).length;
+  // Whitespace-free scripts (CJK etc.) would count as one word, so also
+  // budget by characters and take the larger of the two.
+  const units = Math.max(words, Math.ceil(text.length / 6));
+  return Math.min(90000, Math.max(FAILSAFE_GRACE_MS, units * 700 + 5000));
+};
 const VOICE_QUALITY_KEYWORDS = [
   "neural",
   "natural",
@@ -126,6 +145,9 @@ export function useMeetTts({
   audioOutputDeviceId,
 }: UseMeetTtsOptions = {}) {
   const [ttsSpeakerId, setTtsSpeakerId] = useState<string | null>(null);
+  const [activeTtsMessageId, setActiveTtsMessageId] = useState<string | null>(
+    null,
+  );
   const [availableSystemVoices, setAvailableSystemVoices] = useState<
     TtsSystemVoiceOption[]
   >([]);
@@ -136,10 +158,13 @@ export function useMeetTts({
     readStoredClonedVoice,
   );
   const activeTokenRef = useRef<number | null>(null);
-  const fallbackTimeoutRef = useRef<number | null>(null);
+  const tokenCounterRef = useRef(0);
+  const queueRef = useRef<TtsPayload[]>([]);
+  const speakPayloadRef = useRef<(payload: TtsPayload) => void>(() => {});
+  const failsafeTimeoutRef = useRef<number | null>(null);
+  const advanceTimeoutRef = useRef<number | null>(null);
   const unlockTimeoutRef = useRef<number | null>(null);
   const voiceRef = useRef<SpeechSynthesisVoice | null>(null);
-  const pendingPayloadRef = useRef<TtsPayload | null>(null);
   const clonedSpeechAbortRef = useRef<AbortController | null>(null);
   const clonedSpeechAudioRef = useRef<HTMLAudioElement | null>(null);
   const clonedSpeechUrlRef = useRef<string | null>(null);
@@ -165,10 +190,36 @@ export function useMeetTts({
     }
   }, []);
 
-  const clearHighlight = useCallback((token: number) => {
-    if (activeTokenRef.current !== token) return;
-    setTtsSpeakerId(null);
+  const startNextInQueue = useCallback(() => {
+    if (activeTokenRef.current !== null) return;
+    const next = queueRef.current.shift();
+    if (next) speakPayloadRef.current(next);
   }, []);
+
+  /**
+   * Single completion path for a playback attempt: clears the speaking
+   * indicators and, after a short beat, plays the next queued message.
+   * Safe to call multiple times — only the owning token wins.
+   */
+  const finishPlayback = useCallback((token: number) => {
+    if (activeTokenRef.current !== token) return;
+    activeTokenRef.current = null;
+    setTtsSpeakerId(null);
+    setActiveTtsMessageId(null);
+    if (failsafeTimeoutRef.current !== null) {
+      window.clearTimeout(failsafeTimeoutRef.current);
+      failsafeTimeoutRef.current = null;
+    }
+    if (queueRef.current.length) {
+      if (advanceTimeoutRef.current !== null) {
+        window.clearTimeout(advanceTimeoutRef.current);
+      }
+      advanceTimeoutRef.current = window.setTimeout(() => {
+        advanceTimeoutRef.current = null;
+        startNextInQueue();
+      }, QUEUE_ADVANCE_DELAY_MS);
+    }
+  }, [startNextInQueue]);
 
   const refreshPreferredVoice = useCallback(() => {
     if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
@@ -185,6 +236,32 @@ export function useMeetTts({
       voices.find((voice) => voice.voiceURI === selectedSystemVoiceUri) ??
       pickBestVoice(voices, preferredLanguageRef.current);
   }, [selectedSystemVoiceUri]);
+
+  // The mount effect must not re-run when the selected voice changes (its
+  // cleanup tears down live playback), so it reaches the latest refresher
+  // through a ref while this effect applies selection changes immediately.
+  const refreshPreferredVoiceRef = useRef(refreshPreferredVoice);
+  useEffect(() => {
+    refreshPreferredVoiceRef.current = refreshPreferredVoice;
+    refreshPreferredVoice();
+  }, [refreshPreferredVoice]);
+
+  /**
+   * Arms the stuck-playback failsafe for the active token. Real completion
+   * comes from the utterance/audio end events; this only rescues playback
+   * that never reports back so the queue cannot wedge.
+   */
+  const armFailsafe = useCallback((token: number, delayMs: number) => {
+    if (failsafeTimeoutRef.current !== null) {
+      window.clearTimeout(failsafeTimeoutRef.current);
+    }
+    failsafeTimeoutRef.current = window.setTimeout(() => {
+      failsafeTimeoutRef.current = null;
+      if (activeTokenRef.current !== token) return;
+      stopClonedSpeech();
+      finishPlayback(token);
+    }, delayMs);
+  }, [finishPlayback, stopClonedSpeech]);
 
   const setSelectedSystemVoiceUri = useCallback((voiceUri: string | null) => {
     const normalized = voiceUri?.trim() || null;
@@ -218,6 +295,7 @@ export function useMeetTts({
   ) => {
     if (activeTokenRef.current !== token) return;
     if (typeof window === "undefined" || !("speechSynthesis" in window)) {
+      finishPlayback(token);
       return;
     }
 
@@ -225,7 +303,8 @@ export function useMeetTts({
       const synth = window.speechSynthesis;
       if (synth.speaking || synth.pending) synth.cancel();
       synth.resume();
-      if (!voiceRef.current) refreshPreferredVoice();
+      if (!voiceRef.current) refreshPreferredVoiceRef.current();
+      armFailsafe(token, estimateSpeechMs(payload.text));
 
       const utterance = new SpeechSynthesisUtterance(payload.text.trim());
       utterance.rate = TTS_RATE;
@@ -241,13 +320,13 @@ export function useMeetTts({
       utterance.onstart = () => {
         isSpeechUnlockedRef.current = true;
       };
-      utterance.onend = () => clearHighlight(token);
-      utterance.onerror = () => clearHighlight(token);
+      utterance.onend = () => finishPlayback(token);
+      utterance.onerror = () => finishPlayback(token);
       synth.speak(utterance);
     } catch {
-      clearHighlight(token);
+      finishPlayback(token);
     }
-  }, [clearHighlight, refreshPreferredVoice, ttsVolume]);
+  }, [armFailsafe, finishPlayback, ttsVolume]);
 
   const speakWithClonedVoice = useCallback(async (
     payload: TtsPayload,
@@ -261,6 +340,13 @@ export function useMeetTts({
 
     const controller = new AbortController();
     clonedSpeechAbortRef.current = controller;
+    // Generation gets its own clock: a slow provider falls back to the system
+    // voice instead of eating into (or being killed by) the playback failsafe.
+    let generationTimedOut = false;
+    const generationTimeout = window.setTimeout(() => {
+      generationTimedOut = true;
+      controller.abort();
+    }, CLONED_GENERATION_TIMEOUT_MS);
     try {
       const response = await fetch("/api/tts/speech", {
         method: "POST",
@@ -270,6 +356,7 @@ export function useMeetTts({
       });
       if (!response.ok) throw new Error("Cloned speech was unavailable.");
       const blob = await response.blob();
+      window.clearTimeout(generationTimeout);
       if (activeTokenRef.current !== token || controller.signal.aborted) return;
 
       const url = URL.createObjectURL(blob);
@@ -283,9 +370,10 @@ export function useMeetTts({
       if (audioOutputDeviceId && sinkCapable.setSinkId) {
         await sinkCapable.setSinkId(audioOutputDeviceId).catch(() => {});
       }
+      if (activeTokenRef.current !== token || controller.signal.aborted) return;
       audio.onended = () => {
         stopClonedSpeech();
-        clearHighlight(token);
+        finishPlayback(token);
       };
       audio.onerror = () => {
         stopClonedSpeech();
@@ -293,14 +381,24 @@ export function useMeetTts({
       };
       isSpeechUnlockedRef.current = true;
       await audio.play();
+      const knownDurationMs =
+        Number.isFinite(audio.duration) && audio.duration > 0
+          ? audio.duration * 1000 + FAILSAFE_GRACE_MS
+          : estimateSpeechMs(payload.text);
+      armFailsafe(token, knownDurationMs);
     } catch {
-      if (controller.signal.aborted || activeTokenRef.current !== token) return;
+      window.clearTimeout(generationTimeout);
+      if (activeTokenRef.current !== token) return;
+      // A user-initiated stop aborts too; only the generation timeout should
+      // fall back to the system voice.
+      if (controller.signal.aborted && !generationTimedOut) return;
       stopClonedSpeech();
       speakWithSystemVoice(payload, token);
     }
   }, [
+    armFailsafe,
     audioOutputDeviceId,
-    clearHighlight,
+    finishPlayback,
     speakWithSystemVoice,
     stopClonedSpeech,
     ttsVolume,
@@ -310,39 +408,34 @@ export function useMeetTts({
     const text = payload.text?.trim();
     if (!text) return;
 
-    const token = Date.now();
+    const token = ++tokenCounterRef.current;
     activeTokenRef.current = token;
     setTtsSpeakerId(payload.userId);
+    setActiveTtsMessageId(payload.messageId ?? null);
     stopClonedSpeech();
 
-    if (fallbackTimeoutRef.current) {
-      window.clearTimeout(fallbackTimeoutRef.current);
+    if (failsafeTimeoutRef.current !== null) {
+      window.clearTimeout(failsafeTimeoutRef.current);
+      failsafeTimeoutRef.current = null;
     }
-
-    const words = text.split(/\s+/).filter(Boolean).length;
-    const estimatedMs = Math.min(15000, Math.max(2000, Math.ceil(words * 420)));
-    fallbackTimeoutRef.current = window.setTimeout(() => {
-      clearHighlight(token);
-    }, estimatedMs);
-
+    // The cloned path arms its playback failsafe once audio actually starts
+    // (generation has its own timeout); until then, guard the fetch window.
     if (payload.ttsVoiceToken) {
+      armFailsafe(token, CLONED_GENERATION_TIMEOUT_MS + estimateSpeechMs(text));
       void speakWithClonedVoice(payload, token);
     } else {
       speakWithSystemVoice(payload, token);
     }
-  }, [clearHighlight, speakWithClonedVoice, speakWithSystemVoice, stopClonedSpeech]);
+  }, [armFailsafe, speakWithClonedVoice, speakWithSystemVoice, stopClonedSpeech]);
 
-  const flushPendingPayload = useCallback(() => {
-    const pendingPayload = pendingPayloadRef.current;
-    if (!pendingPayload) return;
-    pendingPayloadRef.current = null;
-    speakPayload(pendingPayload);
+  useEffect(() => {
+    speakPayloadRef.current = speakPayload;
   }, [speakPayload]);
 
   const unlockSpeech = useCallback(() => {
     if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
     if (isSpeechUnlockedRef.current) {
-      flushPendingPayload();
+      startNextInQueue();
       return;
     }
 
@@ -355,11 +448,11 @@ export function useMeetTts({
       primer.lang = preferredLanguageRef.current;
       primer.onend = () => {
         isSpeechUnlockedRef.current = true;
-        flushPendingPayload();
+        startNextInQueue();
       };
       primer.onerror = () => {
         isSpeechUnlockedRef.current = true;
-        flushPendingPayload();
+        startNextInQueue();
       };
       synth.speak(primer);
 
@@ -368,33 +461,76 @@ export function useMeetTts({
       }
       unlockTimeoutRef.current = window.setTimeout(() => {
         isSpeechUnlockedRef.current = true;
-        flushPendingPayload();
+        startNextInQueue();
       }, 150);
     } catch {
       isSpeechUnlockedRef.current = true;
-      flushPendingPayload();
+      startNextInQueue();
     }
-  }, [flushPendingPayload]);
+  }, [startNextInQueue]);
 
   const handleTtsMessage = useCallback((payload: TtsPayload) => {
-    if (shouldGateSpeechRef.current && !isSpeechUnlockedRef.current) {
-      pendingPayloadRef.current = payload;
+    if (!payload.text?.trim()) return;
+    const mustQueue =
+      activeTokenRef.current !== null ||
+      // Messages already waiting keep their order even during the short
+      // advance gap between playbacks.
+      queueRef.current.length > 0 ||
+      (shouldGateSpeechRef.current && !isSpeechUnlockedRef.current);
+    if (mustQueue) {
+      queueRef.current.push(payload);
+      while (queueRef.current.length > MAX_QUEUED_TTS) {
+        queueRef.current.shift();
+      }
       return;
     }
     speakPayload(payload);
   }, [speakPayload]);
 
+  /** Stops the current message (if any) and plays this payload right away. */
+  const replayTts = useCallback((payload: TtsPayload) => {
+    if (!payload.text?.trim()) return;
+    // Replay always comes from a click, so speech is user-gesture unlocked.
+    isSpeechUnlockedRef.current = true;
+    if (typeof window !== "undefined" && "speechSynthesis" in window) {
+      try {
+        window.speechSynthesis.cancel();
+      } catch {}
+    }
+    speakPayload(payload);
+  }, [speakPayload]);
+
+  /** Stops the current message and drops everything queued behind it. */
+  const stopTts = useCallback(() => {
+    queueRef.current = [];
+    if (advanceTimeoutRef.current !== null) {
+      window.clearTimeout(advanceTimeoutRef.current);
+      advanceTimeoutRef.current = null;
+    }
+    if (typeof window !== "undefined" && "speechSynthesis" in window) {
+      try {
+        window.speechSynthesis.cancel();
+      } catch {}
+    }
+    stopClonedSpeech();
+    const token = activeTokenRef.current;
+    if (token !== null) finishPlayback(token);
+  }, [finishPlayback, stopClonedSpeech]);
+
+  // Mount-only lifecycle (all deps are stable callbacks): re-running this
+  // effect would tear down live playback and leave the queue wedged.
   useEffect(() => {
     if (typeof window !== "undefined" && "speechSynthesis" in window) {
       const synth = window.speechSynthesis;
       const handleUserGesture = () => {
         unlockSpeech();
       };
+      const handleVoicesChanged = () => refreshPreferredVoiceRef.current();
 
       shouldGateSpeechRef.current = shouldGateSpeechUntilGesture();
       isSpeechUnlockedRef.current = !shouldGateSpeechRef.current;
-      refreshPreferredVoice();
-      synth.addEventListener("voiceschanged", refreshPreferredVoice);
+      refreshPreferredVoiceRef.current();
+      synth.addEventListener("voiceschanged", handleVoicesChanged);
       if (shouldGateSpeechRef.current) {
         window.addEventListener("pointerdown", handleUserGesture);
         window.addEventListener("touchstart", handleUserGesture);
@@ -402,8 +538,11 @@ export function useMeetTts({
       }
 
       return () => {
-        if (fallbackTimeoutRef.current) {
-          window.clearTimeout(fallbackTimeoutRef.current);
+        if (failsafeTimeoutRef.current !== null) {
+          window.clearTimeout(failsafeTimeoutRef.current);
+        }
+        if (advanceTimeoutRef.current !== null) {
+          window.clearTimeout(advanceTimeoutRef.current);
         }
         if (unlockTimeoutRef.current) {
           window.clearTimeout(unlockTimeoutRef.current);
@@ -411,26 +550,32 @@ export function useMeetTts({
         window.removeEventListener("pointerdown", handleUserGesture);
         window.removeEventListener("touchstart", handleUserGesture);
         window.removeEventListener("keydown", handleUserGesture);
-        synth.removeEventListener("voiceschanged", refreshPreferredVoice);
+        synth.removeEventListener("voiceschanged", handleVoicesChanged);
         synth.cancel();
         stopClonedSpeech();
       };
     }
 
     return () => {
-      if (fallbackTimeoutRef.current) {
-        window.clearTimeout(fallbackTimeoutRef.current);
+      if (failsafeTimeoutRef.current !== null) {
+        window.clearTimeout(failsafeTimeoutRef.current);
+      }
+      if (advanceTimeoutRef.current !== null) {
+        window.clearTimeout(advanceTimeoutRef.current);
       }
       if (unlockTimeoutRef.current) {
         window.clearTimeout(unlockTimeoutRef.current);
       }
       stopClonedSpeech();
     };
-  }, [refreshPreferredVoice, stopClonedSpeech, unlockSpeech]);
+  }, [stopClonedSpeech, unlockSpeech]);
 
   return {
     ttsSpeakerId,
+    activeTtsMessageId,
     handleTtsMessage,
+    replayTts,
+    stopTts,
     availableSystemVoices,
     selectedSystemVoiceUri,
     setSelectedSystemVoiceUri,

--- a/apps/web/src/app/lib/chat-commands.ts
+++ b/apps/web/src/app/lib/chat-commands.ts
@@ -4,6 +4,8 @@ export {
   getActionText,
   getCommandSuggestions,
   getHelpText,
+  getTtsMessageText,
   normalizeChatMessage,
   parseChatCommand,
+  TTS_MAX_TEXT_LENGTH,
 } from "@conclave/meeting-core/chat-commands";

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -75,7 +75,8 @@ import {
   getStoredVoiceAgentKey,
   storeVoiceAgentKey,
 } from "./lib/voice-agent-key";
-import type { JoinMode, PrejoinMediaHandoff } from "./lib/types";
+import type { ChatMessage, JoinMode, PrejoinMediaHandoff } from "./lib/types";
+import { getTtsMessageText } from "./lib/chat-commands";
 import {
   readStoredMeetViewSettings,
   writeStoredMeetViewSettings,
@@ -1034,7 +1035,10 @@ export default function MeetsClient({
 
   const {
     ttsSpeakerId,
+    activeTtsMessageId,
     handleTtsMessage,
+    replayTts,
+    stopTts,
     availableSystemVoices,
     selectedSystemVoiceUri,
     setSelectedSystemVoiceUri,
@@ -1047,6 +1051,19 @@ export default function MeetsClient({
     audioOutputDeviceId: selectedAudioOutputDeviceId,
   });
   const effectiveActiveSpeakerId = ttsSpeakerId ?? activeSpeakerId;
+
+  const handleReplayTtsMessage = useCallback(
+    (message: ChatMessage) => {
+      replayTts({
+        userId: message.userId,
+        displayName: message.displayName,
+        text: getTtsMessageText(message.content),
+        ttsVoiceToken: message.ttsVoiceToken,
+        messageId: message.id,
+      });
+    },
+    [replayTts],
+  );
 
   // Latest transcript snapshot for the "@Conclave" assistant. Updated from the
   // transcript hook below; read lazily so useMeetChat stays decoupled from it.
@@ -3185,6 +3202,10 @@ export default function MeetsClient({
         replyTarget={replyTarget}
         onReplyToMessage={startReply}
         onCancelReply={cancelReply}
+        activeTtsMessageId={activeTtsMessageId}
+        onReplayTtsMessage={handleReplayTtsMessage}
+        onStopTts={stopTts}
+        hasClonedTtsVoice={Boolean(clonedVoice)}
         assistantApiKeyPrompt={assistantApiKeyPrompt}
         onSubmitAssistantApiKey={submitAssistantApiKey}
         onCancelAssistantApiKey={cancelAssistantApiKeyPrompt}

--- a/apps/web/src/lib/tts-voice.ts
+++ b/apps/web/src/lib/tts-voice.ts
@@ -1,14 +1,18 @@
 import { CompactEncrypt, compactDecrypt } from "jose";
+import { TTS_MAX_TEXT_LENGTH } from "@conclave/meeting-core/chat-commands";
 
 const ELEVENLABS_API_BASE = "https://api.elevenlabs.io/v1";
 const VOICE_TOKEN_ISSUER = "conclave-web";
 const VOICE_TOKEN_AUDIENCE = "conclave-tts";
 const VOICE_TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60;
 
-export const MAX_TTS_TEXT_LENGTH = 500;
-export const MAX_VOICE_SAMPLE_BYTES = 8 * 1024 * 1024;
-export const MIN_VOICE_SAMPLE_SECONDS = 10;
-export const MAX_VOICE_SAMPLE_SECONDS = 25;
+export const MAX_TTS_TEXT_LENGTH = TTS_MAX_TEXT_LENGTH;
+export const MAX_VOICE_SAMPLE_BYTES = 12 * 1024 * 1024;
+// Instant clones want 1 to 2 minutes of clean audio (per the provider's IVC
+// guidance); more than ~3 minutes stops helping. The client records 60-120s;
+// the server bounds allow slight timer skew on either side.
+export const MIN_VOICE_SAMPLE_SECONDS = 55;
+export const MAX_VOICE_SAMPLE_SECONDS = 150;
 
 interface VoiceTokenPayload {
   voiceId: string;
@@ -130,6 +134,7 @@ export const createInstantVoiceClone = async ({
   formData.append("remove_background_noise", "false");
   formData.append("files", audio, audio.name || "conclave-voice-sample.webm");
 
+  // Instant Voice Cloning: the SDK's voices.ivc.create maps to this REST path.
   const response = await fetch(`${ELEVENLABS_API_BASE}/voices/add`, {
     method: "POST",
     headers: { "xi-api-key": requireElevenLabsApiKey() },

--- a/packages/meeting-core/src/chat-commands.ts
+++ b/packages/meeting-core/src/chat-commands.ts
@@ -135,6 +135,11 @@ export function getHelpText(): string {
   return `Commands: ${items}`;
 }
 
+/** Hard cap on spoken text, mirrored by the web TTS speech endpoint. */
+export const TTS_MAX_TEXT_LENGTH = 500;
+
+const TTS_CONTENT_PREFIX = "TTS: ";
+
 export function getTtsText(content: string): string | null {
   const match = content.match(/^\/tts\s+(.+)/i);
   if (!match) return null;
@@ -143,7 +148,14 @@ export function getTtsText(content: string): string | null {
 }
 
 export function formatTtsContent(text: string): string {
-  return `TTS: ${text}`;
+  return `${TTS_CONTENT_PREFIX}${text}`;
+}
+
+/** Spoken text of an already-normalized TTS message ("TTS: hi" → "hi"). */
+export function getTtsMessageText(content: string): string {
+  return content.startsWith(TTS_CONTENT_PREFIX)
+    ? content.slice(TTS_CONTENT_PREFIX.length)
+    : content;
 }
 
 export function getActionText(content: string): string | null {
@@ -167,7 +179,7 @@ export function normalizeChatMessage(message: ChatMessage): {
   const ttsText = getTtsText(message.content);
   if (!ttsText) return { message };
   return {
-    message: { ...message, content: formatTtsContent(ttsText) },
+    message: { ...message, content: formatTtsContent(ttsText), isTts: true },
     ttsText,
   };
 }

--- a/packages/meeting-core/src/types.ts
+++ b/packages/meeting-core/src/types.ts
@@ -50,6 +50,11 @@ export interface ChatMessage {
   dmTargetUserId?: string;
   dmTargetDisplayName?: string;
   replyTo?: ChatReplyPreview;
+  /**
+   * Set client-side by normalizeChatMessage on /tts messages so UIs can
+   * render them as spoken voice messages. Never sent over the wire.
+   */
+  isTts?: boolean;
   /** Encrypted capability for the sender's consented cloned TTS voice. */
   ttsVoiceToken?: string;
   /** Sender dismissed the link preview; clients must not render embeds. */

--- a/packages/meeting-core/test/chat-commands.test.ts
+++ b/packages/meeting-core/test/chat-commands.test.ts
@@ -7,9 +7,11 @@ import {
   getActionText,
   getCommandSuggestions,
   getHelpText,
+  getTtsMessageText,
   getTtsText,
   normalizeChatMessage,
   parseChatCommand,
+  TTS_MAX_TEXT_LENGTH,
 } from "../src/chat-commands";
 import type { ChatMessage } from "../src/types";
 
@@ -138,8 +140,24 @@ describe("formatters", () => {
     expect(formatTtsContent("hi")).toBe("TTS: hi");
   });
 
+  it("getTtsMessageText strips the TTS prefix", () => {
+    expect(getTtsMessageText("TTS: hi there")).toBe("hi there");
+  });
+
+  it("getTtsMessageText leaves other content alone", () => {
+    expect(getTtsMessageText("hi there")).toBe("hi there");
+  });
+
+  it("round-trips through formatTtsContent", () => {
+    expect(getTtsMessageText(formatTtsContent("speak up"))).toBe("speak up");
+  });
+
   it("formatActionContent prefixes /me", () => {
     expect(formatActionContent("waves")).toBe("/me waves");
+  });
+
+  it("exposes a sane spoken-text cap", () => {
+    expect(TTS_MAX_TEXT_LENGTH).toBeGreaterThan(0);
   });
 });
 
@@ -150,6 +168,7 @@ describe("normalizeChatMessage", () => {
     );
     expect(result.ttsText).toBe("hi there");
     expect(result.message.content).toBe("TTS: hi there");
+    expect(result.message.isTts).toBe(true);
     expect(result.message.ttsVoiceToken).toBe("encrypted-token");
   });
 

--- a/packages/sfu/server/socket/handlers/chatHandlers.ts
+++ b/packages/sfu/server/socket/handlers/chatHandlers.ts
@@ -56,6 +56,9 @@ const MAX_GIF_URL_LENGTH = 2048;
 const MAX_REPLY_CONTENT_LENGTH = 280;
 const MAX_REPLY_NAME_LENGTH = 120;
 const MAX_TTS_VOICE_TOKEN_LENGTH = 2048;
+// Mirrors TTS_MAX_TEXT_LENGTH in @conclave/meeting-core (the SFU stays
+// dependency-free of it) and the web /api/tts/speech endpoint.
+const MAX_TTS_TEXT_LENGTH = 500;
 const TTS_VOICE_TOKEN_PATTERN = /^[A-Za-z0-9._~-]+$/;
 const KLIPY_MEDIA_HOSTS = new Set(["static.klipy.com"]);
 const KLIPY_PAGE_HOSTS = new Set(["klipy.com", "www.klipy.com"]);
@@ -851,13 +854,20 @@ export const registerChatHandlers = (context: ConnectionContext): void => {
           messageContent = image.fileName;
         }
 
+        // Any whitespace after /tts counts (matches meeting-core's parser),
+        // so tab-separated messages cannot bypass the host toggle or cap.
         const isTtsMessage =
-          !directMessageIntent &&
-          (messageContent.toLowerCase().startsWith("/tts ") ||
-            messageContent.toLowerCase() === "/tts");
+          !directMessageIntent && /^\/tts(\s|$)/i.test(messageContent);
         if (isTtsMessage) {
           if (room.isTtsDisabled) {
             rejectMessage("TTS is disabled by the host in this room.");
+            return;
+          }
+          const spokenText = messageContent.slice("/tts".length).trim();
+          if (spokenText.length > MAX_TTS_TEXT_LENGTH) {
+            rejectMessage(
+              `TTS messages are limited to ${MAX_TTS_TEXT_LENGTH} characters.`,
+            );
             return;
           }
         }


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR expands chat TTS into a voice-message flow. The main changes are:

- Adds voice-message rendering, replay, stop, and composer limits.
- Adds queued TTS playback with generation and playback timeouts.
- Adds recording review, cloned-voice previews, and output-device routing.
- Enforces the TTS text limit in the client and SFU.
- Refines activity-dock behavior and visual status.

<h3>Confidence Score: 4/5</h3>

Shared speech-synthesis ownership can truncate live meeting messages and should be fixed before merging.

Settings previews cancel the browser-wide speech queue. Stale preview ownership can cancel a replacement meeting utterance during cleanup. A timed-out clone fallback can outlive its original failsafe.

apps/web/src/app/components/TtsVoiceSettings.tsx and apps/web/src/app/hooks/useMeetTts.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I created a narrow Next.js component harness and a Playwright script to render TtsVoiceSettings, useMeetTts, enqueue two meeting utterances, activate preview, and record SpeechSynthesis events.
- I attempted to start the harness runtime to capture a video, poster, and trace, but the run was blocked by a stale Next.js process and a port conflict.
- I began reconfiguring the harness; the first server run failed due to unresolved repository component imports, I corrected the imports, but the server and Playwright flow could not be rerun within the execution budget.
- I captured startup logs from pre-change and post-change runs to diagnose environment differences, using voice-settings-access-01-before.log and voice-settings-access-02-after.log.
- I documented that runtime cancellation could not be captured within the current execution budget, so a formal reproduction could not be claimed from static inspection alone.

<a href="https://app.greptile.com/trex/runs/14134592/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/components/TtsVoiceSettings.tsx | Adds recording review and voice previews, but preview ownership can interrupt meeting speech. |
| apps/web/src/app/hooks/useMeetTts.ts | Adds queueing, replay, stop, highlighting, and failsafes; the clone-timeout fallback can retain the earlier timer. |
| apps/web/src/app/components/ChatPanel.tsx | Adds voice-message presentation, playback controls, and TTS composer feedback. |
| packages/meeting-core/src/chat-commands.ts | Adds shared TTS limits, message normalization, and display-text extraction. |
| packages/sfu/server/socket/handlers/chatHandlers.ts | Adds server-side TTS command recognition and spoken-text length enforcement. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Meeting as Meeting TTS
participant Synth as speechSynthesis
participant Settings as Voice settings
Meeting->>Synth: Speak meeting message
Settings->>Synth: cancel()
Settings->>Synth: Speak preview
Note over Meeting,Synth: Meeting message is truncated
Meeting->>Synth: Preempt preview and speak next message
Settings->>Synth: cancel() during cleanup
Note over Meeting,Synth: Stale ownership can truncate the replacement
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Meeting as Meeting TTS
participant Synth as speechSynthesis
participant Settings as Voice settings
Meeting->>Synth: Speak meeting message
Settings->>Synth: cancel()
Settings->>Synth: Speak preview
Note over Meeting,Synth: Meeting message is truncated
Meeting->>Synth: Preempt preview and speak next message
Settings->>Synth: cancel() during cleanup
Note over Meeting,Synth: Stale ownership can truncate the replacement
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FTtsVoiceSettings.tsx%3A596%0A**Preview%20Cancels%20Meeting%20Speech**%0A%0AWhen%20a%20system-voice%20%60%2Ftts%60%20message%20is%20playing%2C%20starting%20this%20preview%20calls%20the%20browser-wide%20%60speechSynthesis.cancel%28%29%60.%20That%20truncates%20the%20meeting%20message%20and%20advances%20its%20queue%20as%20though%20playback%20finished.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FTtsVoiceSettings.tsx%3A670-675%0A**Stale%20Preview%20Ownership%20Cancels%20Speech**%0A%0AIf%20meeting%20TTS%20preempts%20the%20settings%20preview%20without%20firing%20its%20completion%20callbacks%2C%20%60ownsSystemPreviewRef%60%20remains%20true.%20Closing%20settings%20then%20cancels%20the%20meeting%20utterance%20that%20replaced%20the%20preview%2C%20truncating%20that%20message.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetTts.ts%3A424%0A**Fallback%20Reuses%20Generation%20Failsafe**%0A%0AWhen%20cloned%20generation%20reaches%20its%2015-second%20timeout%2C%20system%20speech%20starts%20with%20the%20same%20token%20while%20this%20original%20failsafe%20remains%20armed.%20If%20the%20fallback%20takes%20longer%20than%20the%20estimate%2C%20the%20failsafe%20clears%20its%20active%20state%20and%20the%20next%20queued%20message%20cancels%20it%2C%20so%20listeners%20hear%20a%20truncated%20message.%0A%0A&repo=acm-vit%2Fconclave&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FTtsVoiceSettings.tsx%3A596%0A**Preview%20Cancels%20Meeting%20Speech**%0A%0AWhen%20a%20system-voice%20%60%2Ftts%60%20message%20is%20playing%2C%20starting%20this%20preview%20calls%20the%20browser-wide%20%60speechSynthesis.cancel%28%29%60.%20That%20truncates%20the%20meeting%20message%20and%20advances%20its%20queue%20as%20though%20playback%20finished.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FTtsVoiceSettings.tsx%3A670-675%0A**Stale%20Preview%20Ownership%20Cancels%20Speech**%0A%0AIf%20meeting%20TTS%20preempts%20the%20settings%20preview%20without%20firing%20its%20completion%20callbacks%2C%20%60ownsSystemPreviewRef%60%20remains%20true.%20Closing%20settings%20then%20cancels%20the%20meeting%20utterance%20that%20replaced%20the%20preview%2C%20truncating%20that%20message.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetTts.ts%3A424%0A**Fallback%20Reuses%20Generation%20Failsafe**%0A%0AWhen%20cloned%20generation%20reaches%20its%2015-second%20timeout%2C%20system%20speech%20starts%20with%20the%20same%20token%20while%20this%20original%20failsafe%20remains%20armed.%20If%20the%20fallback%20takes%20longer%20than%20the%20estimate%2C%20the%20failsafe%20clears%20its%20active%20state%20and%20the%20next%20queued%20message%20cancels%20it%2C%20so%20listeners%20hear%20a%20truncated%20message.%0A%0A&repo=acm-vit%2Fconclave&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FTtsVoiceSettings.tsx%3A596%0A**Preview%20Cancels%20Meeting%20Speech**%0A%0AWhen%20a%20system-voice%20%60%2Ftts%60%20message%20is%20playing%2C%20starting%20this%20preview%20calls%20the%20browser-wide%20%60speechSynthesis.cancel%28%29%60.%20That%20truncates%20the%20meeting%20message%20and%20advances%20its%20queue%20as%20though%20playback%20finished.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fcomponents%2FTtsVoiceSettings.tsx%3A670-675%0A**Stale%20Preview%20Ownership%20Cancels%20Speech**%0A%0AIf%20meeting%20TTS%20preempts%20the%20settings%20preview%20without%20firing%20its%20completion%20callbacks%2C%20%60ownsSystemPreviewRef%60%20remains%20true.%20Closing%20settings%20then%20cancels%20the%20meeting%20utterance%20that%20replaced%20the%20preview%2C%20truncating%20that%20message.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fapp%2Fhooks%2FuseMeetTts.ts%3A424%0A**Fallback%20Reuses%20Generation%20Failsafe**%0A%0AWhen%20cloned%20generation%20reaches%20its%2015-second%20timeout%2C%20system%20speech%20starts%20with%20the%20same%20token%20while%20this%20original%20failsafe%20remains%20armed.%20If%20the%20fallback%20takes%20longer%20than%20the%20estimate%2C%20the%20failsafe%20clears%20its%20active%20state%20and%20the%20next%20queued%20message%20cancels%20it%2C%20so%20listeners%20hear%20a%20truncated%20message.%0A%0A&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["add"](https://github.com/acm-vit/conclave/commit/2f7fe2837d03a61bd91182fc297bf3b44738c66b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43599791)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->