### PR TITLE
fix: simplify Kitesurf participant rail

### DIFF
--- a/apps/web/src/app/components/BrowserLayout.tsx
+++ b/apps/web/src/app/components/BrowserLayout.tsx
@@ -255,12 +255,8 @@ function BrowserLayout({
             </section>
 
             <aside className="min-h-[160px] min-w-0 lg:min-h-0">
-                <section
-                    className="overflow-hidden rounded-2xl"
-                    style={{ backgroundColor: color.surface, border: `1px solid ${color.border}` }}
-                    aria-label="Meeting participants"
-                >
-                    <div className="flex max-h-44 gap-2 overflow-auto p-2 lg:max-h-52 lg:flex-col">
+                <section aria-label="Meeting participants">
+                    <div className="flex max-h-44 gap-2 overflow-auto lg:max-h-52 lg:flex-col">
                         <div className={`acm-video-tile h-28 w-40 shrink-0 lg:w-auto ${isLocalActiveSpeaker ? "speaking" : ""}`}>
                             <video
                                 ref={localVideoRef}

--- a/packages/sfu/server/browserServiceClient.ts
+++ b/packages/sfu/server/browserServiceClient.ts
@@ -70,13 +70,15 @@ let cachedCapabilities:
   | undefined;
 let pendingCapabilities: Promise<BrowserServiceCapabilities> | undefined;
 
-const parseInteger = (
+export const parseBrowserInteger = (
   value: string | undefined,
   fallback: number,
   maximum = Number.POSITIVE_INFINITY,
+  minimum = 1,
 ): number => {
   const parsed = Number(value);
-  const configured = Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+  const configured =
+    Number.isInteger(parsed) && parsed >= minimum ? parsed : fallback;
   return Math.min(configured, maximum);
 };
 
@@ -95,23 +97,28 @@ const getEmbeddedKitesurf = (): BrowserManager => {
     cloudflareApiToken: credentials.apiToken,
     cloudflareBrowserRunBaseUrl:
       process.env.CLOUDFLARE_BROWSER_RUN_BASE_URL?.trim() || undefined,
-    cloudflareRequestTimeoutMs: parseInteger(
+    cloudflareRequestTimeoutMs: parseBrowserInteger(
       process.env.CLOUDFLARE_BROWSER_RUN_TIMEOUT_MS,
       15000,
       MAX_BACKEND_REQUEST_TIMEOUT_MS,
     ),
-    kitesurfKeepAliveMs: parseInteger(process.env.KITESURF_KEEP_ALIVE_MS, 600000),
-    kitesurfViewportWidth: parseInteger(
+    kitesurfKeepAliveMs: parseBrowserInteger(
+      process.env.KITESURF_KEEP_ALIVE_MS,
+      600000,
+    ),
+    kitesurfViewportWidth: parseBrowserInteger(
       process.env.KITESURF_VIEWPORT_WIDTH,
       1920,
       3840,
+      800,
     ),
-    kitesurfViewportHeight: parseInteger(
+    kitesurfViewportHeight: parseBrowserInteger(
       process.env.KITESURF_VIEWPORT_HEIGHT,
       1080,
       2160,
+      600,
     ),
-    containerIdleTimeoutMs: parseInteger(
+    containerIdleTimeoutMs: parseBrowserInteger(
       process.env.KITESURF_IDLE_TIMEOUT_MS || process.env.CONTAINER_IDLE_TIMEOUT,
       1800000,
     ),

--- a/packages/sfu/test/browser-service-client.test.ts
+++ b/packages/sfu/test/browser-service-client.test.ts
@@ -4,6 +4,7 @@ import {
   getCachedBrowserServiceCapabilities,
   getBrowserServiceCapabilities,
   isMissingBrowserSessionError,
+  parseBrowserInteger,
   shutdownBrowserBackend,
 } from "../server/browserServiceClient.js";
 
@@ -152,5 +153,14 @@ describe("external browser service errors", () => {
     expect(second).toEqual(first);
     expect(third).toEqual(first);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("embedded browser configuration", () => {
+  it("falls back when viewport dimensions are below their supported minimums", () => {
+    expect(parseBrowserInteger("1", 1920, 3840, 800)).toBe(1920);
+    expect(parseBrowserInteger("1", 1080, 2160, 600)).toBe(1080);
+    expect(parseBrowserInteger("800", 1920, 3840, 800)).toBe(800);
+    expect(parseBrowserInteger("600", 1080, 2160, 600)).toBe(600);
   });
 });


### PR DESCRIPTION
## Summary

- remove the redundant visual wrapper around participant tiles in browser layout
- enforce the shared-browser `800x600` minimum viewport bounds in the embedded SFU path
- add regression coverage for undersized viewport configuration

## Why

The participant rail still rendered a second border and background around tiles that already have their own visual treatment. Separately, malformed SFU environment values could bypass the shared-browser viewport minimums and create an unusable Kitesurf session.

## Impacted surfaces

- `apps/web`
- `packages/sfu`

## Validation

- `pnpm -C apps/web exec eslint src/app/components/BrowserLayout.tsx`
- `pnpm -C apps/web exec tsc --noEmit`
- `pnpm -C packages/sfu exec vitest run test/browser-service-client.test.ts`
- `pnpm -C packages/sfu run typecheck`

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This change simplifies the meeting participant rail and adds configurable Kitesurf viewport dimensions with minimum bounds. A controlled browser-session exercise found that, after navigation, the configured viewport can be applied to an unrelated tab when Browser Run omits the newly created target's optional URL. The viewport operation needs to be associated with the created target before merging.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until Kitesurf viewport configuration is reliably applied to the newly created navigation target.

The affected launch and navigation behavior was reproduced with a controlled Browser Run response and Puppeteer connector, including a comparison where the target URL is present versus omitted.

**Files Needing Attention:** packages/shared-browser/src/KitesurfManager.ts needs target-specific page selection for viewport configuration.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proof for a posted P1 finding and linked it to the corresponding review comment.
- T-Rex exercised the focused shared-browser Kitesurf test-suite and captured viewport-target selection results for URL-present and URL-absent scenarios.
- T-Rex summarized the contract-validation findings showing that with a URL, the redirected target received one 1365×777 viewport and the unrelated tab received none.
- T-Rex verified that omitting target.url still yields success, but the navigation target received zero viewport calls while the unrelated newest tab received one.
- T-Rex traced the root cause to withConnectedPage(), which selects pages by URL/current URL and falls back to the newest non-blank page, with no target-ID correlation.

<a href="https://app.greptile.com/trex/runs/18253624/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/shared-browser/src/KitesurfManager.ts`, line 451-454 ([link](https://github.com/acm-vit/conclave/blob/af16d48903f29d6e65080358bc4f4f71aa98cc51/packages/shared-browser/src/KitesurfManager.ts#L451-L454)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Viewport configuration can target an unrelated Kitesurf tab**

   `navigateTo()` configures the viewport using `target.url || options.url`, but Browser Run can omit the created target's optional `url`. In that case `withConnectedPage()` cannot identify the new target and falls back to the newest non-blank Puppeteer page, which can be an unrelated tab. The requested navigation still succeeds, but the new page retains its previous viewport while another page receives the configured dimensions. Resolve the Puppeteer page by the created Browser Run target ID, or use a target-specific CDP operation, instead of using the newest-page fallback.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Controlled Kitesurf viewport target-selection validation source](https://app.greptile.com/trex/artifacts/f8756fcf-0a32-437f-8f0b-d39c294ef92a)**

   - A temporary executable TypeScript validation uses fake Browser Run and Puppeteer implementations to run the exact launch and navigation paths with redirected and missing target URLs; it demonstrates the target-selection condition.

   **[Viewport target selection with Browser Run target URL returned](https://app.greptile.com/trex/artifacts/224e4e4b-764d-42e7-bb89-46d093618192)**

   - The controlled baseline command completed successfully and shows the intended redirected navigation target received the 1365×777 viewport while the unrelated page received none.

   **[Viewport target selection with Browser Run target URL absent](https://app.greptile.com/trex/artifacts/ad5b4cbe-d59c-4b6d-a070-208cc49a6428)**

   - The controlled missing-URL command completed successfully and shows the navigation target received no viewport while the unrelated newest page received it, proving the regression.

   **[Focused shared-browser Kitesurf test-suite output](https://app.greptile.com/trex/artifacts/28d067dd-f9c0-4c45-bc2d-c232282f39db)**

   - The focused shared-browser test command completed with 15 passing tests, confirming existing coverage remains green despite the untested missing-target-URL case.

   <a href="https://app.greptile.com/trex/runs/18253624/artifacts?artifact=f8756fcf-0a32-437f-8f0b-d39c294ef92a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fshared-browser%2Fsrc%2FKitesurfManager.ts%0ALine%3A%20451-454%0A%0AComment%3A%0A**Viewport%20configuration%20can%20target%20an%20unrelated%20Kitesurf%20tab**%0A%0A%60navigateTo%28%29%60%20configures%20the%20viewport%20using%20%60target.url%20%7C%7C%20options.url%60%2C%20but%20Browser%20Run%20can%20omit%20the%20created%20target's%20optional%20%60url%60.%20In%20that%20case%20%60withConnectedPage%28%29%60%20cannot%20identify%20the%20new%20target%20and%20falls%20back%20to%20the%20newest%20non-blank%20Puppeteer%20page%2C%20which%20can%20be%20an%20unrelated%20tab.%20The%20requested%20navigation%20still%20succeeds%2C%20but%20the%20new%20page%20retains%20its%20previous%20viewport%20while%20another%20page%20receives%20the%20configured%20dimensions.%20Resolve%20the%20Puppeteer%20page%20by%20the%20created%20Browser%20Run%20target%20ID%2C%20or%20use%20a%20target-specific%20CDP%20operation%2C%20instead%20of%20using%20the%20newest-page%20fallback.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=acm-vit%2Fconclave&pr=219&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fshared-browser%2Fsrc%2FKitesurfManager.ts%0ALine%3A%20451-454%0A%0AComment%3A%0A**Viewport%20configuration%20can%20target%20an%20unrelated%20Kitesurf%20tab**%0A%0A%60navigateTo%28%29%60%20configures%20the%20viewport%20using%20%60target.url%20%7C%7C%20options.url%60%2C%20but%20Browser%20Run%20can%20omit%20the%20created%20target's%20optional%20%60url%60.%20In%20that%20case%20%60withConnectedPage%28%29%60%20cannot%20identify%20the%20new%20target%20and%20falls%20back%20to%20the%20newest%20non-blank%20Puppeteer%20page%2C%20which%20can%20be%20an%20unrelated%20tab.%20The%20requested%20navigation%20still%20succeeds%2C%20but%20the%20new%20page%20retains%20its%20previous%20viewport%20while%20another%20page%20receives%20the%20configured%20dimensions.%20Resolve%20the%20Puppeteer%20page%20by%20the%20created%20Browser%20Run%20target%20ID%2C%20or%20use%20a%20target-specific%20CDP%20operation%2C%20instead%20of%20using%20the%20newest-page%20fallback.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=acm-vit%2Fconclave&pr=219&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fshared-browser%2Fsrc%2FKitesurfManager.ts%0ALine%3A%20451-454%0A%0AComment%3A%0A**Viewport%20configuration%20can%20target%20an%20unrelated%20Kitesurf%20tab**%0A%0A%60navigateTo%28%29%60%20configures%20the%20viewport%20using%20%60target.url%20%7C%7C%20options.url%60%2C%20but%20Browser%20Run%20can%20omit%20the%20created%20target's%20optional%20%60url%60.%20In%20that%20case%20%60withConnectedPage%28%29%60%20cannot%20identify%20the%20new%20target%20and%20falls%20back%20to%20the%20newest%20non-blank%20Puppeteer%20page%2C%20which%20can%20be%20an%20unrelated%20tab.%20The%20requested%20navigation%20still%20succeeds%2C%20but%20the%20new%20page%20retains%20its%20previous%20viewport%20while%20another%20page%20receives%20the%20configured%20dimensions.%20Resolve%20the%20Puppeteer%20page%20by%20the%20created%20Browser%20Run%20target%20ID%2C%20or%20use%20a%20target-specific%20CDP%20operation%2C%20instead%20of%20using%20the%20newest-page%20fallback.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=219&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Viewport configuration can target an unrelated Kitesurf tab when Browser Run omits the target URL**

   - **Bug**
     - `navigateTo()` successfully creates and records the requested target, but its newly added viewport setup selects a Puppeteer page by `target.url || options.url`. When the Browser Run target response omits its optional `url` and another non-blank page is newer, the fallback applies the configured viewport to that unrelated page instead of the new navigation target. The controlled execution showed `navigationTargetViewportCalls: 0` and `unrelatedNewestPageViewportCalls: 1` with 1365×777 configured dimensions.
   - **Cause**
     - `packages/shared-browser/src/KitesurfManager.ts:451-454` selects by URL and falls back to the newest non-blank page. The PR invokes this selection from `navigateTo()` at lines 549-553 after creating a target whose `url` is optional, without correlating the Puppeteer page to the Browser Run `target.id`.
   - **Fix**
     - Pass the created Browser Run target ID into the viewport configuration path and resolve the matching Puppeteer target/page by ID (or use a CDP target-specific viewport command). Do not use newest-page fallback for newly created targets when the API does not report a URL.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fconclave%22%20on%20the%20existing%20branch%20%22staging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22staging%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fshared-browser%2Fsrc%2FKitesurfManager.ts%3A451-454%0A**Viewport%20configuration%20can%20target%20an%20unrelated%20Kitesurf%20tab**%0A%0A%60navigateTo%28%29%60%20configures%20the%20viewport%20using%20%60target.url%20%7C%7C%20options.url%60%2C%20but%20Browser%20Run%20can%20omit%20the%20created%20target's%20optional%20%60url%60.%20In%20that%20case%20%60withConnectedPage%28%29%60%20cannot%20identify%20the%20new%20target%20and%20falls%20back%20to%20the%20newest%20non-blank%20Puppeteer%20page%2C%20which%20can%20be%20an%20unrelated%20tab.%20The%20requested%20navigation%20still%20succeeds%2C%20but%20the%20new%20page%20retains%20its%20previous%20viewport%20while%20another%20page%20receives%20the%20configured%20dimensions.%20Resolve%20the%20Puppeteer%20page%20by%20the%20created%20Browser%20Run%20target%20ID%2C%20or%20use%20a%20target-specific%20CDP%20operation%2C%20instead%20of%20using%20the%20newest-page%20fallback.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=acm-vit%2Fconclave&pr=219&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fshared-browser%2Fsrc%2FKitesurfManager.ts%3A451-454%0A**Viewport%20configuration%20can%20target%20an%20unrelated%20Kitesurf%20tab**%0A%0A%60navigateTo%28%29%60%20configures%20the%20viewport%20using%20%60target.url%20%7C%7C%20options.url%60%2C%20but%20Browser%20Run%20can%20omit%20the%20created%20target's%20optional%20%60url%60.%20In%20that%20case%20%60withConnectedPage%28%29%60%20cannot%20identify%20the%20new%20target%20and%20falls%20back%20to%20the%20newest%20non-blank%20Puppeteer%20page%2C%20which%20can%20be%20an%20unrelated%20tab.%20The%20requested%20navigation%20still%20succeeds%2C%20but%20the%20new%20page%20retains%20its%20previous%20viewport%20while%20another%20page%20receives%20the%20configured%20dimensions.%20Resolve%20the%20Puppeteer%20page%20by%20the%20created%20Browser%20Run%20target%20ID%2C%20or%20use%20a%20target-specific%20CDP%20operation%2C%20instead%20of%20using%20the%20newest-page%20fallback.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=acm-vit%2Fconclave&pr=219&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fshared-browser%2Fsrc%2FKitesurfManager.ts%3A451-454%0A**Viewport%20configuration%20can%20target%20an%20unrelated%20Kitesurf%20tab**%0A%0A%60navigateTo%28%29%60%20configures%20the%20viewport%20using%20%60target.url%20%7C%7C%20options.url%60%2C%20but%20Browser%20Run%20can%20omit%20the%20created%20target's%20optional%20%60url%60.%20In%20that%20case%20%60withConnectedPage%28%29%60%20cannot%20identify%20the%20new%20target%20and%20falls%20back%20to%20the%20newest%20non-blank%20Puppeteer%20page%2C%20which%20can%20be%20an%20unrelated%20tab.%20The%20requested%20navigation%20still%20succeeds%2C%20but%20the%20new%20page%20retains%20its%20previous%20viewport%20while%20another%20page%20receives%20the%20configured%20dimensions.%20Resolve%20the%20Puppeteer%20page%20by%20the%20created%20Browser%20Run%20target%20ID%2C%20or%20use%20a%20target-specific%20CDP%20operation%2C%20instead%20of%20using%20the%20newest-page%20fallback.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=219&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: simplify Kitesurf participant rail"](https://github.com/acm-vit/conclave/commit/af16d48903f29d6e65080358bc4f4f71aa98cc51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52096133)</sub>

<!-- /greptile_comment -->