### PR TITLE
Whiteboard: laser dot/trail fix, object snapping, letter hotkeys, per-user close

### DIFF
--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -557,6 +557,8 @@ export default function MeetsMainContent({
     closeApp,
     setLocked,
     refreshState,
+    isHiddenForMe,
+    showForMe,
   } = useApps();
   const { isActive: isGameActive, refresh: refreshGameState } = useGame();
   const [isGamesOpen, setIsGamesOpen] = useState(false);
@@ -1699,6 +1701,8 @@ export default function MeetsMainContent({
     isWhiteboardActive,
     onOpenWhiteboard: isAdmin ? openWhiteboard : undefined,
     onCloseWhiteboard: isAdmin ? closeWhiteboard : undefined,
+    isWhiteboardHiddenForMe: isHiddenForMe,
+    onShowWhiteboardForMe: showForMe,
     isWatchActive,
     onOpenWatch: isAdmin ? openWatch : undefined,
     onCloseWatch: isAdmin ? closeWatch : undefined,
@@ -2119,7 +2123,8 @@ export default function MeetsMainContent({
           )}
         </div>
       ) : ActiveMeetingApp &&
-        (!isDevPlaygroundActive || isDevPlaygroundEnabled) ? (
+        (!isDevPlaygroundActive || isDevPlaygroundEnabled) &&
+        !isHiddenForMe ? (
         <MeetingAppLayout
           app={ActiveMeetingApp}
           frameContent={!isDevPlaygroundActive}

--- a/apps/web/src/app/components/apps/AppsPanel.tsx
+++ b/apps/web/src/app/components/apps/AppsPanel.tsx
@@ -34,8 +34,17 @@ export function AppsPanel({
   maxDockWidth?: number;
   onDockWidthChange?: (width: number) => void;
 }) {
-  const { apps, state, openApp, closeApp, setLocked, isAdmin, isReadOnly } =
-    useApps();
+  const {
+    apps,
+    state,
+    openApp,
+    closeApp,
+    setLocked,
+    isAdmin,
+    isReadOnly,
+    isHiddenForMe,
+    showForMe,
+  } = useApps();
   const [busyAppId, setBusyAppId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -51,8 +60,14 @@ export function AppsPanel({
   };
 
   const handlePick = (appId: string) => {
-    if (!canManage || busyAppId) return;
+    if (busyAppId) return;
     const isActive = state.activeAppId === appId;
+    // Anyone can bring back an app they hid just for themselves, admin or not.
+    if (isActive && isHiddenForMe) {
+      showForMe();
+      return;
+    }
+    if (!canManage) return;
     void run(appId, () => (isActive ? closeApp() : openApp(appId)));
   };
 
@@ -84,8 +99,9 @@ export function AppsPanel({
 
           {apps.map((app) => {
             const isActive = state.activeAppId === app.id;
+            const isHiddenHere = isActive && isHiddenForMe;
             const isBusy = busyAppId === app.id;
-            const interactive = canManage && !busyAppId;
+            const interactive = (canManage || isHiddenHere) && !busyAppId;
             return (
               <button
                 key={app.id}
@@ -93,7 +109,11 @@ export function AppsPanel({
                 disabled={!interactive}
                 onClick={() => handlePick(app.id)}
                 aria-label={
-                  isActive ? `Close ${app.name}` : `Open ${app.name}`
+                  isHiddenHere
+                    ? `Show ${app.name} (still open for others)`
+                    : isActive
+                      ? `Close ${app.name}`
+                      : `Open ${app.name}`
                 }
                 className="group relative flex w-full items-center gap-3 overflow-hidden rounded-xl border p-3 text-left transition-colors disabled:cursor-default"
                 style={{
@@ -117,10 +137,16 @@ export function AppsPanel({
                   <span className="text-[14.5px] font-medium text-[#fafafa]">
                     {app.name}
                   </span>
-                  {app.description && (
-                    <span className="truncate text-[12px] text-[#a1a1aa]">
-                      {app.description}
+                  {isHiddenHere ? (
+                    <span className="truncate text-[12px]" style={{ color: color.accent }}>
+                      In use by others — tap to rejoin
                     </span>
+                  ) : (
+                    app.description && (
+                      <span className="truncate text-[12px] text-[#a1a1aa]">
+                        {app.description}
+                      </span>
+                    )
                   )}
                 </span>
                 <span className="flex shrink-0 items-center gap-2">
@@ -131,6 +157,13 @@ export function AppsPanel({
                       className="animate-spin text-[#a1a1aa]"
                       aria-hidden="true"
                     />
+                  ) : isHiddenHere ? (
+                    <span
+                      className="text-[11.5px] font-medium"
+                      style={{ color: color.accent }}
+                    >
+                      Rejoin
+                    </span>
                   ) : isActive ? (
                     // The accent border + icon already say "this one is on";
                     // a quiet dot marks it without LIVE-badge chrome.

--- a/apps/web/src/app/components/controls-config.ts
+++ b/apps/web/src/app/components/controls-config.ts
@@ -1,6 +1,7 @@
 import {
   AudioLines,
   Blocks,
+  Eye,
   Gamepad2,
   FileText,
   Globe,
@@ -120,6 +121,8 @@ export interface ControlsBarProps {
   isWhiteboardActive?: boolean;
   onOpenWhiteboard?: () => void;
   onCloseWhiteboard?: () => void;
+  isWhiteboardHiddenForMe?: boolean;
+  onShowWhiteboardForMe?: () => void;
   isWatchActive?: boolean;
   onOpenWatch?: () => void;
   onCloseWatch?: () => void;
@@ -205,6 +208,9 @@ export const BROWSER_APPS: { id: string; name: string; description: string; url:
 
 function canManageWhiteboard(p: ControlsBarProps): boolean {
   return Boolean(p.isAdmin && (p.onOpenWhiteboard || p.onCloseWhiteboard));
+}
+function canShowWhiteboardForMe(p: ControlsBarProps): boolean {
+  return Boolean(p.isWhiteboardActive && p.isWhiteboardHiddenForMe && p.onShowWhiteboardForMe);
 }
 function canManageWatch(p: ControlsBarProps): boolean {
   return Boolean(p.isAdmin && (p.onOpenWatch || p.onCloseWatch));
@@ -462,6 +468,15 @@ export function buildControlsConfig(p: ControlsBarProps): ControlsConfig {
       active: p.isWhiteboardActive,
       paletteOnly: appsPanelOwnsApps,
       onPress: () => (p.isWhiteboardActive ? p.onCloseWhiteboard?.() : p.onOpenWhiteboard?.()),
+    });
+  }
+  if (canShowWhiteboardForMe(p)) {
+    overflow.push({
+      id: "whiteboard-show-for-me",
+      icon: Eye,
+      label: "Show whiteboard",
+      paletteOnly: appsPanelOwnsApps,
+      onPress: () => p.onShowWhiteboardForMe?.(),
     });
   }
   if (canManageWatch(p)) {

--- a/packages/apps-sdk/src/apps/whiteboard/core/tools/engine.ts
+++ b/packages/apps-sdk/src/apps/whiteboard/core/tools/engine.ts
@@ -1,6 +1,7 @@
 import type { Point, WhiteboardElement } from "../model/types";
 import { createId, addElement, updateElement, removeElement, getPageElements } from "../doc/index";
-import { hitTestElement, translateElement } from "../model/geometry";
+import { getBoundsForElement, hitTestElement, translateElement } from "../model/geometry";
+import { computeSnapAdjustment, type SnapGuide } from "./snapping";
 import type * as Y from "yjs";
 
 export type ToolKind =
@@ -64,6 +65,8 @@ export class ToolEngine {
   private dragStart: Point | null = null;
   private lastPoint: Point | null = null;
   private selectedId: string | null = null;
+  private snapThresholdCanvasUnits = 0;
+  private snapGuides: SnapGuide[] = [];
 
   constructor(doc: Y.Doc, pageId: string, tool: ToolKind, settings: ToolSettings) {
     this.doc = doc;
@@ -77,6 +80,7 @@ export class ToolEngine {
       this.activeElementId = null;
       this.dragStart = null;
       this.lastPoint = null;
+      this.snapGuides = [];
       if (tool !== "select" && tool !== "pan") {
         this.selectedId = null;
       }
@@ -88,11 +92,20 @@ export class ToolEngine {
     this.settings = settings;
   }
 
+  setSnapThreshold(canvasUnits: number) {
+    this.snapThresholdCanvasUnits = canvasUnits;
+  }
+
+  getSnapGuides(): SnapGuide[] {
+    return this.snapGuides;
+  }
+
   setPage(pageId: string) {
     this.pageId = pageId;
     this.activeElementId = null;
     this.dragStart = null;
     this.lastPoint = null;
+    this.snapGuides = [];
   }
 
   getSelectedId() {
@@ -268,8 +281,20 @@ export class ToolEngine {
       const dx = point.x - this.lastPoint.x;
       const dy = point.y - this.lastPoint.y;
       if (dx === 0 && dy === 0) return;
-      const next = translateElement(element, dx, dy);
+      const prospective = translateElement(element, dx, dy);
+      const otherBounds = elements
+        .filter((item) => item.id !== element.id)
+        .map(getBoundsForElement);
+      const adjustment = computeSnapAdjustment(
+        getBoundsForElement(prospective),
+        otherBounds,
+        this.snapThresholdCanvasUnits
+      );
+      this.snapGuides = adjustment.guides;
+      const next = translateElement(element, dx + adjustment.dx, dy + adjustment.dy);
       updateElement(this.doc, this.pageId, next);
+      // Keep lastPoint raw (unsnapped) so small moves within the snap radius
+      // don't accumulate drift between the cursor and the element.
       this.lastPoint = point;
       return;
     }
@@ -301,6 +326,7 @@ export class ToolEngine {
     this.dragStart = null;
     this.lastPoint = null;
     this.activeElementId = null;
+    this.snapGuides = [];
   }
 
   private eraseAtPoint(point: Point) {

--- a/packages/apps-sdk/src/apps/whiteboard/core/tools/snapping.ts
+++ b/packages/apps-sdk/src/apps/whiteboard/core/tools/snapping.ts
@@ -1,0 +1,94 @@
+import type { Bounds } from "../model/geometry";
+
+export type SnapEdge = "start" | "center" | "end";
+export type SnapGuide = { axis: "x" | "y"; position: number; spanStart: number; spanEnd: number };
+export type SnapAdjustment = { dx: number; dy: number; guides: SnapGuide[] };
+
+const ALL_EDGES: SnapEdge[] = ["start", "center", "end"];
+
+const edgeValue = (bounds: Bounds, axis: "x" | "y", edge: SnapEdge): number => {
+  const start = axis === "x" ? bounds.x : bounds.y;
+  const size = axis === "x" ? bounds.width : bounds.height;
+  if (edge === "start") return start;
+  if (edge === "end") return start + size;
+  return start + size / 2;
+};
+
+type AxisSnap = { offset: number; guide: SnapGuide };
+
+const computeAxisSnap = (
+  movingBounds: Bounds,
+  otherBounds: Bounds[],
+  axis: "x" | "y",
+  edges: SnapEdge[],
+  threshold: number
+): AxisSnap | null => {
+  let best: { offset: number; distance: number; position: number; other: Bounds } | null = null;
+
+  for (const edge of edges) {
+    const value = edgeValue(movingBounds, axis, edge);
+    for (const other of otherBounds) {
+      for (const otherEdge of ALL_EDGES) {
+        const target = edgeValue(other, axis, otherEdge);
+        const distance = Math.abs(value - target);
+        if (distance <= threshold && (!best || distance < best.distance)) {
+          best = { offset: target - value, distance, position: target, other };
+        }
+      }
+    }
+  }
+
+  if (!best) return null;
+
+  const crossAxis = axis === "x" ? "y" : "x";
+  const movingStart = crossAxis === "x" ? movingBounds.x : movingBounds.y;
+  const movingSize = crossAxis === "x" ? movingBounds.width : movingBounds.height;
+  const otherStart = crossAxis === "x" ? best.other.x : best.other.y;
+  const otherSize = crossAxis === "x" ? best.other.width : best.other.height;
+
+  return {
+    offset: best.offset,
+    guide: {
+      axis,
+      position: best.position,
+      spanStart: Math.min(movingStart, otherStart),
+      spanEnd: Math.max(movingStart + movingSize, otherStart + otherSize),
+    },
+  };
+};
+
+/**
+ * Compares movingBounds' edges/centers against every bounds in otherBounds on
+ * each axis independently, and returns the delta needed to align to the
+ * closest match within threshold (0 if nothing is close enough to snap).
+ */
+export function computeSnapAdjustment(
+  movingBounds: Bounds,
+  otherBounds: Bounds[],
+  thresholdCanvasUnits: number,
+  options?: { xEdges?: SnapEdge[]; yEdges?: SnapEdge[] }
+): SnapAdjustment {
+  if (thresholdCanvasUnits <= 0 || otherBounds.length === 0) {
+    return { dx: 0, dy: 0, guides: [] };
+  }
+
+  const xEdges = options?.xEdges ?? ALL_EDGES;
+  const yEdges = options?.yEdges ?? ALL_EDGES;
+  const guides: SnapGuide[] = [];
+  let dx = 0;
+  let dy = 0;
+
+  const xSnap = computeAxisSnap(movingBounds, otherBounds, "x", xEdges, thresholdCanvasUnits);
+  if (xSnap) {
+    dx = xSnap.offset;
+    guides.push(xSnap.guide);
+  }
+
+  const ySnap = computeAxisSnap(movingBounds, otherBounds, "y", yEdges, thresholdCanvasUnits);
+  if (ySnap) {
+    dy = ySnap.offset;
+    guides.push(ySnap.guide);
+  }
+
+  return { dx, dy, guides };
+}

--- a/packages/apps-sdk/src/apps/whiteboard/web/components/WhiteboardCanvas.tsx
+++ b/packages/apps-sdk/src/apps/whiteboard/web/components/WhiteboardCanvas.tsx
@@ -12,6 +12,7 @@ import { buildRenderList } from "../../core/exports/renderList";
 import type { ToolKind, ToolSettings } from "../../core/tools/engine";
 import { ToolEngine } from "../../core/tools/engine";
 import { getPageElements, removeElement, updateElement } from "../../core/doc/index";
+import { computeSnapAdjustment, type SnapEdge, type SnapGuide } from "../../core/tools/snapping";
 import { useWhiteboardElements } from "../../shared/hooks/useWhiteboardElements";
 import { renderCanvas } from "../renderer/renderCanvas";
 import type { AppUser } from "../../../../sdk/types/index";
@@ -69,29 +70,70 @@ const ROTATE_HANDLE_HIT_RADIUS = 10;
 const ROTATION_EPSILON = 0.0001;
 const SELECTION_COLOR = "#F95F4A";
 const ERASER_HIT_RADIUS = 12;
+const SNAP_THRESHOLD_SCREEN_PX = 8;
+const SNAP_GUIDE_COLOR = "#F95F4A";
 
 // Laser trails live in awareness only and fade out after this long. Points travel
 // as [x, y, ageMs] relative to send time so receiver clocks never need to agree.
-const LASER_TTL_MS = 1000;
+const LASER_TTL_MS = 1400;
 const LASER_MAX_POINTS = 48;
 const LASER_GAP_RESET_MS = 300;
+// The tip dot tracks the live cursor independently of the trail, so hovering
+// (no hold) shows just a dot and releasing lets the trail fade out on its own
+// instead of snapping away. It goes stale shortly after motion stops.
+const LASER_DOT_TTL_MS = 500;
+// Points are drawn in a handful of smoothed, independently-faded bands rather
+// than one segment per point pair — far fewer strokes, no beaded-dot look.
+const LASER_TRAIL_BANDS = 6;
 
 type LaserPoint = { x: number; y: number; t: number };
-type LaserTrail = { points: LaserPoint[]; color: string };
+type LaserTrail = { points: LaserPoint[]; dot: LaserPoint | null; color: string };
+type ParsedLaser = { points: LaserPoint[]; dot: LaserPoint | null };
 
-const parseLaserField = (value: unknown, receivedAt: number): LaserPoint[] | null => {
-  const record = value as { pts?: unknown } | null;
-  if (!record || !Array.isArray(record.pts)) return null;
+const parseLaserPoint = (entry: unknown, receivedAt: number): LaserPoint | null => {
+  if (!Array.isArray(entry) || entry.length < 3) return null;
+  const [x, y, age] = entry as readonly unknown[];
+  if (typeof x !== "number" || typeof y !== "number" || typeof age !== "number") return null;
+  return { x, y, t: receivedAt - age };
+};
+
+const parseLaserField = (value: unknown, receivedAt: number): ParsedLaser | null => {
+  const record = value as { pts?: unknown; dot?: unknown } | null;
+  if (!record) return null;
+
   const points: LaserPoint[] = [];
-  const rawPoints: readonly unknown[] = record.pts;
-  for (const entry of rawPoints) {
-    if (!Array.isArray(entry) || entry.length < 3) continue;
-    const tuple: readonly unknown[] = entry;
-    const [x, y, age] = tuple;
-    if (typeof x !== "number" || typeof y !== "number" || typeof age !== "number") continue;
-    points.push({ x, y, t: receivedAt - age });
+  if (Array.isArray(record.pts)) {
+    for (const entry of record.pts as readonly unknown[]) {
+      const point = parseLaserPoint(entry, receivedAt);
+      if (point) points.push(point);
+    }
   }
-  return points.length > 0 ? points : null;
+
+  const dot = parseLaserPoint(record.dot, receivedAt);
+
+  if (points.length === 0 && !dot) return null;
+  return { points, dot };
+};
+
+/** Smooth multi-point path via quadratic curves through segment midpoints. */
+const strokeSmoothPath = (ctx: CanvasRenderingContext2D, points: LaserPoint[]) => {
+  if (points.length < 2) return;
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, points[0].y);
+  if (points.length === 2) {
+    ctx.lineTo(points[1].x, points[1].y);
+  } else {
+    for (let i = 1; i < points.length - 1; i += 1) {
+      const current = points[i];
+      const next = points[i + 1];
+      const midX = (current.x + next.x) / 2;
+      const midY = (current.y + next.y) / 2;
+      ctx.quadraticCurveTo(current.x, current.y, midX, midY);
+    }
+    const last = points[points.length - 1];
+    ctx.lineTo(last.x, last.y);
+  }
+  ctx.stroke();
 };
 
 const measureTextBounds = (text: string, fontSize: number) => {
@@ -233,6 +275,13 @@ const getRotateHandlePoint = (bounds: Bounds) => ({
 const isPointOnRotateHandle = (bounds: Bounds, point: { x: number; y: number }) => {
   const handle = getRotateHandlePoint(bounds);
   return Math.hypot(point.x - handle.x, point.y - handle.y) <= ROTATE_HANDLE_HIT_RADIUS;
+};
+
+const RESIZE_HANDLE_EDGES: Record<ResizeHandle, { x: SnapEdge; y: SnapEdge }> = {
+  nw: { x: "start", y: "start" },
+  ne: { x: "end", y: "start" },
+  sw: { x: "start", y: "end" },
+  se: { x: "end", y: "end" },
 };
 
 const getResizeHandleAtPoint = (
@@ -428,9 +477,55 @@ export function WhiteboardCanvas({
   const laserSyncRafRef = useRef<number | null>(null);
   const eraserRingRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef(viewport);
+  const snapOverlayRef = useRef<HTMLCanvasElement>(null);
+  const snapGuidesRef = useRef<SnapGuide[]>([]);
+
+  const paintSnapGuides = useCallback(() => {
+    const overlay = snapOverlayRef.current;
+    const container = containerRef.current;
+    if (!overlay || !container) return;
+
+    const rect = container.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    const pixelWidth = Math.max(1, Math.round(rect.width * dpr));
+    const pixelHeight = Math.max(1, Math.round(rect.height * dpr));
+    if (overlay.width !== pixelWidth || overlay.height !== pixelHeight) {
+      overlay.width = pixelWidth;
+      overlay.height = pixelHeight;
+      overlay.style.width = `${rect.width}px`;
+      overlay.style.height = `${rect.height}px`;
+    }
+    const ctx = overlay.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, overlay.width, overlay.height);
+
+    const guides = snapGuidesRef.current;
+    if (guides.length === 0) return;
+
+    const vp = viewportRef.current;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.translate(vp.translateX, vp.translateY);
+    ctx.scale(vp.scale, vp.scale);
+    ctx.strokeStyle = SNAP_GUIDE_COLOR;
+    ctx.lineWidth = 1 / vp.scale;
+
+    for (const guide of guides) {
+      ctx.beginPath();
+      if (guide.axis === "x") {
+        ctx.moveTo(guide.position, guide.spanStart);
+        ctx.lineTo(guide.position, guide.spanEnd);
+      } else {
+        ctx.moveTo(guide.spanStart, guide.position);
+        ctx.lineTo(guide.spanEnd, guide.position);
+      }
+      ctx.stroke();
+    }
+  }, []);
 
   useEffect(() => {
     viewportRef.current = viewport;
+    engineRef.current?.setSnapThreshold(SNAP_THRESHOLD_SCREEN_PX / viewport.scale);
   }, [viewport]);
 
   const paintLaserFrame = useCallback(() => {
@@ -443,7 +538,10 @@ export function WhiteboardCanvas({
     const trails = laserTrailsRef.current;
     for (const [key, trail] of trails) {
       trail.points = trail.points.filter((point) => now - point.t < LASER_TTL_MS);
-      if (trail.points.length === 0) {
+      if (trail.dot && now - trail.dot.t >= LASER_DOT_TTL_MS) {
+        trail.dot = null;
+      }
+      if (trail.points.length === 0 && !trail.dot) {
         trails.delete(key);
         if (key === "self") {
           awareness.setLocalStateField("laser", null);
@@ -476,29 +574,29 @@ export function WhiteboardCanvas({
 
     for (const trail of trails.values()) {
       const points = trail.points;
-      for (let i = 1; i < points.length; i += 1) {
-        const from = points[i - 1];
-        const to = points[i];
-        const life = 1 - (now - to.t) / LASER_TTL_MS;
-        if (life <= 0) continue;
-        ctx.strokeStyle = trail.color;
-        ctx.globalAlpha = Math.min(0.9, life);
-        ctx.lineWidth = (1 + 2.6 * life) / vp.scale;
-        ctx.beginPath();
-        ctx.moveTo(from.x, from.y);
-        ctx.lineTo(to.x, to.y);
-        ctx.stroke();
-      }
-      const head = points[points.length - 1];
-      if (head) {
-        const life = 1 - (now - head.t) / LASER_TTL_MS;
-        if (life > 0) {
-          ctx.globalAlpha = Math.min(1, life + 0.1);
-          ctx.fillStyle = trail.color;
-          ctx.beginPath();
-          ctx.arc(head.x, head.y, 3.4 / vp.scale, 0, Math.PI * 2);
-          ctx.fill();
+      const n = points.length;
+      if (n >= 2) {
+        const bandCount = Math.min(LASER_TRAIL_BANDS, n - 1);
+        for (let band = 0; band < bandCount; band += 1) {
+          const startIdx = Math.floor((band * (n - 1)) / bandCount);
+          const endIdx = Math.floor(((band + 1) * (n - 1)) / bandCount);
+          const segment = points.slice(startIdx, endIdx + 1);
+          if (segment.length < 2) continue;
+          const newest = segment[segment.length - 1];
+          const life = 1 - (now - newest.t) / LASER_TTL_MS;
+          if (life <= 0) continue;
+          ctx.strokeStyle = trail.color;
+          ctx.globalAlpha = Math.min(0.9, life);
+          ctx.lineWidth = (1 + 2.6 * life) / vp.scale;
+          strokeSmoothPath(ctx, segment);
         }
+      }
+      if (trail.dot) {
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = trail.color;
+        ctx.beginPath();
+        ctx.arc(trail.dot.x, trail.dot.y, 3.4 / vp.scale, 0, Math.PI * 2);
+        ctx.fill();
       }
     }
     ctx.globalAlpha = 1;
@@ -518,36 +616,45 @@ export function WhiteboardCanvas({
     laserSyncRafRef.current = requestAnimationFrame(() => {
       laserSyncRafRef.current = null;
       const trail = laserTrailsRef.current.get("self");
-      if (!trail || trail.points.length === 0) return;
+      if (!trail || (trail.points.length === 0 && !trail.dot)) return;
       const now = Date.now();
       awareness.setLocalStateField("laser", {
         pts: trail.points.map((point) => [point.x, point.y, now - point.t]),
+        dot: trail.dot ? [trail.dot.x, trail.dot.y, now - trail.dot.t] : null,
       });
     });
   }, [awareness]);
 
   const appendOwnLaserPoint = useCallback(
-    (point: { x: number; y: number }) => {
+    (point: { x: number; y: number }, held: boolean) => {
       const now = Date.now();
       const trails = laserTrailsRef.current;
-      let trail = trails.get("self");
       const color = getColorForUser(user?.id ?? "guest");
-      // A pause breaks the trail instead of drawing a catch-up streak
-      if (trail && trail.points.length > 0) {
-        const last = trail.points[trail.points.length - 1];
-        if (now - last.t > LASER_GAP_RESET_MS) {
-          trail.points = [];
-        }
-      }
+
+      let trail = trails.get("self");
       if (!trail) {
-        trail = { points: [], color };
+        trail = { points: [], dot: null, color };
         trails.set("self", trail);
       }
       trail.color = color;
-      trail.points.push({ x: point.x, y: point.y, t: now });
-      if (trail.points.length > LASER_MAX_POINTS) {
-        trail.points.splice(0, trail.points.length - LASER_MAX_POINTS);
+      // The dot always tracks the live cursor; releasing the button just
+      // stops growing the trail behind it, letting it fade out on its own.
+      trail.dot = { x: point.x, y: point.y, t: now };
+
+      if (held) {
+        // A pause breaks the trail instead of drawing a catch-up streak
+        if (trail.points.length > 0) {
+          const last = trail.points[trail.points.length - 1];
+          if (now - last.t > LASER_GAP_RESET_MS) {
+            trail.points = [];
+          }
+        }
+        trail.points.push({ x: point.x, y: point.y, t: now });
+        if (trail.points.length > LASER_MAX_POINTS) {
+          trail.points.splice(0, trail.points.length - LASER_MAX_POINTS);
+        }
       }
+
       syncOwnLaser();
       kickLaserLoop();
     },
@@ -562,10 +669,11 @@ export function WhiteboardCanvas({
       awareness.getStates().forEach((state, clientId) => {
         if (clientId === awareness.clientID) return;
         const record = state as { laser?: unknown; user?: { color?: string } } | null;
-        const points = parseLaserField(record?.laser, receivedAt);
-        if (!points) return;
+        const parsed = parseLaserField(record?.laser, receivedAt);
+        if (!parsed) return;
         laserTrailsRef.current.set(clientId, {
-          points,
+          points: parsed.points,
+          dot: parsed.dot,
           color: record?.user?.color ?? "#a1a1aa",
         });
         changed = true;
@@ -640,6 +748,7 @@ export function WhiteboardCanvas({
   useEffect(() => {
     if (!engineRef.current) {
       engineRef.current = new ToolEngine(doc, pageId, tool, settings);
+      engineRef.current.setSnapThreshold(SNAP_THRESHOLD_SCREEN_PX / viewportRef.current.scale);
     }
     engineRef.current.setPage(pageId);
     engineRef.current.setTool(tool);
@@ -892,7 +1001,11 @@ export function WhiteboardCanvas({
     moveRafRef.current = null;
     if (!point || locked) return;
     engineRef.current?.onPointerMove(point);
-  }, [locked]);
+    if (tool === "select") {
+      snapGuidesRef.current = engineRef.current?.getSnapGuides() ?? [];
+      paintSnapGuides();
+    }
+  }, [locked, tool, paintSnapGuides]);
 
   const queuePointerMove = useCallback(
     (point: { x: number; y: number; pressure?: number }) => {
@@ -1076,7 +1189,7 @@ export function WhiteboardCanvas({
       const canvasPoint = toCanvasPoint(event.clientX, event.clientY, rect);
       const point = { x: canvasPoint.x, y: canvasPoint.y, pressure: event.pressure };
       if (tool === "laser") {
-        appendOwnLaserPoint(point);
+        appendOwnLaserPoint(point, true);
         scheduleCursorSync(point.x, point.y);
         return;
       }
@@ -1168,8 +1281,8 @@ export function WhiteboardCanvas({
         return;
       }
       if (tool === "laser") {
-        // No click needed: pointing is the whole gesture
-        appendOwnLaserPoint(point);
+        // Hovering shows a dot; holding the button paints a trail
+        appendOwnLaserPoint(point, Boolean(event.buttons));
         scheduleCursorSync(point.x, point.y);
         return;
       }
@@ -1202,13 +1315,34 @@ export function WhiteboardCanvas({
         if (resizeSession) {
           event.preventDefault();
           const { minWidth, minHeight } = getResizeMinimums(resizeSession.startElement);
-          const nextBounds = getResizedBounds(
+          let nextBounds = getResizedBounds(
             resizeSession.startBounds,
             resizeSession.handle,
             point,
             minWidth,
             minHeight
           );
+          const activeEdges = RESIZE_HANDLE_EDGES[resizeSession.handle];
+          const otherBounds = getPageElements(doc, pageId)
+            .filter((item) => item.id !== resizeSession.elementId)
+            .map(getBoundsForElement);
+          const snap = computeSnapAdjustment(
+            nextBounds,
+            otherBounds,
+            SNAP_THRESHOLD_SCREEN_PX / viewport.scale,
+            { xEdges: [activeEdges.x], yEdges: [activeEdges.y] }
+          );
+          if (snap.dx !== 0 || snap.dy !== 0) {
+            nextBounds = getResizedBounds(
+              resizeSession.startBounds,
+              resizeSession.handle,
+              { x: point.x + snap.dx, y: point.y + snap.dy },
+              minWidth,
+              minHeight
+            );
+          }
+          snapGuidesRef.current = snap.guides;
+          paintSnapGuides();
           const nextElement = applyResizedBounds(
             resizeSession.startElement,
             resizeSession.startBounds,
@@ -1230,10 +1364,12 @@ export function WhiteboardCanvas({
       moveEraserRing,
       onPanMove,
       pageId,
+      paintSnapGuides,
       queuePointerMove,
       scheduleCursorSync,
       toCanvasPoint,
       tool,
+      viewport,
     ]
   );
 
@@ -1247,6 +1383,9 @@ export function WhiteboardCanvas({
       return;
     }
     if (tool === "laser") {
+      const rect = event.currentTarget.getBoundingClientRect();
+      const canvasPoint = toCanvasPoint(event.clientX, event.clientY, rect);
+      appendOwnLaserPoint(canvasPoint, false);
       return;
     }
     const rotateSession = rotateSessionRef.current;
@@ -1260,6 +1399,8 @@ export function WhiteboardCanvas({
     if (resizeSession) {
       resizeSessionRef.current = null;
       setSelectedId(resizeSession.elementId);
+      snapGuidesRef.current = [];
+      paintSnapGuides();
       clearCursor();
       return;
     }
@@ -1267,9 +1408,20 @@ export function WhiteboardCanvas({
       flushPendingMove();
       engineRef.current?.onPointerUp();
       setSelectedId(engineRef.current?.getSelectedId() ?? null);
+      snapGuidesRef.current = [];
+      paintSnapGuides();
     }
     clearCursor();
-  }, [locked, clearCursor, flushPendingMove, onPanEnd, tool]);
+  }, [
+    appendOwnLaserPoint,
+    locked,
+    clearCursor,
+    flushPendingMove,
+    onPanEnd,
+    paintSnapGuides,
+    toCanvasPoint,
+    tool,
+  ]);
 
   const handlePointerLeave = useCallback(
     (event: React.PointerEvent<HTMLCanvasElement>) => {
@@ -1494,6 +1646,11 @@ export function WhiteboardCanvas({
       />
       <canvas
         ref={laserOverlayRef}
+        className="absolute inset-0 pointer-events-none"
+        aria-hidden
+      />
+      <canvas
+        ref={snapOverlayRef}
         className="absolute inset-0 pointer-events-none"
         aria-hidden
       />

--- a/packages/apps-sdk/src/apps/whiteboard/web/components/WhiteboardToolbar.tsx
+++ b/packages/apps-sdk/src/apps/whiteboard/web/components/WhiteboardToolbar.tsx
@@ -144,9 +144,9 @@ const ExportIcon = () => (
 type ShapeKind = Extract<ToolKind, "rect" | "ellipse" | "line" | "arrow">;
 
 const SHAPE_KINDS: { id: ShapeKind; label: string; key: string; icon: React.FC }[] = [
-  { id: "rect", label: "Rectangle", key: "5", icon: RectIcon },
-  { id: "ellipse", label: "Ellipse", key: "6", icon: EllipseIcon },
-  { id: "line", label: "Line", key: "7", icon: LineIcon },
+  { id: "rect", label: "Rectangle", key: "R", icon: RectIcon },
+  { id: "ellipse", label: "Ellipse", key: "O", icon: EllipseIcon },
+  { id: "line", label: "Line", key: "L", icon: LineIcon },
   { id: "arrow", label: "Arrow", key: "A", icon: ArrowIcon },
 ];
 
@@ -257,6 +257,7 @@ function PopupCard({
 
 function BarButton({
   label,
+  hotkey,
   active,
   disabled,
   onClick,
@@ -264,6 +265,8 @@ function BarButton({
   buttonRef,
 }: {
   label: string;
+  /** Single-letter/digit hotkey shown as a small persistent badge, Excalidraw-style. */
+  hotkey?: string;
   active?: boolean;
   disabled?: boolean;
   onClick: () => void;
@@ -297,6 +300,15 @@ function BarButton({
       }
     >
       {children}
+      {hotkey ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-0 right-0.5 text-[8.5px] font-medium leading-none"
+          style={{ color: active ? ACCENT : "rgba(255,255,255,0.4)" }}
+        >
+          {hotkey}
+        </span>
+      ) : null}
     </button>
   );
 }
@@ -328,7 +340,7 @@ function ShapeSlot({
   return (
     <div className="relative flex shrink-0 items-center">
       <BarButton
-        label={`Shapes (${SHAPE_KINDS.find((kind) => kind.id === current)?.key ?? "5"})`}
+        label={`Shapes (${SHAPE_KINDS.find((kind) => kind.id === current)?.key ?? "R"})`}
         active={active}
         disabled={disabled}
         buttonRef={triggerRef}
@@ -641,17 +653,18 @@ export function WhiteboardToolbar({
         boxShadow: "0 12px 32px rgba(0,0,0,0.45)",
       }}
     >
-      <BarButton label="Select (1)" active={tool === "select"} onClick={() => onToolChange("select")}>
+      <BarButton label="Select (V)" hotkey="V" active={tool === "select"} onClick={() => onToolChange("select")}>
         <SelectIcon />
       </BarButton>
-      <BarButton label="Pan (H)" active={tool === "pan"} onClick={() => onToolChange("pan")}>
+      <BarButton label="Pan (H)" hotkey="H" active={tool === "pan"} onClick={() => onToolChange("pan")}>
         <PanIcon />
       </BarButton>
 
       <BarDivider />
 
       <BarButton
-        label="Pen (2)"
+        label="Pen (P)"
+        hotkey="P"
         active={tool === "pen"}
         disabled={editDisabled}
         onClick={() => onToolChange("pen")}
@@ -660,6 +673,7 @@ export function WhiteboardToolbar({
       </BarButton>
       <BarButton
         label="Highlighter (3)"
+        hotkey="3"
         active={tool === "highlighter"}
         disabled={editDisabled}
         onClick={() => onToolChange("highlighter")}
@@ -667,7 +681,8 @@ export function WhiteboardToolbar({
         <HighlighterIcon />
       </BarButton>
       <BarButton
-        label="Eraser (4)"
+        label="Eraser (E)"
+        hotkey="E"
         active={tool === "eraser"}
         disabled={editDisabled}
         onClick={() => onToolChange("eraser")}
@@ -679,7 +694,8 @@ export function WhiteboardToolbar({
 
       <ShapeSlot tool={tool} onToolChange={onToolChange} disabled={editDisabled} />
       <BarButton
-        label="Text (8)"
+        label="Text (T)"
+        hotkey="T"
         active={tool === "text"}
         disabled={editDisabled}
         onClick={() => onToolChange("text")}
@@ -687,14 +703,15 @@ export function WhiteboardToolbar({
         <TextIcon />
       </BarButton>
       <BarButton
-        label="Sticky note (9)"
+        label="Sticky note (S)"
+        hotkey="S"
         active={tool === "sticky"}
         disabled={editDisabled}
         onClick={() => onToolChange("sticky")}
       >
         <StickyIcon />
       </BarButton>
-      <BarButton label="Laser pointer (L)" active={tool === "laser"} onClick={() => onToolChange("laser")}>
+      <BarButton label="Laser pointer (K)" hotkey="K" active={tool === "laser"} onClick={() => onToolChange("laser")}>
         <LaserIcon />
       </BarButton>
 

--- a/packages/apps-sdk/src/apps/whiteboard/web/components/WhiteboardWebApp.tsx
+++ b/packages/apps-sdk/src/apps/whiteboard/web/components/WhiteboardWebApp.tsx
@@ -38,7 +38,8 @@ function KeyHint({ label }: { label: string }) {
 }
 
 export function WhiteboardWebApp() {
-  const { user, isAdmin, isReadOnly: appReadOnly } = useApps();
+  const { user, isAdmin, isReadOnly: appReadOnly, closeApp, hideForMe } = useApps();
+  const [isCloseMenuOpen, setIsCloseMenuOpen] = useState(false);
   const { doc, awareness, locked } = useAppDoc("whiteboard");
   const { states } = useAppPresence("whiteboard");
   const { tool, setTool, settings, setSettings } = useToolState();
@@ -189,6 +190,9 @@ export function WhiteboardWebApp() {
   }, []);
 
   useEffect(() => {
+    // Letters are the primary bindings (mnemonic: Pen, Eraser, Rect, cirO,
+    // Line, Arrow, Text, Sticky, Hand/pan, laser poinKer). Numbers 1-9 stay as
+    // a secondary alias in the original tool order for muscle memory.
     const toolsByKey: Record<string, typeof tool> = {
       "1": "select",
       "2": "pen",
@@ -197,11 +201,19 @@ export function WhiteboardWebApp() {
       "5": "rect",
       "6": "ellipse",
       "7": "line",
+      "8": "arrow",
+      "9": "text",
+      v: "select",
+      p: "pen",
+      e: "eraser",
+      r: "rect",
+      o: "ellipse",
+      l: "line",
       a: "arrow",
-      "8": "text",
-      "9": "sticky",
+      t: "text",
+      s: "sticky",
       h: "pan",
-      l: "laser",
+      k: "laser",
     };
     const toolsByCode: Record<string, typeof tool> = {
       Digit1: "select",
@@ -211,11 +223,19 @@ export function WhiteboardWebApp() {
       Digit5: "rect",
       Digit6: "ellipse",
       Digit7: "line",
+      Digit8: "arrow",
+      Digit9: "text",
+      KeyV: "select",
+      KeyP: "pen",
+      KeyE: "eraser",
+      KeyR: "rect",
+      KeyO: "ellipse",
+      KeyL: "line",
       KeyA: "arrow",
-      Digit8: "text",
-      Digit9: "sticky",
+      KeyT: "text",
+      KeyS: "sticky",
       KeyH: "pan",
-      KeyL: "laser",
+      KeyK: "laser",
       Numpad1: "select",
       Numpad2: "pen",
       Numpad3: "highlighter",
@@ -223,8 +243,8 @@ export function WhiteboardWebApp() {
       Numpad5: "rect",
       Numpad6: "ellipse",
       Numpad7: "line",
-      Numpad8: "text",
-      Numpad9: "sticky",
+      Numpad8: "arrow",
+      Numpad9: "text",
     };
 
     const widthSteps = [2, 3, 5, 8, 12];
@@ -340,7 +360,8 @@ export function WhiteboardWebApp() {
         .map((state) => ({
           clientId: state.clientId,
           color: state.user?.color ?? "#a1a1aa",
-          name: state.user?.name ?? "",
+          // First name only keeps the label small next to the pointer
+          name: (state.user?.name ?? "").trim().split(/\s+/)[0] ?? "",
           x: (state.cursor?.x ?? 0) * viewport.scale + viewport.translateX,
           y: (state.cursor?.y ?? 0) * viewport.scale + viewport.translateY,
         })),
@@ -411,11 +432,11 @@ export function WhiteboardWebApp() {
               Sketch, drop sticky notes, or point things out with the laser. Everyone in the call sees it live.
             </p>
             <div className="mt-1 flex items-center gap-2 text-[11px]" style={{ color: "rgba(255,255,255,0.35)" }}>
-              <KeyHint label="2" /> pen
+              <KeyHint label="P" /> pen
               <span className="mx-0.5">·</span>
-              <KeyHint label="9" /> sticky
+              <KeyHint label="S" /> sticky
               <span className="mx-0.5">·</span>
-              <KeyHint label="L" /> laser
+              <KeyHint label="K" /> laser
             </div>
           </div>
         </div>
@@ -480,27 +501,84 @@ export function WhiteboardWebApp() {
         </div>
       ) : null}
 
-      {stressToolsEnabled ? (
-        <div className="absolute right-3 top-3 flex items-center gap-2">
-          <button
-            type="button"
-            onClick={triggerStressTest}
-            disabled={isReadOnly || stressTestRunning}
-            className="rounded-full px-3 py-2 text-[11px] font-medium text-[#d8d8d8] transition-colors hover:text-white disabled:cursor-not-allowed disabled:opacity-40 cursor-pointer"
-            style={CAPSULE_STYLE}
-          >
-            {stressTestRunning ? "Running stress" : "Run stress test"}
-          </button>
-          {stressTestResult ? (
-            <div
-              className="whitespace-nowrap rounded-full px-3 py-2 text-[10px] text-[#b8b8b8]"
+      <div className="absolute right-3 top-3 flex items-center gap-2">
+        {stressToolsEnabled ? (
+          <>
+            <button
+              type="button"
+              onClick={triggerStressTest}
+              disabled={isReadOnly || stressTestRunning}
+              className="rounded-full px-3 py-2 text-[11px] font-medium text-[#d8d8d8] transition-colors hover:text-white disabled:cursor-not-allowed disabled:opacity-40 cursor-pointer"
               style={CAPSULE_STYLE}
             >
-              {`${Math.round(stressTestResult.durationMs)}ms · ${stressTestResult.strokeCount} strokes · ${stressTestResult.queuedMoveEvents} moves`}
-            </div>
+              {stressTestRunning ? "Running stress" : "Run stress test"}
+            </button>
+            {stressTestResult ? (
+              <div
+                className="whitespace-nowrap rounded-full px-3 py-2 text-[10px] text-[#b8b8b8]"
+                style={CAPSULE_STYLE}
+              >
+                {`${Math.round(stressTestResult.durationMs)}ms · ${stressTestResult.strokeCount} strokes · ${stressTestResult.queuedMoveEvents} moves`}
+              </div>
+            ) : null}
+          </>
+        ) : null}
+
+        <div className="relative">
+          <button
+            type="button"
+            aria-label={isAdmin ? "Close whiteboard" : "Close whiteboard for me"}
+            onClick={() => {
+              if (isAdmin) {
+                setIsCloseMenuOpen((prev) => !prev);
+              } else {
+                hideForMe();
+              }
+            }}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-[#d8d8d8] transition-colors hover:text-white cursor-pointer"
+            style={CAPSULE_STYLE}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+
+          {isAdmin && isCloseMenuOpen ? (
+            <>
+              <div
+                className="fixed inset-0 z-10"
+                onClick={() => setIsCloseMenuOpen(false)}
+              />
+              <div
+                className="absolute right-0 top-[calc(100%+8px)] z-20 flex w-44 flex-col overflow-hidden rounded-xl py-1"
+                style={CAPSULE_STYLE}
+              >
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsCloseMenuOpen(false);
+                    hideForMe();
+                  }}
+                  className="px-3 py-2 text-left text-[12px] text-[#d8d8d8] transition-colors hover:bg-white/5 hover:text-white cursor-pointer"
+                >
+                  Close for me
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsCloseMenuOpen(false);
+                    void closeApp();
+                  }}
+                  className="px-3 py-2 text-left text-[12px] text-[#d8d8d8] transition-colors hover:bg-white/5 hover:text-white cursor-pointer"
+                >
+                  Close for everyone
+                </button>
+              </div>
+            </>
           ) : null}
         </div>
-      ) : null}
+      </div>
 
       <div className="pointer-events-none absolute inset-x-0 bottom-3 flex justify-center px-3">
         <div

--- a/packages/apps-sdk/src/sdk/runtime/AppsProvider.tsx
+++ b/packages/apps-sdk/src/sdk/runtime/AppsProvider.tsx
@@ -132,6 +132,17 @@ export function AppsProvider({
 }: AppsProviderProps) {
   const [state, setState] = useState<AppsState>({ activeAppId: null, locked: false });
   const [roster, setRoster] = useState<AppUser[]>(() => participants ?? []);
+  // Local-only, per-tab visibility toggle ("close for me"). Not synced to
+  // other clients, and resets whenever the active app changes so a fresh
+  // open always shows for everyone.
+  const [isHiddenForMe, setIsHiddenForMe] = useState(false);
+
+  useEffect(() => {
+    setIsHiddenForMe(false);
+  }, [state.activeAppId]);
+
+  const hideForMe = useCallback(() => setIsHiddenForMe(true), []);
+  const showForMe = useCallback(() => setIsHiddenForMe(false), []);
 
   useEffect(() => {
     const next = participants ?? [];
@@ -498,6 +509,9 @@ export function AppsProvider({
       participants: roster,
       isAdmin,
       isReadOnly,
+      isHiddenForMe,
+      hideForMe,
+      showForMe,
     }),
     [
       state,
@@ -512,6 +526,9 @@ export function AppsProvider({
       roster,
       isAdmin,
       isReadOnly,
+      isHiddenForMe,
+      hideForMe,
+      showForMe,
     ]
   );
 

--- a/packages/apps-sdk/src/sdk/types/index.ts
+++ b/packages/apps-sdk/src/sdk/types/index.ts
@@ -75,6 +75,10 @@ export type AppsContextValue = {
   participants?: AppUser[];
   isAdmin?: boolean;
   isReadOnly?: boolean;
+  /** Local-only ("close for me") visibility toggle; not synced to other clients. */
+  isHiddenForMe: boolean;
+  hideForMe: () => void;
+  showForMe: () => void;
 };
 
 export type ConclaveApp = {


### PR DESCRIPTION
## Summary

- **Laser pointer** (closes #190): selecting the laser now shows a plain dot that follows the cursor; a fading trail only paints while the button is held, and releasing lets it fade out on its own instead of vanishing instantly. The trail is also drawn as a handful of smoothed, independently-faded bands instead of one straight segment per point pair, so it reads as a continuous line rather than a string of dots.
- **Object snapping** (closes #191): dragging or resizing a shape now snaps to nearby elements' edges/centers (Figma-style alignment guides), with a guide line shown while the gesture is active.
- **Tool hotkeys**: remapped to letter mnemonics (`V` select, `H` pan, `P` pen, `E` eraser, `R` rect, `O` ellipse, `L` line, `A` arrow, `T` text, `S` sticky, `K` laser), with `1`-`9` kept as a secondary alias in the original order. Every toolbar button now shows its shortcut as a small persistent badge instead of only a hover tooltip.
- **Per-user close**: the whiteboard now has a corner close control. Everyone can hide it just for themselves (with a "Show whiteboard" control to bring it back while it's still running), and admins additionally get a "close for everyone" option. Also fixed the Apps panel, which previously disabled all interaction for non-admins and — for an admin — would have called `closeApp()` (closing for everyone) instead of un-hiding it locally.
- **Cursor labels**: remote presence cursors now show first name only, keeping the label compact next to the pointer.

## Test plan

- [x] `pnpm typecheck` passes for `apps-sdk` and `apps/web`
- [x] Manually verified in two live browser sessions (admin + participant) against a local dev server: drawing, moving, and resizing a shape all sync correctly in both directions
- [x] Verified laser dot/trail behavior and toolbar hotkey badges visually
- [x] Verified close-for-me / close-for-everyone flow, including the Apps panel rejoin fix

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR expands the collaborative whiteboard experience. The main changes are:

- Adds edge and center snapping with alignment guides.
- Reworks laser pointers into live dots and fading trails.
- Adds mnemonic tool shortcuts and persistent badges.
- Adds per-user hiding, rejoin controls, and admin shared close.
- Shortens remote cursor labels to first names.

<h3>Confidence Score: 4/5</h3>

Incremental object dragging can remain stuck on a snap target and should be fixed before merging.

Snapping starts each move from the element's already-snapped position. Small pointer movements can repeatedly snap back to the same target. Pointer cancellation can leave guides and gesture state active. No security issue was identified in the changed close controls.

packages/apps-sdk/src/apps/whiteboard/core/tools/engine.ts and packages/apps-sdk/src/apps/whiteboard/web/components/WhiteboardCanvas.tsx

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The TypeScript harness against the real ToolEngine and Yjs helpers reproduced the snapped drag that remained pinned at x=80 with snap guides, despite four consecutive -3 unit pointer moves.
- With a target at x=100 and a 5-unit threshold, the test observed that cumulative movement beyond the threshold did not detach the element, which remained snapped at x=80.
- A runtime trace was collected to show raw pointer deltas, cumulative movement, bounds, and snap guides, and it confirmed that the final positions remained \[80,80,80,80\].
- UI-level evidence was captured as before-server and after-server logs to verify the UI flow, and no screenshots or videos were produced due to blank, loading, or timeout captures.

<a href="https://app.greptile.com/trex/runs/14135999/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/apps-sdk/src/apps/whiteboard/core/tools/engine.ts | Adds move snapping and guide state, but incremental movement can prevent an object from detaching gradually. |
| packages/apps-sdk/src/apps/whiteboard/core/tools/snapping.ts | Adds per-axis edge and center matching with guide generation. |
| packages/apps-sdk/src/apps/whiteboard/web/components/WhiteboardCanvas.tsx | Integrates snapping, guide rendering, and revised laser behavior, but cancellation lacks gesture cleanup. |
| packages/apps-sdk/src/apps/whiteboard/web/components/WhiteboardWebApp.tsx | Adds mnemonic shortcuts, local and shared close controls, and shorter cursor labels. |
| packages/apps-sdk/src/sdk/runtime/AppsProvider.tsx | Adds local per-tab app visibility state that resets when the active shared app changes. |
| apps/web/src/app/components/apps/AppsPanel.tsx | Allows participants to rejoin a locally hidden active app while retaining admin-only shared management. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Pointer[Pointer move] --> Canvas[Whiteboard canvas]
  Canvas --> Engine[Tool engine]
  Engine --> Bounds[Prospective bounds]
  Bounds --> Snap[Snap adjustment]
  Snap --> Document[Yjs element update]
  Snap --> Guides[Guide overlay]
  LocalClose[Close for me] --> Hidden[Local hidden state]
  Hidden --> Layout[Meeting app visibility]
  SharedClose[Close for everyone] --> Server[Shared app close]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart LR
  Pointer[Pointer move] --> Canvas[Whiteboard canvas]
  Canvas --> Engine[Tool engine]
  Engine --> Bounds[Prospective bounds]
  Bounds --> Snap[Snap adjustment]
  Snap --> Document[Yjs element update]
  Snap --> Guides[Guide overlay]
  LocalClose[Close for me] --> Hidden[Local hidden state]
  Hidden --> Layout[Meeting app visibility]
  SharedClose[Close for everyone] --> Server[Shared app close]
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fapps-sdk%2Fsrc%2Fapps%2Fwhiteboard%2Fcore%2Ftools%2Fengine.ts%3A293-294%0A**Snapped%20Drag%20Cannot%20Detach%20Gradually**%0A%0AAfter%20an%20element%20snaps%2C%20the%20next%20candidate%20starts%20from%20that%20already-snapped%20position%20but%20uses%20only%20the%20latest%20raw%20pointer%20delta.%20Moving%20away%20by%20less%20than%20the%20threshold%20per%20frame%20therefore%20snaps%20the%20element%20back%20on%20every%20move%2C%20so%20it%20remains%20stuck%20until%20one%20pointer%20event%20crosses%20the%20full%20threshold.%20The%20candidate%20position%20needs%20to%20come%20from%20an%20unsnapped%20drag%20origin%20or%20account%20for%20the%20previous%20snap%20offset.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fapps-sdk%2Fsrc%2Fapps%2Fwhiteboard%2Fweb%2Fcomponents%2FWhiteboardCanvas.tsx%3A1004-1007%0A**Pointer%20Cancellation%20Leaves%20Snap%20State**%0A%0AA%20%60pointercancel%60%20during%20a%20snapped%20move%20or%20resize%20never%20reaches%20the%20new%20pointer-up%20cleanup.%20Touch%20interruption%20or%20lost%20pointer%20capture%20can%20therefore%20leave%20the%20guide%20overlay%20visible%20and%20the%20engine%20or%20resize%20session%20active%2C%20causing%20the%20next%20gesture%20to%20continue%20stale%20state%20instead%20of%20starting%20cleanly.%0A%0A&repo=acm-vit%2Fconclave&pr=200&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fapps-sdk%2Fsrc%2Fapps%2Fwhiteboard%2Fcore%2Ftools%2Fengine.ts%3A293-294%0A**Snapped%20Drag%20Cannot%20Detach%20Gradually**%0A%0AAfter%20an%20element%20snaps%2C%20the%20next%20candidate%20starts%20from%20that%20already-snapped%20position%20but%20uses%20only%20the%20latest%20raw%20pointer%20delta.%20Moving%20away%20by%20less%20than%20the%20threshold%20per%20frame%20therefore%20snaps%20the%20element%20back%20on%20every%20move%2C%20so%20it%20remains%20stuck%20until%20one%20pointer%20event%20crosses%20the%20full%20threshold.%20The%20candidate%20position%20needs%20to%20come%20from%20an%20unsnapped%20drag%20origin%20or%20account%20for%20the%20previous%20snap%20offset.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fapps-sdk%2Fsrc%2Fapps%2Fwhiteboard%2Fweb%2Fcomponents%2FWhiteboardCanvas.tsx%3A1004-1007%0A**Pointer%20Cancellation%20Leaves%20Snap%20State**%0A%0AA%20%60pointercancel%60%20during%20a%20snapped%20move%20or%20resize%20never%20reaches%20the%20new%20pointer-up%20cleanup.%20Touch%20interruption%20or%20lost%20pointer%20capture%20can%20therefore%20leave%20the%20guide%20overlay%20visible%20and%20the%20engine%20or%20resize%20session%20active%2C%20causing%20the%20next%20gesture%20to%20continue%20stale%20state%20instead%20of%20starting%20cleanly.%0A%0A&repo=acm-vit%2Fconclave&pr=200&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fapps-sdk%2Fsrc%2Fapps%2Fwhiteboard%2Fcore%2Ftools%2Fengine.ts%3A293-294%0A**Snapped%20Drag%20Cannot%20Detach%20Gradually**%0A%0AAfter%20an%20element%20snaps%2C%20the%20next%20candidate%20starts%20from%20that%20already-snapped%20position%20but%20uses%20only%20the%20latest%20raw%20pointer%20delta.%20Moving%20away%20by%20less%20than%20the%20threshold%20per%20frame%20therefore%20snaps%20the%20element%20back%20on%20every%20move%2C%20so%20it%20remains%20stuck%20until%20one%20pointer%20event%20crosses%20the%20full%20threshold.%20The%20candidate%20position%20needs%20to%20come%20from%20an%20unsnapped%20drag%20origin%20or%20account%20for%20the%20previous%20snap%20offset.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fapps-sdk%2Fsrc%2Fapps%2Fwhiteboard%2Fweb%2Fcomponents%2FWhiteboardCanvas.tsx%3A1004-1007%0A**Pointer%20Cancellation%20Leaves%20Snap%20State**%0A%0AA%20%60pointercancel%60%20during%20a%20snapped%20move%20or%20resize%20never%20reaches%20the%20new%20pointer-up%20cleanup.%20Touch%20interruption%20or%20lost%20pointer%20capture%20can%20therefore%20leave%20the%20guide%20overlay%20visible%20and%20the%20engine%20or%20resize%20session%20active%2C%20causing%20the%20next%20gesture%20to%20continue%20stale%20state%20instead%20of%20starting%20cleanly.%0A%0A&pr=200&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(whiteboard): remap tool hotkeys, pe..."](https://github.com/acm-vit/conclave/commit/ada6488f44201f20b94f2a4b57d4ac18cce7238a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43602367)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->