### PR TITLE
Feat: added zip as a game

### DIFF
--- a/apps/web/src/app/components/games/ZipGame.tsx
+++ b/apps/web/src/app/components/games/ZipGame.tsx
@@ -1,0 +1,1109 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { color, radius } from "@conclave/ui-tokens";
+import {
+  GameLobby,
+  HEAD_FONT,
+  useRemaining,
+  type GameViewProps,
+} from "./gameUi";
+
+/* ------------------------------------------------------------------ */
+/*  Wire types (matching publicView / playerView from the server)     */
+/* ------------------------------------------------------------------ */
+
+type CellCoord = { row: number; col: number };
+type CellIndex = number;
+type BarrierEdge = { from: CellIndex; to: CellIndex };
+type WallEdge = { a: CellCoord; b: CellCoord };
+type PlayerOutcome = "win" | "timeout";
+
+type ZipPublic = {
+  phase: "lobby" | "playing" | "results";
+  gridSize: number;
+  anchors: Record<string, number>;
+  barriers: BarrierEdge[];
+  deadCells: CellIndex[];
+  serverNow: number;
+  roundStartedAt: number | null;
+  standings: Array<{
+    playerId: string;
+    playerName: string;
+    cellsFilled: number;
+    totalCells: number;
+    outcome: PlayerOutcome | null;
+    hintsUsed: number;
+    solvedAt: number | null;
+  }>;
+  finishedCount: number;
+  totalPlayers: number;
+  currentRound: number;
+  totalRounds: number;
+  isFinalRound: boolean;
+  scores: Array<{ playerId: string; playerName: string; score: number }>;
+  result: {
+    solutionPath: CellIndex[];
+    winnerId: string | null;
+    winnerName: string | null;
+  } | null;
+};
+
+type ZipMe = {
+  path: CellIndex[];
+  outcome: PlayerOutcome | null;
+  solvedAt: number | null;
+  hintsUsed: number;
+  hintAvailableAt: number;
+  mistakes: number;
+};
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+const ZIP_GOLD = "#f6c744";
+const ZIP_VIOLET = "#6c5ce7";
+const GRID_BG = "#232327";
+const GRID_LINE = "rgba(250, 250, 250, 0.10)";
+const WALL_COLOR = "#fafafa";
+const CHECKPOINT_BG = "#1a1a1a";
+const CHECKPOINT_TEXT = "#ffffff";
+const ERROR_RED = "#ff4d4f";
+const CELL_PAD = 2;
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+const coordKey = (c: CellCoord): string => `${c.row},${c.col}`;
+const cellEdgeKey = (a: CellIndex, b: CellIndex): string =>
+  a < b ? `${a}:${b}` : `${b}:${a}`;
+const cellToCoord = (cell: CellIndex, gridSize: number): CellCoord => ({
+  row: Math.floor(cell / gridSize),
+  col: cell % gridSize,
+});
+const coordToCell = (cell: CellCoord, gridSize: number): CellIndex =>
+  cell.row * gridSize + cell.col;
+
+const edgeKey = (a: CellCoord, b: CellCoord): string => {
+  const k1 = coordKey(a);
+  const k2 = coordKey(b);
+  return k1 < k2 ? `${k1}|${k2}` : `${k2}|${k1}`;
+};
+
+/** Interpolate between two hex colors. */
+const lerpColor = (c1: string, c2: string, t: number): string => {
+  const parse = (hex: string) => {
+    const h = hex.replace("#", "");
+    return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+  };
+  const [r1, g1, b1] = parse(c1);
+  const [r2, g2, b2] = parse(c2);
+  const clamp = (v: number) => Math.max(0, Math.min(255, Math.round(v)));
+  const r = clamp(r1 + (r2 - r1) * t);
+  const g = clamp(g1 + (g2 - g1) * t);
+  const b = clamp(b1 + (b2 - b1) * t);
+  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+};
+
+const statusText = (outcome: PlayerOutcome | null): string => {
+  if (outcome === "win") return "Solved";
+  if (outcome === "timeout") return "Timed out";
+  return "Playing";
+};
+
+const formatElapsedTime = (ms: number): string => {
+  const totalMs = Math.max(0, Math.floor(ms));
+  const minutes = Math.floor(totalMs / 60_000);
+  const seconds = Math.floor(totalMs / 1_000) % 60;
+  const milliseconds = (totalMs % 1_000).toString().padStart(3, "0");
+  const secondPart = seconds.toString().padStart(2, "0");
+
+  return minutes > 0
+    ? `${minutes.toString().padStart(2, "0")}:${secondPart}:${milliseconds}`
+    : `${secondPart}:${milliseconds}`;
+};
+
+const formatSolveTime = (solvedAt: number | null, roundStartedAt: number | null): string | null => {
+  if (solvedAt == null || roundStartedAt == null) return null;
+
+  const tenths = Math.max(0, Math.round((solvedAt - roundStartedAt) / 100));
+  const minutes = Math.floor(tenths / 600).toString();
+  const seconds = Math.floor((tenths % 600) / 10).toString().padStart(2, "0");
+  return `${minutes}:${seconds}.${tenths % 10}`;
+};
+
+const useElapsedTime = (
+  roundStartedAt: number | null | undefined,
+  serverNow: number | null | undefined,
+): number => {
+  const [elapsed, setElapsed] = useState(0);
+  const baseRef = useRef({ roundStartedAt, serverNow, at: Date.now() });
+
+  useEffect(() => {
+    if (roundStartedAt == null || serverNow == null) {
+      setElapsed(0);
+      return;
+    }
+
+    baseRef.current = { roundStartedAt, serverNow, at: Date.now() };
+    const update = () => {
+      const base = baseRef.current;
+      if (base.roundStartedAt == null || base.serverNow == null) {
+        setElapsed(0);
+        return;
+      }
+      setElapsed(Math.max(0, base.serverNow - base.roundStartedAt + Date.now() - base.at));
+    };
+    update();
+    const interval = window.setInterval(update, 50);
+    return () => window.clearInterval(interval);
+  }, [roundStartedAt, serverNow]);
+
+  return elapsed;
+};
+
+/* ------------------------------------------------------------------ */
+/*  SVG Grid component                                                 */
+/* ------------------------------------------------------------------ */
+
+function ZipGrid({
+  gridSize,
+  checkpoints,
+  walls,
+  deadCells,
+  path,
+  solutionPath,
+  showSolution,
+  onPointerDownCell,
+  onPointerEnterCell,
+  onPointerUp,
+  flashCell,
+}: {
+  gridSize: number;
+  checkpoints: CellCoord[];
+  walls: WallEdge[];
+  deadCells: CellCoord[];
+  path: CellCoord[];
+  solutionPath?: CellCoord[];
+  showSolution: boolean;
+  onPointerDownCell: (cell: CellCoord) => void;
+  onPointerEnterCell: (cell: CellCoord) => void;
+  onPointerUp: () => void;
+  flashCell: CellCoord | null;
+}) {
+  const cellSize = 60;
+  const totalSize = gridSize * cellSize;
+  const activePointerIdRef = useRef<number | null>(null);
+  const lastPointerCellRef = useRef<CellCoord | null>(null);
+  const pathSet = useMemo(() => new Set(path.map(coordKey)), [path]);
+
+  const cellFromPointer = (clientX: number, clientY: number, svg: SVGSVGElement): CellCoord | null => {
+    const bounds = svg.getBoundingClientRect();
+    if (!bounds.width || !bounds.height) return null;
+
+    const x = clientX - bounds.left;
+    const y = clientY - bounds.top;
+    if (x < 0 || y < 0 || x >= bounds.width || y >= bounds.height) return null;
+
+    return {
+      row: Math.min(gridSize - 1, Math.floor((y / bounds.height) * gridSize)),
+      col: Math.min(gridSize - 1, Math.floor((x / bounds.width) * gridSize)),
+    };
+  };
+
+  const moveThroughCells = (nextCell: CellCoord) => {
+    const previous = lastPointerCellRef.current;
+    if (!previous || (previous.row === nextCell.row && previous.col === nextCell.col)) return;
+
+    const rowDelta = nextCell.row - previous.row;
+    const colDelta = nextCell.col - previous.col;
+    const rowStep = Math.sign(rowDelta);
+    const colStep = Math.sign(colDelta);
+    const moveRowsFirst = Math.abs(rowDelta) > Math.abs(colDelta);
+    let row = previous.row;
+    let col = previous.col;
+
+    const visit = () => onPointerEnterCell({ row, col });
+    const moveRows = () => {
+      while (row !== nextCell.row) {
+        row += rowStep;
+        visit();
+      }
+    };
+    const moveColumns = () => {
+      while (col !== nextCell.col) {
+        col += colStep;
+        visit();
+      }
+    };
+
+    if (moveRowsFirst) {
+      moveRows();
+      moveColumns();
+    } else {
+      moveColumns();
+      moveRows();
+    }
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (event.button !== 0) return;
+    const cell = cellFromPointer(event.clientX, event.clientY, event.currentTarget);
+    if (!cell) return;
+
+    event.preventDefault();
+    activePointerIdRef.current = event.pointerId;
+    lastPointerCellRef.current = cell;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    onPointerDownCell(cell);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (activePointerIdRef.current !== event.pointerId) return;
+
+    event.preventDefault();
+    const cell = cellFromPointer(event.clientX, event.clientY, event.currentTarget);
+    if (!cell) return;
+    moveThroughCells(cell);
+    lastPointerCellRef.current = cell;
+  };
+
+  const finishPointer = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (activePointerIdRef.current !== event.pointerId) return;
+
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    activePointerIdRef.current = null;
+    lastPointerCellRef.current = null;
+    onPointerUp();
+  };
+
+  // Path position lookup for gradient coloring.
+  const pathIndexMap = useMemo(() => {
+    const m = new Map<string, number>();
+    for (let i = 0; i < path.length; i++) m.set(coordKey(path[i]), i);
+    return m;
+  }, [path]);
+
+  const displayPath = showSolution && solutionPath ? solutionPath : path;
+
+  // Build SVG path segments with per-segment gradient colors.
+  const pathSegments = useMemo(() => {
+    if (displayPath.length < 2) return [];
+    const segments: Array<{
+      x1: number; y1: number;
+      x2: number; y2: number;
+      color: string;
+    }> = [];
+    for (let i = 0; i < displayPath.length - 1; i++) {
+      const a = displayPath[i];
+      const b = displayPath[i + 1];
+      const t = displayPath.length > 1 ? i / (displayPath.length - 1) : 0;
+      segments.push({
+        x1: a.col * cellSize + cellSize / 2,
+        y1: a.row * cellSize + cellSize / 2,
+        x2: b.col * cellSize + cellSize / 2,
+        y2: b.row * cellSize + cellSize / 2,
+        color: lerpColor(ZIP_GOLD, ZIP_VIOLET, t),
+      });
+    }
+    return segments;
+  }, [displayPath, cellSize]);
+
+  const headCell = path.length > 0 ? path[path.length - 1] : null;
+
+  return (
+    <svg
+      viewBox={`0 0 ${totalSize} ${totalSize}`}
+      style={{
+        width: "100%",
+        maxWidth: 400,
+        aspectRatio: "1",
+        touchAction: "none",
+        userSelect: "none",
+        display: "block",
+        margin: "0 auto",
+      }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={finishPointer}
+      onPointerCancel={finishPointer}
+    >
+      {/* Background */}
+      <rect width={totalSize} height={totalSize} rx={8} fill={GRID_BG} />
+
+      {/* Grid lines */}
+      {Array.from({ length: gridSize - 1 }, (_, i) => (
+        <React.Fragment key={`lines-${i}`}>
+          <line
+            x1={(i + 1) * cellSize} y1={CELL_PAD}
+            x2={(i + 1) * cellSize} y2={totalSize - CELL_PAD}
+            stroke={GRID_LINE} strokeWidth={1}
+          />
+          <line
+            x1={CELL_PAD} y1={(i + 1) * cellSize}
+            x2={totalSize - CELL_PAD} y2={(i + 1) * cellSize}
+            stroke={GRID_LINE} strokeWidth={1}
+          />
+        </React.Fragment>
+      ))}
+
+      {/* Visited cell tint */}
+      {path.map((cell) => {
+        const idx = pathIndexMap.get(coordKey(cell)) ?? 0;
+        const t = path.length > 1 ? idx / (path.length - 1) : 0;
+        const tintColor = lerpColor(ZIP_GOLD, ZIP_VIOLET, t);
+        return (
+          <rect
+            key={`tint-${coordKey(cell)}`}
+            x={cell.col * cellSize + 1}
+            y={cell.row * cellSize + 1}
+            width={cellSize - 2}
+            height={cellSize - 2}
+            rx={4}
+            fill={tintColor}
+            opacity={0.12}
+          />
+        );
+      })}
+
+      {/* Cells removed from this puzzle. */}
+      {deadCells.map((cell) => (
+        <g key={`dead-${coordKey(cell)}`}>
+          <rect
+            x={cell.col * cellSize + 1}
+            y={cell.row * cellSize + 1}
+            width={cellSize - 2}
+            height={cellSize - 2}
+            rx={4}
+            fill="#111114"
+          />
+          <line
+            x1={cell.col * cellSize + 12}
+            y1={cell.row * cellSize + 12}
+            x2={(cell.col + 1) * cellSize - 12}
+            y2={(cell.row + 1) * cellSize - 12}
+            stroke={GRID_LINE}
+            strokeWidth={2}
+          />
+        </g>
+      ))}
+
+      {/* Path line segments */}
+      {pathSegments.map((seg, i) => (
+        <line
+          key={`path-${i}`}
+          x1={seg.x1} y1={seg.y1}
+          x2={seg.x2} y2={seg.y2}
+          stroke={seg.color}
+          strokeWidth={cellSize * 0.38}
+          strokeLinecap="round"
+        />
+      ))}
+
+      {/* Head cell glow */}
+      {headCell && !showSolution ? (
+        <circle
+          cx={headCell.col * cellSize + cellSize / 2}
+          cy={headCell.row * cellSize + cellSize / 2}
+          r={cellSize * 0.16}
+          fill="#fff"
+          opacity={0.7}
+        >
+          <animate
+            attributeName="opacity"
+            values="0.7;0.3;0.7"
+            dur="1.5s"
+            repeatCount="indefinite"
+          />
+          <animate
+            attributeName="r"
+            values={`${cellSize * 0.16};${cellSize * 0.2};${cellSize * 0.16}`}
+            dur="1.5s"
+            repeatCount="indefinite"
+          />
+        </circle>
+      ) : null}
+
+      {/* Walls */}
+      {walls.map((w) => {
+        const horizontal = w.a.row === w.b.row;
+        const wallThickness = 4;
+        let x1: number, y1: number, x2: number, y2: number;
+        if (horizontal) {
+          const col = Math.max(w.a.col, w.b.col);
+          x1 = col * cellSize;
+          x2 = col * cellSize;
+          y1 = Math.min(w.a.row, w.b.row) * cellSize + 4;
+          y2 = Math.min(w.a.row, w.b.row) * cellSize + cellSize - 4;
+        } else {
+          const row = Math.max(w.a.row, w.b.row);
+          x1 = Math.min(w.a.col, w.b.col) * cellSize + 4;
+          x2 = Math.min(w.a.col, w.b.col) * cellSize + cellSize - 4;
+          y1 = row * cellSize;
+          y2 = row * cellSize;
+        }
+        return (
+          <line
+            key={`wall-${edgeKey(w.a, w.b)}`}
+            x1={x1} y1={y1} x2={x2} y2={y2}
+            stroke={WALL_COLOR}
+            strokeWidth={wallThickness}
+            strokeLinecap="round"
+          />
+        );
+      })}
+
+      {/* Checkpoint circles */}
+      {checkpoints.map((cp, i) => {
+        const cx = cp.col * cellSize + cellSize / 2;
+        const cy = cp.row * cellSize + cellSize / 2;
+        const visited = pathSet.has(coordKey(cp));
+        const idx = pathIndexMap.get(coordKey(cp));
+        const cpColor = visited && idx !== undefined
+          ? lerpColor(ZIP_GOLD, ZIP_VIOLET, path.length > 1 ? idx / (path.length - 1) : 0)
+          : CHECKPOINT_BG;
+        return (
+          <g key={`cp-${i}`}>
+            <circle
+              cx={cx} cy={cy}
+              r={cellSize * 0.3}
+              fill={cpColor}
+            />
+            <text
+              x={cx} y={cy}
+              textAnchor="middle"
+              dominantBaseline="central"
+              fill={CHECKPOINT_TEXT}
+              fontSize={cellSize * 0.32}
+              fontWeight={700}
+              fontFamily={HEAD_FONT}
+              style={{ pointerEvents: "none" }}
+            >
+              {i + 1}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* Flash cell (error feedback) */}
+      {flashCell ? (
+        <rect
+          x={flashCell.col * cellSize + 2}
+          y={flashCell.row * cellSize + 2}
+          width={cellSize - 4}
+          height={cellSize - 4}
+          rx={6}
+          fill={ERROR_RED}
+          opacity={0.45}
+        >
+          <animate
+            attributeName="opacity"
+            values="0.45;0;0"
+            dur="0.3s"
+            fill="freeze"
+          />
+        </rect>
+      ) : null}
+
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main renderer                                                      */
+/* ------------------------------------------------------------------ */
+
+export default function ZipGame({
+  pub,
+  me,
+  players,
+  isAdmin,
+  readOnly = false,
+  move,
+}: GameViewProps<ZipPublic, ZipMe>) {
+  const [localPath, setLocalPath] = useState<CellIndex[]>(me.path);
+  const drawingRef = useRef(false);
+  const [busy, setBusy] = useState(false);
+  const busyRef = useRef(false);
+  const [error, setError] = useState<string | null>(null);
+  const [flashCell, setFlashCell] = useState<CellCoord | null>(null);
+  const pathRef = useRef(localPath);
+
+  const elapsedMs = useElapsedTime(pub.roundStartedAt, pub.serverNow);
+  const hintCooldownMs = useRemaining(me.hintAvailableAt, pub.serverNow);
+  const checkpoints = useMemo(
+    () =>
+      Object.entries(pub.anchors)
+        .sort(([, a], [, b]) => a - b)
+        .map(([cell]) => cellToCoord(Number(cell), pub.gridSize)),
+    [pub.anchors, pub.gridSize],
+  );
+  const walls = useMemo(
+    () =>
+      pub.barriers.map(({ from, to }) => ({
+        a: cellToCoord(from, pub.gridSize),
+        b: cellToCoord(to, pub.gridSize),
+      })),
+    [pub.barriers, pub.gridSize],
+  );
+  const deadCells = useMemo(
+    () => pub.deadCells.map((cell) => cellToCoord(cell, pub.gridSize)),
+    [pub.deadCells, pub.gridSize],
+  );
+  const pathCoords = useMemo(
+    () => localPath.map((cell) => cellToCoord(cell, pub.gridSize)),
+    [localPath, pub.gridSize],
+  );
+  const solutionPath = useMemo(
+    () => pub.result?.solutionPath.map((cell) => cellToCoord(cell, pub.gridSize)),
+    [pub.result, pub.gridSize],
+  );
+  const totalCells = pub.gridSize * pub.gridSize - pub.deadCells.length;
+  const mySolveTime = formatSolveTime(me.solvedAt, pub.roundStartedAt);
+  const hintCooldownSeconds = Math.ceil(hintCooldownMs / 1000);
+  const startCell = useMemo(() => {
+    const anchor = Object.entries(pub.anchors).find(([, order]) => order === 1)?.[0];
+    return anchor === undefined ? null : Number(anchor);
+  }, [pub.anchors]);
+
+  // Sync local path from server when server view changes.
+  useEffect(() => {
+    pathRef.current = me.path;
+    setLocalPath(me.path);
+  }, [me.path]);
+
+  const updateLocalPath = useCallback((nextPath: CellIndex[]) => {
+    pathRef.current = nextPath;
+    setLocalPath(nextPath);
+  }, []);
+
+  // Wall set for local validation.
+  const wallSet = useMemo(
+    () => new Set(pub.barriers.map(({ from, to }) => cellEdgeKey(from, to))),
+    [pub.barriers],
+  );
+  const deadCellSet = useMemo(() => new Set(pub.deadCells), [pub.deadCells]);
+  const checkpointOrder = useMemo(
+    () => new Map(Object.entries(pub.anchors).map(([cell, order]) => [Number(cell), order])),
+    [pub.anchors],
+  );
+
+  const submitPath = useCallback(
+    async (cells: CellIndex[]) => {
+      if (busyRef.current) return;
+
+      busyRef.current = true;
+      setBusy(true);
+      setError(null);
+      try {
+        const result = await move("move", { cells });
+        if (!result.success) {
+          setError(result.error ?? "Invalid move");
+          updateLocalPath(me.path);
+        }
+      } catch {
+        setError("Something went wrong");
+        updateLocalPath(me.path);
+      } finally {
+        busyRef.current = false;
+        setBusy(false);
+      }
+    },
+    [me.path, move, updateLocalPath],
+  );
+
+  const isValidLocalMove = useCallback(
+    (currentPath: CellIndex[], next: CellIndex): boolean => {
+      if (currentPath.length === 0) return false;
+      const head = currentPath[currentPath.length - 1];
+
+      // Orthogonal adjacency.
+      const dr = Math.abs(Math.floor(next / pub.gridSize) - Math.floor(head / pub.gridSize));
+      const dc = Math.abs((next % pub.gridSize) - (head % pub.gridSize));
+      if (dr + dc !== 1) return false;
+
+      // Wall check.
+      if (wallSet.has(cellEdgeKey(head, next))) return false;
+
+      if (deadCellSet.has(next)) return false;
+
+      // Revisit check.
+      if (currentPath.includes(next)) return false;
+
+      // Checkpoint ordering.
+      let nextExpectedCp = 1;
+      for (const cell of currentPath) {
+        if (checkpointOrder.get(cell) === nextExpectedCp) nextExpectedCp++;
+      }
+      const checkpoint = checkpointOrder.get(next);
+      if (checkpoint !== undefined && checkpoint !== nextExpectedCp) return false;
+
+      return true;
+    },
+    [checkpointOrder, deadCellSet, pub.gridSize, wallSet],
+  );
+
+  const handlePointerDownCell = useCallback(
+    (cell: CellCoord) => {
+      if (readOnly || me.outcome != null || pub.phase !== "playing" || startCell == null) return;
+
+      const nextCell = coordToCell(cell, pub.gridSize);
+      const currentPath = pathRef.current;
+
+      // Can start from checkpoint 1 (fresh) or resume from the head.
+      const head = currentPath[currentPath.length - 1];
+      if (currentPath.length === 0 || nextCell === startCell) {
+        // Fresh start.
+        updateLocalPath([startCell]);
+        drawingRef.current = true;
+        return;
+      }
+      if (head === nextCell) {
+        // Resume from head.
+        drawingRef.current = true;
+        return;
+      }
+
+      // Check if this cell is in the path (backward drag to truncate).
+      const idx = currentPath.indexOf(nextCell);
+      if (idx >= 0) {
+        updateLocalPath(currentPath.slice(0, idx + 1));
+        drawingRef.current = true;
+        return;
+      }
+
+      // Invalid start point — flash.
+      setFlashCell(cell);
+      setTimeout(() => setFlashCell(null), 300);
+    },
+    [me.outcome, pub.gridSize, pub.phase, readOnly, startCell, updateLocalPath],
+  );
+
+  const handlePointerEnterCell = useCallback(
+    (cell: CellCoord) => {
+      if (!drawingRef.current || readOnly || me.outcome != null || pub.phase !== "playing") return;
+
+      const nextCell = coordToCell(cell, pub.gridSize);
+      const currentPath = pathRef.current;
+
+      // Check for backward drag (retraction).
+      if (currentPath.length >= 2) {
+        const secondToLast = currentPath[currentPath.length - 2];
+        if (nextCell === secondToLast) {
+          updateLocalPath(currentPath.slice(0, -1));
+          return;
+        }
+      }
+
+      // Check for valid forward move.
+      if (isValidLocalMove(currentPath, nextCell)) {
+        updateLocalPath([...currentPath, nextCell]);
+        return;
+      }
+
+      // Invalid — flash.
+      if (!currentPath.includes(nextCell)) {
+        setFlashCell(cell);
+        setTimeout(() => setFlashCell(null), 300);
+      }
+    },
+    [isValidLocalMove, me.outcome, pub.gridSize, pub.phase, readOnly, updateLocalPath],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    if (drawingRef.current) {
+      drawingRef.current = false;
+      void submitPath(pathRef.current);
+    }
+  }, [submitPath]);
+
+  const runMove = async (type: string, payload?: unknown) => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await move(type, payload);
+      if (!result.success) setError(result.error ?? "Something went wrong");
+    } catch {
+      setError("Something went wrong");
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  };
+
+  const handleUndo = () => {
+    if (localPath.length <= 1 || readOnly || me.outcome != null) return;
+    const newPath = localPath.slice(0, -1);
+    updateLocalPath(newPath);
+    void submitPath(newPath);
+  };
+
+  const handleReset = () => {
+    if (readOnly || me.outcome != null || startCell == null) return;
+    updateLocalPath([startCell]);
+    void runMove("reset");
+  };
+
+  const handleHint = () => {
+    if (readOnly || me.outcome != null || hintCooldownMs > 0) return;
+    void runMove("hint");
+  };
+
+  // --- Lobby ---
+  if (pub.phase === "lobby") {
+    return (
+      <GameLobby
+        gameId="zip"
+        title="Draw one path, fill every cell"
+        blurb={`Race to complete a ${pub.gridSize}×${pub.gridSize} grid puzzle. Visit numbered checkpoints in order. Fewest hints and fastest time wins.`}
+        players={players}
+        isAdmin={isAdmin}
+        readOnly={readOnly}
+        canStart={players.length >= 1}
+        busy={busy}
+        disabledLabel="Need at least 1 player"
+        startLabel="Start Zip"
+        busyLabel="Starting Zip…"
+        error={error}
+        onStart={() => void runMove("start")}
+      />
+    );
+  }
+
+  // --- Results ---
+  if (pub.phase === "results" && pub.result) {
+    const multiRound = pub.totalRounds > 1;
+    const winner = pub.standings.find((entry) => entry.playerId === pub.result?.winnerId);
+    const winnerSolveTime = winner
+      ? formatSolveTime(winner.solvedAt, pub.roundStartedAt)
+      : null;
+    return (
+      <div style={{ padding: "4px 2px" }}>
+        {multiRound ? (
+          <p style={{ fontSize: 11, color: color.textFaint, fontFamily: HEAD_FONT, textAlign: "center", margin: "0 0 2px" }}>
+            Round {pub.currentRound} of {pub.totalRounds}
+          </p>
+        ) : null}
+        <p style={{ fontFamily: HEAD_FONT, fontSize: 18, color: color.text, margin: "0 0 4px", textAlign: "center" }}>
+          {pub.isFinalRound
+            ? multiRound ? "Game over" : pub.result.winnerName ? "Puzzle complete" : "Time's up"
+            : pub.result.winnerName ? "Round complete" : "No winner"}
+        </p>
+        {pub.result.winnerName ? (
+          <p style={{ fontSize: 13, color: ZIP_GOLD, textAlign: "center", margin: "0 0 10px" }}>
+            {pub.result.winnerName} solved it first{winnerSolveTime ? ` in ${winnerSolveTime}` : ""}
+          </p>
+        ) : null}
+
+        {/* Show solved grid */}
+        <ZipGrid
+          gridSize={pub.gridSize}
+          checkpoints={checkpoints}
+          walls={walls}
+          deadCells={deadCells}
+          path={me.outcome === "win" ? pathCoords : []}
+          solutionPath={solutionPath}
+          showSolution={true}
+          onPointerDownCell={() => {}}
+          onPointerEnterCell={() => {}}
+          onPointerUp={() => {}}
+          flashCell={null}
+        />
+
+        {/* Score table */}
+        {multiRound && pub.scores.length > 0 ? (
+          <div style={{ marginTop: 12 }}>
+            <p style={{ fontSize: 11, color: color.textFaint, fontFamily: HEAD_FONT, margin: "0 0 6px" }}>
+              {pub.isFinalRound ? "Final scores" : "Scores"}
+            </p>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+              {pub.scores.map((entry, i) => (
+                <div
+                  key={entry.playerId}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    padding: "7px 10px",
+                    borderRadius: radius.sm,
+                    background: i === 0 && pub.isFinalRound ? `${ZIP_GOLD}22` : "transparent",
+                  }}
+                >
+                  <span style={{ width: 16, fontSize: 12, color: i === 0 ? ZIP_GOLD : color.textFaint, fontFamily: HEAD_FONT, fontWeight: 500 }}>
+                    {i + 1}
+                  </span>
+                  <span style={{ flex: 1, minWidth: 0, fontSize: 13.5, color: color.text, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {entry.playerName}
+                  </span>
+                  <span style={{ fontSize: 12, color: ZIP_GOLD, fontFamily: HEAD_FONT, fontWeight: 600 }}>
+                    {entry.score} pt{entry.score !== 1 ? "s" : ""}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 4, marginTop: 12 }}>
+            {pub.standings.map((entry, i) => {
+              const solveTime = formatSolveTime(entry.solvedAt, pub.roundStartedAt);
+              const hintText = entry.hintsUsed > 0
+                ? `${entry.hintsUsed} hint${entry.hintsUsed > 1 ? "s" : ""}`
+                : "No hints";
+              return (
+                <div
+                key={entry.playerId}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "7px 10px",
+                  borderRadius: radius.sm,
+                  background: entry.outcome === "win" ? `${ZIP_GOLD}22` : "transparent",
+                }}
+              >
+                <span style={{ width: 16, fontSize: 12, color: i === 0 && entry.outcome === "win" ? ZIP_GOLD : color.textFaint, fontFamily: HEAD_FONT, fontWeight: 500 }}>
+                  {i + 1}
+                </span>
+                <span style={{ flex: 1, minWidth: 0, fontSize: 13.5, color: color.text, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {entry.playerName}
+                </span>
+                <span style={{ fontSize: 12, color: color.textMuted, fontFamily: HEAD_FONT }}>
+                  {entry.outcome === "win"
+                    ? `${solveTime ? `Solved in ${solveTime}` : "Solved"} · ${hintText}`
+                    : statusText(entry.outcome)}
+                </span>
+              </div>
+              );
+            })}
+          </div>
+        )}
+
+        {!pub.isFinalRound && isAdmin && !readOnly ? (
+          <button
+            disabled={busy}
+            onClick={() => void runMove("nextRound")}
+            style={{
+              width: "100%",
+              marginTop: 12,
+              padding: "10px 0",
+              borderRadius: radius.md,
+              border: "none",
+              background: ZIP_GOLD,
+              color: "#1a1a1a",
+              fontFamily: HEAD_FONT,
+              fontWeight: 700,
+              fontSize: 15,
+              cursor: busy ? "default" : "pointer",
+              opacity: busy ? 0.5 : 1,
+            }}
+          >
+            Next Round
+          </button>
+        ) : !pub.isFinalRound ? (
+          <p style={{ fontSize: 12, color: color.textMuted, textAlign: "center", margin: "12px 0 0" }}>
+            Waiting for host to start next round...
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  // --- Playing ---
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <div>
+          <p style={{ margin: 0, color: ZIP_GOLD, fontFamily: HEAD_FONT, fontSize: 12 }}>
+            Zip{pub.totalRounds > 1 ? ` · Round ${pub.currentRound}/${pub.totalRounds}` : ""}
+          </p>
+          <p style={{ margin: "2px 0 0", color: color.textFaint, fontSize: 11 }}>
+            {pub.finishedCount}/{pub.totalPlayers} finished
+          </p>
+        </div>
+        <div style={{ textAlign: "right" }}>
+          <p style={{ margin: 0, color: color.textFaint, fontFamily: HEAD_FONT, fontSize: 10 }}>
+            Elapsed
+          </p>
+          <p style={{ margin: "2px 0 0", color: color.text, fontFamily: HEAD_FONT, fontSize: 16 }}>
+            {formatElapsedTime(elapsedMs)}
+          </p>
+        </div>
+      </div>
+
+      {/* Grid */}
+      <ZipGrid
+        gridSize={pub.gridSize}
+        checkpoints={checkpoints}
+        walls={walls}
+        deadCells={deadCells}
+        path={pathCoords}
+        showSolution={false}
+        onPointerDownCell={handlePointerDownCell}
+        onPointerEnterCell={handlePointerEnterCell}
+        onPointerUp={handlePointerUp}
+        flashCell={flashCell}
+      />
+
+      {/* Progress */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <div style={{
+          flex: 1,
+          height: 4,
+          borderRadius: 2,
+          background: color.surfaceRaised,
+          overflow: "hidden",
+        }}>
+          <div style={{
+            width: `${(localPath.length / totalCells) * 100}%`,
+            height: "100%",
+            borderRadius: 2,
+            background: `linear-gradient(90deg, ${ZIP_GOLD}, ${ZIP_VIOLET})`,
+            transition: "width 120ms ease",
+          }} />
+        </div>
+        <span style={{ fontSize: 11, color: color.textFaint, fontFamily: HEAD_FONT, whiteSpace: "nowrap" }}>
+          {localPath.length}/{totalCells}
+        </span>
+      </div>
+
+      {/* Action buttons */}
+      {!me.outcome && !readOnly ? (
+        <div style={{ display: "flex", gap: 8, justifyContent: "center" }}>
+          <button
+            onClick={handleUndo}
+            disabled={localPath.length <= 1 || busy}
+            style={{
+              padding: "8px 16px",
+              borderRadius: radius.md,
+              border: `1px solid ${color.border}`,
+              background: "transparent",
+              color: color.textMuted,
+              fontFamily: HEAD_FONT,
+              fontSize: 13,
+              fontWeight: 500,
+              cursor: localPath.length <= 1 || busy ? "default" : "pointer",
+              opacity: localPath.length <= 1 || busy ? 0.4 : 1,
+            }}
+          >
+            ↩ Undo
+          </button>
+          <button
+            onClick={handleReset}
+            disabled={localPath.length <= 1 || busy}
+            style={{
+              padding: "8px 16px",
+              borderRadius: radius.md,
+              border: `1px solid ${color.border}`,
+              background: "transparent",
+              color: color.textMuted,
+              fontFamily: HEAD_FONT,
+              fontSize: 13,
+              fontWeight: 500,
+              cursor: localPath.length <= 1 || busy ? "default" : "pointer",
+              opacity: localPath.length <= 1 || busy ? 0.4 : 1,
+            }}
+          >
+            ⟲ Reset
+          </button>
+          <button
+            onClick={handleHint}
+            disabled={busy || hintCooldownMs > 0}
+            style={{
+              padding: "8px 16px",
+              borderRadius: radius.md,
+              border: `1px solid ${color.border}`,
+              background: "transparent",
+              color: ZIP_GOLD,
+              fontFamily: HEAD_FONT,
+              fontSize: 13,
+              fontWeight: 500,
+              cursor: busy || hintCooldownMs > 0 ? "default" : "pointer",
+              opacity: busy || hintCooldownMs > 0 ? 0.4 : 1,
+            }}
+          >
+            💡 Hint{hintCooldownMs > 0 ? ` (${hintCooldownSeconds}s)` : me.hintsUsed > 0 ? ` (${me.hintsUsed})` : ""}
+          </button>
+        </div>
+      ) : null}
+
+      {/* Outcome banner */}
+      {me.outcome ? (
+        <div style={{
+          textAlign: "center",
+          padding: "10px 14px",
+          borderRadius: radius.md,
+          background: me.outcome === "win" ? `${ZIP_GOLD}18` : color.surfaceRaised,
+        }}>
+          <span style={{ fontSize: 14, fontFamily: HEAD_FONT, color: me.outcome === "win" ? ZIP_GOLD : color.textMuted }}>
+            {me.outcome === "win" ? `Solved${mySolveTime ? ` in ${mySolveTime}` : "!"}` : "Time's up"}
+          </span>
+        </div>
+      ) : null}
+
+      {/* Live standings */}
+      {pub.standings.length > 0 && pub.phase === "playing" ? (
+        <div style={{ paddingTop: 10, borderTop: `1px solid ${color.border}` }}>
+          <p style={{ fontSize: 11, color: color.textFaint, fontFamily: HEAD_FONT, margin: "0 0 6px" }}>Standings</p>
+          <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+            {pub.standings.map((entry, i) => {
+              const solveTime = formatSolveTime(entry.solvedAt, pub.roundStartedAt);
+              return (
+                <div
+                key={entry.playerId}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "5px 10px",
+                  borderRadius: radius.sm,
+                  background: entry.outcome === "win" ? `${ZIP_GOLD}22` : "transparent",
+                }}
+              >
+                <span style={{ width: 16, fontSize: 12, color: i === 0 && entry.outcome === "win" ? ZIP_GOLD : color.textFaint, fontFamily: HEAD_FONT, fontWeight: 500 }}>
+                  {i + 1}
+                </span>
+                <span style={{ flex: 1, minWidth: 0, fontSize: 13, color: color.text, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {entry.playerName}
+                </span>
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <div style={{
+                    width: 60,
+                    height: 4,
+                    borderRadius: 2,
+                    background: color.surfaceRaised,
+                    overflow: "hidden",
+                  }}>
+                    <div style={{
+                      width: `${(entry.cellsFilled / entry.totalCells) * 100}%`,
+                      height: "100%",
+                      borderRadius: 2,
+                      background: entry.outcome === "win" ? ZIP_GOLD : color.textFaint,
+                    }} />
+                  </div>
+                  <span style={{ fontSize: 11, color: entry.outcome === "win" ? ZIP_GOLD : color.textMuted, fontFamily: HEAD_FONT, whiteSpace: "nowrap" }}>
+                    {entry.outcome === "win"
+                      ? solveTime ? `Solved in ${solveTime}` : "Solved"
+                      : entry.outcome
+                        ? statusText(entry.outcome)
+                        : `${entry.cellsFilled}/${entry.totalCells}`}
+                  </span>
+                </div>
+              </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+
+      {error ? <p style={{ margin: 0, color: color.danger, fontSize: 12 }}>{error}</p> : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/components/games/covers.tsx
+++ b/apps/web/src/app/components/games/covers.tsx
@@ -10,6 +10,7 @@ const GAME_ACCENTS: Record<string, string> = {
   imposter: "#E0863A",
   wordle: "#6AAA64",
   chess: "#C08552",
+  zip: "#F6C744",
 };
 
 const GAME_NAMES: Record<string, string> = {
@@ -21,6 +22,7 @@ const GAME_NAMES: Record<string, string> = {
   imposter: "Imposter",
   wordle: "Wordle",
   chess: "Chess",
+  zip: "Zip",
 };
 
 export const accentFor = (gameId?: string): string =>

--- a/apps/web/src/app/components/games/gameUi.tsx
+++ b/apps/web/src/app/components/games/gameUi.tsx
@@ -416,8 +416,11 @@ export function GameLobby({
   isAdmin,
   readOnly = false,
   canStart = true,
+  busy = false,
   startLabel = "Start",
+  busyLabel = "Starting…",
   disabledLabel,
+  error,
   onStart,
   waitingText = "The host will start the round",
 }: {
@@ -429,8 +432,11 @@ export function GameLobby({
   userId?: string | null;
   readOnly?: boolean;
   canStart?: boolean;
+  busy?: boolean;
   startLabel?: string;
+  busyLabel?: string;
   disabledLabel?: string;
+  error?: string | null;
   onStart: () => void;
   waitingText?: string;
 }) {
@@ -477,8 +483,12 @@ export function GameLobby({
 
         <div style={{ width: "100%", maxWidth: 300, marginTop: 26 }}>
           {isAdmin && !readOnly ? (
-            <PrimaryButton full disabled={!canStart} onClick={onStart}>
-              {canStart ? startLabel : disabledLabel ?? startLabel}
+            <PrimaryButton full disabled={!canStart || busy} onClick={onStart}>
+              {busy
+                ? busyLabel
+                : canStart
+                  ? startLabel
+                  : disabledLabel ?? startLabel}
             </PrimaryButton>
           ) : (
             <div
@@ -502,6 +512,11 @@ export function GameLobby({
               </span>
             </div>
           )}
+          {error ? (
+            <p role="alert" style={{ fontSize: 12, color: color.danger, margin: "12px 0 0" }}>
+              {error}
+            </p>
+          ) : null}
           <p style={{ fontSize: 12, color: color.textFaint, margin: "12px 0 0" }}>{count}</p>
         </div>
       </div>

--- a/apps/web/src/app/components/games/registry.tsx
+++ b/apps/web/src/app/components/games/registry.tsx
@@ -10,6 +10,7 @@ import ReactionGame from "./ReactionGame";
 import ImposterGame from "./ImposterGame";
 import WordleGame from "./WordleGame";
 import ChessGame from "./ChessGame";
+import ZipGame from "./ZipGame";
 
 // Add a web renderer here (one line). The key is the game id from the SFU
 // module. Everything else (launcher, stage routing) reads from this map.
@@ -22,6 +23,7 @@ const GAME_RENDERERS: Record<string, React.ComponentType<GameViewProps>> = {
   imposter: ImposterGame as React.ComponentType<GameViewProps>,
   wordle: WordleGame as React.ComponentType<GameViewProps>,
   chess: ChessGame as React.ComponentType<GameViewProps>,
+  zip: ZipGame as React.ComponentType<GameViewProps>,
 };
 
 export const getGameRenderer = (

--- a/apps/web/src/lib/sfu-url.ts
+++ b/apps/web/src/lib/sfu-url.ts
@@ -1,5 +1,5 @@
 const PUBLIC_SFU_URL = "https://sfu.acmvit.in";
-const LOCAL_DEV_SFU_URL = "http://localhost:3031";
+
 const envValue = (value: string | undefined): string | undefined => {
   const trimmed = value?.trim();
   return trimmed || undefined;
@@ -66,14 +66,11 @@ export const resolveSfuUrls = (): string[] => {
     envValue(process.env.NEXT_PUBLIC_SFU_URL),
   ].filter((value): value is string => Boolean(value));
 
-  const fallbackUrl = isProductionRuntime() ? PUBLIC_SFU_URL : LOCAL_DEV_SFU_URL;
-  return uniqueUrls(singletonUrls.length > 0 ? singletonUrls : [fallbackUrl]);
+  return uniqueUrls(singletonUrls.length > 0 ? singletonUrls : [PUBLIC_SFU_URL]);
 };
 
-export const resolveSfuUrl = (): string => {
-  const fallbackUrl = isProductionRuntime() ? PUBLIC_SFU_URL : LOCAL_DEV_SFU_URL;
-  return resolveSfuUrls()[0] ?? productionSafeSfuUrl(fallbackUrl);
-};
+export const resolveSfuUrl = (): string =>
+  resolveSfuUrls()[0] ?? productionSafeSfuUrl(PUBLIC_SFU_URL);
 
 export const normalizeRoutedSfuUrl = (value: unknown): string | null => {
   if (typeof value !== "string" || !value.trim()) {

--- a/apps/web/src/lib/sfu-url.ts
+++ b/apps/web/src/lib/sfu-url.ts
@@ -1,5 +1,5 @@
 const PUBLIC_SFU_URL = "https://sfu.acmvit.in";
-
+const LOCAL_DEV_SFU_URL = "http://localhost:3031";
 const envValue = (value: string | undefined): string | undefined => {
   const trimmed = value?.trim();
   return trimmed || undefined;
@@ -66,11 +66,14 @@ export const resolveSfuUrls = (): string[] => {
     envValue(process.env.NEXT_PUBLIC_SFU_URL),
   ].filter((value): value is string => Boolean(value));
 
-  return uniqueUrls(singletonUrls.length > 0 ? singletonUrls : [PUBLIC_SFU_URL]);
+  const fallbackUrl = isProductionRuntime() ? PUBLIC_SFU_URL : LOCAL_DEV_SFU_URL;
+  return uniqueUrls(singletonUrls.length > 0 ? singletonUrls : [fallbackUrl]);
 };
 
-export const resolveSfuUrl = (): string =>
-  resolveSfuUrls()[0] ?? productionSafeSfuUrl(PUBLIC_SFU_URL);
+export const resolveSfuUrl = (): string => {
+  const fallbackUrl = isProductionRuntime() ? PUBLIC_SFU_URL : LOCAL_DEV_SFU_URL;
+  return resolveSfuUrls()[0] ?? productionSafeSfuUrl(fallbackUrl);
+};
 
 export const normalizeRoutedSfuUrl = (value: unknown): string | null => {
   if (typeof value !== "string" || !value.trim()) {

--- a/packages/sfu/server/games/modules/zip.ts
+++ b/packages/sfu/server/games/modules/zip.ts
@@ -1,0 +1,528 @@
+import {
+  GameMoveError,
+  type GameContext,
+  type GameModule,
+  type GameMove,
+} from "../types.js";
+import { numberOption, selectOption } from "../config.js";
+import {
+  generatePuzzle,
+  validateMove,
+  validateCompletePath,
+  solveForHint,
+  getFirstAnchor,
+  type CellIndex,
+  type BarrierEdge,
+  type AnchorMap,
+  type GeneratedPuzzle,
+  type SupportedGridSize,
+} from "./zipSolver.js";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+type PlayerOutcome = "win" | "timeout";
+
+type PlayerBoard = {
+  path: CellIndex[];
+  outcome: PlayerOutcome | null;
+  solvedAt: number | null;
+  hintsUsed: number;
+  hintAvailableAt: number;
+  mistakes: number;
+};
+
+type ZipState = {
+  phase: "lobby" | "playing" | "results";
+  gridSize: SupportedGridSize;
+  anchors: AnchorMap;
+  barriers: BarrierEdge[];
+  deadCells: CellIndex[];
+  solutionPath: CellIndex[];
+  players: Record<string, PlayerBoard>;
+  roundStartedAt: number;
+  winnerId: string | null;
+  totalRounds: number;
+  currentRound: number;
+  scores: Record<string, number>;
+};
+
+/* ------------------------------------------------------------------ */
+/*  Scoring                                                            */
+/* ------------------------------------------------------------------ */
+
+const SOLVE_BASE = 100;
+const HINT_PENALTY = 15;
+const HINT_COOLDOWN_MS = 3_000;
+const MIN_SOLVE_SCORE = 10;
+const SPEED_BONUS_MAX = 50;
+const SPEED_DIVISOR = 3000; // ms per point lost
+
+const roundScore = (board: PlayerBoard, roundStartedAt: number): number => {
+  if (board.outcome !== "win" || board.solvedAt == null) return 0;
+
+  // Base minus hint penalty.
+  const base = Math.max(MIN_SOLVE_SCORE, SOLVE_BASE - board.hintsUsed * HINT_PENALTY);
+
+  // Speed bonus: full bonus for instant solve, decreasing linearly.
+  const solveTimeMs = Math.max(0, board.solvedAt - roundStartedAt);
+  const speedBonus = Math.max(0, SPEED_BONUS_MAX - Math.floor(solveTimeMs / SPEED_DIVISOR));
+
+  return base + speedBonus;
+};
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+const winnerName = (ctx: GameContext, winnerId: string | null): string | null => {
+  if (!winnerId) return null;
+  return ctx.players.find((p) => p.id === winnerId)?.name ?? null;
+};
+
+const computeWinnerId = (state: ZipState): string | null => {
+  const winners = Object.entries(state.players)
+    .filter(([, board]) => board.outcome === "win" && board.solvedAt != null)
+    .sort(([, a], [, b]) => {
+      // Fewest hints first.
+      const hints = a.hintsUsed - b.hintsUsed;
+      if (hints !== 0) return hints;
+      // Then fastest time.
+      return (a.solvedAt ?? Infinity) - (b.solvedAt ?? Infinity);
+    });
+  return winners[0]?.[0] ?? null;
+};
+
+const allPlayersFinished = (state: ZipState): boolean => {
+  const ids = Object.keys(state.players);
+  return ids.length > 0 && ids.every((id) => state.players[id].outcome != null);
+};
+
+const accumulateScores = (state: ZipState): Record<string, number> => {
+  const scores = { ...state.scores };
+  for (const [playerId, board] of Object.entries(state.players)) {
+    scores[playerId] = (scores[playerId] ?? 0) + roundScore(board, state.roundStartedAt);
+  }
+  return scores;
+};
+
+const withResultsIfComplete = (state: ZipState): ZipState => {
+  if (!allPlayersFinished(state)) return state;
+  return {
+    ...state,
+    phase: "results",
+    winnerId: computeWinnerId(state),
+    scores: accumulateScores(state),
+  };
+};
+
+const parseGridSize = (value: string): SupportedGridSize => {
+  const n = parseInt(value, 10);
+  if (n === 6 || n === 7 || n === 8 || n === 9) return n;
+  return 6;
+};
+
+const getAnchorCountForSize = (size: SupportedGridSize): number => {
+  switch (size) {
+    case 6:
+      return 8;
+    case 7:
+      return 10;
+    case 8:
+      return 12;
+    case 9:
+      return 14;
+    default:
+      return 8;
+  }
+};
+
+const startPlaying = (state: ZipState, ctx: GameContext, round: number): ZipState => {
+  const size = parseGridSize(selectOption(ctx.config, "gridSize", "6"));
+  const puzzle = generatePuzzle({
+    size,
+    anchorCount: getAnchorCountForSize(size),
+    seed: Math.floor(ctx.rng.next() * 0x1_0000_0000) >>> 0,
+  });
+
+  const startCell = getFirstAnchor(puzzle);
+
+  const players: Record<string, PlayerBoard> = {};
+  for (const player of ctx.activePlayers) {
+    players[player.id] = {
+      path: [startCell],
+      outcome: null,
+      solvedAt: null,
+      hintsUsed: 0,
+      hintAvailableAt: 0,
+      mistakes: 0,
+    };
+  }
+
+  return {
+    ...state,
+    phase: "playing",
+    gridSize: size,
+    anchors: puzzle.anchors,
+    barriers: puzzle.barriers,
+    deadCells: puzzle.deadCells,
+    solutionPath: puzzle.solutionPath,
+    players,
+    roundStartedAt: ctx.now,
+    winnerId: null,
+    currentRound: round,
+  };
+};
+
+const buildPuzzleForValidation = (state: ZipState): GeneratedPuzzle => ({
+  size: state.gridSize,
+  anchors: state.anchors,
+  barriers: state.barriers,
+  deadCells: state.deadCells,
+  solutionPath: state.solutionPath,
+  seed: 0,
+  anchorCount: 0,
+});
+
+/* ------------------------------------------------------------------ */
+/*  Module                                                             */
+/* ------------------------------------------------------------------ */
+
+export const zipModule: GameModule<ZipState> = {
+  id: "zip",
+  name: "Zip",
+  description: "Draw one path through every cell",
+  minPlayers: 1,
+  maxPlayers: 32,
+  tickMs: 500,
+  hasLeaderboard: true,
+  options: [
+    {
+      id: "gridSize",
+      type: "select",
+      label: "Grid",
+      default: "6",
+      choices: [
+        { value: "6", label: "6×6 Easy" },
+        { value: "7", label: "7×7 Medium" },
+        { value: "8", label: "8×8 Hard" },
+        { value: "9", label: "9×9 Expert" },
+      ],
+    },
+    {
+      id: "rounds",
+      type: "number",
+      label: "Rounds",
+      min: 1,
+      max: 5,
+      default: 1,
+      presets: [1, 3, 5],
+    },
+  ],
+
+  setup(ctx: GameContext): ZipState {
+    return {
+      phase: "lobby",
+      gridSize: parseGridSize(selectOption(ctx.config, "gridSize", "6")),
+      anchors: {},
+      barriers: [],
+      deadCells: [],
+      solutionPath: [],
+      players: {},
+      roundStartedAt: 0,
+      winnerId: null,
+      totalRounds: numberOption(ctx.config, "rounds", 1),
+      currentRound: 0,
+      scores: {},
+    };
+  },
+
+  onMove(state, move: GameMove, ctx): ZipState {
+    switch (move.type) {
+      case "start": {
+        if (!ctx.isAdmin(move.playerId)) {
+          throw new GameMoveError("Only the host can start");
+        }
+        if (state.phase !== "lobby") {
+          throw new GameMoveError("Already running");
+        }
+        if (ctx.activePlayers.length < 1) {
+          throw new GameMoveError("Need at least 1 player");
+        }
+        return startPlaying(state, ctx, 1);
+      }
+
+      case "move": {
+        if (state.phase !== "playing") {
+          throw new GameMoveError("Not accepting moves right now");
+        }
+        const board = state.players[move.playerId];
+        if (!board) {
+          throw new GameMoveError("You are not in this round");
+        }
+        if (board.outcome) {
+          throw new GameMoveError("You already finished");
+        }
+
+        const payload = move.payload as { cells?: unknown } | undefined;
+        if (!payload || !Array.isArray(payload.cells)) {
+          throw new GameMoveError("Invalid move payload");
+        }
+
+        if (
+          payload.cells.some(
+            (cell) =>
+              !Number.isInteger(cell) ||
+              cell < 0 ||
+              cell >= state.gridSize * state.gridSize,
+          )
+        ) {
+          throw new GameMoveError("Path must contain valid cell IDs");
+        }
+
+        const cells = payload.cells as CellIndex[];
+        if (cells.length === 0) {
+          throw new GameMoveError("No cells provided");
+        }
+        if (cells.length > state.gridSize * state.gridSize - state.deadCells.length) {
+          throw new GameMoveError("Path is longer than this puzzle allows");
+        }
+
+        // The client sends the full updated path. Validate it from scratch.
+        const puzzle = buildPuzzleForValidation(state);
+
+        // Validate the path is a valid prefix.
+        const firstCell = cells[0];
+        const expectedStart = getFirstAnchor(puzzle);
+        if (firstCell !== expectedStart) {
+          throw new GameMoveError("Path must start at anchor 1");
+        }
+
+        // Validate each step.
+        for (let i = 1; i < cells.length; i++) {
+          const result = validateMove(cells.slice(0, i), cells[i], puzzle);
+          if (!result.valid) {
+            throw new GameMoveError(result.reason);
+          }
+        }
+
+        const nextBoard: PlayerBoard = {
+          ...board,
+          path: cells,
+        };
+
+        // Check for win.
+        const totalValidCells = state.gridSize * state.gridSize - state.deadCells.length;
+        if (cells.length === totalValidCells) {
+          const winCheck = validateCompletePath(cells, puzzle);
+          if (winCheck.valid) {
+            nextBoard.outcome = "win";
+            nextBoard.solvedAt = ctx.now;
+          }
+        }
+
+        const nextState: ZipState = {
+          ...state,
+          players: {
+            ...state.players,
+            [move.playerId]: nextBoard,
+          },
+        };
+
+        return withResultsIfComplete(nextState);
+      }
+
+      case "hint": {
+        if (state.phase !== "playing") {
+          throw new GameMoveError("Not accepting hints right now");
+        }
+        const board = state.players[move.playerId];
+        if (!board) {
+          throw new GameMoveError("You are not in this round");
+        }
+        if (board.outcome) {
+          throw new GameMoveError("You already finished");
+        }
+        if (ctx.now < board.hintAvailableAt) {
+          const remainingSeconds = Math.ceil((board.hintAvailableAt - ctx.now) / 1000);
+          throw new GameMoveError(`Hint available in ${remainingSeconds}s`);
+        }
+
+        const puzzle = buildPuzzleForValidation(state);
+        const hintResult = solveForHint(puzzle, board.path);
+        if (!hintResult) {
+          throw new GameMoveError("Unable to compute hint");
+        }
+
+        const newPath = [...hintResult.validPrefix, hintResult.nextCell];
+
+        const nextBoard: PlayerBoard = {
+          ...board,
+          path: newPath,
+          hintsUsed: board.hintsUsed + 1,
+          hintAvailableAt: ctx.now + HINT_COOLDOWN_MS,
+        };
+
+        // Check for win after hint.
+        const totalValidCells = state.gridSize * state.gridSize - state.deadCells.length;
+        if (newPath.length === totalValidCells) {
+          const winCheck = validateCompletePath(newPath, puzzle);
+          if (winCheck.valid) {
+            nextBoard.outcome = "win";
+            nextBoard.solvedAt = ctx.now;
+          }
+        }
+
+        const nextState: ZipState = {
+          ...state,
+          players: {
+            ...state.players,
+            [move.playerId]: nextBoard,
+          },
+        };
+        return withResultsIfComplete(nextState);
+      }
+
+      case "reset": {
+        if (state.phase !== "playing") {
+          throw new GameMoveError("Not accepting resets right now");
+        }
+        const board = state.players[move.playerId];
+        if (!board) {
+          throw new GameMoveError("You are not in this round");
+        }
+        if (board.outcome) {
+          throw new GameMoveError("You already finished");
+        }
+
+        const puzzle = buildPuzzleForValidation(state);
+
+        return {
+          ...state,
+          players: {
+            ...state.players,
+            [move.playerId]: {
+              ...board,
+              path: [getFirstAnchor(puzzle)],
+            },
+          },
+        };
+      }
+
+      case "nextRound": {
+        if (!ctx.isAdmin(move.playerId)) {
+          throw new GameMoveError("Only the host can advance rounds");
+        }
+        if (state.phase !== "results") {
+          throw new GameMoveError("Round is not finished yet");
+        }
+        if (state.currentRound >= state.totalRounds) {
+          throw new GameMoveError("All rounds are complete");
+        }
+        return startPlaying(state, ctx, state.currentRound + 1);
+      }
+
+      default:
+        throw new GameMoveError(`Unknown move: ${move.type}`);
+    }
+  },
+
+  onTick(state): ZipState {
+    if (state.phase !== "playing") return state;
+
+    // Early completion: all players finished.
+    if (allPlayersFinished(state)) {
+      return {
+        ...state,
+        phase: "results",
+        winnerId: computeWinnerId(state),
+        scores: accumulateScores(state),
+      };
+    }
+
+    return state;
+  },
+
+  getPhase: (state) => state.phase,
+
+  publicView(state, ctx) {
+    const totalValidCells = state.phase === "lobby" ? 0 : state.gridSize * state.gridSize - state.deadCells.length;
+
+    const standings = Object.entries(state.players)
+      .map(([playerId, board]) => ({
+        playerId,
+        playerName: ctx.players.find((p) => p.id === playerId)?.name ?? "Unknown",
+        cellsFilled: board.path.length,
+        totalCells: totalValidCells,
+        outcome: board.outcome,
+        hintsUsed: board.hintsUsed,
+        solvedAt: board.solvedAt,
+      }))
+      .sort((a, b) => {
+        const aWon = a.outcome === "win";
+        const bWon = b.outcome === "win";
+        if (aWon !== bWon) return aWon ? -1 : 1;
+        if (aWon && bWon) {
+          const hints = a.hintsUsed - b.hintsUsed;
+          if (hints !== 0) return hints;
+          return (a.solvedAt ?? Infinity) - (b.solvedAt ?? Infinity);
+        }
+        // Sort by progress.
+        return b.cellsFilled - a.cellsFilled;
+      });
+
+    const scoreEntries = Object.entries(state.scores)
+      .map(([playerId, score]) => ({
+        playerId,
+        playerName: ctx.players.find((p) => p.id === playerId)?.name ?? "Unknown",
+        score,
+      }))
+      .sort((a, b) => b.score - a.score);
+
+    const scoreboard = ctx.players
+      .map((p) => ({ id: p.id, name: p.name, score: state.scores[p.id] ?? 0 }))
+      .sort((a, b) => b.score - a.score);
+
+    return {
+      phase: state.phase,
+      gridSize: state.gridSize,
+      anchors: state.anchors,
+      barriers: state.barriers,
+      deadCells: state.deadCells,
+      serverNow: ctx.now,
+      roundStartedAt: state.phase === "lobby" ? null : state.roundStartedAt,
+      standings,
+      finishedCount: standings.filter((s) => s.outcome != null).length,
+      totalPlayers: standings.length,
+      currentRound: state.currentRound,
+      totalRounds: state.totalRounds,
+      isFinalRound: state.currentRound >= state.totalRounds,
+      scores: scoreEntries,
+      scoreboard,
+      result:
+        state.phase === "results"
+          ? {
+              solutionPath: state.solutionPath,
+              winnerId: state.winnerId,
+              winnerName: winnerName(ctx, state.winnerId),
+            }
+          : null,
+    };
+  },
+
+  playerView(state, playerId) {
+    const board = state.players[playerId] ?? null;
+    return {
+      path: board?.path ?? [],
+      outcome: board?.outcome ?? null,
+      solvedAt: board?.solvedAt ?? null,
+      hintsUsed: board?.hintsUsed ?? 0,
+      hintAvailableAt: board?.hintAvailableAt ?? 0,
+      mistakes: board?.mistakes ?? 0,
+    };
+  },
+
+  isFinished: (state) =>
+    state.phase === "results" && state.currentRound >= state.totalRounds,
+};

--- a/packages/sfu/server/games/modules/zip.ts
+++ b/packages/sfu/server/games/modules/zip.ts
@@ -94,10 +94,9 @@ const computeWinnerId = (state: ZipState): string | null => {
   return winners[0]?.[0] ?? null;
 };
 
-const allPlayersFinished = (state: ZipState): boolean => {
-  const ids = Object.keys(state.players);
-  return ids.length > 0 && ids.every((id) => state.players[id].outcome != null);
-};
+const allPlayersFinished = (state: ZipState, ctx: GameContext): boolean =>
+  ctx.activePlayers.length > 0 &&
+  ctx.activePlayers.every((player) => state.players[player.id]?.outcome != null);
 
 const accumulateScores = (state: ZipState): Record<string, number> => {
   const scores = { ...state.scores };
@@ -107,8 +106,8 @@ const accumulateScores = (state: ZipState): Record<string, number> => {
   return scores;
 };
 
-const withResultsIfComplete = (state: ZipState): ZipState => {
-  if (!allPlayersFinished(state)) return state;
+const withResultsIfComplete = (state: ZipState, ctx: GameContext): ZipState => {
+  if (!allPlayersFinished(state, ctx)) return state;
   return {
     ...state,
     phase: "results",
@@ -330,7 +329,7 @@ export const zipModule: GameModule<ZipState> = {
           },
         };
 
-        return withResultsIfComplete(nextState);
+        return withResultsIfComplete(nextState, ctx);
       }
 
       case "hint": {
@@ -381,7 +380,7 @@ export const zipModule: GameModule<ZipState> = {
             [move.playerId]: nextBoard,
           },
         };
-        return withResultsIfComplete(nextState);
+        return withResultsIfComplete(nextState, ctx);
       }
 
       case "reset": {
@@ -428,11 +427,11 @@ export const zipModule: GameModule<ZipState> = {
     }
   },
 
-  onTick(state): ZipState {
+  onTick(state, ctx): ZipState {
     if (state.phase !== "playing") return state;
 
     // Early completion: all players finished.
-    if (allPlayersFinished(state)) {
+    if (allPlayersFinished(state, ctx)) {
       return {
         ...state,
         phase: "results",

--- a/packages/sfu/server/games/modules/zipSolver.ts
+++ b/packages/sfu/server/games/modules/zipSolver.ts
@@ -1,0 +1,475 @@
+export type CellIndex = number;
+export type AnchorMap = Record<CellIndex, number>;
+
+export interface BarrierEdge {
+  from: CellIndex;
+  to: CellIndex;
+}
+
+export const MIN_GRID_SIZE = 6;
+export const MAX_GRID_SIZE = 9;
+
+export const ANCHOR_RANGES = {
+  6: { min: 6, max: 12 },
+  7: { min: 7, max: 14 },
+  8: { min: 8, max: 16 },
+  9: { min: 9, max: 18 },
+} as const satisfies Record<number, { min: number; max: number }>;
+
+export type SupportedGridSize = keyof typeof ANCHOR_RANGES;
+
+export interface PuzzleConfig {
+  size: SupportedGridSize;
+  anchorCount: number;
+  seed?: number;
+}
+
+export interface GeneratedPuzzle extends PuzzleConfig {
+  seed: number;
+  solutionPath: CellIndex[];
+  anchors: AnchorMap;
+  barriers: BarrierEdge[];
+  deadCells: CellIndex[];
+}
+
+export type RandomSource = () => number;
+
+function randomIntInclusive(min: number, max: number, random: RandomSource): number {
+  return min + Math.floor(random() * (max - min + 1));
+}
+
+function randomSeed(): number {
+  return Math.floor(Math.random() * 0x1_0000_0000) >>> 0;
+}
+
+export function createSeededRandom(seed: number): RandomSource {
+  if (!Number.isFinite(seed)) throw new RangeError("Puzzle seed must be a finite number.");
+
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+
+    return ((value ^ (value >>> 14)) >>> 0) / 0x1_0000_0000;
+  };
+}
+
+function isSupportedGridSize(size: number): size is SupportedGridSize {
+  return Object.hasOwn(ANCHOR_RANGES, size);
+}
+
+function validatePuzzleConfig(config: PuzzleConfig): void {
+  if (!Number.isInteger(config.size) || !isSupportedGridSize(config.size)) {
+    throw new RangeError(`Puzzle size must be an integer from ${MIN_GRID_SIZE} to ${MAX_GRID_SIZE}.`);
+  }
+
+  const range = ANCHOR_RANGES[config.size];
+  if (
+    !Number.isInteger(config.anchorCount) ||
+    config.anchorCount < range.min ||
+    config.anchorCount > range.max
+  ) {
+    throw new RangeError(
+      `Puzzle anchor count for ${config.size}x${config.size} must be between ${range.min} and ${range.max}.`,
+    );
+  }
+
+  if (config.seed !== undefined && !Number.isFinite(config.seed)) {
+    throw new RangeError("Puzzle seed must be a finite number.");
+  }
+}
+
+export function edgeKey(a: CellIndex, b: CellIndex): string {
+  return a < b ? `${a}:${b}` : `${b}:${a}`;
+}
+
+export function generateRandomPuzzleConfig(seed = randomSeed()): PuzzleConfig {
+  const random = createSeededRandom(seed);
+  const size = randomIntInclusive(MIN_GRID_SIZE, MAX_GRID_SIZE, random) as SupportedGridSize;
+  const range = ANCHOR_RANGES[size];
+
+  return {
+    size,
+    anchorCount: randomIntInclusive(range.min, range.max, random),
+    seed,
+  };
+}
+
+function baseSerpentinePath(size: SupportedGridSize): CellIndex[] {
+  const path: CellIndex[] = [];
+
+  for (let row = 0; row < size; row += 1) {
+    if (row % 2 === 0) {
+      for (let col = 0; col < size; col += 1) path.push(row * size + col);
+    } else {
+      for (let col = size - 1; col >= 0; col -= 1) path.push(row * size + col);
+    }
+  }
+
+  return path;
+}
+
+function neighborsOf(index: CellIndex, size: SupportedGridSize): CellIndex[] {
+  const row = Math.floor(index / size);
+  const col = index % size;
+  const neighbors: CellIndex[] = [];
+
+  if (row > 0) neighbors.push(index - size);
+  if (col + 1 < size) neighbors.push(index + 1);
+  if (row + 1 < size) neighbors.push(index + size);
+  if (col > 0) neighbors.push(index - 1);
+
+  return neighbors;
+}
+
+function applyBackbiteMove(path: CellIndex[], size: SupportedGridSize, random: RandomSource): boolean {
+  const lastIndex = path.length - 1;
+  const useStart = random() < 0.5;
+  const endpoint = useStart ? path[0] : path[lastIndex];
+  const neighbors = neighborsOf(endpoint, size);
+  const neighbor = neighbors[randomIntInclusive(0, neighbors.length - 1, random)];
+  const neighborIndex = path.indexOf(neighbor);
+
+  if (useStart) {
+    if (neighborIndex <= 1) return false;
+
+    const moved = path.slice(1, neighborIndex).reverse();
+    moved.push(endpoint, ...path.slice(neighborIndex));
+    path.splice(0, path.length, ...moved);
+    return true;
+  }
+
+  if (neighborIndex < 0 || neighborIndex >= lastIndex - 1) return false;
+
+  const moved = path.slice(0, neighborIndex + 1);
+  moved.push(endpoint, ...path.slice(neighborIndex + 1, lastIndex).reverse());
+  path.splice(0, path.length, ...moved);
+  return true;
+}
+
+function randomizePath(path: CellIndex[], size: SupportedGridSize, random: RandomSource): void {
+  // Use N^2 moves for proper mixing, where N is the number of cells (size * size)
+  const targetMoves = size * size * size * size;
+  const maxAttempts = targetMoves * 10;
+  let acceptedMoves = 0;
+
+  for (let attempt = 0; attempt < maxAttempts && acceptedMoves < targetMoves; attempt += 1) {
+    if (applyBackbiteMove(path, size, random)) acceptedMoves += 1;
+  }
+}
+
+function transformCell(index: CellIndex, size: SupportedGridSize, transform: number): CellIndex {
+  const row = Math.floor(index / size);
+  const col = index % size;
+  let nextRow = row;
+  let nextCol = col;
+
+  switch (transform) {
+    case 0:
+      break;
+    case 1:
+      nextRow = col;
+      nextCol = size - 1 - row;
+      break;
+    case 2:
+      nextRow = size - 1 - row;
+      nextCol = size - 1 - col;
+      break;
+    case 3:
+      nextRow = size - 1 - col;
+      nextCol = row;
+      break;
+    case 4:
+      nextCol = size - 1 - col;
+      break;
+    case 5:
+      nextRow = size - 1 - row;
+      break;
+    case 6:
+      nextRow = col;
+      nextCol = row;
+      break;
+    default:
+      nextRow = size - 1 - col;
+      nextCol = size - 1 - row;
+      break;
+  }
+
+  return nextRow * size + nextCol;
+}
+
+function isCentralCell(cell: CellIndex, size: SupportedGridSize): boolean {
+  const row = Math.floor(cell / size);
+  const col = cell % size;
+
+  return row > 0 && row + 1 < size && col > 0 && col + 1 < size;
+}
+
+export function generateSolutionPath(
+  size: SupportedGridSize,
+  random: RandomSource = Math.random,
+): CellIndex[] {
+  const transform = randomIntInclusive(0, 7, random);
+  const path = baseSerpentinePath(size).map((cell) => transformCell(cell, size, transform));
+
+  if (random() < 0.5) path.reverse();
+  randomizePath(path, size, random);
+
+  return path;
+}
+
+function canSkipSegment(
+  path: readonly CellIndex[],
+  index: number,
+  length: number,
+  size: SupportedGridSize,
+): boolean {
+  if (index <= 0 || index + length >= path.length) return false;
+
+  const previous = path[index - 1];
+  const next = path[index + length];
+
+  return neighborsOf(previous, size).includes(next);
+}
+
+export function carveDeadCells(
+  path: CellIndex[],
+  size: SupportedGridSize,
+  random: RandomSource = Math.random,
+): CellIndex[] {
+  if (random() < 0.5) return [];
+
+  const segmentLength = 2;
+  const targetCount = randomIntInclusive(1, Math.max(1, Math.floor(size / 3)), random) * segmentLength;
+  const deadCells: CellIndex[] = [];
+  let attemptsWithoutRemoval = 0;
+
+  while (deadCells.length < targetCount && attemptsWithoutRemoval < path.length * 3) {
+    const index = randomIntInclusive(1, path.length - segmentLength - 1, random);
+    if (!canSkipSegment(path, index, segmentLength, size)) {
+      attemptsWithoutRemoval += 1;
+      continue;
+    }
+
+    deadCells.push(...path.splice(index, segmentLength));
+    attemptsWithoutRemoval = 0;
+  }
+
+  return deadCells;
+}
+
+export function chooseAnchors(
+  path: readonly CellIndex[],
+  requestedCount: number,
+  random: RandomSource = Math.random,
+): AnchorMap {
+  const count = Math.min(path.length, Math.max(2, Math.trunc(requestedCount)));
+  const offsets = new Set<number>([0, path.length - 1]);
+
+  while (offsets.size < count) {
+    offsets.add(Math.floor(random() * path.length));
+  }
+
+  return Array.from(offsets)
+    .sort((a, b) => a - b)
+    .reduce<AnchorMap>((map, offset, index) => {
+      const cell = path[offset];
+      if (cell !== undefined) map[cell] = index + 1;
+      return map;
+    }, {});
+}
+
+export function generateBarriers(
+  path: readonly CellIndex[],
+  size: SupportedGridSize,
+  deadCells: readonly CellIndex[] = [],
+  random: RandomSource = Math.random,
+): BarrierEdge[] {
+  if (random() < 0.45) return [];
+  const solutionEdges = new Set<string>();
+  for (let index = 1; index < path.length; index += 1) {
+    solutionEdges.add(edgeKey(path[index - 1], path[index]));
+  }
+  const deadSet = new Set(deadCells);
+
+  const candidates: BarrierEdge[] = [];
+  for (let cell = 0; cell < size * size; cell += 1) {
+    if (deadSet.has(cell) || !isCentralCell(cell, size)) continue;
+
+    const right = cell + 1;
+    if (!deadSet.has(right) && cell % size + 1 < size && isCentralCell(right, size) && !solutionEdges.has(edgeKey(cell, right))) {
+      candidates.push({ from: cell, to: right });
+    }
+
+    const down = cell + size;
+    if (!deadSet.has(down) && down < size * size && isCentralCell(down, size) && !solutionEdges.has(edgeKey(cell, down))) {
+      candidates.push({ from: cell, to: down });
+    }
+  }
+
+  const targetCount = Math.min(candidates.length, randomIntInclusive(Math.max(2, size - 3), size + 2, random));
+  const barriers: BarrierEdge[] = [];
+
+  while (barriers.length < targetCount && candidates.length > 0) {
+    const index = randomIntInclusive(0, candidates.length - 1, random);
+    const [barrier] = candidates.splice(index, 1);
+    if (barrier) barriers.push(barrier);
+  }
+
+  return barriers;
+}
+
+export function generatePuzzle(config: PuzzleConfig = generateRandomPuzzleConfig()): GeneratedPuzzle {
+  validatePuzzleConfig(config);
+
+  const seed = config.seed ?? randomSeed();
+  const random = createSeededRandom(seed);
+  const solutionPath = generateSolutionPath(config.size, random);
+  const deadCells = carveDeadCells(solutionPath, config.size, random);
+
+  return {
+    ...config,
+    seed,
+    solutionPath,
+    anchors: chooseAnchors(solutionPath, config.anchorCount, random),
+    barriers: generateBarriers(solutionPath, config.size, deadCells, random),
+    deadCells,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Validation & Solving logic for Game Server                         */
+/* ------------------------------------------------------------------ */
+
+export type ValidationResult =
+  | { valid: true }
+  | { valid: false; reason: string };
+
+export function getFirstAnchor(puzzle: GeneratedPuzzle): CellIndex {
+  for (const [cellStr, order] of Object.entries(puzzle.anchors)) {
+    if (order === 1) return parseInt(cellStr, 10);
+  }
+  return puzzle.solutionPath[0];
+}
+
+export function validateMove(
+  currentPath: CellIndex[],
+  nextCell: CellIndex,
+  puzzle: GeneratedPuzzle,
+): ValidationResult {
+  const { size, anchors, barriers, deadCells } = puzzle;
+
+  if (nextCell < 0 || nextCell >= size * size) {
+    return { valid: false, reason: "Cell is out of bounds" };
+  }
+
+  if (currentPath.length === 0) {
+    return { valid: false, reason: "Path is empty" };
+  }
+
+  const head = currentPath[currentPath.length - 1];
+
+  const headRow = Math.floor(head / size);
+  const headCol = head % size;
+  const nextRow = Math.floor(nextCell / size);
+  const nextCol = nextCell % size;
+
+  if (Math.abs(headRow - nextRow) + Math.abs(headCol - nextCol) !== 1) {
+    return { valid: false, reason: "Cell is not orthogonally adjacent" };
+  }
+
+  if (deadCells.includes(nextCell)) {
+    return { valid: false, reason: "Cell is a dead cell" };
+  }
+
+  if (currentPath.includes(nextCell)) {
+    return { valid: false, reason: "Cell already visited" };
+  }
+
+  const edge = edgeKey(head, nextCell);
+  for (const b of barriers) {
+    if (edgeKey(b.from, b.to) === edge) {
+      return { valid: false, reason: "A barrier blocks this move" };
+    }
+  }
+
+  let nextExpectedAnchor = 1;
+  for (const cell of currentPath) {
+    if (anchors[cell] === nextExpectedAnchor) {
+      nextExpectedAnchor++;
+    }
+  }
+
+  if (anchors[nextCell] !== undefined && anchors[nextCell] !== nextExpectedAnchor) {
+    return { valid: false, reason: "Anchor visited out of order" };
+  }
+
+  return { valid: true };
+}
+
+export function validateCompletePath(
+  path: CellIndex[],
+  puzzle: GeneratedPuzzle,
+): ValidationResult {
+  const { size, deadCells, anchors } = puzzle;
+  const totalValidCells = size * size - deadCells.length;
+
+  if (path.length !== totalValidCells) {
+    return { valid: false, reason: "Path does not cover all available cells" };
+  }
+
+  if (path.length > 0) {
+    if (anchors[path[0]] !== 1) {
+      return { valid: false, reason: "Path must start at the first anchor" };
+    }
+
+    let nextExpectedAnchor = 1;
+    for (let i = 0; i < path.length; i++) {
+      if (i > 0) {
+        const cur = path[i];
+        const res = validateMove(path.slice(0, i), cur, puzzle);
+        if (!res.valid) return res;
+      }
+      if (anchors[path[i]] === nextExpectedAnchor) {
+        nextExpectedAnchor++;
+      }
+    }
+
+    if (nextExpectedAnchor - 1 !== Object.keys(anchors).length) {
+      return { valid: false, reason: "Not all anchors visited" };
+    }
+  }
+
+  return { valid: true };
+}
+
+export function solveForHint(
+  puzzle: GeneratedPuzzle,
+  currentPath: CellIndex[]
+): { validPrefix: CellIndex[]; nextCell: CellIndex } | null {
+  // To keep hint solving fast and robust for the 1D backbite algorithm without DFS,
+  // we align the player's path with the generated solution path.
+  let matchLen = 0;
+  while (
+    matchLen < currentPath.length &&
+    matchLen < puzzle.solutionPath.length &&
+    currentPath[matchLen] === puzzle.solutionPath[matchLen]
+  ) {
+    matchLen++;
+  }
+
+  if (matchLen === 0) {
+    return { validPrefix: [], nextCell: puzzle.solutionPath[0] };
+  }
+
+  if (matchLen < puzzle.solutionPath.length) {
+    return {
+      validPrefix: puzzle.solutionPath.slice(0, matchLen),
+      nextCell: puzzle.solutionPath[matchLen],
+    };
+  }
+
+  return null;
+}

--- a/packages/sfu/server/games/registry.ts
+++ b/packages/sfu/server/games/registry.ts
@@ -6,6 +6,7 @@ import { reactionModule } from "./modules/reaction.js";
 import { triviaModule } from "./modules/trivia.js";
 import { wordleModule } from "./modules/wordle.js";
 import { wouldYouRatherModule } from "./modules/wouldYouRather.js";
+import { zipModule } from "./modules/zip.js";
 import type { GameCatalogEntry, GameModule } from "./types.js";
 
 // Register a game here (one line). The order is the order shown in the launcher.
@@ -18,6 +19,7 @@ const MODULES: GameModule[] = [
   imposterModule,
   wordleModule,
   chessModule,
+  zipModule,
 ];
 
 const REGISTRY = new Map<string, GameModule>(

--- a/packages/sfu/test/zip.test.ts
+++ b/packages/sfu/test/zip.test.ts
@@ -298,6 +298,32 @@ describe("zip game module", () => {
     }
   });
 
+  it("finishes when all remaining active players have completed after a disconnect", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+    const withHostFinished = zipModule.onMove(
+      playing,
+      { playerId: "host", type: "move", payload: { cells: playing.solutionPath } },
+      context(2000),
+    );
+    const withRemainingPlayersFinished = zipModule.onMove(
+      withHostFinished,
+      { playerId: "alice", type: "move", payload: { cells: playing.solutionPath } },
+      context(3000),
+    );
+
+    const completed = zipModule.onTick!(
+      withRemainingPlayersFinished,
+      context(4000, { currentPlayers: players.slice(0, 2) }),
+    );
+
+    expect(completed.players.bob.outcome).toBeNull();
+    expect(completed.phase).toBe("results");
+  });
   it("supports nextRound for multi-round games", () => {
     const ctx = (now: number): GameContext => ({
       players,

--- a/packages/sfu/test/zip.test.ts
+++ b/packages/sfu/test/zip.test.ts
@@ -1,0 +1,423 @@
+import { describe, expect, it } from "vitest";
+import { zipModule } from "../server/games/modules/zip.js";
+import type { GameContext, GamePlayer, GameRng } from "../server/games/types.js";
+
+const players: GamePlayer[] = [
+  { id: "host", name: "Host" },
+  { id: "alice", name: "Alice" },
+  { id: "bob", name: "Bob" },
+];
+
+const rng = (pickIndex = 0): GameRng => ({
+  next: () => 0.5,
+  int: (max) => pickIndex % max,
+  shuffle: (items) => items.slice(),
+  pick: (items) => items[pickIndex % items.length] ?? items[0],
+});
+
+const context = (
+  now: number,
+  options?: { currentPlayers?: GamePlayer[]; pickIndex?: number },
+): GameContext => ({
+  players,
+  activePlayers: options?.currentPlayers ?? players,
+  rng: rng(options?.pickIndex),
+  config: { gridSize: "6", rounds: 1 },
+  content: null,
+  now,
+  isAdmin: (playerId) => playerId === "host",
+});
+
+const completeRound = (
+  state: ReturnType<typeof zipModule.setup>,
+  now: number,
+  getContext: (currentNow: number) => GameContext = context,
+) => {
+  let completed = state;
+  for (const [index, playerId] of ["host", "alice", "bob"].entries()) {
+    completed = zipModule.onMove(
+      completed,
+      { playerId, type: "move", payload: { cells: completed.solutionPath } },
+      getContext(now + index),
+    );
+  }
+  return completed;
+};
+
+describe("zip game module", () => {
+  it("starts in lobby phase", () => {
+    const state = zipModule.setup(context(0));
+    expect(state.phase).toBe("lobby");
+    expect(zipModule.getPhase(state)).toBe("lobby");
+  });
+
+  it("does not expose a configurable time limit", () => {
+    expect(zipModule.options?.some((option) => option.id === "timeLimitMinutes")).toBe(false);
+  });
+
+  it("rejects start from non-admin", () => {
+    const state = zipModule.setup(context(0));
+    expect(() =>
+      zipModule.onMove(
+        state,
+        { playerId: "alice", type: "start", payload: undefined },
+        context(1000),
+      ),
+    ).toThrow("Only the host can start");
+  });
+
+  it("transitions to playing on start", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+    expect(playing.phase).toBe("playing");
+    expect(playing.gridSize).toBe(6);
+    expect(Object.keys(playing.anchors).length).toBeGreaterThanOrEqual(2);
+    expect(playing.solutionPath.length).toBeGreaterThan(0);
+    expect(playing.currentRound).toBe(1);
+    expect(playing.roundStartedAt).toBe(1000);
+  });
+
+  it("creates player boards for all active players", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+    expect(Object.keys(playing.players)).toEqual(["host", "alice", "bob"]);
+    for (const board of Object.values(playing.players)) {
+      expect(board.path.length).toBe(1);
+      expect(board.outcome).toBeNull();
+      expect(board.hintsUsed).toBe(0);
+    }
+  });
+
+  it("accepts valid move with full path update", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+    const solution = playing.solutionPath;
+
+    // Send first two cells of the solution.
+    const cells = [solution[0], solution[1]];
+    const afterMove = zipModule.onMove(
+      playing,
+      { playerId: "alice", type: "move", payload: { cells } },
+      context(2000),
+    );
+    expect(afterMove.players["alice"].path.length).toBe(2);
+  });
+
+  it("rejects move when path doesn't start at anchor 1", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+    const solution = playing.solutionPath;
+    expect(() =>
+      zipModule.onMove(
+        playing,
+        {
+          playerId: "alice",
+          type: "move",
+          payload: { cells: [solution[1]] },
+        },
+        context(2000),
+      ),
+    ).toThrow("anchor 1");
+  });
+
+  it("rejects non-numeric cell payloads", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+
+    expect(() =>
+      zipModule.onMove(
+        playing,
+        {
+          playerId: "alice",
+          type: "move",
+          payload: { cells: [{ row: 0, col: 0 }] },
+        },
+        context(2000),
+      ),
+    ).toThrow("valid cell IDs");
+  });
+
+  it("detects a win when the solution path is submitted", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+    const solution = playing.solutionPath;
+
+    // Submit the full solution for alice.
+    const afterWin = zipModule.onMove(
+      playing,
+      { playerId: "alice", type: "move", payload: { cells: solution } },
+      context(2000),
+    );
+    expect(afterWin.players["alice"].outcome).toBe("win");
+    expect(afterWin.players["alice"].solvedAt).toBe(2000);
+  });
+
+  it("resets a player's path to anchor 1", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+    const solution = playing.solutionPath;
+    const partial = zipModule.onMove(
+      playing,
+      { playerId: "alice", type: "move", payload: { cells: [solution[0], solution[1]] } },
+      context(2000),
+    );
+    const reset = zipModule.onMove(
+      partial,
+      { playerId: "alice", type: "reset", payload: undefined },
+      context(3000),
+    );
+    expect(reset.players["alice"].path.length).toBe(1);
+    expect(reset.players["alice"].path[0]).toEqual(solution[0]);
+  });
+
+  it("increments hintsUsed on hint move", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+    const afterHint = zipModule.onMove(
+      playing,
+      { playerId: "alice", type: "hint", payload: undefined },
+      context(2000),
+    );
+    expect(afterHint.players["alice"].hintsUsed).toBe(1);
+    expect(afterHint.players["alice"].path.length).toBeGreaterThan(1);
+    expect(afterHint.players["alice"].hintAvailableAt).toBe(5000);
+  });
+
+  it("enforces a three-second cooldown between hints", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+    const firstHint = zipModule.onMove(
+      playing,
+      { playerId: "alice", type: "hint", payload: undefined },
+      context(2000),
+    );
+
+    expect(() =>
+      zipModule.onMove(
+        firstHint,
+        { playerId: "alice", type: "hint", payload: undefined },
+        context(4999),
+      ),
+    ).toThrow("Hint available in 1s");
+
+    const secondHint = zipModule.onMove(
+      firstHint,
+      { playerId: "alice", type: "hint", payload: undefined },
+      context(5000),
+    );
+    expect(secondHint.players["alice"].hintsUsed).toBe(2);
+  });
+
+  it("moves straight to results when a hint completes the final player path", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+    const solution = playing.solutionPath;
+    const withAliceFinished = zipModule.onMove(
+      playing,
+      { playerId: "alice", type: "move", payload: { cells: solution } },
+      context(2000),
+    );
+    const withBobFinished = zipModule.onMove(
+      withAliceFinished,
+      { playerId: "bob", type: "move", payload: { cells: solution } },
+      context(3000),
+    );
+    const almostDone = {
+      ...withBobFinished,
+      players: {
+        ...withBobFinished.players,
+        host: {
+          ...withBobFinished.players.host,
+          path: solution.slice(0, -1),
+        },
+      },
+    };
+
+    const completed = zipModule.onMove(
+      almostDone,
+      { playerId: "host", type: "hint", payload: undefined },
+      context(4000),
+    );
+
+    expect(completed.players.host.outcome).toBe("win");
+    expect(completed.phase).toBe("results");
+  });
+
+  it("does not end the round after arbitrary elapsed time", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+
+    const stillPlaying = zipModule.onTick!(playing, context(playing.roundStartedAt + 3_600_000));
+    expect(stillPlaying.phase).toBe("playing");
+    for (const board of Object.values(stillPlaying.players)) {
+      expect(board.outcome).toBeNull();
+    }
+  });
+
+  it("supports nextRound for multi-round games", () => {
+    const ctx = (now: number): GameContext => ({
+      players,
+      activePlayers: players,
+      rng: rng(),
+      config: { gridSize: "6", rounds: 3 },
+      content: null,
+      now,
+      isAdmin: (playerId) => playerId === "host",
+    });
+
+    const state = zipModule.setup(ctx(0));
+    const r1 = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      ctx(1000),
+    );
+    expect(r1.currentRound).toBe(1);
+    expect(r1.totalRounds).toBe(3);
+
+    const r1Done = completeRound(r1, 2000, ctx);
+    expect(r1Done.phase).toBe("results");
+
+    // Advance to round 2.
+    const r2 = zipModule.onMove(
+      r1Done,
+      { playerId: "host", type: "nextRound", payload: undefined },
+      ctx(5000),
+    );
+    expect(r2.phase).toBe("playing");
+    expect(r2.currentRound).toBe(2);
+  });
+
+  it("rejects nextRound when all rounds are complete", () => {
+    const ctx = (now: number): GameContext => ({
+      players,
+      activePlayers: players,
+      rng: rng(),
+      config: { gridSize: "6", rounds: 1 },
+      content: null,
+      now,
+      isAdmin: (playerId) => playerId === "host",
+    });
+
+    const state = zipModule.setup(ctx(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      ctx(1000),
+    );
+    const done = completeRound(playing, 2000, ctx);
+
+    expect(() =>
+      zipModule.onMove(
+        done,
+        { playerId: "host", type: "nextRound", payload: undefined },
+        ctx(5000),
+      ),
+    ).toThrow("All rounds are complete");
+  });
+
+  it("isFinished returns true only when final round results are reached", () => {
+    const state = zipModule.setup(context(0));
+    expect(zipModule.isFinished!(state)).toBe(false);
+
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+    expect(zipModule.isFinished!(playing)).toBe(false);
+
+    const done = completeRound(playing, 2000);
+    expect(done.phase).toBe("results");
+    expect(zipModule.isFinished!(done)).toBe(true); // 1 round, final
+  });
+
+  it("publicView exposes the client puzzle contract without the solution during play", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+
+    const pub = zipModule.publicView(playing, context(2000)) as {
+      phase: string;
+      anchors: Record<string, number>;
+      barriers: Array<{ from: number; to: number }>;
+      deadCells: number[];
+      roundStartedAt: number;
+      standings: Array<{ playerId: string; cellsFilled: number }>;
+      result: unknown;
+    };
+    expect(pub.phase).toBe("playing");
+    expect(Object.values(pub.anchors)).toContain(1);
+    expect(Array.isArray(pub.barriers)).toBe(true);
+    expect(Array.isArray(pub.deadCells)).toBe(true);
+    expect(pub.roundStartedAt).toBe(1000);
+    expect(pub.standings.length).toBe(3);
+    expect(pub.result).toBeNull(); // Solution not revealed during play.
+  });
+
+  it("playerView reveals only the player's own path", () => {
+    const state = zipModule.setup(context(0));
+    const playing = zipModule.onMove(
+      state,
+      { playerId: "host", type: "start", payload: undefined },
+      context(1000),
+    );
+
+    const view = zipModule.playerView(playing, "alice", context(2000)) as {
+      path: Array<number>;
+      outcome: string | null;
+      hintsUsed: number;
+      hintAvailableAt: number;
+    };
+    expect(view.path.length).toBe(1);
+    expect(view.outcome).toBeNull();
+    expect(view.hintsUsed).toBe(0);
+    expect(view.hintAvailableAt).toBe(0);
+  });
+});

--- a/packages/sfu/test/zipSolver.test.ts
+++ b/packages/sfu/test/zipSolver.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  generatePuzzle,
+  validateMove,
+  validateCompletePath,
+  solveForHint,
+  type GeneratedPuzzle,
+} from "../server/games/modules/zipSolver.js";
+
+describe("zipSolver", () => {
+  describe("puzzle variation", () => {
+    it("produces different layouts for independently seeded starts", () => {
+      const signatures = new Set(
+        [101, 202, 303, 404].map((seed) => {
+          const puzzle = generatePuzzle({ size: 6, anchorCount: 8, seed });
+          return JSON.stringify({
+            anchors: puzzle.anchors,
+            barriers: puzzle.barriers,
+            solutionPath: puzzle.solutionPath,
+          });
+        }),
+      );
+
+      expect(signatures.size).toBe(4);
+    });
+
+    it("creates a valid complete path at every supported grid size", () => {
+      for (const size of [6, 7, 8, 9] as const) {
+        const puzzle = generatePuzzle({
+          size,
+          anchorCount: { 6: 8, 7: 10, 8: 12, 9: 14 }[size],
+          seed: size,
+        });
+        expect(validateCompletePath(puzzle.solutionPath, puzzle).valid).toBe(true);
+      }
+    });
+  });
+
+  describe("validateMove", () => {
+    const puzzle: GeneratedPuzzle = {
+      size: 6,
+      anchorCount: 3,
+      seed: 123,
+      solutionPath: [0, 1, 2, 8, 14, 15],
+      anchors: {
+        0: 1,
+        2: 2,
+        15: 3,
+      },
+      barriers: [{ from: 1, to: 7 }],
+      deadCells: [7],
+    };
+
+    it("accepts valid orthogonal move", () => {
+      const result = validateMove([0], 1, puzzle);
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects diagonal move", () => {
+      const result = validateMove([0], 7, puzzle);
+      expect(result.valid).toBe(false);
+      expect(result.valid === false && result.reason).toContain("adjacent");
+    });
+
+    it("rejects wall/barrier crossing", () => {
+      // Barrier is 1 -> 7 (but 7 is dead anyway)
+      const result = validateMove([1], 7, puzzle);
+      expect(result.valid).toBe(false);
+      expect(result.valid === false && result.reason).toContain("dead cell");
+    });
+
+    it("rejects revisiting a cell", () => {
+      const result = validateMove([0, 1], 0, puzzle);
+      expect(result.valid).toBe(false);
+      expect(result.valid === false && result.reason).toContain("visited");
+    });
+
+    it("rejects out-of-order anchor", () => {
+      // Expected anchor is 2 (at cell 2), visiting 15 first
+      const result = validateMove([0, 6, 12, 13, 14], 15, puzzle);
+      expect(result.valid).toBe(false);
+      expect(result.valid === false && result.reason).toContain("order");
+    });
+  });
+
+  describe("validateCompletePath", () => {
+    it("accepts a valid complete path", () => {
+      const puzzle = generatePuzzle({ size: 6, anchorCount: 8, seed: 123 });
+      const path = puzzle.solutionPath;
+      const result = validateCompletePath(path, puzzle);
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects an incomplete path", () => {
+      const puzzle = generatePuzzle({ size: 6, anchorCount: 8, seed: 123 });
+      const path = puzzle.solutionPath.slice(0, -1);
+      const result = validateCompletePath(path, puzzle);
+      expect(result.valid).toBe(false);
+      expect(result.valid === false && result.reason).toContain("cover all available cells");
+    });
+  });
+
+  describe("solveForHint", () => {
+    it("returns the next correct cell from a valid prefix matching solutionPath", () => {
+      const puzzle = generatePuzzle({ size: 6, anchorCount: 8, seed: 123 });
+      const path = puzzle.solutionPath;
+
+      const hint = solveForHint(puzzle, [path[0]]);
+      expect(hint).not.toBeNull();
+      if (hint) {
+        expect(hint.validPrefix).toEqual([path[0]]);
+        expect(hint.nextCell).toBe(path[1]);
+      }
+    });
+
+    it("trims back an invalid prefix before hinting", () => {
+      const puzzle = generatePuzzle({ size: 6, anchorCount: 8, seed: 123 });
+      const path = puzzle.solutionPath;
+
+      // Make an invalid path: start correctly, then deviate to something wrong
+      const invalidPath = [path[0], path[1], path[0]];
+      const hint = solveForHint(puzzle, invalidPath);
+
+      expect(hint).not.toBeNull();
+      if (hint) {
+        expect(hint.validPrefix.length).toBe(2);
+        expect(hint.validPrefix).toEqual([path[0], path[1]]);
+        expect(hint.nextCell).toBe(path[2]);
+      }
+    });
+  });
+});


### PR DESCRIPTION
<img width="436" height="86" alt="image" src="https://github.com/user-attachments/assets/8d13410c-8026-472c-9b71-de097c258084" />


<img width="443" height="551" alt="image" src="https://github.com/user-attachments/assets/10a8a29c-806a-4aaa-9155-81c3fe0b411b" />


<img width="453" height="927" alt="image" src="https://github.com/user-attachments/assets/b1360a06-658f-446a-b2ce-aeaaef32fb8a" />


dynamic zip generation added no 2 zips are same

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR adds Zip as a dynamically generated multiplayer puzzle game. The main changes are:

- Adds the interactive Zip grid and game screens to the web app.
- Adds puzzle generation, validation, hints, scoring, and multi-round play to the SFU.
- Registers Zip in the web and server game catalogs.
- Adds tests for the game module and puzzle solver.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Active-player reconciliation prevents disconnected boards from blocking completion.
- No separate blocking issue remains in the updated request-handling path.
- The new imports and registrations match the existing build and module contracts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/sfu/server/games/modules/zip.ts | Adds the Zip game lifecycle, move validation, hints, scoring, views, and multi-round handling. |
| packages/sfu/server/games/modules/zipSolver.ts | Adds dynamic puzzle generation and path-solving helpers. |
| apps/web/src/app/components/games/ZipGame.tsx | Adds the interactive puzzle grid, controls, standings, timing, and results UI. |
| packages/sfu/test/zip.test.ts | Adds coverage for the Zip game lifecycle and player actions. |
| packages/sfu/test/zipSolver.test.ts | Adds coverage for puzzle generation and solver behavior. |

<sub>Reviews (2): Last reviewed commit: ["fix(sfu): complete zip rounds after disc..."](https://github.com/acm-vit/conclave/commit/5de1b5a6f627d0c2e0f8b2575757951445ca40c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43688743)</sub>

<!-- /greptile_comment -->