### PR TITLE
bnch of stuff

### DIFF
--- a/apps/web/src/app/components/AudioStreamPlayer.tsx
+++ b/apps/web/src/app/components/AudioStreamPlayer.tsx
@@ -16,8 +16,8 @@ const playerConfigs = {
   participant: {
     playbackErrorMessage: "[Meets] Audio play error:",
     audioOutputErrorMessage: "[Meets] Failed to update audio output:",
-    replayOnForeground: false,
-    preload: "none",
+    replayOnForeground: true,
+    preload: "auto",
   },
   screenShare: {
     playbackErrorMessage: "[Meets] Screen share audio play error:",
@@ -148,9 +148,11 @@ function AudioStreamPlayer({
     const scheduleReplay = playbackRecovery.schedule;
     const audioTrack = stream.getAudioTracks()[0];
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        scheduleReplay();
-      }
+      // Assert playback at both lifecycle edges. The hidden transition happens
+      // before background timer throttling and keeps the live media element in
+      // the browser's audible-playback path; the visible transition repairs a
+      // player suspended by page freezing or an output-device handoff.
+      scheduleReplay();
     };
     const handleUserGesture = () => {
       if (autoplayBlockedRef.current) {

--- a/apps/web/src/app/components/GridLayout.tsx
+++ b/apps/web/src/app/components/GridLayout.tsx
@@ -37,6 +37,7 @@ import {
   getRenderableParticipantVideoStream,
   isRenderingParticipantScreenShare,
 } from "../lib/participant-media";
+import { getVisibleRemoteParticipantLimit } from "../lib/participant-order-policy";
 import type { Participant } from "../lib/types";
 import { isSystemUserId, truncateDisplayName } from "../lib/utils";
 import { observeRemoteVideoPresentation } from "../lib/remote-video-presentation";
@@ -1357,6 +1358,11 @@ function GridLayout({
     0,
     maxGridTiles - gridReservedTiles,
   );
+  const maxVisibleRemoteParticipants = getVisibleRemoteParticipantLimit({
+    remoteParticipantCount: remoteInput.length,
+    maxRemoteWithoutOverflow,
+    isOverflowOpen,
+  });
   const orderedRemoteParticipants = useSmartParticipantOrder(
     remoteInput,
     activeSpeakerId,
@@ -1364,7 +1370,7 @@ function GridLayout({
       promoteDelayMs: ROOM_TILING_PROMOTE_DELAY_MS,
       minSwitchIntervalMs: ROOM_TILING_MIN_SWITCH_INTERVAL_MS,
       minParticipantsForReorder: maxRemoteWithoutOverflow + 1,
-      visibleParticipantLimit: maxRemoteWithoutOverflow,
+      visibleParticipantLimit: maxVisibleRemoteParticipants,
     },
   );
   const orderedRemoteParticipantIds = useMemo(
@@ -1404,13 +1410,7 @@ function GridLayout({
       setPinnedId(null);
     }
   }, [pinnedId, hasPresentation]);
-  const hasOverflow = orderedRemoteParticipants.length > maxRemoteWithoutOverflow;
   const isSolo = orderedRemoteParticipants.length === 0 && !hasPresentation;
-  const maxVisibleRemoteParticipants = hasOverflow
-    ? isOverflowOpen
-      ? maxRemoteWithoutOverflow
-      : Math.max(0, maxGridTiles - gridReservedTiles - 1)
-    : maxRemoteWithoutOverflow;
   const visibleParticipants = useMemo(() => {
     if (maxVisibleRemoteParticipants <= 0) {
       return [];

--- a/apps/web/src/app/components/GridLayout.tsx
+++ b/apps/web/src/app/components/GridLayout.tsx
@@ -282,8 +282,8 @@ const computeMobilePortraitGridLayout = (
   };
 };
 const ROOM_TILING_METADATA_INTERVAL_MS = 200;
-const ROOM_TILING_PROMOTE_DELAY_MS = 220;
-const ROOM_TILING_MIN_SWITCH_INTERVAL_MS = 2200;
+const ROOM_TILING_PROMOTE_DELAY_MS = 1200;
+const ROOM_TILING_MIN_SWITCH_INTERVAL_MS = 8000;
 const FLIP_DURATION_MS = 220;
 // Discrete side-panel reflow glides over the SAME duration/easing as the panel
 // slide (meet-panel-in) so the stage and the panel move together.
@@ -1364,6 +1364,7 @@ function GridLayout({
       promoteDelayMs: ROOM_TILING_PROMOTE_DELAY_MS,
       minSwitchIntervalMs: ROOM_TILING_MIN_SWITCH_INTERVAL_MS,
       minParticipantsForReorder: maxRemoteWithoutOverflow + 1,
+      visibleParticipantLimit: maxRemoteWithoutOverflow,
     },
   );
   const orderedRemoteParticipantIds = useMemo(
@@ -3290,6 +3291,8 @@ function GridLayout({
               isDynamicCropEnabled={usesAutoDynamicCrop}
               isFullVideoShown={fullVideoTileIds.has(participant.userId)}
               onToggleFullVideo={toggleFullVideoTile}
+              tileWidth={layout.tileWidth || undefined}
+              tileHeight={layout.tileHeight || undefined}
             />
           </div>
         ))}
@@ -3358,6 +3361,8 @@ function GridLayout({
               isAdmin={isAdmin}
               isPinned={false}
               videoObjectFit={getGridVideoObjectFit(participant.userId)}
+              tileWidth={layout.tileWidth || undefined}
+              tileHeight={layout.tileHeight || undefined}
               // No interactive controls on a warm (off-screen, aria-hidden) tile
               // — passing onTogglePin would render a focusable pin button that a
               // keyboard / screen reader could still reach inside aria-hidden.

--- a/apps/web/src/app/components/MeetSettingsPanel.tsx
+++ b/apps/web/src/app/components/MeetSettingsPanel.tsx
@@ -10,10 +10,12 @@ import {
   MessageCircleQuestion,
   MessageSquare,
   MessageSquareLock,
+  Mic,
   RotateCw,
   ShieldBan,
   Smile,
   Users,
+  Video,
   Volume2,
   X,
   type LucideIcon,
@@ -66,6 +68,10 @@ interface MeetSettingsPanelProps {
   onToggleImageAttachments?: () => void;
   isReactionsDisabled: boolean;
   onToggleReactionsDisabled?: () => void;
+  isParticipantUnmuteAllowed: boolean;
+  onToggleParticipantUnmuteAllowed?: () => void;
+  isParticipantVideoAllowed: boolean;
+  onToggleParticipantVideoAllowed?: () => void;
   meetingRequiresInviteCode: boolean;
   onGetMeetingConfig?: () => Promise<MeetingConfigSnapshot | null>;
   onUpdateMeetingConfig?: (
@@ -457,6 +463,10 @@ export default function MeetSettingsPanel({
   onToggleImageAttachments,
   isReactionsDisabled,
   onToggleReactionsDisabled,
+  isParticipantUnmuteAllowed,
+  onToggleParticipantUnmuteAllowed,
+  isParticipantVideoAllowed,
+  onToggleParticipantVideoAllowed,
   meetingRequiresInviteCode,
   onGetMeetingConfig,
   onUpdateMeetingConfig,
@@ -677,6 +687,26 @@ export default function MeetSettingsPanel({
             tone="warning"
             onClick={onToggleNoGuests}
             disabled={!onToggleNoGuests}
+          />
+
+          <Separator />
+
+          <SectionHeader label="Participant media" />
+          <SwitchRow
+            icon={Mic}
+            label="Allow participants to unmute"
+            isOn={isParticipantUnmuteAllowed}
+            tone="success"
+            onClick={onToggleParticipantUnmuteAllowed}
+            disabled={!onToggleParticipantUnmuteAllowed}
+          />
+          <SwitchRow
+            icon={Video}
+            label="Allow participants to turn on video"
+            isOn={isParticipantVideoAllowed}
+            tone="success"
+            onClick={onToggleParticipantVideoAllowed}
+            disabled={!onToggleParticipantVideoAllowed}
           />
 
           <Separator />

--- a/apps/web/src/app/components/MeetsMainContent.tsx
+++ b/apps/web/src/app/components/MeetsMainContent.tsx
@@ -173,7 +173,6 @@ interface MeetsMainContentProps {
   onPrejoinMediaCommit?: (handoff: PrejoinMediaHandoff) => void;
   isCameraOff: boolean;
   isMuted: boolean;
-  isMuteTogglePending?: boolean;
   isHandRaised: boolean;
   participants: Map<string, Participant>;
   isMirrorCamera: boolean;
@@ -304,6 +303,10 @@ interface MeetsMainContentProps {
   isDmEnabled: boolean;
   areImageAttachmentsEnabled: boolean;
   isReactionsDisabled: boolean;
+  isParticipantUnmuteAllowed: boolean;
+  onToggleParticipantUnmuteAllowed: () => void;
+  isParticipantVideoAllowed: boolean;
+  onToggleParticipantVideoAllowed: () => void;
   meetingRequiresInviteCode: boolean;
   webinarConfig?: WebinarConfigSnapshot | null;
   webinarRole?: "attendee" | "participant" | "host" | null;
@@ -450,7 +453,6 @@ export default function MeetsMainContent({
   onPrejoinMediaCommit,
   isCameraOff,
   isMuted,
-  isMuteTogglePending = false,
   isHandRaised,
   participants,
   isMirrorCamera,
@@ -565,6 +567,10 @@ export default function MeetsMainContent({
   isDmEnabled,
   areImageAttachmentsEnabled,
   isReactionsDisabled,
+  isParticipantUnmuteAllowed,
+  onToggleParticipantUnmuteAllowed,
+  isParticipantVideoAllowed,
+  onToggleParticipantVideoAllowed,
   meetingRequiresInviteCode,
   webinarConfig,
   webinarRole,
@@ -1717,6 +1723,10 @@ export default function MeetsMainContent({
   const toggleAppsLock = useCallback(() => {
     void handleToggleAppsLock();
   }, [handleToggleAppsLock]);
+  const isParticipantMicrophoneActivationBlocked =
+    !isAdmin && !isParticipantUnmuteAllowed;
+  const isParticipantCameraActivationBlocked =
+    !isAdmin && !isParticipantVideoAllowed;
   // Assembled once so the bar and the Mod+K quick-actions palette stay in
   // lockstep: every control the bar offers is exactly what the palette can
   // search and run.
@@ -1726,8 +1736,9 @@ export default function MeetsMainContent({
     coachAvatars,
     roomId,
     isMuted,
-    isMuteTogglePending,
+    isMicrophoneUnmuteDisabled: isParticipantMicrophoneActivationBlocked,
     isCameraOff,
+    isCameraEnableDisabled: isParticipantCameraActivationBlocked,
     isAudioOnly: viewSettings.audioOnlyMode,
     isScreenSharing,
     activeScreenShareId,
@@ -2047,6 +2058,7 @@ export default function MeetsMainContent({
         <ReactionOverlay
           store={reactionStore}
           getDisplayName={resolveDisplayName}
+          participantCount={nonSystemParticipants.length + 1}
         />
       )}
       {isDevToolsEnabled && isJoined && !isWebinarAttendee && (
@@ -2538,6 +2550,12 @@ export default function MeetsMainContent({
             onToggleImageAttachments={handleToggleImageAttachments}
             isReactionsDisabled={isReactionsDisabled}
             onToggleReactionsDisabled={handleToggleReactionsDisabled}
+            isParticipantUnmuteAllowed={isParticipantUnmuteAllowed}
+            onToggleParticipantUnmuteAllowed={
+              onToggleParticipantUnmuteAllowed
+            }
+            isParticipantVideoAllowed={isParticipantVideoAllowed}
+            onToggleParticipantVideoAllowed={onToggleParticipantVideoAllowed}
             meetingRequiresInviteCode={meetingRequiresInviteCode}
             onGetMeetingConfig={onGetMeetingConfig}
             onUpdateMeetingConfig={onUpdateMeetingConfig}
@@ -2566,6 +2584,7 @@ export default function MeetsMainContent({
           activeCount={activeVideoEffectsCount}
           deferPreload={deferVideoEffectsPreload}
           cameraPermissionBlocked={isCameraPermissionBlocked}
+          cameraActivationBlocked={isParticipantCameraActivationBlocked}
           onToggleCamera={toggleCamera}
           isCameraPreviewActive={panelPreviewIsLocalOnly}
           isCameraPreviewStarting={isCameraPreviewStarting}

--- a/apps/web/src/app/components/ParticipantVideo.tsx
+++ b/apps/web/src/app/components/ParticipantVideo.tsx
@@ -41,6 +41,9 @@ interface ParticipantVideoProps {
   isDynamicCropEnabled?: boolean;
   isFullVideoShown?: boolean;
   onToggleFullVideo?: (userId: string) => void;
+  /** Known grid dimensions avoid one ResizeObserver/state path per tile. */
+  tileWidth?: number;
+  tileHeight?: number;
 }
 
 function ParticipantVideo({
@@ -62,12 +65,22 @@ function ParticipantVideo({
   isDynamicCropEnabled = false,
   isFullVideoShown = false,
   onToggleFullVideo,
+  tileWidth,
+  tileHeight,
 }: ParticipantVideoProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   // The grid packer shrinks tiles well below the fixed chrome sizes in big
   // calls — measure the tile and scale the face/pill/badges to fit.
   const tileRef = useRef<HTMLDivElement>(null);
-  const tileSize = useElementSize(tileRef);
+  const hasKnownTileSize =
+    typeof tileWidth === "number" &&
+    tileWidth > 0 &&
+    typeof tileHeight === "number" &&
+    tileHeight > 0;
+  const measuredTileSize = useElementSize(tileRef, !hasKnownTileSize);
+  const tileSize = hasKnownTileSize
+    ? { width: tileWidth, height: tileHeight }
+    : measuredTileSize;
   const { dense, avatarSize, avatarLift } = computeTileChrome(tileSize, {
     maxAvatar: compact ? 48 : 80,
   });

--- a/apps/web/src/app/components/ReactionOverlay.tsx
+++ b/apps/web/src/app/components/ReactionOverlay.tsx
@@ -1,14 +1,22 @@
 "use client";
 
 import { memo, useSyncExternalStore } from "react";
-import type { ReactionStore } from "../lib/reaction-store";
+import {
+  getReactionRenderLimit,
+  type ReactionStore,
+} from "../lib/reaction-store";
 
 interface ReactionOverlayProps {
   store: ReactionStore;
   getDisplayName: (userId: string) => string;
+  participantCount: number;
 }
 
-function ReactionOverlay({ store, getDisplayName }: ReactionOverlayProps) {
+function ReactionOverlay({
+  store,
+  getDisplayName,
+  participantCount,
+}: ReactionOverlayProps) {
   // Subscribing here (instead of receiving reactions as a prop) keeps
   // reaction traffic from re-rendering anything above this overlay.
   const reactions = useSyncExternalStore(
@@ -19,9 +27,20 @@ function ReactionOverlay({ store, getDisplayName }: ReactionOverlayProps) {
 
   if (reactions.length === 0) return null;
 
+  // A wall of translucent animated layers is expensive to composite over a
+  // large live-video grid. Keep the newest reactions visible while bounding
+  // the amount of per-frame paint/composite work.
+  const renderLimit = getReactionRenderLimit(participantCount);
+  const visibleReactions =
+    reactions.length > renderLimit ? reactions.slice(-renderLimit) : reactions;
+
   return (
-    <div className="pointer-events-none absolute inset-0 z-20">
-      {reactions.map((reaction) => {
+    <div
+      className="meet-reaction-overlay pointer-events-none absolute inset-0 z-20"
+      data-meet-reaction-count={visibleReactions.length}
+      data-meet-reaction-limit={renderLimit}
+    >
+      {visibleReactions.map((reaction) => {
         const displayName = getDisplayName(reaction.userId);
         return (
           <div
@@ -33,6 +52,7 @@ function ReactionOverlay({ store, getDisplayName }: ReactionOverlayProps) {
               <div
                 className="animate-reaction-float flex flex-col items-center gap-1.5"
                 style={{ animationDuration: "2s" }}
+                onAnimationEnd={() => store.remove(reaction.id)}
               >
                 <div className="flex h-11 w-11 items-center justify-center rounded-full border border-[#fafafa]/10 bg-[#18181b]/90 text-2xl sm:h-14 sm:w-14 sm:text-3xl">
                   {reaction.kind === "emoji" ? (

--- a/apps/web/src/app/components/ReactionOverlay.tsx
+++ b/apps/web/src/app/components/ReactionOverlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useSyncExternalStore } from "react";
+import { memo, useEffect, useSyncExternalStore } from "react";
 import {
   getReactionRenderLimit,
   type ReactionStore,
@@ -24,13 +24,17 @@ function ReactionOverlay({
     store.getSnapshot,
     store.getSnapshot
   );
+  const renderLimit = getReactionRenderLimit(participantCount);
+
+  useEffect(() => {
+    store.setVisibleLimit(renderLimit);
+  }, [renderLimit, store]);
 
   if (reactions.length === 0) return null;
 
   // A wall of translucent animated layers is expensive to composite over a
   // large live-video grid. Keep the newest reactions visible while bounding
   // the amount of per-frame paint/composite work.
-  const renderLimit = getReactionRenderLimit(participantCount);
   const visibleReactions =
     reactions.length > renderLimit ? reactions.slice(-renderLimit) : reactions;
 

--- a/apps/web/src/app/components/VideoEffectsPanel.tsx
+++ b/apps/web/src/app/components/VideoEffectsPanel.tsx
@@ -78,6 +78,7 @@ interface VideoEffectsPanelProps {
   debugStats?: VideoEffectsDebugStats | null;
   activeCount: number;
   cameraPermissionBlocked?: boolean;
+  cameraActivationBlocked?: boolean;
   onRecenterFraming?: () => void;
   /** Turns the REAL meeting camera on/off (visible to everyone). */
   onToggleCamera?: () => void;
@@ -413,6 +414,7 @@ function VideoEffectsPreview({
   preparingLabel,
   onToggleCamera,
   cameraToggleDisabled = false,
+  cameraPreviewDisabled = cameraToggleDisabled,
   isPreviewOnly = false,
   isPreviewStarting = false,
   onStartPreview,
@@ -425,6 +427,7 @@ function VideoEffectsPreview({
   preparingLabel: string;
   onToggleCamera?: () => void;
   cameraToggleDisabled?: boolean;
+  cameraPreviewDisabled?: boolean;
   isPreviewOnly?: boolean;
   isPreviewStarting?: boolean;
   onStartPreview?: () => void;
@@ -476,7 +479,7 @@ function VideoEffectsPreview({
                 type="button"
                 data-testid="video-effects-start-preview"
                 onClick={onStartPreview}
-                disabled={cameraToggleDisabled || isPreviewStarting}
+                disabled={cameraPreviewDisabled || isPreviewStarting}
                 aria-busy={isPreviewStarting || undefined}
                 className="inline-flex items-center gap-2 rounded-full bg-[#F95F4A] px-4 py-2 text-[13px] font-medium text-white transition-[filter] duration-[120ms] hover:brightness-105 disabled:cursor-not-allowed disabled:bg-[#232327] disabled:text-[#fafafa]/40"
               >
@@ -565,6 +568,7 @@ export default function VideoEffectsPanel({
   debugStats = null,
   activeCount,
   cameraPermissionBlocked = false,
+  cameraActivationBlocked = false,
   onRecenterFraming,
   onToggleCamera,
   isCameraPreviewActive = false,
@@ -1191,7 +1195,10 @@ export default function VideoEffectsPanel({
           isPreparing={isPreparingEffects}
           preparingLabel={preparingLabel}
           onToggleCamera={onToggleCamera}
-          cameraToggleDisabled={cameraPermissionBlocked}
+          cameraToggleDisabled={
+            cameraPermissionBlocked || cameraActivationBlocked
+          }
+          cameraPreviewDisabled={cameraPermissionBlocked}
           isPreviewOnly={isCameraPreviewActive}
           isPreviewStarting={isCameraPreviewStarting}
           onStartPreview={onStartCameraPreview}
@@ -1209,14 +1216,20 @@ export default function VideoEffectsPanel({
             <span className="text-[12px] leading-snug text-[#fafafa]/74">
               Camera is off for the meeting.
             </span>
-            <button
-              type="button"
-              data-testid="video-effects-turn-on-for-everyone"
-              onClick={onToggleCamera}
-              className="shrink-0 rounded-full border border-[#F95F4A]/40 bg-[#F95F4A]/[0.14] px-3 py-1.5 text-[12px] font-medium text-[#F95F4A] transition-colors duration-[120ms] hover:bg-[#F95F4A] hover:text-white"
-            >
-              Turn on for everyone
-            </button>
+            {cameraActivationBlocked ? (
+              <span className="shrink-0 text-[12px] font-medium text-[#a1a1aa]">
+                Disabled by host
+              </span>
+            ) : (
+              <button
+                type="button"
+                data-testid="video-effects-turn-on-for-everyone"
+                onClick={onToggleCamera}
+                className="shrink-0 rounded-full border border-[#F95F4A]/40 bg-[#F95F4A]/[0.14] px-3 py-1.5 text-[12px] font-medium text-[#F95F4A] transition-colors duration-[120ms] hover:bg-[#F95F4A] hover:text-white"
+              >
+                Turn on for everyone
+              </button>
+            )}
           </div>
         ) : null}
         {cameraPreviewError ? (

--- a/apps/web/src/app/components/controls-config.ts
+++ b/apps/web/src/app/components/controls-config.ts
@@ -50,8 +50,9 @@ export interface ControlsBarProps {
   coachAvatars?: { id: string; name: string }[];
   roomId?: string;
   isMuted: boolean;
-  isMuteTogglePending?: boolean;
+  isMicrophoneUnmuteDisabled?: boolean;
   isCameraOff: boolean;
+  isCameraEnableDisabled?: boolean;
   isAudioOnly?: boolean;
   isScreenSharing: boolean;
   activeScreenShareId: string | null;
@@ -287,16 +288,14 @@ export function buildControlsConfig(p: ControlsBarProps): ControlsConfig {
     {
       id: "mic",
       icon: p.isMuted ? MicOff : Mic,
-      label: p.isMuteTogglePending
-          ? p.isMuted
-            ? "Unmuting"
-            : "Muting"
-          : p.isMuted
-            ? "Unmute"
-            : "Mute",
+      label: p.isMuted && p.isMicrophoneUnmuteDisabled
+        ? "Microphone disabled by host"
+        : p.isMuted
+          ? "Unmute"
+          : "Mute",
       hotkey: HOTKEYS.toggleMute.keys,
       variant: p.isMuted ? "muted" : "default",
-      loading: Boolean(p.isMuteTogglePending),
+      disabled: Boolean(p.isMuted && p.isMicrophoneUnmuteDisabled),
       onPress: p.onToggleMute,
     },
     {
@@ -304,12 +303,16 @@ export function buildControlsConfig(p: ControlsBarProps): ControlsConfig {
       icon: p.isCameraOff ? VideoOff : Video,
       label: p.isAudioOnly
         ? "Camera disabled in audio-only mode"
-        : p.isCameraOff
-          ? "Turn on camera"
-          : "Turn off camera",
+        : p.isCameraOff && p.isCameraEnableDisabled
+          ? "Camera disabled by host"
+          : p.isCameraOff
+            ? "Turn on camera"
+            : "Turn off camera",
       hotkey: HOTKEYS.toggleCamera.keys,
       variant: p.isCameraOff ? "muted" : "default",
-      disabled: p.isAudioOnly,
+      disabled: Boolean(
+        p.isAudioOnly || (p.isCameraOff && p.isCameraEnableDisabled),
+      ),
       onPress: p.onToggleCamera,
     },
   ];

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -139,6 +139,11 @@ select:focus {
   animation: reaction-float 2.8s ease-out forwards;
 }
 
+.meet-reaction-overlay {
+  contain: layout paint;
+  isolation: isolate;
+}
+
 @keyframes reaction-float {
   0% {
     opacity: 0;
@@ -188,6 +193,7 @@ select:focus {
   background: #131316;
   border-radius: 16px;
   overflow: hidden;
+  contain: layout paint;
   border: 1px solid rgba(250, 250, 250, 0.08);
   /* The active-speaker ring is an INSET shadow, not a border-width change;
      toggling 1px→2px border resized the video content box on every speaker

--- a/apps/web/src/app/hooks/useElementSize.ts
+++ b/apps/web/src/app/hooks/useElementSize.ts
@@ -20,10 +20,12 @@ export interface ElementSize {
  */
 export function useElementSize(
   ref: RefObject<HTMLElement | null>,
+  enabled = true,
 ): ElementSize | null {
   const [size, setSize] = useState<ElementSize | null>(null);
 
   useLayoutEffect(() => {
+    if (!enabled) return;
     const el = ref.current;
     if (!el) {
       setSize(null);
@@ -42,7 +44,7 @@ export function useElementSize(
     const observer = new ResizeObserver(measure);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [ref]);
+  }, [enabled, ref]);
 
   return size;
 }

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -117,6 +117,8 @@ interface UseMeetMediaOptions {
   isCameraOff: boolean;
   setIsCameraOff: (value: boolean) => void;
   cameraDisabled?: boolean;
+  microphoneUnmuteDisabled?: boolean;
+  cameraEnableDisabled?: boolean;
   isScreenSharing: boolean;
   setIsScreenSharing: (value: boolean) => void;
   activeScreenShareId: string | null;
@@ -499,6 +501,8 @@ export function useMeetMedia({
   isCameraOff,
   setIsCameraOff,
   cameraDisabled = false,
+  microphoneUnmuteDisabled = false,
+  cameraEnableDisabled = false,
   isScreenSharing,
   setIsScreenSharing,
   activeScreenShareId,
@@ -779,8 +783,14 @@ export function useMeetMedia({
   useEffect(() => {
     isCameraOffRef.current = isCameraOff;
   }, [isCameraOff]);
-  const videoPublishingDisabledRef = useRef(cameraDisabled);
-  videoPublishingDisabledRef.current = cameraDisabled;
+  const microphoneUnmuteDisabledRef = useRef(microphoneUnmuteDisabled);
+  microphoneUnmuteDisabledRef.current = microphoneUnmuteDisabled;
+  const cameraPublishingDisabledRef = useRef(
+    cameraDisabled || cameraEnableDisabled,
+  );
+  cameraPublishingDisabledRef.current = cameraDisabled || cameraEnableDisabled;
+  const screenSharePublishingDisabledRef = useRef(cameraDisabled);
+  screenSharePublishingDisabledRef.current = cameraDisabled;
   const isScreenSharingRef = useRef(isScreenSharing);
   useEffect(() => {
     isScreenSharingRef.current = isScreenSharing;
@@ -793,7 +803,6 @@ export function useMeetMedia({
     [setIsMuted],
   );
   const toggleMuteInFlightRef = useRef(false);
-  const [isMuteTogglePending, setIsMuteTogglePending] = useState(false);
   const toggleCameraInFlightRef = useRef(false);
   const markAudioTrackForSpeech = useCallback(
     (track?: MediaStreamTrack | null) => {
@@ -3348,9 +3357,9 @@ export function useMeetMedia({
 
   const toggleMute = useCallback(async () => {
     if (isObserverMode) return;
+    if (microphoneUnmuteDisabledRef.current && isMuted) return;
     if (toggleMuteInFlightRef.current) return;
     toggleMuteInFlightRef.current = true;
-    setIsMuteTogglePending(true);
     const previousMuted = isMuted;
     const nextMuted = !previousMuted;
     let producer = audioProducerRef.current;
@@ -3505,7 +3514,6 @@ export function useMeetMedia({
       setMeetError(meetErr);
     } finally {
       toggleMuteInFlightRef.current = false;
-      setIsMuteTogglePending(false);
     }
   }, [
     isObserverMode,
@@ -3621,6 +3629,13 @@ export function useMeetMedia({
         return;
       }
     }
+    if (microphoneUnmuteDisabledRef.current && !isMutedRef.current) {
+      (localStreamRef.current ?? localStream)
+        ?.getAudioTracks()
+        .forEach((track) => setNoiseCancellationTrackEnabled(track, false));
+      setMutedIntent(true);
+      return;
+    }
     if (audioRecoveryInFlightRef.current) return;
 
     let cancelled = false;
@@ -3674,7 +3689,6 @@ export function useMeetMedia({
           }
         }
 
-        const shouldStartPaused = isMutedRef.current;
         let audioTrack = getFirstLiveTrack(
           (localStreamRef.current ?? localStream)?.getAudioTracks() ?? [],
         );
@@ -3703,6 +3717,11 @@ export function useMeetMedia({
           return;
         }
 
+        const shouldStartPaused =
+          isMutedRef.current || microphoneUnmuteDisabledRef.current;
+        if (shouldStartPaused && !isMutedRef.current) {
+          setMutedIntent(true);
+        }
         setNoiseCancellationTrackEnabled(audioTrack, !shouldStartPaused);
 
         if (createdTrack) {
@@ -3749,6 +3768,10 @@ export function useMeetMedia({
         console.error("[Meets] Audio producer recovery failed:", err);
         removeCreatedTrackFromLocalStream();
         if (!cancelled) {
+          if (microphoneUnmuteDisabledRef.current) {
+            setMutedIntent(true);
+            return;
+          }
           const meetErr = createMeetError(err, "MEDIA_ERROR");
           const failedMutedWarmup = isMutedRef.current;
           if (
@@ -3801,6 +3824,7 @@ export function useMeetMedia({
     flushPendingAudioProcessingSwitch,
     getPublishNetworkProfile,
     requestAudioProducerRecovery,
+    setMutedIntent,
   ]);
 
   useEffect(() => {
@@ -3921,7 +3945,7 @@ export function useMeetMedia({
 
   const toggleCamera = useCallback(async () => {
     if (isObserverMode) return;
-    if (videoPublishingDisabledRef.current && isCameraOff) return;
+    if (cameraPublishingDisabledRef.current && isCameraOff) return;
     if (toggleCameraInFlightRef.current) return;
     toggleCameraInFlightRef.current = true;
 
@@ -4015,7 +4039,7 @@ export function useMeetMedia({
           createdTrack = videoTrack ?? null;
 
           if (!videoTrack) throw new Error("No video track obtained");
-          if (videoPublishingDisabledRef.current) {
+          if (cameraPublishingDisabledRef.current) {
             stopLocalTrack(videoTrack);
             createdTrack = null;
             setIsCameraOff(true);
@@ -4043,7 +4067,7 @@ export function useMeetMedia({
             videoTrack,
           );
           attachLocalVideoTrackHandlers(publishTrack);
-          if (videoPublishingDisabledRef.current) {
+          if (cameraPublishingDisabledRef.current) {
             stopLocalTrack(videoTrack);
             const currentStream = localStreamRef.current;
             if (currentStream?.getTracks().includes(videoTrack)) {
@@ -4082,7 +4106,7 @@ export function useMeetMedia({
             context: "camera-toggle",
           });
 
-          if (videoPublishingDisabledRef.current) {
+          if (cameraPublishingDisabledRef.current) {
             socketRef.current?.emit(
               "closeProducer",
               { producerId: videoProducer.id },
@@ -4168,6 +4192,7 @@ export function useMeetMedia({
     if (isObserverMode) return;
     if (connectionState !== "joined") return;
     if (cameraDisabled) return;
+    if (cameraEnableDisabled) return;
     if (isCameraOff) return;
     if (isMediaRecoveryBlocked()) return;
 
@@ -4281,6 +4306,8 @@ export function useMeetMedia({
     };
   }, [
     connectionState,
+    cameraDisabled,
+    cameraEnableDisabled,
     isCameraOff,
     isMediaRecoveryBlocked,
     isObserverMode,
@@ -5140,10 +5167,36 @@ export function useMeetMedia({
     if (existingProducer) {
       closeLocalVideoProducerForReplacement(existingProducer);
     }
+    if (cameraPublishingDisabledRef.current) {
+      const currentStream = localStreamRef.current;
+      currentStream?.getVideoTracks().forEach((track) => {
+        stopLocalTrack(track);
+      });
+      const remainingTracks =
+        currentStream?.getTracks().filter((track) => track.kind !== "video") ??
+        [];
+      commitLocalStream(new MediaStream(remainingTracks));
+      isCameraOffRef.current = true;
+      setIsCameraOff(true);
+      return;
+    }
     if (cameraRecoveryInFlightRef.current) return;
 
     let cancelled = false;
     let createdTrack: MediaStreamTrack | null = null;
+    const disableBlockedCameraIntent = () => {
+      const currentStream = localStreamRef.current;
+      currentStream?.getVideoTracks().forEach((track) => {
+        stopLocalTrack(track);
+      });
+      const remainingTracks =
+        currentStream?.getTracks().filter((track) => track.kind !== "video") ??
+        [];
+      commitLocalStream(new MediaStream(remainingTracks));
+      createdTrack = null;
+      isCameraOffRef.current = true;
+      setIsCameraOff(true);
+    };
     const removeCreatedTrackFromLocalStream = () => {
       if (!createdTrack) return;
       stopLocalTrack(createdTrack);
@@ -5278,11 +5331,20 @@ export function useMeetMedia({
           context: "camera-recovery",
         });
 
-        if (cancelled || videoPublishingDisabledRef.current) {
+        if (cancelled || cameraPublishingDisabledRef.current) {
+          socketRef.current?.emit(
+            "closeProducer",
+            { producerId: recoveredProducer.id },
+            () => {},
+          );
           try {
             recoveredProducer.close();
           } catch {}
-          removeCreatedTrackFromLocalStream();
+          if (cameraPublishingDisabledRef.current) {
+            disableBlockedCameraIntent();
+          } else {
+            removeCreatedTrackFromLocalStream();
+          }
           return;
         }
 
@@ -5304,6 +5366,10 @@ export function useMeetMedia({
         setIsCameraOff(false);
       } catch (err) {
         console.error("[Meets] Camera producer recovery failed:", err);
+        if (cameraPublishingDisabledRef.current) {
+          disableBlockedCameraIntent();
+          return;
+        }
         removeCreatedTrackFromLocalStream();
         if (!cancelled) {
           const meetErr = createMeetError(err, "MEDIA_ERROR");
@@ -5344,12 +5410,14 @@ export function useMeetMedia({
     isObserverMode,
     connectionState,
     cameraDisabled,
+    cameraEnableDisabled,
     cameraProducerRecoveryPulse,
     isCameraOff,
     isMediaRecoveryBlocked,
     attachLocalVideoTrackHandlers,
     handleLocalTrackEnded,
     stopLocalTrack,
+    commitLocalStream,
     setLocalStream,
     setIsCameraOff,
     setMeetError,
@@ -5780,7 +5848,7 @@ export function useMeetMedia({
       return;
     }
 
-    if (videoPublishingDisabledRef.current) return;
+    if (screenSharePublishingDisabledRef.current) return;
 
     if (activeScreenShareId) {
       setMeetError({
@@ -5799,7 +5867,7 @@ export function useMeetMedia({
       if (!transport) {
         const transportReady =
           (await ensureProducerTransportRef?.current?.()) ?? false;
-        if (videoPublishingDisabledRef.current) return;
+        if (screenSharePublishingDisabledRef.current) return;
         transport = getUsableProducerTransport(producerTransportRef.current);
         if (!transportReady || !transport) {
           throw new Error("Screen share transport unavailable");
@@ -5867,7 +5935,7 @@ export function useMeetMedia({
         }
       }
       acquiredScreenShareStream = stream;
-      if (videoPublishingDisabledRef.current) {
+      if (screenSharePublishingDisabledRef.current) {
         stopScreenShareStream(stream);
         resetScreenShareControlState();
         return;
@@ -5895,7 +5963,7 @@ export function useMeetMedia({
         screenNetworkProfile,
         screenPublishSettings,
       );
-      if (videoPublishingDisabledRef.current) {
+      if (screenSharePublishingDisabledRef.current) {
         stopScreenShareStream(stream);
         resetScreenShareControlState();
         return;
@@ -5912,7 +5980,7 @@ export function useMeetMedia({
         publishSettings: screenPublishSettings,
       });
 
-      if (videoPublishingDisabledRef.current) {
+      if (screenSharePublishingDisabledRef.current) {
         socketRef.current?.emit(
           "closeProducer",
           { producerId: producer.id },
@@ -5994,7 +6062,7 @@ export function useMeetMedia({
         );
       }
 
-      if (videoPublishingDisabledRef.current) {
+      if (screenSharePublishingDisabledRef.current) {
         finishScreenShare();
         return;
       }
@@ -6030,7 +6098,7 @@ export function useMeetMedia({
           }
 
           if (
-            videoPublishingDisabledRef.current ||
+            screenSharePublishingDisabledRef.current ||
             screenVideoEnded ||
             track.readyState !== "live" ||
             screenShareStreamRef.current !== stream
@@ -6103,7 +6171,6 @@ export function useMeetMedia({
     mediaState,
     showPermissionHint,
     screenShareControlState,
-    isMuteTogglePending,
     requestMediaPermissions,
     handleAudioInputDeviceChange,
     handleVideoInputDeviceChange,

--- a/apps/web/src/app/hooks/useMeetMedia.ts
+++ b/apps/web/src/app/hooks/useMeetMedia.ts
@@ -99,7 +99,7 @@ import {
   createLatestWinsAsyncQueue,
   type LatestWinsAsyncQueue,
 } from "../lib/latest-wins-async-queue";
-import type { ConnectionQualityStats } from "./useConnectionQuality";
+import { resumeProducerWithServerConfirmation } from "../lib/media-toggle-policy";
 import {
   createLatestWinsTopologyReplacementQueue,
   getWebcamTopologyReplacementFailureDisposition,
@@ -108,6 +108,7 @@ import {
   type WebcamTopologyReplacementResult,
   type WebcamTopologyReplacementTarget,
 } from "../lib/webcam-topology-transition";
+import type { ConnectionQualityStats } from "./useConnectionQuality";
 
 interface UseMeetMediaOptions {
   isObserverMode?: boolean;
@@ -272,6 +273,7 @@ const getFallbackInputDeviceId = (devices: readonly MediaDeviceInfo[]) =>
 const TOGGLE_MUTE_STRICT_ACK_TIMEOUT_MS = 5000;
 const TOGGLE_MUTE_FAST_ACK_TIMEOUT_MS = 1500;
 const TOGGLE_MUTE_BACKGROUND_ACK_TIMEOUT_MS = 3000;
+const TOGGLE_CAMERA_ACK_TIMEOUT_MS = 5000;
 
 const getUsableProducerTransport = (
   transport: Transport | null | undefined,
@@ -1060,11 +1062,12 @@ export function useMeetMedia({
     }
   }, [getAudioContext]);
 
-  const emitToggleMute = useCallback(
+  const emitToggleMedia = useCallback(
     (
+      eventName: "toggleMute" | "toggleCamera",
       producerId: string,
       paused: boolean,
-      options?: { timeoutMs?: number },
+      timeoutMs: number,
     ) => {
       const socket = socketRef.current;
       if (!socket || !socket.connected) {
@@ -1076,16 +1079,14 @@ export function useMeetMedia({
 
       return new Promise<{ ok: boolean; error?: string }>((resolve) => {
         let settled = false;
-        const timeoutMs =
-          options?.timeoutMs ?? TOGGLE_MUTE_STRICT_ACK_TIMEOUT_MS;
         const timeout = window.setTimeout(() => {
           if (settled) return;
           settled = true;
-          resolve({ ok: false, error: "toggleMute timeout" });
+          resolve({ ok: false, error: `${eventName} timeout` });
         }, timeoutMs);
 
         socket.emit(
-          "toggleMute",
+          eventName,
           { producerId, paused },
           (response: { success: boolean } | { error: string }) => {
             if (settled) return;
@@ -1101,6 +1102,32 @@ export function useMeetMedia({
       });
     },
     [socketRef]
+  );
+
+  const emitToggleMute = useCallback(
+    (
+      producerId: string,
+      paused: boolean,
+      options?: { timeoutMs?: number },
+    ) =>
+      emitToggleMedia(
+        "toggleMute",
+        producerId,
+        paused,
+        options?.timeoutMs ?? TOGGLE_MUTE_STRICT_ACK_TIMEOUT_MS,
+      ),
+    [emitToggleMedia],
+  );
+
+  const emitToggleCamera = useCallback(
+    (producerId: string, paused: boolean) =>
+      emitToggleMedia(
+        "toggleCamera",
+        producerId,
+        paused,
+        TOGGLE_CAMERA_ACK_TIMEOUT_MS,
+      ),
+    [emitToggleMedia],
   );
 
   const closeLocalAudioProducerForReplacement = useCallback(
@@ -3984,13 +4011,21 @@ export function useMeetMedia({
         }
 
         if (producer.track?.readyState === "live") {
-          producer.resume();
-          setIsCameraOff(false);
-          socketRef.current?.emit(
-            "toggleCamera",
-            { producerId: producer.id, paused: false },
-            () => {}
+          const toggleResult = await resumeProducerWithServerConfirmation(
+            producer,
+            () => emitToggleCamera(producer.id, false),
           );
+          if (!toggleResult.ok) {
+            console.warn(
+              "[Meets] toggleCamera failed, rolling back camera resume:",
+              toggleResult.error,
+            );
+            isCameraOffRef.current = true;
+            setIsCameraOff(true);
+            return;
+          }
+          isCameraOffRef.current = false;
+          setIsCameraOff(false);
           return;
         }
 
@@ -4181,6 +4216,7 @@ export function useMeetMedia({
     videoQualityRef,
     setIsCameraOff,
     setMeetError,
+    emitToggleCamera,
     waitForPreferredVideoPublishTrack,
     buildVideoConstraints,
     getPublishNetworkProfile,

--- a/apps/web/src/app/hooks/useMeetPopout.ts
+++ b/apps/web/src/app/hooks/useMeetPopout.ts
@@ -35,6 +35,8 @@ export interface UseMeetPopoutOptions {
   currentUserId: string;
   isCameraOff: boolean;
   isMuted: boolean;
+  isMicrophoneUnmuteDisabled?: boolean;
+  isCameraEnableDisabled?: boolean;
   mirrorLocalPreview: boolean;
   getDisplayName: (userId: string) => string;
   onToggleMute: () => void;
@@ -268,6 +270,13 @@ const POPOUT_CSS = `
     background: rgba(249, 95, 74, 0.12);
   }
 
+  .ctrl-btn:disabled,
+  .ctrl-btn:disabled:hover {
+    color: rgba(250, 250, 250, 0.3);
+    background: transparent;
+    cursor: not-allowed;
+  }
+
   .ctrl-btn svg {
     width: 15px;
     height: 15px;
@@ -314,6 +323,8 @@ export function useMeetPopout({
   currentUserId,
   isCameraOff,
   isMuted,
+  isMicrophoneUnmuteDisabled = false,
+  isCameraEnableDisabled = false,
   mirrorLocalPreview,
   getDisplayName,
   onToggleMute,
@@ -523,17 +534,30 @@ export function useMeetPopout({
       labelMuted.style.display = participant.isMuted ? "flex" : "none";
     }
 
-    const muteBtn = doc.getElementById("btn-mute");
-    const camBtn = doc.getElementById("btn-cam");
+    const muteBtn = doc.getElementById("btn-mute") as HTMLButtonElement | null;
+    const camBtn = doc.getElementById("btn-cam") as HTMLButtonElement | null;
     if (muteBtn) {
       muteBtn.className = `ctrl-btn${isMuted ? " muted" : ""}`;
       muteBtn.innerHTML = isMuted ? MIC_OFF_SVG : MIC_ON_SVG;
+      muteBtn.disabled = isMuted && isMicrophoneUnmuteDisabled;
+      muteBtn.title = muteBtn.disabled
+        ? "Microphone disabled by host"
+        : "Toggle mute";
     }
     if (camBtn) {
       camBtn.className = `ctrl-btn${isCameraOff ? " muted" : ""}`;
       camBtn.innerHTML = isCameraOff ? CAM_OFF_SVG : CAM_ON_SVG;
+      camBtn.disabled = isCameraOff && isCameraEnableDisabled;
+      camBtn.title = camBtn.disabled ? "Camera disabled by host" : "Toggle camera";
     }
-  }, [getVisibleParticipants, isMuted, isCameraOff, mirrorLocalPreview]);
+  }, [
+    getVisibleParticipants,
+    isMuted,
+    isCameraOff,
+    isMicrophoneUnmuteDisabled,
+    isCameraEnableDisabled,
+    mirrorLocalPreview,
+  ]);
 
   useEffect(() => { updatePopoutRef.current = updatePopoutContent; }, [updatePopoutContent]);
 

--- a/apps/web/src/app/hooks/useMeetSocket.ts
+++ b/apps/web/src/app/hooks/useMeetSocket.ts
@@ -101,6 +101,7 @@ import {
   rememberProvenVp9EncoderIncompatibility,
 } from "../lib/webcam-codec-policy";
 import { setNoiseCancellationTrackEnabled } from "../lib/noise-cancellation";
+import { applyBackgroundAudioBuffer } from "../lib/background-audio-playback";
 import {
   getMostConstrainedWebcamProducerNetworkProfile,
   getScreenShareReceiveNetworkProfileForAvailableIncomingBitrate,
@@ -914,6 +915,8 @@ interface UseMeetSocketOptions {
   setIsDmEnabled: (value: boolean) => void;
   setAreImageAttachmentsEnabled: (value: boolean) => void;
   setIsReactionsDisabled: (value: boolean) => void;
+  setIsParticipantUnmuteAllowed: (value: boolean) => void;
+  setIsParticipantVideoAllowed: (value: boolean) => void;
   setActiveScreenShareId: (value: string | null) => void;
   setActiveSpeakerId: React.Dispatch<React.SetStateAction<string | null>>;
   setServerActiveSpeakerAvailable: (value: boolean) => void;
@@ -1027,6 +1030,8 @@ export function useMeetSocket({
   setIsDmEnabled,
   setAreImageAttachmentsEnabled,
   setIsReactionsDisabled,
+  setIsParticipantUnmuteAllowed,
+  setIsParticipantVideoAllowed,
   setActiveScreenShareId,
   setActiveSpeakerId,
   setServerActiveSpeakerAvailable,
@@ -1242,6 +1247,13 @@ export function useMeetSocket({
     iceRestartInFlightRef,
     producerSyncIntervalRef,
   } = refs;
+
+  useEffect(() => {
+    consumersRef.current.forEach((consumer) => {
+      if (consumer.kind !== "audio" || consumer.closed) return;
+      applyBackgroundAudioBuffer(consumer.rtpReceiver, isDocumentVisible);
+    });
+  }, [consumersRef, isDocumentVisible]);
 
   const writeWebcamStartupLatencyResetDebug = useCallback(
     (state: WebcamStartupLatencyResetRuntime) => {
@@ -4124,13 +4136,26 @@ export function useMeetSocket({
   );
 
   const produce = useCallback(
-    async (stream: MediaStream): Promise<void> => {
+    async (
+      stream: MediaStream,
+      participantMediaPermissions: {
+        unmuteAllowed: boolean;
+        videoAllowed: boolean;
+      } = { unmuteAllowed: true, videoAllowed: true },
+    ): Promise<void> => {
       const transport = producerTransportRef.current;
       if (!transport) return;
       const publicationWarnings: string[] = [];
       const mediaIntent = resolveMediaPublishIntent(stream);
-      const shouldPauseAudio = !mediaIntent.isMicOn;
-      const shouldPauseVideo = !mediaIntent.isCameraOn;
+      const shouldPauseAudio =
+        !mediaIntent.isMicOn || !participantMediaPermissions.unmuteAllowed;
+      const shouldPauseVideo =
+        !mediaIntent.isCameraOn || !participantMediaPermissions.videoAllowed;
+
+      if (mediaIntent.isMicOn && shouldPauseAudio) {
+        isMutedRef.current = true;
+        setIsMuted(true);
+      }
 
       let audioTrack = getFirstLiveTrack(stream.getAudioTracks());
       if (audioTrack) {
@@ -4188,7 +4213,7 @@ export function useMeetSocket({
           });
         } catch (err) {
           console.error("[Meets] Failed to produce audio:", err);
-          if (mediaIntent.isMicOn) {
+          if (mediaIntent.isMicOn && !shouldPauseAudio) {
             if (audioTrack.readyState === "live") {
               publicationWarnings.push("microphone publish retry scheduled");
               setNoiseCancellationTrackEnabled(audioTrack, true);
@@ -4219,8 +4244,16 @@ export function useMeetSocket({
         setIsMuted(true);
       }
 
-      if (!mediaIntent.isCameraOn) {
-        dropVideoTracksForCameraOff(stream, "camera-off publish intent");
+      if (shouldPauseVideo) {
+        dropVideoTracksForCameraOff(
+          stream,
+          mediaIntent.isCameraOn
+            ? "host-disabled camera publish intent"
+            : "camera-off publish intent",
+        );
+        if (mediaIntent.isCameraOn) {
+          setIsCameraOff(true);
+        }
         if (publicationWarnings.length > 0) {
           console.warn(
             `[Meets] Continuing join without some local media: ${publicationWarnings.join(", ")}`
@@ -4751,6 +4784,12 @@ export function useMeetSocket({
               }
 
               consumersRef.current.set(producerInfo.producerId, consumer);
+              if (consumer.kind === "audio") {
+                applyBackgroundAudioBuffer(
+                  consumer.rtpReceiver,
+                  isDocumentVisible,
+                );
+              }
               const stagedTelemetry =
                 pendingConsumerTelemetryByIdRef.current.get(consumer.id);
               pendingConsumerTelemetryByIdRef.current.delete(consumer.id);
@@ -6766,6 +6805,12 @@ export function useMeetSocket({
                 response.areImageAttachmentsEnabled ?? true,
               );
               setIsReactionsDisabled(response.isReactionsDisabled ?? false);
+              setIsParticipantUnmuteAllowed(
+                response.isParticipantUnmuteAllowed ?? true,
+              );
+              setIsParticipantVideoAllowed(
+                response.isParticipantVideoAllowed ?? true,
+              );
               resolve("waiting");
               return;
             }
@@ -6789,6 +6834,12 @@ export function useMeetSocket({
                 response.areImageAttachmentsEnabled ?? true,
               );
               setIsReactionsDisabled(response.isReactionsDisabled ?? false);
+              setIsParticipantUnmuteAllowed(
+                response.isParticipantUnmuteAllowed ?? true,
+              );
+              setIsParticipantVideoAllowed(
+                response.isParticipantVideoAllowed ?? true,
+              );
               if (
                 Object.prototype.hasOwnProperty.call(response, "activeSpeakerId")
               ) {
@@ -6899,8 +6950,21 @@ export function useMeetSocket({
                 createConsumerTransport(socket, device),
               ]);
 
+              const joiningUserIsHost =
+                response.webinarRole === "host" ||
+                response.hostUserId === userId ||
+                response.hostUserIds?.includes(userId) === true;
               const producePromise =
-                shouldProduce && stream ? produce(stream) : Promise.resolve();
+                shouldProduce && stream
+                  ? produce(stream, {
+                      unmuteAllowed:
+                        joiningUserIsHost ||
+                        (response.isParticipantUnmuteAllowed ?? true),
+                      videoAllowed:
+                        joiningUserIsHost ||
+                        (response.isParticipantVideoAllowed ?? true),
+                    })
+                  : Promise.resolve();
 
               for (const producer of response.existingProducers) {
                 if (producer.producerUserId !== userId) {
@@ -8473,6 +8537,23 @@ export function useMeetSocket({
             );
 
             socket.on(
+              "participantMediaPermissionsChanged",
+              ({
+                unmuteAllowed,
+                videoAllowed,
+                roomId: eventRoomId,
+              }: {
+                unmuteAllowed: boolean;
+                videoAllowed: boolean;
+                roomId?: string;
+              }) => {
+                if (!isRoomEvent(eventRoomId)) return;
+                setIsParticipantUnmuteAllowed(unmuteAllowed);
+                setIsParticipantVideoAllowed(videoAllowed);
+              },
+            );
+
+            socket.on(
               "noGuestsChanged",
               ({
                 noGuests,
@@ -9607,6 +9688,35 @@ export function useMeetSocket({
     [socketRef]
   );
 
+  const setParticipantMediaPermissions = useCallback(
+    (permissions: {
+      unmuteAllowed?: boolean;
+      videoAllowed?: boolean;
+    }): Promise<boolean> => {
+      const socket = socketRef.current;
+      if (!socket) return Promise.resolve(false);
+
+      return new Promise((resolve) => {
+        socket.emit(
+          "setParticipantMediaPermissions",
+          permissions,
+          (response: { success: boolean } | { error: string }) => {
+            if ("error" in response) {
+              console.error(
+                "[Meets] Failed to update participant media permissions:",
+                response.error,
+              );
+              resolve(false);
+              return;
+            }
+            resolve(response.success);
+          },
+        );
+      });
+    },
+    [socketRef],
+  );
+
   const endRoomForEveryone = useCallback(
     (
       options: { message?: string; delayMs?: number } = {},
@@ -10077,6 +10187,7 @@ export function useMeetSocket({
     toggleRoomLock,
     toggleNoGuests,
     toggleChatLock,
+    setParticipantMediaPermissions,
     endRoomForEveryone,
     getTranscriptToken,
     getTranscriptSfuRelayStatus,

--- a/apps/web/src/app/hooks/useMeetState.ts
+++ b/apps/web/src/app/hooks/useMeetState.ts
@@ -48,6 +48,10 @@ export function useMeetState({ initialRoomId }: UseMeetStateOptions) {
   const [areImageAttachmentsEnabled, setAreImageAttachmentsEnabled] =
     useState(true);
   const [isReactionsDisabled, setIsReactionsDisabled] = useState(false);
+  const [isParticipantUnmuteAllowed, setIsParticipantUnmuteAllowed] =
+    useState(true);
+  const [isParticipantVideoAllowed, setIsParticipantVideoAllowed] =
+    useState(true);
   const [isBrowserAudioMuted, setIsBrowserAudioMuted] = useState(false);
   const [meetVolume, setMeetVolumeValue] = useState(DEFAULT_MEET_VOLUME);
   const setMeetVolume = useCallback((value: SetStateAction<number>) => {
@@ -131,6 +135,10 @@ export function useMeetState({ initialRoomId }: UseMeetStateOptions) {
     setAreImageAttachmentsEnabled,
     isReactionsDisabled,
     setIsReactionsDisabled,
+    isParticipantUnmuteAllowed,
+    setIsParticipantUnmuteAllowed,
+    isParticipantVideoAllowed,
+    setIsParticipantVideoAllowed,
     isBrowserAudioMuted,
     setIsBrowserAudioMuted,
     meetVolume,

--- a/apps/web/src/app/hooks/useSmartParticipantOrder.ts
+++ b/apps/web/src/app/hooks/useSmartParticipantOrder.ts
@@ -1,6 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  isSpeakerOutsideVisibleWindow,
+  placeParticipantAtVisibleBoundary,
+} from "../lib/participant-order-policy";
 
 interface ParticipantWithMediaHints {
   userId: string;
@@ -16,6 +20,7 @@ interface UseSmartParticipantOrderOptions {
   promoteDelayMs?: number;
   minSwitchIntervalMs?: number;
   minParticipantsForReorder?: number;
+  visibleParticipantLimit?: number;
 }
 
 interface SmartParticipantOrderResult<T extends ParticipantWithMediaHints> {
@@ -57,6 +62,7 @@ function useSmartParticipantOrderWithMetadata<
     promoteDelayMs = 700,
     minSwitchIntervalMs = 2200,
     minParticipantsForReorder = DEFAULT_MIN_PARTICIPANTS_FOR_REORDER,
+    visibleParticipantLimit,
   } = options;
   const canReorderParticipants = participants.length >= minParticipantsForReorder;
   const participantIdsKey = useMemo(
@@ -165,6 +171,20 @@ function useSmartParticipantOrderWithMetadata<
       return;
     }
 
+    if (
+      activeSpeakerId === featuredSpeakerIdRef.current ||
+      !isSpeakerOutsideVisibleWindow({
+        speakerId: activeSpeakerId,
+        participants: participantsRef.current,
+        previousOrder: previousOrderRef.current,
+        visibleParticipantLimit,
+      })
+    ) {
+      candidateIdRef.current = null;
+      candidateSinceRef.current = 0;
+      return;
+    }
+
     const now = Date.now();
     if (candidateIdRef.current !== activeSpeakerId) {
       candidateIdRef.current = activeSpeakerId;
@@ -178,6 +198,16 @@ function useSmartParticipantOrderWithMetadata<
         return;
       }
       if (featuredSpeakerIdRef.current === candidateId) return;
+      if (
+        !isSpeakerOutsideVisibleWindow({
+          speakerId: candidateId,
+          participants: participantsRef.current,
+          previousOrder: previousOrderRef.current,
+          visibleParticipantLimit,
+        })
+      ) {
+        return;
+      }
 
       const nowMs = Date.now();
       const elapsedSinceSwitch = nowMs - lastSwitchAtRef.current;
@@ -207,6 +237,7 @@ function useSmartParticipantOrderWithMetadata<
     participantIdsKey,
     promoteDelayMs,
     minSwitchIntervalMs,
+    visibleParticipantLimit,
   ]);
 
   const orderedParticipants = useMemo(() => {
@@ -222,10 +253,13 @@ function useSmartParticipantOrderWithMetadata<
       raisedOrder.map((userId, index) => [userId, index] as const)
     );
 
-    return [...participants].sort((left, right) => {
+    const sortedParticipants = [...participants].sort((left, right) => {
       const leftIsFeatured = left.userId === featuredSpeakerId ? 1 : 0;
       const rightIsFeatured = right.userId === featuredSpeakerId ? 1 : 0;
-      if (leftIsFeatured !== rightIsFeatured) {
+      if (
+        visibleParticipantLimit === undefined &&
+        leftIsFeatured !== rightIsFeatured
+      ) {
         return rightIsFeatured - leftIsFeatured;
       }
 
@@ -269,7 +303,19 @@ function useSmartParticipantOrderWithMetadata<
 
       return left.userId.localeCompare(right.userId);
     });
-  }, [canReorderParticipants, participants, featuredSpeakerId, raisedOrder]);
+
+    return placeParticipantAtVisibleBoundary(
+      sortedParticipants,
+      featuredSpeakerId,
+      visibleParticipantLimit,
+    );
+  }, [
+    canReorderParticipants,
+    participants,
+    featuredSpeakerId,
+    raisedOrder,
+    visibleParticipantLimit,
+  ]);
 
   // Return the SAME array reference when the resulting order is element-
   // identical (e.g. a participant's mute toggled but the sort didn't move

--- a/apps/web/src/app/lib/background-audio-playback.ts
+++ b/apps/web/src/app/lib/background-audio-playback.ts
@@ -1,0 +1,69 @@
+export const BACKGROUND_AUDIO_JITTER_BUFFER_TARGET_MS = 180;
+
+export type BackgroundAudioBufferApplyStatus =
+  | "applied"
+  | "unchanged"
+  | "reset"
+  | "unsupported"
+  | "error";
+
+export type BackgroundAudioBufferApplyResult = {
+  status: BackgroundAudioBufferApplyStatus;
+  observedTargetMs: number | null;
+};
+
+type ReceiverWithJitterBufferTarget = {
+  jitterBufferTarget: DOMHighResTimeStamp | null;
+};
+
+/**
+ * Gives hidden meeting tabs enough received-audio headroom to tolerate browser
+ * scheduling jitter. Returning to the foreground restores browser-controlled
+ * buffering so interactive latency does not stay elevated.
+ */
+export const applyBackgroundAudioBuffer = (
+  receiver: unknown,
+  isDocumentVisible: boolean,
+): BackgroundAudioBufferApplyResult => {
+  if (
+    (typeof receiver !== "object" || receiver === null) &&
+    typeof receiver !== "function"
+  ) {
+    return { status: "unsupported", observedTargetMs: null };
+  }
+
+  try {
+    if (!("jitterBufferTarget" in receiver)) {
+      return { status: "unsupported", observedTargetMs: null };
+    }
+
+    const targetReceiver = receiver as ReceiverWithJitterBufferTarget;
+    const currentTarget = targetReceiver.jitterBufferTarget;
+    if (
+      currentTarget !== null &&
+      (typeof currentTarget !== "number" || !Number.isFinite(currentTarget))
+    ) {
+      return { status: "error", observedTargetMs: null };
+    }
+
+    const requestedTarget = isDocumentVisible
+      ? null
+      : BACKGROUND_AUDIO_JITTER_BUFFER_TARGET_MS;
+    if (currentTarget === requestedTarget) {
+      return { status: "unchanged", observedTargetMs: currentTarget };
+    }
+
+    targetReceiver.jitterBufferTarget = requestedTarget;
+    const observedTarget = targetReceiver.jitterBufferTarget;
+    if (observedTarget !== requestedTarget) {
+      return { status: "error", observedTargetMs: observedTarget };
+    }
+
+    return {
+      status: requestedTarget === null ? "reset" : "applied",
+      observedTargetMs: observedTarget,
+    };
+  } catch {
+    return { status: "error", observedTargetMs: null };
+  }
+};

--- a/apps/web/src/app/lib/media-toggle-policy.ts
+++ b/apps/web/src/app/lib/media-toggle-policy.ts
@@ -1,0 +1,28 @@
+export type MediaToggleResult = { ok: boolean; error?: string };
+
+type ResumableProducer = {
+  resume: () => void;
+  pause: () => void;
+};
+
+export const resumeProducerWithServerConfirmation = async (
+  producer: ResumableProducer,
+  confirmResume: () => Promise<MediaToggleResult>,
+): Promise<MediaToggleResult> => {
+  producer.resume();
+  let result: MediaToggleResult;
+  try {
+    result = await confirmResume();
+  } catch (error) {
+    try {
+      producer.pause();
+    } catch {}
+    throw error;
+  }
+  if (!result.ok) {
+    try {
+      producer.pause();
+    } catch {}
+  }
+  return result;
+};

--- a/apps/web/src/app/lib/noise-cancellation.ts
+++ b/apps/web/src/app/lib/noise-cancellation.ts
@@ -240,6 +240,28 @@ const resumeContext = (context: AudioContext) => {
   }
 };
 
+type AudioContextWithSilentSink = AudioContext & {
+  setSinkId?: (sinkId: string | { type: "none" }) => Promise<void>;
+};
+
+const connectSilentRealtimeDestination = async (
+  context: AudioContext,
+  source: AudioNode,
+): Promise<void> => {
+  const contextWithSink = context as AudioContextWithSilentSink;
+  if (typeof contextWithSink.setSinkId !== "function") return;
+
+  try {
+    // Chromium can throttle an AudioContext whose only destination is a
+    // MediaStream when its tab is hidden. Its silent sink keeps the realtime
+    // audio clock rendering without feeding the microphone back to speakers.
+    await contextWithSink.setSinkId({ type: "none" });
+    source.connect(context.destination);
+  } catch {
+    // The MediaStream destination remains the portable fallback.
+  }
+};
+
 const loadNoiseCancellationWorklet = (context: AudioContext): Promise<boolean> => {
   if (!context.audioWorklet) {
     return Promise.resolve(false);
@@ -439,6 +461,7 @@ export async function createNoiseCancellationPipeline(
     destination,
   ];
   connectNodes(nodes);
+  await connectSilentRealtimeDestination(context, outputGain);
 
   const outputTrack = destination.stream.getAudioTracks()[0];
   if (!outputTrack) {

--- a/apps/web/src/app/lib/participant-order-policy.ts
+++ b/apps/web/src/app/lib/participant-order-policy.ts
@@ -1,0 +1,62 @@
+type ParticipantOrderEntry = {
+  userId: string;
+};
+
+export const isSpeakerOutsideVisibleWindow = ({
+  speakerId,
+  participants,
+  previousOrder,
+  visibleParticipantLimit,
+}: {
+  speakerId: string;
+  participants: readonly ParticipantOrderEntry[];
+  previousOrder: ReadonlyMap<string, number>;
+  visibleParticipantLimit: number | undefined;
+}): boolean => {
+  if (visibleParticipantLimit === undefined) return true;
+  if (visibleParticipantLimit <= 0) return false;
+
+  const previousIndex = previousOrder.get(speakerId);
+  const fallbackIndex = participants.findIndex(
+    (participant) => participant.userId === speakerId,
+  );
+  const currentIndex = previousIndex ?? fallbackIndex;
+  return currentIndex >= visibleParticipantLimit;
+};
+
+/**
+ * Promotes an overflow speaker with a single seat swap instead of moving them
+ * to the front and shifting every visible tile.
+ */
+export const placeParticipantAtVisibleBoundary = <
+  T extends ParticipantOrderEntry,
+>(
+  participants: readonly T[],
+  participantId: string | null,
+  visibleParticipantLimit: number | undefined,
+): T[] => {
+  const next = [...participants];
+  if (
+    !participantId ||
+    visibleParticipantLimit === undefined ||
+    visibleParticipantLimit <= 0
+  ) {
+    return next;
+  }
+
+  const participantIndex = next.findIndex(
+    (participant) => participant.userId === participantId,
+  );
+  const boundaryIndex = Math.min(visibleParticipantLimit, next.length) - 1;
+  if (participantIndex < visibleParticipantLimit || boundaryIndex < 0) {
+    return next;
+  }
+
+  const boundaryParticipant = next[boundaryIndex];
+  const promotedParticipant = next[participantIndex];
+  if (!boundaryParticipant || !promotedParticipant) return next;
+
+  next[boundaryIndex] = promotedParticipant;
+  next[participantIndex] = boundaryParticipant;
+  return next;
+};

--- a/apps/web/src/app/lib/participant-order-policy.ts
+++ b/apps/web/src/app/lib/participant-order-policy.ts
@@ -2,6 +2,22 @@ type ParticipantOrderEntry = {
   userId: string;
 };
 
+export const getVisibleRemoteParticipantLimit = ({
+  remoteParticipantCount,
+  maxRemoteWithoutOverflow,
+  isOverflowOpen,
+}: {
+  remoteParticipantCount: number;
+  maxRemoteWithoutOverflow: number;
+  isOverflowOpen: boolean;
+}): number => {
+  const hasOverflow = remoteParticipantCount > maxRemoteWithoutOverflow;
+  if (!hasOverflow || isOverflowOpen) {
+    return maxRemoteWithoutOverflow;
+  }
+  return Math.max(0, maxRemoteWithoutOverflow - 1);
+};
+
 export const isSpeakerOutsideVisibleWindow = ({
   speakerId,
   participants,

--- a/apps/web/src/app/lib/reaction-store.ts
+++ b/apps/web/src/app/lib/reaction-store.ts
@@ -16,12 +16,40 @@ export interface ReactionStore {
   clear: () => void;
 }
 
-export function createReactionStore(maxReactions: number): ReactionStore {
+export const getReactionRenderLimit = (participantCount: number) => {
+  if (participantCount >= 36) return 8;
+  if (participantCount >= 20) return 12;
+  return 20;
+};
+
+type ScheduleReactionStoreFlush = (flush: () => void) => void;
+
+const scheduleReactionStoreFlush: ScheduleReactionStoreFlush = (flush) => {
+  if (
+    typeof window !== "undefined" &&
+    typeof window.requestAnimationFrame === "function"
+  ) {
+    window.requestAnimationFrame(() => flush());
+    return;
+  }
+  queueMicrotask(flush);
+};
+
+export function createReactionStore(
+  maxReactions: number,
+  scheduleFlush: ScheduleReactionStoreFlush = scheduleReactionStoreFlush,
+): ReactionStore {
   let snapshot: ReactionEvent[] = [];
   const listeners = new Set<() => void>();
+  let flushScheduled = false;
 
   const emit = () => {
-    for (const listener of listeners) listener();
+    if (flushScheduled) return;
+    flushScheduled = true;
+    scheduleFlush(() => {
+      flushScheduled = false;
+      for (const listener of listeners) listener();
+    });
   };
 
   return {

--- a/apps/web/src/app/lib/reaction-store.ts
+++ b/apps/web/src/app/lib/reaction-store.ts
@@ -11,6 +11,7 @@ import type { ReactionEvent } from "./types";
 export interface ReactionStore {
   subscribe: (listener: () => void) => () => void;
   getSnapshot: () => ReactionEvent[];
+  setVisibleLimit: (limit: number) => void;
   add: (event: ReactionEvent) => void;
   remove: (id: string) => void;
   clear: () => void;
@@ -40,6 +41,7 @@ export function createReactionStore(
   scheduleFlush: ScheduleReactionStoreFlush = scheduleReactionStoreFlush,
 ): ReactionStore {
   let snapshot: ReactionEvent[] = [];
+  let visibleLimit = maxReactions;
   const listeners = new Set<() => void>();
   let flushScheduled = false;
 
@@ -60,9 +62,22 @@ export function createReactionStore(
       };
     },
     getSnapshot: () => snapshot,
+    setVisibleLimit(limit) {
+      const nextLimit = Math.min(
+        maxReactions,
+        Math.max(0, Math.floor(Number.isFinite(limit) ? limit : maxReactions)),
+      );
+      if (nextLimit === visibleLimit) return;
+      visibleLimit = nextLimit;
+      if (snapshot.length <= visibleLimit) return;
+      snapshot = visibleLimit === 0 ? [] : snapshot.slice(-visibleLimit);
+      emit();
+    },
     add(event) {
+      if (visibleLimit === 0) return;
       const next = [...snapshot, event];
-      snapshot = next.length > maxReactions ? next.slice(-maxReactions) : next;
+      snapshot =
+        next.length > visibleLimit ? next.slice(-visibleLimit) : next;
       emit();
     },
     remove(id) {

--- a/apps/web/src/app/meets-client.tsx
+++ b/apps/web/src/app/meets-client.tsx
@@ -577,6 +577,10 @@ export default function MeetsClient({
     setAreImageAttachmentsEnabled,
     isReactionsDisabled,
     setIsReactionsDisabled,
+    isParticipantUnmuteAllowed,
+    setIsParticipantUnmuteAllowed,
+    isParticipantVideoAllowed,
+    setIsParticipantVideoAllowed,
     isBrowserAudioMuted,
     setIsBrowserAudioMuted,
     meetVolume,
@@ -1182,6 +1186,11 @@ export default function MeetsClient({
     ],
   );
 
+  const isParticipantMicrophoneActivationBlocked =
+    !isAdminFlag && !isParticipantUnmuteAllowed;
+  const isParticipantCameraActivationBlocked =
+    !isAdminFlag && !isParticipantVideoAllowed;
+
   const {
     showPermissionHint,
     screenShareControlState,
@@ -1195,7 +1204,6 @@ export default function MeetsClient({
     requestCameraProducerRecovery,
     prepareAudioPublishTrack,
     toggleMute,
-    isMuteTogglePending,
     toggleCamera,
     toggleScreenShare,
     stopLocalTrack,
@@ -1211,6 +1219,8 @@ export default function MeetsClient({
     isCameraOff,
     setIsCameraOff,
     cameraDisabled: viewSettings.audioOnlyMode,
+    microphoneUnmuteDisabled: isParticipantMicrophoneActivationBlocked,
+    cameraEnableDisabled: isParticipantCameraActivationBlocked,
     isScreenSharing,
     setIsScreenSharing,
     activeScreenShareId,
@@ -2349,6 +2359,8 @@ export default function MeetsClient({
     setIsDmEnabled,
     setAreImageAttachmentsEnabled,
     setIsReactionsDisabled,
+    setIsParticipantUnmuteAllowed,
+    setIsParticipantVideoAllowed,
     setActiveScreenShareId,
     setActiveSpeakerId,
     setServerActiveSpeakerAvailable,
@@ -2836,6 +2848,8 @@ export default function MeetsClient({
       currentUserId: userId,
       isCameraOff,
       isMuted,
+      isMicrophoneUnmuteDisabled: isParticipantMicrophoneActivationBlocked,
+      isCameraEnableDisabled: isParticipantCameraActivationBlocked,
       mirrorLocalPreview,
       getDisplayName: resolveDisplayName,
       onToggleMute: () => {
@@ -3404,7 +3418,6 @@ export default function MeetsClient({
         onPrejoinMediaCommit={handlePrejoinMediaCommit}
         isCameraOff={isCameraOff}
         isMuted={isMuted}
-        isMuteTogglePending={isMuteTogglePending}
         isHandRaised={isHandRaised}
         participants={participants}
         isMirrorCamera={isMirrorCamera}
@@ -3498,6 +3511,22 @@ export default function MeetsClient({
         isDmEnabled={isDmEnabled}
         areImageAttachmentsEnabled={areImageAttachmentsEnabled}
         isReactionsDisabled={isReactionsDisabled}
+        isParticipantUnmuteAllowed={isParticipantUnmuteAllowed}
+        onToggleParticipantUnmuteAllowed={() => {
+          if (canModerateMeeting) {
+            void socket.setParticipantMediaPermissions({
+              unmuteAllowed: !isParticipantUnmuteAllowed,
+            });
+          }
+        }}
+        isParticipantVideoAllowed={isParticipantVideoAllowed}
+        onToggleParticipantVideoAllowed={() => {
+          if (canModerateMeeting) {
+            void socket.setParticipantMediaPermissions({
+              videoAllowed: !isParticipantVideoAllowed,
+            });
+          }
+        }}
         onToggleLock={() => {
           if (canModerateMeeting) void socket.toggleRoomLock(!isRoomLocked);
         }}

--- a/apps/web/src/app/sfu-admin/types.ts
+++ b/apps/web/src/app/sfu-admin/types.ts
@@ -60,7 +60,10 @@ export type RoomPolicies = {
   noGuests: boolean;
   ttsDisabled: boolean;
   dmEnabled: boolean;
+  imageAttachmentsEnabled: boolean;
   reactionsDisabled: boolean;
+  participantUnmuteAllowed: boolean;
+  participantVideoAllowed: boolean;
   requiresMeetingInviteCode: boolean;
 };
 

--- a/apps/web/test/background-audio-playback.test.ts
+++ b/apps/web/test/background-audio-playback.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyBackgroundAudioBuffer,
+  BACKGROUND_AUDIO_JITTER_BUFFER_TARGET_MS,
+} from "../src/app/lib/background-audio-playback";
+
+describe("background audio playback", () => {
+  it("adds receive headroom while the document is hidden", () => {
+    const receiver = { jitterBufferTarget: null as number | null };
+
+    expect(applyBackgroundAudioBuffer(receiver, false)).toEqual({
+      status: "applied",
+      observedTargetMs: BACKGROUND_AUDIO_JITTER_BUFFER_TARGET_MS,
+    });
+    expect(receiver.jitterBufferTarget).toBe(
+      BACKGROUND_AUDIO_JITTER_BUFFER_TARGET_MS,
+    );
+  });
+
+  it("restores browser-managed buffering in the foreground", () => {
+    const receiver = {
+      jitterBufferTarget: BACKGROUND_AUDIO_JITTER_BUFFER_TARGET_MS as
+        | number
+        | null,
+    };
+
+    expect(applyBackgroundAudioBuffer(receiver, true)).toEqual({
+      status: "reset",
+      observedTargetMs: null,
+    });
+    expect(receiver.jitterBufferTarget).toBeNull();
+  });
+
+  it("fails safely when the receiver does not support the API", () => {
+    expect(applyBackgroundAudioBuffer({}, false)).toEqual({
+      status: "unsupported",
+      observedTargetMs: null,
+    });
+  });
+});

--- a/apps/web/test/command-palette-actions.test.ts
+++ b/apps/web/test/command-palette-actions.test.ts
@@ -91,6 +91,38 @@ describe("buildPaletteActions", () => {
     expect(share?.label).toBe("Stop sharing");
   });
 
+  it("disables only participant media activation blocked by the host", () => {
+    const inactive = buildPaletteActions(
+      baseProps({
+        isMuted: true,
+        isCameraOff: true,
+        isMicrophoneUnmuteDisabled: true,
+        isCameraEnableDisabled: true,
+      }),
+      noDevices,
+    );
+    expect(inactive.find((action) => action.id === "mic")?.disabled).toBe(true);
+    expect(inactive.find((action) => action.id === "camera")?.disabled).toBe(
+      true,
+    );
+
+    const active = buildPaletteActions(
+      baseProps({
+        isMuted: false,
+        isCameraOff: false,
+        isMicrophoneUnmuteDisabled: true,
+        isCameraEnableDisabled: true,
+      }),
+      noDevices,
+    );
+    expect(active.find((action) => action.id === "mic")?.disabled).not.toBe(
+      true,
+    );
+    expect(active.find((action) => action.id === "camera")?.disabled).not.toBe(
+      true,
+    );
+  });
+
   it("only offers panel toggles whose handlers exist", () => {
     const without = buildPaletteActions(baseProps(), noDevices);
     expect(ids(without)).not.toContain("participants");

--- a/apps/web/test/controls-config.test.ts
+++ b/apps/web/test/controls-config.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildControlsConfig,
+  type ControlsBarProps,
+} from "../src/app/components/controls-config";
+
+const noop = () => {};
+
+const buildProps = (isMuted: boolean): ControlsBarProps => ({
+  roomId: "test-room",
+  isMuted,
+  isCameraOff: false,
+  isScreenSharing: false,
+  activeScreenShareId: null,
+  isChatOpen: false,
+  unreadCount: 0,
+  isHandRaised: false,
+  reactionOptions: [],
+  onToggleMute: noop,
+  onToggleCamera: noop,
+  onToggleScreenShare: noop,
+  onToggleChat: noop,
+  onToggleHandRaised: noop,
+  onSendReaction: noop,
+  onLeave: noop,
+});
+
+describe("microphone control", () => {
+  it.each([
+    { isMuted: false, label: "Mute" },
+    { isMuted: true, label: "Unmute" },
+  ])("shows $label immediately", ({ isMuted, label }) => {
+    const mic = buildControlsConfig(buildProps(isMuted)).center.find(
+      (control) => control.id === "mic",
+    );
+
+    expect(mic?.label).toBe(label);
+    expect(mic?.loading).not.toBe(true);
+  });
+});

--- a/apps/web/test/media-toggle-policy.test.ts
+++ b/apps/web/test/media-toggle-policy.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { resumeProducerWithServerConfirmation } from "../src/app/lib/media-toggle-policy";
+
+describe("media toggle policy", () => {
+  it("keeps a resumed producer active after server confirmation", async () => {
+    const producer = { resume: vi.fn(), pause: vi.fn() };
+
+    const result = await resumeProducerWithServerConfirmation(
+      producer,
+      async () => ({ ok: true }),
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(producer.resume).toHaveBeenCalledOnce();
+    expect(producer.pause).not.toHaveBeenCalled();
+  });
+
+  it("re-pauses a producer when the server rejects its resume", async () => {
+    const producer = { resume: vi.fn(), pause: vi.fn() };
+
+    const result = await resumeProducerWithServerConfirmation(
+      producer,
+      async () => ({ ok: false, error: "Video permission revoked" }),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Video permission revoked",
+    });
+    expect(producer.resume).toHaveBeenCalledOnce();
+    expect(producer.pause).toHaveBeenCalledOnce();
+  });
+
+  it("re-pauses a producer when resume confirmation fails", async () => {
+    const producer = { resume: vi.fn(), pause: vi.fn() };
+
+    await expect(
+      resumeProducerWithServerConfirmation(producer, async () => {
+        throw new Error("Socket disconnected");
+      }),
+    ).rejects.toThrow("Socket disconnected");
+
+    expect(producer.resume).toHaveBeenCalledOnce();
+    expect(producer.pause).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/test/participant-order-policy.test.ts
+++ b/apps/web/test/participant-order-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getVisibleRemoteParticipantLimit,
   isSpeakerOutsideVisibleWindow,
   placeParticipantAtVisibleBoundary,
 } from "../src/app/lib/participant-order-policy";
@@ -9,6 +10,46 @@ const participants = ["a", "b", "c", "d", "e"].map((userId) => ({
 }));
 
 describe("participant order policy", () => {
+  it("uses the collapsed grid capacity for overflow speaker promotion", () => {
+    const visibleParticipantLimit = getVisibleRemoteParticipantLimit({
+      remoteParticipantCount: 5,
+      maxRemoteWithoutOverflow: 4,
+      isOverflowOpen: false,
+    });
+    const reordered = placeParticipantAtVisibleBoundary(
+      participants,
+      "e",
+      visibleParticipantLimit,
+    );
+
+    expect(visibleParticipantLimit).toBe(3);
+    expect(
+      reordered
+        .slice(0, visibleParticipantLimit)
+        .map((participant) => participant.userId),
+    ).toEqual(["a", "b", "e"]);
+  });
+
+  it("restores the reserved overflow seat when overflow is open", () => {
+    expect(
+      getVisibleRemoteParticipantLimit({
+        remoteParticipantCount: 5,
+        maxRemoteWithoutOverflow: 4,
+        isOverflowOpen: true,
+      }),
+    ).toBe(4);
+  });
+
+  it("does not reserve an overflow seat when every remote fits", () => {
+    expect(
+      getVisibleRemoteParticipantLimit({
+        remoteParticipantCount: 4,
+        maxRemoteWithoutOverflow: 4,
+        isOverflowOpen: false,
+      }),
+    ).toBe(4);
+  });
+
   it("does not promote speakers who already have a visible seat", () => {
     expect(
       isSpeakerOutsideVisibleWindow({

--- a/apps/web/test/participant-order-policy.test.ts
+++ b/apps/web/test/participant-order-policy.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSpeakerOutsideVisibleWindow,
+  placeParticipantAtVisibleBoundary,
+} from "../src/app/lib/participant-order-policy";
+
+const participants = ["a", "b", "c", "d", "e"].map((userId) => ({
+  userId,
+}));
+
+describe("participant order policy", () => {
+  it("does not promote speakers who already have a visible seat", () => {
+    expect(
+      isSpeakerOutsideVisibleWindow({
+        speakerId: "b",
+        participants,
+        previousOrder: new Map(),
+        visibleParticipantLimit: 4,
+      }),
+    ).toBe(false);
+  });
+
+  it("identifies a speaker beyond the visible grid boundary", () => {
+    expect(
+      isSpeakerOutsideVisibleWindow({
+        speakerId: "e",
+        participants,
+        previousOrder: new Map(),
+        visibleParticipantLimit: 4,
+      }),
+    ).toBe(true);
+  });
+
+  it("swaps only the final visible seat when an overflow speaker is promoted", () => {
+    const reordered = placeParticipantAtVisibleBoundary(participants, "e", 4);
+
+    expect(reordered.map((participant) => participant.userId)).toEqual([
+      "a",
+      "b",
+      "c",
+      "e",
+      "d",
+    ]);
+  });
+
+  it("leaves an already-visible featured speaker in place", () => {
+    const reordered = placeParticipantAtVisibleBoundary(participants, "b", 4);
+
+    expect(reordered.map((participant) => participant.userId)).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+    ]);
+  });
+});

--- a/apps/web/test/reaction-store.test.ts
+++ b/apps/web/test/reaction-store.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createReactionStore,
+  getReactionRenderLimit,
+} from "../src/app/lib/reaction-store";
+import type { ReactionEvent } from "../src/app/lib/types";
+
+const makeReaction = (id: string): ReactionEvent => ({
+  id,
+  userId: `user-${id}`,
+  kind: "emoji",
+  value: "👍",
+  label: "Thumbs up",
+  timestamp: 1,
+  lane: 50,
+});
+
+describe("reaction store", () => {
+  it("reduces composited reactions as the call gets larger", () => {
+    expect(getReactionRenderLimit(12)).toBe(20);
+    expect(getReactionRenderLimit(24)).toBe(12);
+    expect(getReactionRenderLimit(48)).toBe(8);
+  });
+
+  it("coalesces a burst into one subscriber notification", () => {
+    const pendingFlushes: Array<() => void> = [];
+    const store = createReactionStore(30, (flush) => {
+      pendingFlushes.push(flush);
+    });
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.add(makeReaction("one"));
+    store.add(makeReaction("two"));
+    store.add(makeReaction("three"));
+
+    expect(store.getSnapshot()).toHaveLength(3);
+    expect(pendingFlushes).toHaveLength(1);
+    expect(listener).not.toHaveBeenCalled();
+
+    pendingFlushes.shift()?.();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps only the newest reactions while a notification is pending", () => {
+    const pendingFlushes: Array<() => void> = [];
+    const store = createReactionStore(2, (flush) => {
+      pendingFlushes.push(flush);
+    });
+
+    store.add(makeReaction("one"));
+    store.add(makeReaction("two"));
+    store.add(makeReaction("three"));
+
+    expect(store.getSnapshot().map((reaction) => reaction.id)).toEqual([
+      "two",
+      "three",
+    ]);
+    expect(pendingFlushes).toHaveLength(1);
+  });
+});

--- a/apps/web/test/reaction-store.test.ts
+++ b/apps/web/test/reaction-store.test.ts
@@ -59,4 +59,30 @@ describe("reaction store", () => {
     ]);
     expect(pendingFlushes).toHaveLength(1);
   });
+
+  it("permanently drops reactions excluded by the visible limit", () => {
+    const store = createReactionStore(30, () => {});
+    store.setVisibleLimit(2);
+
+    store.add(makeReaction("one"));
+    store.add(makeReaction("two"));
+    store.add(makeReaction("three"));
+    store.remove("three");
+
+    expect(store.getSnapshot().map((reaction) => reaction.id)).toEqual(["two"]);
+  });
+
+  it("prunes stored reactions when the visible limit shrinks", () => {
+    const store = createReactionStore(30, () => {});
+    store.add(makeReaction("one"));
+    store.add(makeReaction("two"));
+    store.add(makeReaction("three"));
+
+    store.setVisibleLimit(2);
+
+    expect(store.getSnapshot().map((reaction) => reaction.id)).toEqual([
+      "two",
+      "three",
+    ]);
+  });
 });

--- a/packages/meeting-core/src/types.ts
+++ b/packages/meeting-core/src/types.ts
@@ -391,6 +391,8 @@ export interface JoinRoomResponse {
   isDmEnabled?: boolean;
   areImageAttachmentsEnabled?: boolean;
   isReactionsDisabled?: boolean;
+  isParticipantUnmuteAllowed?: boolean;
+  isParticipantVideoAllowed?: boolean;
   meetingRequiresInviteCode?: boolean;
   webinarRole?: "attendee" | "participant" | "host";
   isWebinarEnabled?: boolean;

--- a/packages/sfu/config/classes/Room.ts
+++ b/packages/sfu/config/classes/Room.ts
@@ -222,6 +222,8 @@ export class Room {
   private _isDmEnabled: boolean = true;
   private _areImageAttachmentsEnabled: boolean = true;
   private _reactionsDisabled: boolean = false;
+  private _participantUnmuteAllowed: boolean = true;
+  private _participantVideoAllowed: boolean = true;
   private _meetingInviteCodeHash: string | null = null;
   public appsState: { activeAppId: string | null; locked: boolean } = {
     activeAppId: null,
@@ -1764,6 +1766,22 @@ export class Room {
 
   setReactionsDisabled(disabled: boolean): void {
     this._reactionsDisabled = disabled;
+  }
+
+  get isParticipantUnmuteAllowed(): boolean {
+    return this._participantUnmuteAllowed;
+  }
+
+  setParticipantUnmuteAllowed(allowed: boolean): void {
+    this._participantUnmuteAllowed = allowed;
+  }
+
+  get isParticipantVideoAllowed(): boolean {
+    return this._participantVideoAllowed;
+  }
+
+  setParticipantVideoAllowed(allowed: boolean): void {
+    this._participantVideoAllowed = allowed;
   }
 
   get requiresMeetingInviteCode(): boolean {

--- a/packages/sfu/server/admin/controlPlane.ts
+++ b/packages/sfu/server/admin/controlPlane.ts
@@ -71,6 +71,8 @@ export type RoomSnapshot = {
     dmEnabled: boolean;
     imageAttachmentsEnabled: boolean;
     reactionsDisabled: boolean;
+    participantUnmuteAllowed: boolean;
+    participantVideoAllowed: boolean;
     requiresMeetingInviteCode: boolean;
   };
   access: {
@@ -146,6 +148,8 @@ export type RoomPolicyUpdate = {
   dmEnabled?: boolean;
   imageAttachmentsEnabled?: boolean;
   reactionsDisabled?: boolean;
+  participantUnmuteAllowed?: boolean;
+  participantVideoAllowed?: boolean;
 };
 
 type ProducerInfo = ReturnType<Client["getProducerInfos"]>[number];
@@ -345,6 +349,8 @@ export const toRoomSnapshot = (room: Room): RoomSnapshot => {
       dmEnabled: room.isDmEnabled,
       imageAttachmentsEnabled: room.areImageAttachmentsEnabled,
       reactionsDisabled: room.isReactionsDisabled,
+      participantUnmuteAllowed: room.isParticipantUnmuteAllowed,
+      participantVideoAllowed: room.isParticipantVideoAllowed,
       requiresMeetingInviteCode: room.requiresMeetingInviteCode,
     },
     access: {
@@ -747,6 +753,33 @@ export const applyRoomPolicyUpdate = (
     changed.reactionsDisabled = update.reactionsDisabled;
     io.to(room.channelId).emit("reactionsDisabledChanged", {
       disabled: update.reactionsDisabled,
+      roomId: room.id,
+    });
+  }
+
+  let participantMediaPermissionsChanged = false;
+  if (
+    typeof update.participantUnmuteAllowed === "boolean" &&
+    update.participantUnmuteAllowed !== room.isParticipantUnmuteAllowed
+  ) {
+    room.setParticipantUnmuteAllowed(update.participantUnmuteAllowed);
+    changed.participantUnmuteAllowed = update.participantUnmuteAllowed;
+    participantMediaPermissionsChanged = true;
+  }
+
+  if (
+    typeof update.participantVideoAllowed === "boolean" &&
+    update.participantVideoAllowed !== room.isParticipantVideoAllowed
+  ) {
+    room.setParticipantVideoAllowed(update.participantVideoAllowed);
+    changed.participantVideoAllowed = update.participantVideoAllowed;
+    participantMediaPermissionsChanged = true;
+  }
+
+  if (participantMediaPermissionsChanged) {
+    io.to(room.channelId).emit("participantMediaPermissionsChanged", {
+      unmuteAllowed: room.isParticipantUnmuteAllowed,
+      videoAllowed: room.isParticipantVideoAllowed,
       roomId: room.id,
     });
   }

--- a/packages/sfu/server/admin/controlPlane.ts
+++ b/packages/sfu/server/admin/controlPlane.ts
@@ -638,6 +638,8 @@ export const closeClientProducers = (options: {
     kind: MediaKind;
     type: ProducerType;
   }> = [];
+  let webcamAudioClosed = false;
+  let webcamVideoClosed = false;
 
   for (const info of infos) {
     const removed = target.removeProducerById(info.producerId);
@@ -654,9 +656,31 @@ export const closeClientProducers = (options: {
       kind: removed.kind,
       type: removed.type,
     });
+    if (removed.type === "webcam" && removed.kind === "audio") {
+      webcamAudioClosed = true;
+    } else if (removed.type === "webcam" && removed.kind === "video") {
+      webcamVideoClosed = true;
+    }
   }
 
   if (closedProducers.length > 0) {
+    if (webcamAudioClosed) {
+      target.isMuted = true;
+      io.to(room.channelId).emit("participantMuted", {
+        userId,
+        muted: true,
+        roomId: room.id,
+      });
+      void state.transcriptRelays.syncRoom(room);
+    }
+    if (webcamVideoClosed) {
+      target.isCameraOff = true;
+      io.to(room.channelId).emit("participantCameraOff", {
+        userId,
+        cameraOff: true,
+        roomId: room.id,
+      });
+    }
     emitWebinarFeedChanged(io, state, room);
     target.socket.emit("admin:mediaEnforced", {
       roomId: room.id,
@@ -672,6 +696,7 @@ export const closeClientProducers = (options: {
 
 export const applyRoomPolicyUpdate = (
   io: SocketIOServer,
+  state: SfuState,
   room: Room,
   update: RoomPolicyUpdate,
 ): { changed: RoomPolicyUpdate } => {
@@ -777,6 +802,42 @@ export const applyRoomPolicyUpdate = (
   }
 
   if (participantMediaPermissionsChanged) {
+    const revokedKinds: MediaKind[] = [];
+    if (changed.participantUnmuteAllowed === false) {
+      revokedKinds.push("audio");
+    }
+    if (changed.participantVideoAllowed === false) {
+      revokedKinds.push("video");
+    }
+
+    if (revokedKinds.length > 0) {
+      for (const client of room.clients.values()) {
+        if (client instanceof Admin || client.isObserver) {
+          continue;
+        }
+
+        const activeRevokedKinds = revokedKinds.filter((kind) => {
+          const producer = client.getProducer(kind, "webcam");
+          return Boolean(producer && !producer.paused);
+        });
+        if (activeRevokedKinds.length === 0) {
+          continue;
+        }
+
+        closeClientProducers({
+          io,
+          state,
+          room,
+          userId: client.id,
+          selector: {
+            kinds: activeRevokedKinds,
+            types: ["webcam"],
+          },
+          reason: "Participant media permission revoked by host",
+        });
+      }
+    }
+
     io.to(room.channelId).emit("participantMediaPermissionsChanged", {
       unmuteAllowed: room.isParticipantUnmuteAllowed,
       videoAllowed: room.isParticipantVideoAllowed,

--- a/packages/sfu/server/http/createApp.ts
+++ b/packages/sfu/server/http/createApp.ts
@@ -979,7 +979,7 @@ export const createSfuApp = ({
       return;
     }
 
-    const result = applyRoomPolicyUpdate(io, lookup.room, update);
+    const result = applyRoomPolicyUpdate(io, state, lookup.room, update);
     res.json({
       success: true,
       changed: result.changed,

--- a/packages/sfu/server/http/createApp.ts
+++ b/packages/sfu/server/http/createApp.ts
@@ -969,6 +969,8 @@ export const createSfuApp = ({
       dmEnabled: readBoolean(body, "dmEnabled"),
       imageAttachmentsEnabled: readBoolean(body, "imageAttachmentsEnabled"),
       reactionsDisabled: readBoolean(body, "reactionsDisabled"),
+      participantUnmuteAllowed: readBoolean(body, "participantUnmuteAllowed"),
+      participantVideoAllowed: readBoolean(body, "participantVideoAllowed"),
     };
 
     const hasUpdates = Object.values(update).some((value) => value !== undefined);

--- a/packages/sfu/server/socket/handlers/adminHandlers.ts
+++ b/packages/sfu/server/socket/handlers/adminHandlers.ts
@@ -1246,7 +1246,7 @@ export const registerAdminHandlers = (
       return;
     }
 
-    const update = applyRoomPolicyUpdate(io, guard.room, { locked });
+    const update = applyRoomPolicyUpdate(io, state, guard.room, { locked });
     Logger.info(`Room ${guard.room.id} ${locked ? "locked" : "unlocked"} by admin`);
 
     respond(cb, {
@@ -1263,7 +1263,7 @@ export const registerAdminHandlers = (
       return;
     }
 
-    const update = applyRoomPolicyUpdate(io, guard.room, { noGuests });
+    const update = applyRoomPolicyUpdate(io, state, guard.room, { noGuests });
     Logger.info(
       `Room ${guard.room.id} ${noGuests ? "blocking" : "allowing"} guests`,
     );
@@ -1282,7 +1282,9 @@ export const registerAdminHandlers = (
       return;
     }
 
-    const update = applyRoomPolicyUpdate(io, guard.room, { chatLocked: locked });
+    const update = applyRoomPolicyUpdate(io, state, guard.room, {
+      chatLocked: locked,
+    });
     Logger.info(`Chat in room ${guard.room.id} ${locked ? "locked" : "unlocked"} by admin`);
 
     respond(cb, {
@@ -1317,7 +1319,9 @@ export const registerAdminHandlers = (
       return;
     }
 
-    const update = applyRoomPolicyUpdate(io, guard.room, { ttsDisabled: disabled });
+    const update = applyRoomPolicyUpdate(io, state, guard.room, {
+      ttsDisabled: disabled,
+    });
     Logger.info(
       `Room ${guard.room.id} TTS ${disabled ? "disabled" : "enabled"} by admin`,
     );
@@ -1349,7 +1353,9 @@ export const registerAdminHandlers = (
       return;
     }
 
-    const update = applyRoomPolicyUpdate(io, guard.room, { dmEnabled: enabled });
+    const update = applyRoomPolicyUpdate(io, state, guard.room, {
+      dmEnabled: enabled,
+    });
     Logger.info(
       `Room ${guard.room.id} direct messages ${enabled ? "enabled" : "disabled"} by admin`,
     );
@@ -1373,7 +1379,7 @@ export const registerAdminHandlers = (
         respond(cb, { error: "Invalid image attachment state" });
         return;
       }
-      applyRoomPolicyUpdate(io, guard.room, {
+      applyRoomPolicyUpdate(io, state, guard.room, {
         imageAttachmentsEnabled: enabled,
       });
       respond(cb, {
@@ -1399,7 +1405,9 @@ export const registerAdminHandlers = (
       return;
     }
 
-    const update = applyRoomPolicyUpdate(io, guard.room, { reactionsDisabled: disabled });
+    const update = applyRoomPolicyUpdate(io, state, guard.room, {
+      reactionsDisabled: disabled,
+    });
     Logger.info(
       `Room ${guard.room.id} reactions ${disabled ? "disabled" : "enabled"} by admin`,
     );
@@ -1442,7 +1450,7 @@ export const registerAdminHandlers = (
         return;
       }
 
-      const update = applyRoomPolicyUpdate(io, guard.room, {
+      const update = applyRoomPolicyUpdate(io, state, guard.room, {
         participantUnmuteAllowed: unmuteAllowed,
         participantVideoAllowed: videoAllowed,
       });
@@ -1477,7 +1485,7 @@ export const registerAdminHandlers = (
         return;
       }
 
-      const update = applyRoomPolicyUpdate(io, guard.room, {
+      const update = applyRoomPolicyUpdate(io, state, guard.room, {
         locked:
           typeof data?.locked === "boolean" ? data.locked : undefined,
         noGuests:

--- a/packages/sfu/server/socket/handlers/adminHandlers.ts
+++ b/packages/sfu/server/socket/handlers/adminHandlers.ts
@@ -1421,6 +1421,41 @@ export const registerAdminHandlers = (
   });
 
   socket.on(
+    "setParticipantMediaPermissions",
+    (
+      data: { unmuteAllowed?: boolean; videoAllowed?: boolean },
+      cb,
+    ) => {
+      const guard = ensureAdminRoom(context);
+      if ("error" in guard) {
+        respond(cb, guard);
+        return;
+      }
+      const unmuteAllowed =
+        typeof data?.unmuteAllowed === "boolean"
+          ? data.unmuteAllowed
+          : undefined;
+      const videoAllowed =
+        typeof data?.videoAllowed === "boolean" ? data.videoAllowed : undefined;
+      if (unmuteAllowed === undefined && videoAllowed === undefined) {
+        respond(cb, { error: "Invalid participant media permissions" });
+        return;
+      }
+
+      const update = applyRoomPolicyUpdate(io, guard.room, {
+        participantUnmuteAllowed: unmuteAllowed,
+        participantVideoAllowed: videoAllowed,
+      });
+      respond(cb, {
+        success: true,
+        changed: update.changed,
+        unmuteAllowed: guard.room.isParticipantUnmuteAllowed,
+        videoAllowed: guard.room.isParticipantVideoAllowed,
+      });
+    },
+  );
+
+  socket.on(
     "admin:setPolicies",
     (
       data: {
@@ -1431,6 +1466,8 @@ export const registerAdminHandlers = (
         dmEnabled?: boolean;
         imageAttachmentsEnabled?: boolean;
         reactionsDisabled?: boolean;
+        participantUnmuteAllowed?: boolean;
+        participantVideoAllowed?: boolean;
       },
       cb,
     ) => {
@@ -1457,6 +1494,14 @@ export const registerAdminHandlers = (
             : undefined,
         reactionsDisabled:
           typeof data?.reactionsDisabled === "boolean" ? data.reactionsDisabled : undefined,
+        participantUnmuteAllowed:
+          typeof data?.participantUnmuteAllowed === "boolean"
+            ? data.participantUnmuteAllowed
+            : undefined,
+        participantVideoAllowed:
+          typeof data?.participantVideoAllowed === "boolean"
+            ? data.participantVideoAllowed
+            : undefined,
       });
 
       respond(cb, {
@@ -1470,6 +1515,8 @@ export const registerAdminHandlers = (
           dmEnabled: guard.room.isDmEnabled,
           imageAttachmentsEnabled: guard.room.areImageAttachmentsEnabled,
           reactionsDisabled: guard.room.isReactionsDisabled,
+          participantUnmuteAllowed: guard.room.isParticipantUnmuteAllowed,
+          participantVideoAllowed: guard.room.isParticipantVideoAllowed,
         },
       });
     },

--- a/packages/sfu/server/socket/handlers/joinRoom.ts
+++ b/packages/sfu/server/socket/handlers/joinRoom.ts
@@ -638,6 +638,8 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
             isDmEnabled: room.isDmEnabled,
             areImageAttachmentsEnabled: room.areImageAttachmentsEnabled,
             isReactionsDisabled: room.isReactionsDisabled,
+            isParticipantUnmuteAllowed: room.isParticipantUnmuteAllowed,
+            isParticipantVideoAllowed: room.isParticipantVideoAllowed,
             meetingRequiresInviteCode: room.requiresMeetingInviteCode,
             webcamCodecPolicy: room.webcamCodecPolicy,
           });
@@ -687,6 +689,8 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
             isDmEnabled: room.isDmEnabled,
             areImageAttachmentsEnabled: room.areImageAttachmentsEnabled,
             isReactionsDisabled: room.isReactionsDisabled,
+            isParticipantUnmuteAllowed: room.isParticipantUnmuteAllowed,
+            isParticipantVideoAllowed: room.isParticipantVideoAllowed,
             meetingRequiresInviteCode: room.requiresMeetingInviteCode,
             webcamCodecPolicy: room.webcamCodecPolicy,
           });
@@ -926,6 +930,12 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           roomId: context.currentRoom.id,
         });
 
+        socket.emit("participantMediaPermissionsChanged", {
+          unmuteAllowed: context.currentRoom.isParticipantUnmuteAllowed,
+          videoAllowed: context.currentRoom.isParticipantVideoAllowed,
+          roomId: context.currentRoom.id,
+        });
+
         socket.emit("apps:state", {
           activeAppId: context.currentRoom.appsState.activeAppId,
           locked: context.currentRoom.appsState.locked,
@@ -1016,6 +1026,9 @@ export const registerJoinRoomHandler = (context: ConnectionContext): void => {
           areImageAttachmentsEnabled:
             context.currentRoom.areImageAttachmentsEnabled,
           isReactionsDisabled: context.currentRoom.isReactionsDisabled,
+          isParticipantUnmuteAllowed:
+            context.currentRoom.isParticipantUnmuteAllowed,
+          isParticipantVideoAllowed: context.currentRoom.isParticipantVideoAllowed,
           meetingRequiresInviteCode: context.currentRoom.requiresMeetingInviteCode,
           webinarRole: context.currentClient.isWebinarAttendee
             ? "attendee"

--- a/packages/sfu/server/socket/handlers/mediaHandlers.ts
+++ b/packages/sfu/server/socket/handlers/mediaHandlers.ts
@@ -16,6 +16,7 @@ import type {
   ToggleMediaData,
 } from "../../../types.js";
 import type { Client } from "../../../config/classes/Client.js";
+import { Admin } from "../../../config/classes/Admin.js";
 import type { Room } from "../../../config/classes/Room.js";
 import { Logger } from "../../../utilities/loggers.js";
 import {
@@ -60,6 +61,21 @@ class ConsumerGenerationDisplacedError extends Error {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === "object" && !Array.isArray(value));
+
+const getParticipantMediaActivationError = (
+  client: Client,
+  room: Room,
+  kind: "audio" | "video",
+): string | null => {
+  if (client instanceof Admin && !client.isObserver) return null;
+  if (kind === "audio" && room.isParticipantUnmuteAllowed === false) {
+    return "The host has blocked participants from unmuting";
+  }
+  if (kind === "video" && room.isParticipantVideoAllowed === false) {
+    return "The host has blocked participants from turning on video";
+  }
+  return null;
+};
 
 const normalizeMediaId = (value: unknown): string | null => {
   if (typeof value !== "string") return null;
@@ -669,6 +685,14 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
           return;
         }
         const paused = appData.paused === true;
+        const activationError =
+          type === "webcam" && !paused
+            ? getParticipantMediaActivationError(currentClient, room, kind)
+            : null;
+        if (activationError) {
+          respond(callback, { error: activationError });
+          return;
+        }
         const rtpParameters = data.rtpParameters;
         const transitionValue = appData.webcamReceiverCapacityTransition;
         const transitionIntent =
@@ -761,6 +785,24 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
             ? { keyFrameRequestDelay: getVideoKeyFrameRequestDelayMs(type) }
             : {}),
         });
+
+        const postCreationActivationError =
+          type === "webcam" && !paused
+            ? getParticipantMediaActivationError(currentClient, room, kind)
+            : null;
+        if (postCreationActivationError) {
+          if (capacityTransitionReservation) {
+            room.cancelWebcamReceiverCapacityTransition(
+              capacityTransitionReservation,
+            );
+            capacityTransitionReservation = null;
+          }
+          try {
+            producer.close();
+          } catch {}
+          respond(callback, { error: postCreationActivationError });
+          return;
+        }
 
         // The room policy can change while mediasoup is creating the producer
         // (for example, an incompatible late join). Revalidate the actual
@@ -1627,6 +1669,17 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
           respond(callback, { error: "Invalid mute state" });
           return;
         }
+        const activationError = !data.paused
+          ? getParticipantMediaActivationError(
+              context.currentClient,
+              context.currentRoom,
+              "audio",
+            )
+          : null;
+        if (activationError) {
+          respond(callback, { error: activationError });
+          return;
+        }
 
         const audioProducer = context.currentClient.getProducer("audio", "webcam");
         if (!audioProducer) {
@@ -1634,10 +1687,19 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
           return;
         }
 
+        let postResumeActivationError: string | null = null;
         if (data.paused) {
           await audioProducer.pause();
         } else {
           await audioProducer.resume();
+          postResumeActivationError = getParticipantMediaActivationError(
+            context.currentClient,
+            context.currentRoom,
+            "audio",
+          );
+          if (postResumeActivationError) {
+            await audioProducer.pause();
+          }
         }
 
         const muted = audioProducer.paused;
@@ -1651,7 +1713,12 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
         emitWebinarFeedChanged(io, state, context.currentRoom);
         void state.transcriptRelays.syncRoom(context.currentRoom);
 
-        respond(callback, { success: true });
+        respond(
+          callback,
+          postResumeActivationError
+            ? { error: postResumeActivationError }
+            : { success: true },
+        );
       } catch (error) {
         respond(callback, { error: (error as Error).message });
       }
@@ -1679,6 +1746,17 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
           respond(callback, { error: "Invalid camera state" });
           return;
         }
+        const activationError = !data.paused
+          ? getParticipantMediaActivationError(
+              context.currentClient,
+              context.currentRoom,
+              "video",
+            )
+          : null;
+        if (activationError) {
+          respond(callback, { error: activationError });
+          return;
+        }
 
         const videoProducer = context.currentClient.getProducer("video", "webcam");
         if (!videoProducer) {
@@ -1686,10 +1764,19 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
           return;
         }
 
+        let postResumeActivationError: string | null = null;
         if (data.paused) {
           await videoProducer.pause();
         } else {
           await videoProducer.resume();
+          postResumeActivationError = getParticipantMediaActivationError(
+            context.currentClient,
+            context.currentRoom,
+            "video",
+          );
+          if (postResumeActivationError) {
+            await videoProducer.pause();
+          }
         }
 
         context.currentRoom.refreshWebcamReceiverCapacityProof(
@@ -1706,7 +1793,12 @@ export const registerMediaHandlers = (context: ConnectionContext): void => {
         });
         emitWebinarFeedChanged(io, state, context.currentRoom);
 
-        respond(callback, { success: true });
+        respond(
+          callback,
+          postResumeActivationError
+            ? { error: postResumeActivationError }
+            : { success: true },
+        );
       } catch (error) {
         respond(callback, { error: (error as Error).message });
       }

--- a/packages/sfu/test/participant-media-permissions.test.ts
+++ b/packages/sfu/test/participant-media-permissions.test.ts
@@ -1,0 +1,340 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import type { Producer, WebRtcTransport } from "mediasoup/types";
+import type { Socket } from "socket.io";
+import { Admin } from "../config/classes/Admin.js";
+import { Client } from "../config/classes/Client.js";
+import type { Room } from "../config/classes/Room.js";
+import type { ConnectionContext } from "../server/socket/context.js";
+import { registerMediaHandlers } from "../server/socket/handlers/mediaHandlers.js";
+import type { SfuState } from "../server/state.js";
+
+type SocketHandler = (...args: never[]) => unknown;
+
+const makeHarness = ({
+  admin = false,
+  unmuteAllowed = true,
+  videoAllowed = true,
+}: {
+  admin?: boolean;
+  unmuteAllowed?: boolean;
+  videoAllowed?: boolean;
+} = {}) => {
+  const handlers = new Map<string, SocketHandler>();
+  const roomBroadcast = { emit: vi.fn() };
+  const socket = {
+    on: vi.fn((event: string, handler: SocketHandler) => {
+      handlers.set(event, handler);
+      return socket;
+    }),
+    to: vi.fn().mockReturnValue(roomBroadcast),
+  } as unknown as Socket;
+  const client = admin
+    ? new Admin({ id: "host", socket })
+    : new Client({ id: "participant", socket });
+  const transportProduce = vi.fn();
+  client.producerTransport = {
+    id: "producer-transport",
+    produce: transportProduce,
+  } as unknown as WebRtcTransport;
+  const refreshWebcamReceiverCapacityProof = vi.fn();
+  const roomState = {
+    id: "room",
+    channelId: "instance:room",
+    isParticipantUnmuteAllowed: unmuteAllowed,
+    isParticipantVideoAllowed: videoAllowed,
+    refreshWebcamReceiverCapacityProof,
+  };
+  const room = roomState as unknown as Room;
+  const state = {
+    rooms: new Map(),
+    webinarConfigs: new Map(),
+    transcriptRelays: { syncRoom: vi.fn() },
+  } as unknown as SfuState;
+
+  registerMediaHandlers({
+    socket,
+    io: {} as ConnectionContext["io"],
+    state,
+    currentRoom: room,
+    currentClient: client,
+    pendingRoomId: null,
+    pendingRoomChannelId: null,
+    pendingUserKey: null,
+    currentUserKey: null,
+    activeConclaveAnswers: new Map(),
+    adminHandlersRegistered: false,
+  });
+
+  return {
+    client,
+    handlers,
+    refreshWebcamReceiverCapacityProof,
+    setParticipantMediaPermissions: (permissions: {
+      unmuteAllowed?: boolean;
+      videoAllowed?: boolean;
+    }) => {
+      if (permissions.unmuteAllowed !== undefined) {
+        roomState.isParticipantUnmuteAllowed = permissions.unmuteAllowed;
+      }
+      if (permissions.videoAllowed !== undefined) {
+        roomState.isParticipantVideoAllowed = permissions.videoAllowed;
+      }
+    },
+    transportProduce,
+  };
+};
+
+const addProducer = (
+  client: Client,
+  kind: "audio" | "video",
+): {
+  producer: Producer;
+  pause: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
+  setPaused: (paused: boolean) => void;
+} => {
+  const events = new EventEmitter();
+  const observer = new EventEmitter();
+  const producerState = {
+    id: `${kind}-producer`,
+    kind,
+    appData: { type: "webcam" },
+    paused: true,
+    on: events.on.bind(events),
+    observer,
+  };
+  const pause = vi.fn(async () => {
+    producerState.paused = true;
+  });
+  const resume = vi.fn(async () => {
+    producerState.paused = false;
+  });
+  const producer = {
+    ...producerState,
+    pause,
+    resume,
+  } as unknown as Producer;
+  Object.defineProperty(producer, "paused", {
+    get: () => producerState.paused,
+  });
+  client.addProducer(producer);
+  return {
+    producer,
+    pause,
+    resume,
+    setPaused: (paused) => {
+      producerState.paused = paused;
+    },
+  };
+};
+
+describe("participant media permissions", () => {
+  it("blocks a participant from resuming microphone and camera", async () => {
+    const { client, handlers } = makeHarness({
+      unmuteAllowed: false,
+      videoAllowed: false,
+    });
+    const audio = addProducer(client, "audio");
+    const video = addProducer(client, "video");
+    const toggleMute = handlers.get("toggleMute") as unknown as (
+      data: { paused: boolean },
+      callback: (response: { success?: boolean; error?: string }) => void,
+    ) => Promise<void>;
+    const toggleCamera = handlers.get("toggleCamera") as unknown as (
+      data: { paused: boolean },
+      callback: (response: { success?: boolean; error?: string }) => void,
+    ) => Promise<void>;
+    const muteCallback = vi.fn();
+    const cameraCallback = vi.fn();
+
+    await toggleMute({ paused: false }, muteCallback);
+    await toggleCamera({ paused: false }, cameraCallback);
+
+    expect(muteCallback).toHaveBeenCalledWith({
+      error: "The host has blocked participants from unmuting",
+    });
+    expect(cameraCallback).toHaveBeenCalledWith({
+      error: "The host has blocked participants from turning on video",
+    });
+    expect(audio.resume).not.toHaveBeenCalled();
+    expect(video.resume).not.toHaveBeenCalled();
+  });
+
+  it("keeps hosts exempt from participant camera restrictions", async () => {
+    const { client, handlers, refreshWebcamReceiverCapacityProof } =
+      makeHarness({ admin: true, videoAllowed: false });
+    const video = addProducer(client, "video");
+    const toggleCamera = handlers.get("toggleCamera") as unknown as (
+      data: { paused: boolean },
+      callback: (response: { success?: boolean; error?: string }) => void,
+    ) => Promise<void>;
+    const callback = vi.fn();
+
+    await toggleCamera({ paused: false }, callback);
+
+    expect(video.resume).toHaveBeenCalledOnce();
+    expect(refreshWebcamReceiverCapacityProof).toHaveBeenCalledWith(
+      video.producer.id,
+    );
+    expect(callback).toHaveBeenCalledWith({ success: true });
+  });
+
+  it("rejects fresh unpaused webcam publications for participants", async () => {
+    const { handlers, transportProduce } = makeHarness({
+      unmuteAllowed: false,
+      videoAllowed: false,
+    });
+    const produce = handlers.get("produce") as unknown as (
+      data: {
+        transportId: string;
+        kind: "audio" | "video";
+        rtpParameters: object;
+        appData: { type: "webcam"; paused: boolean };
+      },
+      callback: (response: { producerId?: string; error?: string }) => void,
+    ) => Promise<void>;
+    const audioCallback = vi.fn();
+    const videoCallback = vi.fn();
+    const rtpParameters = {
+      codecs: [],
+      encodings: [],
+      headerExtensions: [],
+      rtcp: {},
+    };
+
+    await produce(
+      {
+        transportId: "producer-transport",
+        kind: "audio",
+        rtpParameters,
+        appData: { type: "webcam", paused: false },
+      },
+      audioCallback,
+    );
+    await produce(
+      {
+        transportId: "producer-transport",
+        kind: "video",
+        rtpParameters,
+        appData: { type: "webcam", paused: false },
+      },
+      videoCallback,
+    );
+
+    expect(audioCallback).toHaveBeenCalledWith({
+      error: "The host has blocked participants from unmuting",
+    });
+    expect(videoCallback).toHaveBeenCalledWith({
+      error: "The host has blocked participants from turning on video",
+    });
+    expect(transportProduce).not.toHaveBeenCalled();
+  });
+
+  it("rejects a webcam publication when the host disables it in flight", async () => {
+    const { handlers, setParticipantMediaPermissions, transportProduce } =
+      makeHarness();
+    const produce = handlers.get("produce") as unknown as (
+      data: {
+        transportId: string;
+        kind: "audio";
+        rtpParameters: object;
+        appData: { type: "webcam"; paused: boolean };
+      },
+      callback: (response: { producerId?: string; error?: string }) => void,
+    ) => Promise<void>;
+    let finishProduce!: (producer: Producer) => void;
+    transportProduce.mockImplementation(
+      () =>
+        new Promise<Producer>((resolve) => {
+          finishProduce = resolve;
+        }),
+    );
+    const close = vi.fn();
+    const producer = {
+      id: "late-audio-producer",
+      kind: "audio",
+      rtpParameters: {},
+      close,
+    } as unknown as Producer;
+    const callback = vi.fn();
+
+    const publication = produce(
+      {
+        transportId: "producer-transport",
+        kind: "audio",
+        rtpParameters: {},
+        appData: { type: "webcam", paused: false },
+      },
+      callback,
+    );
+    await vi.waitFor(() => expect(transportProduce).toHaveBeenCalledOnce());
+    setParticipantMediaPermissions({ unmuteAllowed: false });
+    finishProduce(producer);
+    await publication;
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith({
+      error: "The host has blocked participants from unmuting",
+    });
+  });
+
+  it("re-pauses media when the host disables it during resume", async () => {
+    const { client, handlers, setParticipantMediaPermissions } = makeHarness();
+    const audio = addProducer(client, "audio");
+    const video = addProducer(client, "video");
+    const toggleMute = handlers.get("toggleMute") as unknown as (
+      data: { paused: boolean },
+      callback: (response: { success?: boolean; error?: string }) => void,
+    ) => Promise<void>;
+    const toggleCamera = handlers.get("toggleCamera") as unknown as (
+      data: { paused: boolean },
+      callback: (response: { success?: boolean; error?: string }) => void,
+    ) => Promise<void>;
+    let finishAudioResume!: () => void;
+    let finishVideoResume!: () => void;
+    audio.resume.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishAudioResume = () => {
+            audio.setPaused(false);
+            resolve();
+          };
+        }),
+    );
+    video.resume.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishVideoResume = () => {
+            video.setPaused(false);
+            resolve();
+          };
+        }),
+    );
+    const muteCallback = vi.fn();
+    const cameraCallback = vi.fn();
+
+    const muteResume = toggleMute({ paused: false }, muteCallback);
+    await vi.waitFor(() => expect(audio.resume).toHaveBeenCalledOnce());
+    setParticipantMediaPermissions({ unmuteAllowed: false });
+    finishAudioResume();
+    await muteResume;
+
+    const cameraResume = toggleCamera({ paused: false }, cameraCallback);
+    await vi.waitFor(() => expect(video.resume).toHaveBeenCalledOnce());
+    setParticipantMediaPermissions({ videoAllowed: false });
+    finishVideoResume();
+    await cameraResume;
+
+    expect(audio.pause).toHaveBeenCalledOnce();
+    expect(video.pause).toHaveBeenCalledOnce();
+    expect(audio.producer.paused).toBe(true);
+    expect(video.producer.paused).toBe(true);
+    expect(muteCallback).toHaveBeenCalledWith({
+      error: "The host has blocked participants from unmuting",
+    });
+    expect(cameraCallback).toHaveBeenCalledWith({
+      error: "The host has blocked participants from turning on video",
+    });
+  });
+});

--- a/packages/sfu/test/participant-media-permissions.test.ts
+++ b/packages/sfu/test/participant-media-permissions.test.ts
@@ -1,10 +1,11 @@
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import type { Producer, WebRtcTransport } from "mediasoup/types";
-import type { Socket } from "socket.io";
+import type { Server as SocketIOServer, Socket } from "socket.io";
 import { Admin } from "../config/classes/Admin.js";
 import { Client } from "../config/classes/Client.js";
 import type { Room } from "../config/classes/Room.js";
+import { applyRoomPolicyUpdate } from "../server/admin/controlPlane.js";
 import type { ConnectionContext } from "../server/socket/context.js";
 import { registerMediaHandlers } from "../server/socket/handlers/mediaHandlers.js";
 import type { SfuState } from "../server/state.js";
@@ -88,8 +89,10 @@ const makeHarness = ({
 const addProducer = (
   client: Client,
   kind: "audio" | "video",
+  initialPaused = true,
 ): {
   producer: Producer;
+  close: ReturnType<typeof vi.fn>;
   pause: ReturnType<typeof vi.fn>;
   resume: ReturnType<typeof vi.fn>;
   setPaused: (paused: boolean) => void;
@@ -100,7 +103,7 @@ const addProducer = (
     id: `${kind}-producer`,
     kind,
     appData: { type: "webcam" },
-    paused: true,
+    paused: initialPaused,
     on: events.on.bind(events),
     observer,
   };
@@ -110,8 +113,12 @@ const addProducer = (
   const resume = vi.fn(async () => {
     producerState.paused = false;
   });
+  const close = vi.fn(() => {
+    observer.emit("close");
+  });
   const producer = {
     ...producerState,
+    close,
     pause,
     resume,
   } as unknown as Producer;
@@ -121,6 +128,7 @@ const addProducer = (
   client.addProducer(producer);
   return {
     producer,
+    close,
     pause,
     resume,
     setPaused: (paused) => {
@@ -130,6 +138,115 @@ const addProducer = (
 };
 
 describe("participant media permissions", () => {
+  it("stops active participant media when the host revokes permissions", () => {
+    const roomBroadcast = { emit: vi.fn() };
+    const io = {
+      to: vi.fn().mockReturnValue(roomBroadcast),
+    } as unknown as SocketIOServer;
+    const participantEmit = vi.fn();
+    const participantSocket = { emit: participantEmit } as unknown as Socket;
+    const pausedParticipantSocket = { emit: vi.fn() } as unknown as Socket;
+    const hostSocket = { emit: vi.fn() } as unknown as Socket;
+    const participant = new Client({
+      id: "participant",
+      socket: participantSocket,
+    });
+    const pausedParticipant = new Client({
+      id: "paused-participant",
+      socket: pausedParticipantSocket,
+    });
+    const host = new Admin({ id: "host", socket: hostSocket });
+    const participantAudio = addProducer(participant, "audio", false);
+    const participantVideo = addProducer(participant, "video", false);
+    const pausedAudio = addProducer(pausedParticipant, "audio", true);
+    const hostAudio = addProducer(host, "audio", false);
+    const hostVideo = addProducer(host, "video", false);
+    const clients = new Map<string, Client>([
+      [participant.id, participant],
+      [pausedParticipant.id, pausedParticipant],
+      [host.id, host],
+    ]);
+    const roomState = {
+      id: "room",
+      channelId: "instance:room",
+      clients,
+      isParticipantUnmuteAllowed: true,
+      isParticipantVideoAllowed: true,
+      setParticipantUnmuteAllowed: (allowed: boolean) => {
+        roomState.isParticipantUnmuteAllowed = allowed;
+      },
+      setParticipantVideoAllowed: (allowed: boolean) => {
+        roomState.isParticipantVideoAllowed = allowed;
+      },
+      getClient: (userId: string) => clients.get(userId),
+      removeProducerIndexById: vi.fn(),
+      clearScreenShareProducer: vi.fn(),
+    };
+    const room = roomState as unknown as Room;
+    const state = {
+      rooms: new Map([[room.channelId, room]]),
+      webinarConfigs: new Map(),
+      transcriptRelays: { syncRoom: vi.fn() },
+    } as unknown as SfuState;
+
+    const result = applyRoomPolicyUpdate(io, state, room, {
+      participantUnmuteAllowed: false,
+      participantVideoAllowed: false,
+    });
+
+    expect(result.changed).toEqual({
+      participantUnmuteAllowed: false,
+      participantVideoAllowed: false,
+    });
+    expect(participantAudio.close).toHaveBeenCalledOnce();
+    expect(participantVideo.close).toHaveBeenCalledOnce();
+    expect(participant.isMuted).toBe(true);
+    expect(participant.isCameraOff).toBe(true);
+    expect(pausedAudio.close).not.toHaveBeenCalled();
+    expect(hostAudio.close).not.toHaveBeenCalled();
+    expect(hostVideo.close).not.toHaveBeenCalled();
+    expect(participantEmit).toHaveBeenCalledWith(
+      "admin:mediaEnforced",
+      {
+        roomId: room.id,
+        userId: participant.id,
+        action: "closed",
+        reason: "Participant media permission revoked by host",
+        producers: [
+          {
+            producerId: "audio-producer",
+            kind: "audio",
+            type: "webcam",
+          },
+          {
+            producerId: "video-producer",
+            kind: "video",
+            type: "webcam",
+          },
+        ],
+      },
+    );
+    expect(roomBroadcast.emit).toHaveBeenCalledWith("participantMuted", {
+      userId: participant.id,
+      muted: true,
+      roomId: room.id,
+    });
+    expect(roomBroadcast.emit).toHaveBeenCalledWith("participantCameraOff", {
+      userId: participant.id,
+      cameraOff: true,
+      roomId: room.id,
+    });
+    expect(roomBroadcast.emit).toHaveBeenCalledWith(
+      "participantMediaPermissionsChanged",
+      {
+        unmuteAllowed: false,
+        videoAllowed: false,
+        roomId: room.id,
+      },
+    );
+    expect(state.transcriptRelays.syncRoom).toHaveBeenCalledWith(room);
+  });
+
   it("blocks a participant from resuming microphone and camera", async () => {
     const { client, handlers } = makeHarness({
       unmuteAllowed: false,

--- a/packages/sfu/types.ts
+++ b/packages/sfu/types.ts
@@ -75,6 +75,8 @@ export interface JoinRoomResponse {
   isDmEnabled?: boolean;
   areImageAttachmentsEnabled?: boolean;
   isReactionsDisabled?: boolean;
+  isParticipantUnmuteAllowed?: boolean;
+  isParticipantVideoAllowed?: boolean;
   meetingRequiresInviteCode?: boolean;
   webinarRole?: "attendee" | "participant" | "host";
   isWebinarEnabled?: boolean;


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This update adds host-controlled microphone and camera permissions, synchronizes media policy across meeting clients, and refines collapsed participant-grid ordering. Focused checks confirmed that revoking permission closes existing non-host media and rejects later resume or publication attempts; they also confirmed that the active speaker is promoted into the final visible collapsed-grid slot.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised media-policy and participant-ordering paths.

No blocking failure remains. The permission-revocation path closes active producers and fails closed for subsequent resume or publication attempts, while the collapsed-grid path keeps the active speaker visible within the rendered capacity.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Inspected the GridLayout capacity calculation and render path, ran a five-remote collapsed-overflow scenario and the participant-order-policy test suite, and confirmed that the legacy four-slot promotion left remote-5 outside the visible tiles while the current three-slot limit renders remote-5 in the final visible tile.
- Ran a focused camera activation harness against a rejected room-policy acknowledgement and exercised the dedicated media-toggle-policy tests, observing that after rejection the legacy path resumed the local producer while the current path re-paused it; the focused suite passed success, server-rejection, and confirmation-failure paths.
- Verified the current overflow behavior shows getVisibleRemoteParticipantLimit as maxRemoteWithoutOverflow - 1, that GridLayout passes this limit to useSmartParticipantOrder, and that the overflow control is rendered in the final tile; the claimed failure was disproved, with results showing the current limit includes the active remote-5.
- Compared before and after behavior for camera-activation acknowledgement and confirmed that the changed helper now re-pauses after rejection, preventing an active local sender, with security assessment concluding no fail-open risk in this path.

<a href="https://app.greptile.com/trex/runs/17728166/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: enforce participant media and overf..."](https://github.com/acm-vit/conclave/commit/c0877b503766d3733da3f1edb8c5ba4e128d62d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51014353)</sub>

<!-- /greptile_comment -->